### PR TITLE
CUDA non-contiguous RoPE

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2924,9 +2924,10 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
         case GGML_OP_DIAG_MASK_INF:
         case GGML_OP_SOFT_MAX:
         case GGML_OP_SOFT_CAP_MAX:
-            return true;
         case GGML_OP_ROPE:
-            return ggml_is_contiguous(op->src[0]);
+            return true;
+        //case GGML_OP_ROPE:
+        //    return ggml_is_contiguous(op->src[0]);
         case GGML_OP_IM2COL:
         case GGML_OP_POOL_2D:
         case GGML_OP_SUM_ROWS:


### PR DESCRIPTION
In this way we can avoid the Q, K, V copies being made after multiplication with the QKV tensor in, e.g., Phi-3.5-mini (see #65 for details). This results in a 6-7% speedup of PP-512(Phi-3.5-mini) on CUDA (RTX-4080). There is also a 2-3% gain on Metal (M2-Max GPU).

Here is the combined effect of this PR and PR #65 on CUDA (RTX-4080) and Metal (M2-Max 30-core GPU) for Phi-3.5-mini:

| model        | backend    | ngl | threads |          test |   t/s (llama.cpp)    |  t/s (this PR)   |  Speedup |
| -------------| ---------- | --: | ------: | ------------: | -------------------: | ---------------: | -------: |
| phi3 3B F16  | Metal      | 100 |       4 |         pp512 |       1003.22 ± 1.31 |   1063.84 ± 0.63 |  1.060   |
| phi3 3B F16  | Metal      | 100 |       4 |         tg128 |         39.32 ± 0.07 |     41.70 ± 0.06 |  1.061   |
| phi3 3B F16  | CUDA       | 100 |       1 |         pp512 |     11280.47 ± 26.75 | 13770.42 ± 84.46 |  1.221   |
| phi3 3B F16  | CUDA       | 100 |       1 |         tg128 |         79.84 ± 0.03 |     81.50 ± 0.02 |  1.021   |

