### PR TITLE
Add support for bf16 to iqk_mul_mat

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3208,52 +3208,6 @@ template <typename Float, int nrc_in> struct QFT final : public QFBase {
     const Float * y[nrc];
 };
 
-
-//template <typename Qy, typename Qx, typename F>
-//IQK_NOINLINE void mul_mat_Qx_Qy_MxN(int n, const char * cx, size_t bx, int ix0, const DataInfo& info) {
-//    assert(n%FBase::k_step == 0);
-//    int nb = n/F::k_step;
-//    int nb4 = n/4;
-//    Qy y(info);
-//    Qx x(cx + ix0*bx, bx);
-//    typename F::Data xv[Qx::nrc];
-//    typename F::Acc  acc[Qx::nrc*Qy::nrc];
-//    auto yv = y.load1(0, 0);
-//    for (int ix = 0; ix < Qx::nrc; ++ix) {
-//        xv[ix] = x.load1(ix, 0);
-//        acc[ix] = F::acc_first(yv, xv[ix]);
-//    }
-//    for (int iy = 1; iy < Qy::nrc; ++iy) {
-//        yv = y.load1(iy, 0);
-//        for (int ix = 0; ix < Qx::nrc; ++ix) acc[Qx::nrc*iy + ix] = F::acc_first(yv, xv[ix]);
-//    }
-//    for (int i = 1; i < nb; ++i) {
-//        yv = y.load1(0, i);
-//        for (int ix = 0; ix < Qx::nrc; ++ix) {
-//            xv[ix] = x.load1(ix, i);
-//            acc[ix] = F::acc(acc[ix], yv, xv[ix]);
-//        }
-//        for (int iy = 1; iy < Qy::nrc; ++iy) {
-//            yv = y.load1(iy, i);
-//            for (int ix = 0; ix < Qx::nrc; ++ix) acc[Qx::nrc*iy + ix] = F::acc(acc[Qx::nrc*iy + ix], yv, xv[ix]);
-//        }
-//    }
-//    if constexpr (F::k_step < 32) {
-//        for (int i = (F::k_step/4)*nb; i < nb4; ++i) {
-//            yv = y.load_tail(0, i);
-//            for (int ix = 0; ix < Qx::nrc; ++ix) {
-//                xv[ix] = x.load_tail(ix, i);
-//                acc[ix] = F::acc(acc[ix], yv, xv[ix]);
-//            }
-//            for (int iy = 1; iy < Qy::nrc; ++iy) {
-//                yv = y.load_tail(iy, i);
-//                for (int ix = 0; ix < Qx::nrc; ++ix) acc[Qx::nrc*iy + ix] = F::acc(acc[Qx::nrc*iy + ix], yv, xv[ix]);
-//            }
-//        }
-//    }
-//    for (int iy = 0; iy < Qy::nrc; ++iy) for (int ix = 0; ix < Qx::nrc; ++ix) info.store(ix0+ix, iy, F::hsum(acc[Qx::nrc*iy+ix]));
-//}
-
 template <typename Qy, typename Qx>
 IQK_NOINLINE void mul_mat_Qx_Qy_MxN(int n, const char * cx, size_t bx, int ix0, const DataInfo& info) {
     int nb = n/QFBase::k_step;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3336,7 +3336,7 @@ IQK_NOINLINE void mul_mat_Qx_Qy_MxN(int n, const char * cx, size_t bx, int ix0, 
 }
 template <int nrc_y>
 void mul_mat_fX_fY_T(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
-    constexpr int k_nx = 5;
+    constexpr int k_nx = nrc_y <= 2 ? 8 : 5;
     const char * cx = (const char *)vx;
     for (int ix = 0; ix < nrc_x/k_nx; ++ix) {
         mul_mat_Qx_Qy_MxN<nrc_y, k_nx>(n, cx, bx, ix*k_nx, info);
@@ -3344,6 +3344,14 @@ void mul_mat_fX_fY_T(int n, const void * vx, size_t bx, const DataInfo& info, in
     int last_x = k_nx*(nrc_x/k_nx);
     if (last_x == nrc_x) return;
     int nx = nrc_x - last_x;
+    if constexpr (nrc_y <= 2) {
+        if (nx >= 4) {
+            mul_mat_Qx_Qy_MxN<nrc_y, 4>(n, cx, bx, last_x, info);
+            last_x += 4;
+            if (last_x == nrc_x) return;
+            nx = nrc_x - last_x;
+        }
+    }
     switch (nx) {
         case 1: mul_mat_Qx_Qy_MxN<nrc_y, 1>(n, cx, bx, last_x, info); break;
         case 2: mul_mat_Qx_Qy_MxN<nrc_y, 2>(n, cx, bx, last_x, info); break;


### PR DESCRIPTION

Only when natively supported (e.g., Zen4), else left to `ggml` to handle.

For LLaMA-3.1-8B we get `PP512 = 205` t/s vs `74 t/s` in `llama.cpp` on my Ryzen-7950X CPU.

I get `204` t/s with [llamafile](https://github.com/Mozilla-Ocho/llamafile), so I guess Justine Tunney has not contributed the more recent `tinyBLAS` improvements to `llama.cpp`.

