### PR TITLE
Adding SWIGLU unary op

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -564,6 +564,7 @@ extern "C" {
         GGML_UNARY_OP_SILU,
         GGML_UNARY_OP_HARDSWISH,
         GGML_UNARY_OP_HARDSIGMOID,
+        GGML_UNARY_OP_SWIGLU,
 
         GGML_UNARY_OP_COUNT,
     };
@@ -1124,6 +1125,10 @@ extern "C" {
             struct ggml_tensor  * a);
 
     GGML_API struct ggml_tensor * ggml_silu_inplace(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a);
+
+    GGML_API struct ggml_tensor * ggml_swiglu(
             struct ggml_context * ctx,
             struct ggml_tensor  * a);
 

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2233,6 +2233,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
                 case GGML_UNARY_OP_SILU:
                     ggml_cuda_op_silu(ctx, dst);
                     break;
+                case GGML_UNARY_OP_SWIGLU:
+                    ggml_cuda_op_swiglu(ctx, dst);
+                    break;
                 case GGML_UNARY_OP_GELU_QUICK:
                     ggml_cuda_op_gelu_quick(ctx, dst);
                     break;
@@ -2773,6 +2776,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
             switch (ggml_get_unary_op(op)) {
                 case GGML_UNARY_OP_GELU:
                 case GGML_UNARY_OP_SILU:
+                case GGML_UNARY_OP_SWIGLU:
                 case GGML_UNARY_OP_RELU:
                 case GGML_UNARY_OP_SIGMOID:
                 case GGML_UNARY_OP_HARDSIGMOID:

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -31,6 +31,18 @@ static __global__ void silu_f32(const float * x, float * dst, const int k) {
     dst[i] = x[i] / (1.0f + expf(-x[i]));
 }
 
+static __global__ void swiglu_f32(const float * x, float * dst, const int k, const int ne0, const int64_t nb1) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    const int row = i/ne0;
+    const int idx = i%ne0;
+    const int j   = row*nb1 + idx;
+    dst[i] = x[j] * x[j + ne0] / (1.0f + expf(-x[j]));
+}
+
 static __global__ void tanh_f32(const float * x, float * dst, int k) {
     const int i  = blockDim.x*blockIdx.x + threadIdx.x;
     if (i >= k) {
@@ -116,6 +128,11 @@ static void silu_f32_cuda(const float * x, float * dst, const int k, cudaStream_
     silu_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, dst, k);
 }
 
+static void swiglu_f32_cuda(const float * x, float * dst, const int k, const int64_t ne0, const int64_t nb1, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_SILU_BLOCK_SIZE - 1) / CUDA_SILU_BLOCK_SIZE;
+    swiglu_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, dst, k, ne0, nb1);
+}
+
 static void tanh_f32_cuda(const float * x, float * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_TANH_BLOCK_SIZE - 1) / CUDA_TANH_BLOCK_SIZE;
     tanh_f32<<<num_blocks, CUDA_TANH_BLOCK_SIZE, 0, stream>>>(x, dst, k);
@@ -182,6 +199,21 @@ void ggml_cuda_op_silu(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT( dst->type == GGML_TYPE_F32);
 
     silu_f32_cuda(src0_d, dst_d, ggml_nelements(src0), stream);
+}
+
+void ggml_cuda_op_swiglu(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    const float * src0_d = (const float *)src0->data;
+    float * dst_d = (float *)dst->data;
+    cudaStream_t stream = ctx.stream();
+
+    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ggml_is_contiguous(dst));
+    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->ne[0] == src0->ne[0]/2);
+
+    swiglu_f32_cuda(src0_d, dst_d, ggml_nelements(dst), dst->ne[0], src0->nb[1]/sizeof(float), stream);
 }
 
 void ggml_cuda_op_gelu_quick(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/unary.cuh
+++ b/ggml/src/ggml-cuda/unary.cuh
@@ -31,3 +31,5 @@ void ggml_cuda_op_leaky_relu(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
 void ggml_cuda_op_sqr(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_sqrt(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+void ggml_cuda_op_swiglu(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-metal.m
+++ b/ggml/src/ggml-metal.m
@@ -1609,19 +1609,22 @@ static enum ggml_status ggml_metal_graph_compute(
 
                                 id<MTLComputePipelineState> pipeline = nil;
 
+                                uint32_t n_per_row = ne0;
+                                uint32_t stride    = src0->nb[1]/sizeof(float);
+
                                 if (ne0 % 4 == 0) {
                                     pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_SWIGLU_4].pipeline;
                                     n /= 4;
+                                    n_per_row /= 4;
+                                    stride /= 4;
                                 } else {
                                     pipeline = ctx->kernels[GGML_METAL_KERNEL_TYPE_SWIGLU].pipeline;
                                 }
 
-                                const int64_t stride = src0->nb[1]/sizeof(float);
-
                                 [encoder setComputePipelineState:pipeline];
                                 [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                                 [encoder setBuffer:id_dst  offset:offs_dst  atIndex:1];
-                                [encoder setBytes:&ne0 length:sizeof(ne0) atIndex:2];
+                                [encoder setBytes:&n_per_row length:sizeof(n_per_row) atIndex:2];
                                 [encoder setBytes:&stride length:sizeof(stride) atIndex:3];
 
                                 [encoder dispatchThreadgroups:MTLSizeMake(n, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];

--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -398,6 +398,30 @@ kernel void kernel_silu_4(
     dst[tpig] = x / (1.0f + exp(-x));
 }
 
+kernel void kernel_swiglu(
+        device const float * src0,
+        device       float * dst,
+        constant   int64_t & ne0,
+        constant   int64_t & stride,
+        uint tpig[[thread_position_in_grid]]) {
+    const int64_t row = tpig/ne0;
+    const int64_t idx = tpig%ne0;
+    const int64_t j   = row*stride + idx;
+    dst[tpig] = src0[j] * src0[j + ne0] / (1.0f + exp(-src0[j]));
+}
+
+kernel void kernel_swiglu_4(
+        device const float4 * src0,
+        device       float4 * dst,
+        constant    int64_t & ne0,
+        constant    int64_t & stride,
+        uint tpig[[thread_position_in_grid]]) {
+    const int64_t row = tpig/(ne0/4);
+    const int64_t idx = tpig%(ne0/4);
+    const int64_t j   = row*(stride/4) + idx;
+    dst[tpig] = src0[j] * src0[j + ne0/4] / (1.0f + exp(-src0[j]));
+}
+
 kernel void kernel_sqr(
         device const float * src0,
         device       float * dst,

--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -401,25 +401,25 @@ kernel void kernel_silu_4(
 kernel void kernel_swiglu(
         device const float * src0,
         device       float * dst,
-        constant   int64_t & ne0,
-        constant   int64_t & stride,
+        constant      uint & ne0,
+        constant      uint & stride,
         uint tpig[[thread_position_in_grid]]) {
-    const int64_t row = tpig/ne0;
-    const int64_t idx = tpig%ne0;
-    const int64_t j   = row*stride + idx;
+    const uint row = tpig/ne0;
+    const uint idx = tpig%ne0;
+    const uint j   = row*stride + idx;
     dst[tpig] = src0[j] * src0[j + ne0] / (1.0f + exp(-src0[j]));
 }
 
 kernel void kernel_swiglu_4(
         device const float4 * src0,
         device       float4 * dst,
-        constant    int64_t & ne0,
-        constant    int64_t & stride,
+        constant       uint & ne0,
+        constant       uint & stride,
         uint tpig[[thread_position_in_grid]]) {
-    const int64_t row = tpig/(ne0/4);
-    const int64_t idx = tpig%(ne0/4);
-    const int64_t j   = row*(stride/4) + idx;
-    dst[tpig] = src0[j] * src0[j + ne0/4] / (1.0f + exp(-src0[j]));
+    const uint row = tpig/ne0;
+    const uint idx = tpig%ne0;
+    const uint j   = row*stride + idx;
+    dst[tpig] = src0[j] * src0[j + ne0] / (1.0f + exp(-src0[j]));
 }
 
 kernel void kernel_sqr(

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -5719,6 +5719,8 @@ struct ggml_tensor * ggml_silu_inplace(
     return ggml_unary_inplace(ctx, a, GGML_UNARY_OP_SILU);
 }
 
+// ggml_swiglu
+
 struct ggml_tensor * ggml_swiglu(
         struct ggml_context * ctx,
         struct ggml_tensor  * a) {
@@ -12287,7 +12289,7 @@ static void ggml_compute_forward_silu(
     }
 }
 
-// ggml_compute_forward_silu
+// ggml_compute_forward_swiglu
 
 static void ggml_compute_forward_swiglu_f32(
         const struct ggml_compute_params * params,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8111,16 +8111,18 @@ static struct ggml_tensor * llm_build_ffn(
             } break;
         case LLM_FFN_SWIGLU:
             {
-                // Project to 4h. If using swiglu double the output width, see https://arxiv.org/pdf/2002.05202.pdf
-                int64_t split_point = cur->ne[0] / 2;
-                struct ggml_tensor * x0 = ggml_cont(ctx, ggml_view_2d(ctx, cur, split_point, cur->ne[1], cur->nb[1], 0));
-                struct ggml_tensor * x1 = ggml_cont(ctx, ggml_view_2d(ctx, cur, split_point, cur->ne[1], cur->nb[1], split_point * ggml_element_size(cur)));
+                cur = ggml_swiglu(ctx, cur);
+                cb(cur, "ffn_swiglu", il);
+                //// Project to 4h. If using swiglu double the output width, see https://arxiv.org/pdf/2002.05202.pdf
+                //int64_t split_point = cur->ne[0] / 2;
+                //struct ggml_tensor * x0 = ggml_cont(ctx, ggml_view_2d(ctx, cur, split_point, cur->ne[1], cur->nb[1], 0));
+                //struct ggml_tensor * x1 = ggml_cont(ctx, ggml_view_2d(ctx, cur, split_point, cur->ne[1], cur->nb[1], split_point * ggml_element_size(cur)));
 
-                x0 = ggml_silu(ctx, x0);
-                cb(cur, "ffn_silu", il);
+                //x0 = ggml_silu(ctx, x0);
+                //cb(cur, "ffn_silu", il);
 
-                cur = ggml_mul(ctx, x0, x1);
-                cb(cur, "ffn_mul", il);
+                //cur = ggml_mul(ctx, x0, x1);
+                //cb(cur, "ffn_mul", il);
             } break;
     }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8113,16 +8113,6 @@ static struct ggml_tensor * llm_build_ffn(
             {
                 cur = ggml_swiglu(ctx, cur);
                 cb(cur, "ffn_swiglu", il);
-                //// Project to 4h. If using swiglu double the output width, see https://arxiv.org/pdf/2002.05202.pdf
-                //int64_t split_point = cur->ne[0] / 2;
-                //struct ggml_tensor * x0 = ggml_cont(ctx, ggml_view_2d(ctx, cur, split_point, cur->ne[1], cur->nb[1], 0));
-                //struct ggml_tensor * x1 = ggml_cont(ctx, ggml_view_2d(ctx, cur, split_point, cur->ne[1], cur->nb[1], split_point * ggml_element_size(cur)));
-
-                //x0 = ggml_silu(ctx, x0);
-                //cb(cur, "ffn_silu", il);
-
-                //cur = ggml_mul(ctx, x0, x1);
-                //cb(cur, "ffn_mul", il);
             } break;
     }
 


### PR DESCRIPTION
Phi-3(.5) (and also ChatGLM) uses a "SWIGLU" operation in its FFN. There is nothing special about "SWIGLU", it is just that the `ffn_up` tensor is actually a combination of the usual `ffn_up` and `ffn_gate` tensors, where in each row the first half contains the `ffn_up` weights and the second half has the `ffn_gate` weights. So that, to implement
```
silu(ffn_up * A) * (ffn_gate * A)
```
(`A` are the activations passed into the FFN network), which is common for many LLMs, one needs `swiglu(ffn_up * A) `. In a typical `ggml` style, instead of adding a dedicated op for that, `ggml` models it as 4 (!) operations
```
x1 = ggml_cont(ffn_up, first row half)
x2 = ggml_cont(ffn_up, second row half)
x3 = ggml_silu(x1)
x4 = ggml_mul(x2, x3)
```
`ggml_cont(x)` is basically a copy operation. The result of this is that on my Ryzen-7950X CPU more than 5% (!) of PP time is spent in `ggml_cont`, i.e., in completely unnecessary copies<sup>1</sup> 

To remedy this unfortunate `ggml` implementation detail, this PR adds a dedicated `ggml_swiglu` operation, implemented for the CPU, CUDA, and Metal back-ends. We get
* ~4% PP speedup on the CPU (Ryzen-7950X, Ryzen-5975WX, M2-Max) 
* ~3% PP speedup on Metal (M2-Max GPU)
* ~12% PP speedup on CUDA (RTX-4080)
* ~1-2% speedup for TG on all tested platforms

**Of note**: Phi-3.5 has been trained in `bf16`. To make sure that my `ggml_swiglu` implementation is correct, I ran a full Wikitext2 perplexity calculation on the CPU. The Ryzen-7950X CPU has native `bf16` support, so I used a GGUF converted directly to `bf16` from the safetensors on HF. As FA with `bf16` KV-cache is slightly faster when there is native `bf16` support, I also used that. The final PPL for a context of 512 tokens is `6.5556`. In comparison, the `fp16` CUDA result is `6.5816`. The difference is small but definitely outside of what one would expect from numerical roundoff errors alone. I guess, there are a few model weights in Phi-3.5-mini, as well as some activations, that fall outside of the `fp16` range.

===
<sup>1</sup> Phi-3(-5) also uses a combined `QKV` tensor, which triggers additional `ggml_cont` operations as implemented in `llama.cpp`:
```
cur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wqkv, attn_norm_output); // this is the QKV * A matrix multiplication
Qcur = ggml_cont(ctx0, ggml_view_2d(ctx0, cur, n_embd,     n_tokens, cur->nb[1], 0 * sizeof(float) * (n_embd)));      
Kcur = ggml_cont(ctx0, ggml_view_2d(ctx0, cur, n_embd_gqa, n_tokens, cur->nb[1], 1 * sizeof(float) * (n_embd)));      
Vcur = ggml_cont(ctx0, ggml_view_2d(ctx0, cur, n_embd_gqa, n_tokens, cur->nb[1], 1 * sizeof(float) * (n_embd + n_embd_gqa)));      
Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
```
The ` ggml_reshape_3d` op requires the tensor being reshaped to be contiguous, so `Qcur` and `Kcur` are created by copying the appropriate data out of `QKV * A`. The `Vcur` copy is completely unnecessary. The exact same result can be achieved, without using any copies, via
```
Qcur = ggml_view_3d(ctx0, cur, n_embd_head, n_head, n_tokens, n_embd_head*sizeof(float), cur->nb[1], cur, 0 * sizeof(float) * (n_embd));
Kcur = ggml_view_3d(ctx0, cur, n_embd_head, n_head_kv, n_tokens, n_embd_head*sizeof(float), cur->nb[1], 1 * sizeof(float) * (n_embd));
Vcur = ggml_view_2d(ctx0, cur, n_embd_gqa, n_tokens, cur->nb[1], 1 * sizeof(float) * (n_embd + n_embd_gqa));
```
This results in an additional 2-3% speedup of PP-512(Phi-3.5-mini) when running on the CPU. Unfortunately CUDA becomes massively slower, so I need to investigate and hence have left this change for a future PR.
