### PR TITLE
Zen4 Flash Attnetion 2

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -16150,8 +16150,7 @@ static void ggml_compute_forward_flash_attn_ext_f16(
     }
 
 #if GGML_USE_IQK_MULMAT
-    if (max_bias <= 0.0f && q->type == GGML_TYPE_F32 && k->type == GGML_TYPE_F16 && v->type == GGML_TYPE_F16 &&
-        mask && mask->type == GGML_TYPE_F16) {
+    if (max_bias <= 0.0f && q->type == GGML_TYPE_F32 && mask && mask->type == GGML_TYPE_F16) {
         int64_t work_per_slice = D*nek1*neq1;
         int ntg = 1;
         if      (nth%8 == 0 && neq1%8 == 0 && work_per_slice >= (1 << 23)) ntg = 8;
@@ -16165,7 +16164,8 @@ static void ggml_compute_forward_flash_attn_ext_f16(
                 for (int64_t iq2 = 0; iq2 < neq2; iq2++) {
                     if (counter++ % (nth/ntg) == ith/ntg) {
                         int iq1 = (ith%ntg)*neq1/ntg;
-                        if (!iqk_flash_attn_noalibi(D, neq1/ntg, nek1, q->nb[1], k->nb[1], v->nb[1], mask->nb[1], ne1*nb1/sizeof(float),
+                        if (!iqk_flash_attn_noalibi(k->type, v->type,
+                                D, neq1/ntg, nek1, q->nb[1], k->nb[1], v->nb[1], mask->nb[1], ne1*nb1/sizeof(float),
                                 (const float *)((const char *)q->data + iq2*q->nb[2] + iq3*q->nb[3] + iq1*q->nb[1]),
                                 (const void  *)((const char *)k->data + iq2/rk2*k->nb[2] + iq3/rk3*k->nb[3]),
                                 (const void  *)((const char *)v->data + iq2/rv2*v->nb[2] + iq3/rv3*v->nb[3]),

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -6529,45 +6529,6 @@ struct FlashAttn {
         }
     }
 
-    //void compute(int nq1, int nk1, int stride_k, int stride_q, int stride_m, int stride_v, int stride_qkv,
-    //        const char * k, const float * q, const char * mask, const char * v, float * qkv) {
-    //    KHelperF16<D, k_step> kh(k, stride_k);
-    //    KHelperF16<D, k_step> vh(v, stride_v);
-    //    for (int i1 = 0; i1 < nq1/q_step; ++i1) {
-    //        init_qstep();
-    //        kh.reset_block();
-    //        vh.reset_block();
-    //        auto mr = mask;
-    //        for (int k1 = 0; k1 < nk1/k_step; ++k1) {
-    //            multiply_mask_kq(kh, stride_q, stride_m, q, mr);
-    //            accumulate_qkv(vh);
-    //            kh.next_block();
-    //            vh.next_block();
-    //            mr += k_step*sizeof(ggml_half);
-    //        }
-    //        normalize_and_store(stride_qkv, qkv);
-
-    //        q    += q_step*stride_q;
-    //        mask += q_step*stride_m;
-    //        qkv  += q_step*stride_qkv;
-    //    }
-    //    int n_left = nq1 - q_step*(nq1/q_step);
-    //    if (n_left > 0) {
-    //        init_qstep();
-    //        kh.reset_block();
-    //        vh.reset_block();
-    //        auto mr = mask;
-    //        for (int k1 = 0; k1 < nk1/k_step; ++k1) {
-    //            multiply_mask_kq(n_left, kh, stride_q, stride_m, q, mr);
-    //            accumulate_qkv(n_left, vh);
-    //            kh.next_block();
-    //            vh.next_block();
-    //            mr += k_step*sizeof(ggml_half);
-    //        }
-    //        normalize_and_store(n_left, stride_qkv, qkv);
-    //    }
-    //}
-
     template <typename KHelper, typename VHelper>
     void compute(KHelper& kh, VHelper& vh, int nq1, int nk1, int stride_q, int stride_m, int stride_qkv,
             const float * q, const char * mask, float * qkv) {

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -21,7 +21,9 @@ bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
-bool iqk_flash_attn_noalibi(int D,                  // head size
+bool iqk_flash_attn_noalibi(int type_k,             // type of k
+                            int type_v,             // type of v
+                            int D,                  // head size
                             int nq,                 // number of columns in q
                             int nk,                 // number of rows in k
                             int stride_q,           // distance between q columns in bytes


### PR DESCRIPTION
This PR is a follow up on #32 and adds the ability to use quantized K- and V-cache in the flash attention (FA) kernel. `Q4_0`, `Q4_1` and `Q8_0` are supported as cache quantization types. It is trivial to add additional types, but the implementation is templated, so number of template instantiations grows quadraticly with the number of supported quantization types, so I decided to settle for these 3 types for now.

Performance is slightly lower than `fp16` cache (see graph below), so main use case is KV-cache size reduction for very large context lengths. Still, unlike mainline `llama.cpp`, performance remains strictly above no-FA.

The graph below shows PP performance as a function of context length (logarithmic scale) for Gemma-2-2b quantized with `Q4_K_S` on a Ryzen-7950X CPU.

![fa_gemma2b_q](https://github.com/user-attachments/assets/8e42d3eb-74f5-45ba-9d63-92d661363e60)

  