### PR TITLE
iqk_mul_mat: better iq4_nl implementation on Zen4/AVX2

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1049,7 +1049,11 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_iq4_nl,
         .from_float_ref           = (ggml_from_float_t)quantize_row_iq4_nl_ref,
         .vec_dot                  = ggml_vec_dot_iq4_nl_q8_0,
+#if GGML_USE_IQK_MULMAT && defined __AVX2__
+        .vec_dot_type             = GGML_TYPE_Q8_1,
+#else
         .vec_dot_type             = GGML_TYPE_Q8_0,
+#endif
         .nrows                    = 1,
         .row_meta_size            = 0,
     },


### PR DESCRIPTION
PP-512 performance for LLaMA-3.1-8B goes to 162.6 t/s up from 133.2 t/s (22% speedup).

This is mostly as preparation for investigating `IQ4_NL` usage for KV-cache, but still quite useful if someone is using it.
