### PR TITLE
ARM_NEON Flash Attention

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -6411,8 +6411,6 @@ inline __m256 v_tanh(__m256 x) {
 #endif
 } // namespace
 
-//#ifndef __aarch64__
-
 namespace {
 
 template <int k_step>
@@ -7650,30 +7648,6 @@ bool iqk_flash_attn_noalibi(int int_type_k,         // type of k
 
     return true;
 }
-
-//#else
-//// TODO
-//bool iqk_flash_attn_noalibi([[maybe_unused]] int int_type_k,         // type of k
-//                            [[maybe_unused]] int int_type_v,         // type of v
-//                            [[maybe_unused]] int D,                  // head size
-//                            [[maybe_unused]] int nq,                 // number of columns in q
-//                            [[maybe_unused]] int nk,                 // number of rows in k
-//                            [[maybe_unused]] int stride_q,           // distance between q columns in bytes
-//                            [[maybe_unused]] int stride_k,           // distance between k rows in bytes
-//                            [[maybe_unused]] int stride_v,           // distance between v rows in bytes
-//                            [[maybe_unused]] int stride_m,           // distance between mask rows (in bytes
-//                            [[maybe_unused]] int stride_qkv,         // distance between rows in mask (in bytes)
-//                            [[maybe_unused]] const float * q,        // q matrix.
-//                            [[maybe_unused]] const void  * k,        // k matrix. Assumed to be fp16, nq x nk elements
-//                            [[maybe_unused]] const void  * v,        // v matrix. Assumed to be fp16, nq x nk elements
-//                            [[maybe_unused]] const void  * mask,     // mask. If not null, assumed to be fp16. nq x nk elements
-//                            [[maybe_unused]] float         scale,    // scale applied before softmax
-//                            [[maybe_unused]] float         softcap,  // if > 0, a "soft-cap" operation is applied before softmax
-//                            [[maybe_unused]] float       * qkv) {    // v*softmax(scale*(k*q))
-//    return false;
-//}
-//
-//#endif
 
 #else  // IQK_IMPLEMENT
 


### PR DESCRIPTION
This PR adds Flash Attention for `ARM_NEON`. The `Zen4/AVX2` implementation is reused with a few platform specific additions for `ARM_NEON`. As with `AVX2`, it is just for `fp16` kv-cache for now.

On `ARM_NEON` `fp16` arithmetic is used to compute `K*Q` (unlike `Zen4/AVX2`, which use `fp32`). Initially I was also using `fp16` to operate on the `K*Q` product (the `soft_max` related stuff), and that worked fine for the models I was using for testing (Gemma2-2b, TriLM-4B). But `fp16` fails for LLaMA-3.1-8B, so I had to change for `fp32`<sup>1</sup>. 

Performance gains are not as good as `Zen4/AVX2`. My guess is that due to the significantly higher memory bandwidth of the M2 Max used for testing the `ARM_NEON` implementation (compared to the `Zen4/AVX2` systems I have available), the penalty of not having intermediate results in the cache when computing `KQV` is less. Nevertheless, for LLaMA-3.1-8B at a context of 2k tokens, using FA is about 4% faster than not using FA on the M2 Max. In contrast, the mainline `llama.cpp` FA implementation is ~17% slower than no-FA.    

<sup>1</sup> I must admit I don't really understand why because `expf` (and `tanh` when soft-capping is involved) are computed in `fp32` even when `K*Q` is `fp16`, so possibly there was a bug that I was not able to find in the `fp32 <-> fp16` conversions rather than a loss of precision.