### PR TITLE
Faster IQ1_BN Metal implementation

### DIFF
--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -7498,9 +7498,9 @@ void dequantize_iq1_bn(device const block_iq1_bn * xb, short il, thread type4x4 
 template <typename type4x4>
 void dequantize_iq2_bn(device const block_iq2_bn * xb, short il, thread type4x4 & reg) {
     // il is in 0...3
-    constexpr float k_scale[4] = {1.f, 0.25f, 0.0625f, 0.015625f};
+    constexpr half k_scale[4] = {1.h, 0.25h, 0.0625h, 0.015625h};
     constexpr uint8_t k_mask[4] = {0x03, 0x0c, 0x30, 0xc0};
-    const float d = k_scale[il];
+    const half d = k_scale[il];
     uint8_t mask = k_mask[il];
 
     for (int j = 0; j < 16; ++j) {

--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -5478,17 +5478,20 @@ void kernel_mul_mv_iq1_bn_f32_impl(
         for (int row = 0; row < N_DST; row++) {
 
             float acc = 0;
-            int i = 0;
+            thread const float * yy = yl;
             for (int k = 0; k < 3; ++k) {
-                uint8_t q = ql[k];
-                for (int j = 0; j < 5; ++j) {
-                    uint8_t v = k_mult[j]*q;
-                    v = 3*v >> 8; //(v + (v >> 1)) >> 7;
-                    acc += yl[i++] * values[v];
+                uint16_t q = ql[k];
+                for (int j = 4; j >= 0; --j) {
+                    uint8_t v = q;
+                    v = 3*v >> 8;
+                    acc += yy[j] * values[v];
+                    q += (q << 1);
                 }
+                yy += 5;
             }
             uint8_t v = k_mult[i16]*extra[0];
-            v = 3*v >> 8; //(v + (v >> 1)) >> 7;
+            v = 3*v >> 8;
+            //v = (v + (v << 1)) >> 8;
             acc += yl[15] * values[v];
 
             sumf[row] += acc;


### PR DESCRIPTION

On my 30-core M2-Max TG-128 for Bitnet-1.58b-3.3B improves from 82 t/s to 94.7 t/s.
PP-512 goes from 686 t/s to 702 t/s.

Integer multiplications are expensive, so the trick used is to replace them with shifts and additions.

There is also a minor `IQ2_BN` PP-512 improvement (710 -> 714 t/s).  