### PR TITLE
Skip barriers of noops

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -749,6 +749,8 @@ extern "C" {
     GGML_API GGML_CALL const char * ggml_op_name  (enum ggml_op   op);
     GGML_API           const char * ggml_op_symbol(enum ggml_op   op);
 
+    GGML_API GGML_CALL bool ggml_is_noop(const struct ggml_tensor * tensor);
+
     GGML_API           const char * ggml_unary_op_name(enum ggml_unary_op op);
     GGML_API GGML_CALL const char * ggml_op_desc(const struct ggml_tensor * t); // unary or op name
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -3581,6 +3581,11 @@ GGML_CALL bool ggml_is_empty(const struct ggml_tensor * tensor) {
     return false;
 }
 
+GGML_CALL bool ggml_is_noop(const struct ggml_tensor * tensor) {
+    return tensor->op == GGML_OP_NONE || tensor->op == GGML_OP_RESHAPE || tensor->op == GGML_OP_VIEW || tensor->op == GGML_OP_PERMUTE || tensor->op == GGML_OP_TRANSPOSE ||
+           ggml_is_empty(tensor) ? true : false;
+}
+
 bool ggml_are_same_shape(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
@@ -19207,6 +19212,8 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
 
     for (int node_n = 0; node_n < cgraph->n_nodes; node_n++) {
         struct ggml_tensor * node = cgraph->nodes[node_n];
+
+        if (ggml_is_noop(node)) continue;
 
         ggml_compute_forward(&params, node);
 


### PR DESCRIPTION
`GGML_OP_RESHAPE, GGML_OP_VIEW, GGML_OP_PERMUTE, GGML_OP_TRANSPOSE`, along with `GGML_OP_NONE`, are all noops in `ggml`. I.e., nothing happens. But `ggml` still has a thread barrier after them, which wastes time. The waste is not too bad for large models where computations are long compared to the time taken for thread synchronization. But for small models skipping those unnecessary waits makes a noticeable difference.

Let's look at a really tiny model - the [99M parameter TriLM ternary model](https://huggingface.co/SpectraSuite/TriLM_99M_Unpacked) quantized with `IQ2_TN`.  The following table compares performance for PP-512 and TG-128 with and without the change in this PR

| CPU        | threads |          test |    t/s (main)    |  t/s (PR)        |  Speedup |
| ---------- | ------: | ------------: | ---------------: | ---------------: | -------: |
| Ryzen-7950X|      16 |         pp512 | 11386.75 ± 19.08 | 11587.58 ± 34.26 |  1.018   |   
| Ryzen-7950X|       8 |         tg128 |   1312.25 ± 1.02 |   1460.80 ± 1.69 |  1.113   |   
| M2-Max     |       8 |         pp512 |  7642.81 ± 22.07 |   7680.29 ± 9.29 |  1.005   |   
| M2-Max     |       8 |         tg128 |   992.83 ± 18.17 |  1096.47 ± 14.45 |  1.104   |

So, basically, for such a small model `ggml` spends 10% of its time waiting for threads to pass through a barrier after a noop when generating tokens.

There are other barriers that can be eliminated. E.g., the typical attention block involves matrix multiplications of the `Q, K` and `V` tensors with the **same** activations, so there is no need to synchronize threads after each such matrix multiplications. In a similar way, in the feed-forward portion of the network the `ffn_up` and `ffn_gate` tensors multiply the same activations, so one can save another barrier there. This is left for a future PR.





