### PR TITLE
Do not process prompts containing binary data for escapes

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -250,7 +250,9 @@ bool gpt_params_parse_ex(int argc, char ** argv, gpt_params & params) {
     gpt_params_handle_hf_token(params);
 
     if (params.escape) {
-        string_process_escapes(params.prompt);
+        if (!params.prompt_is_binary) {
+            string_process_escapes(params.prompt);
+        }
         string_process_escapes(params.input_prefix);
         string_process_escapes(params.input_suffix);
         string_process_escapes(sparams.cfg_negative_prompt);
@@ -334,6 +336,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
     if (arg == "-p" || arg == "--prompt") {
         CHECK_ARG
         params.prompt = argv[i];
+        params.prompt_is_binary = false;
         return true;
     }
     if (arg == "-e" || arg == "--escape") {
@@ -371,6 +374,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         ss << file.rdbuf();
         params.prompt = ss.str();
         fprintf(stderr, "Read %zu bytes from binary file %s\n", params.prompt.size(), argv[i]);
+        params.prompt_is_binary = true;
         return true;
     }
     if (arg == "-f" || arg == "--file") {
@@ -387,6 +391,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         if (!params.prompt.empty() && params.prompt.back() == '\n') {
             params.prompt.pop_back();
         }
+        params.prompt_is_binary = false;
         return true;
     }
     if (arg == "--in-file") {

--- a/common/common.h
+++ b/common/common.h
@@ -122,6 +122,7 @@ struct gpt_params {
     std::string hf_file              = ""; // HF file
     std::string prompt               = "";
     std::string prompt_file          = ""; // store the external prompt file name
+    bool prompt_is_binary            = false; // don't fool around when the prompt contains binary data (as it is for multiple choice)
     std::string path_prompt_cache    = ""; // path to file for saving/loading prompt eval state
     std::string input_prefix         = ""; // string to prefix user inputs with
     std::string input_suffix         = ""; // string to suffix user inputs with


### PR DESCRIPTION

The multiple choice evaluation has been broken in `llama.cpp` via commit `6ff13987a`, and this PR fixes it.

The multiple choice evaluation uses binary data stored in `params.prompt`. Commit `6ff13987a` adds prompt escape character processing, which modifies the binary data and renders unusable. To preserve whatever utility `6ff13987a` might have added, we add a flag indicating if the data stored in `params.prompt` is binary and, if so, avoid the escape processing.