### PR TITLE
softcap: minor improvement

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8325,9 +8325,6 @@ static struct ggml_tensor * llm_build_kqv(
 
         if (hparams.attn_soft_cap) {
             kq = ggml_softcap(ctx, kq, 1.0f / hparams.f_attn_logit_softcapping, hparams.f_attn_logit_softcapping);
-            //kq = ggml_scale(ctx, kq, 1.0f / hparams.f_attn_logit_softcapping);
-            //kq = ggml_tanh(ctx, kq);
-            //kq = ggml_scale(ctx, kq, hparams.f_attn_logit_softcapping);
         }
 
         kq = ggml_soft_max_ext(ctx, kq, kq_mask, kq_scale, hparams.f_max_alibi_bias);


### PR DESCRIPTION

With this change we get 104 t/s for Gemma-2-9b with a context of 8192 tokens on a Ryzen-7950X.

For this model and context size, about 10% of the time is spent in `softcap` (5.8%) and `soft_max` (4.2%) when running on the Ryzen-7950X CPU. I wonder if it wouldn't be better to merge `softcap` and `soft_max` into a single op (for Gemma-2, `softcap` in the attention layer is immediately followed by `soft_max`) 