### PR TITLE
Faster MoE inference

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -933,7 +933,8 @@ extern "C" {
 
     GGML_API struct ggml_tensor * ggml_multi_add(
             struct ggml_context * ctx,
-            struct ggml_tensor ** a);
+            struct ggml_tensor  * a,
+            int n_experts);
 
     // dst = a
     // view(dst, nb1, nb2, nb3, offset) += b

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -494,6 +494,7 @@ extern "C" {
         GGML_OP_GROUP_NORM,
         GGML_OP_FUSED_RMS_NORM,
         GGML_OP_FUSED_MUL_UNARY,
+        GGML_OP_MULTI_ADD,
 
         GGML_OP_MUL_MAT,
         GGML_OP_MUL_MAT_ID,
@@ -929,6 +930,10 @@ extern "C" {
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             struct ggml_tensor  * b);
+
+    GGML_API struct ggml_tensor * ggml_multi_add(
+            struct ggml_context * ctx,
+            struct ggml_tensor ** a);
 
     // dst = a
     // view(dst, nb1, nb2, nb3, offset) += b

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -52,6 +52,21 @@ static __global__ void fused_mul_silu_f32(const float * x, const float * y, floa
     dst[i] = x[i] * y[i] / (1.0f + expf(-x[i]));
 }
 
+static __global__ void multi_add_f32(int nused, int64_t ne0, int64_t ne1, int64_t nb1, int64_t nb01, const char * src0, char * dst) {
+    const int64_t i = blockDim.x*blockIdx.x + threadIdx.x;
+    int64_t k = ne0*ne1;
+    if (i >= k) {
+        return;
+    }
+    int i1 = i / ne0;
+    int i0 = i % ne0;
+    float * result = (float *)(dst + i1*nb1);
+    const float * s = (const float *)(src0 + i1*nb01) + i0;
+    float sum = 0;
+    for (int j = 0; j < nused; ++j) sum += s[j*ne0];
+    result[i0] = sum;
+}
+
 static __global__ void fused_mul_relu_f32(const float * x, const float * y, float * dst, const int k) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 
@@ -216,6 +231,43 @@ static void sqr_f32_cuda(const float * x, float * dst, const int k, cudaStream_t
 static void sqrt_f32_cuda(const float * x, float * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_SQRT_BLOCK_SIZE - 1) / CUDA_SQRT_BLOCK_SIZE;
     sqrt_f32<<<num_blocks, CUDA_SQRT_BLOCK_SIZE, 0, stream>>>(x, dst, k);
+}
+
+static void multi_add_f32_cuda(int nused, int64_t ne0, int64_t ne1, int64_t nb1, int64_t nb01, const char * src0, char * dst, cudaStream_t stream) {
+    int64_t k = ne0 * ne1;
+    const int num_blocks = (k + CUDA_MULTI_ADD_BLOCK_SIZE - 1) / CUDA_MULTI_ADD_BLOCK_SIZE;
+    multi_add_f32<<<num_blocks, CUDA_MULTI_ADD_BLOCK_SIZE, 0, stream>>>(nused, ne0, ne1, nb1, nb01, src0, dst);
+}
+
+void ggml_cuda_op_multi_add(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->ne[2] == 1 && dst->ne[3] == 1);
+    GGML_ASSERT(dst->nb[0] == sizeof(float));
+    int nused = 0;
+    for (int i = 0; i < GGML_MAX_SRC; ++i) {
+        ggml_tensor * src = dst->src[i];
+        if (src) {
+            GGML_ASSERT(src->type == GGML_TYPE_F32);
+            GGML_ASSERT(ggml_are_same_shape(src, dst));
+            GGML_ASSERT(src->ne[2] == 1 && src->ne[3] == 1);
+            GGML_ASSERT(src->nb[0] == sizeof(float));
+            ++nused;
+        } else {
+            break;
+        }
+    }
+    GGML_ASSERT(nused >= 2);
+    const char * src0 = (const char *)dst->src[0]->data;
+    const int64_t nb01 = dst->src[0]->ne[0]*sizeof(float);
+    for (int i = 1; i < nused; ++i) {
+        GGML_ASSERT(dst->src[i]->nb[1] == dst->src[0]->nb[1]);
+        const char * src = (const char *)dst->src[i]->data;
+        GGML_ASSERT(src == src0 + i*nb01);
+        GGML_ASSERT(dst->src[i]->nb[1] == dst->src[0]->nb[1]);
+    }
+    //printf("%s: nused = %d\n", __func__, nused);
+    cudaStream_t stream = ctx.stream();
+    multi_add_f32_cuda(nused, dst->ne[0], dst->ne[1], dst->nb[1], dst->src[0]->nb[1], src0, (char *)dst->data, stream);
 }
 
 void ggml_cuda_op_gelu(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/unary.cuh
+++ b/ggml/src/ggml-cuda/unary.cuh
@@ -9,6 +9,7 @@
 #define CUDA_HARDSWISH_BLOCK_SIZE 256
 #define CUDA_SQR_BLOCK_SIZE 256
 #define CUDA_SQRT_BLOCK_SIZE 256
+#define CUDA_MULTI_ADD_BLOCK_SIZE 256
 
 void ggml_cuda_op_gelu(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
@@ -35,3 +36,5 @@ void ggml_cuda_op_sqrt(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 void ggml_cuda_op_swiglu(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_fused_mul_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+void ggml_cuda_op_multi_add(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-metal.metal
+++ b/ggml/src/ggml-metal.metal
@@ -8235,6 +8235,7 @@ kernel void kernel_mul_mm_id(
         threadgroup    uchar * shared_memory [[threadgroup(0)]],
         uint3                  tgpig[[threadgroup_position_in_grid]],
         uint                   tiitg[[thread_index_in_threadgroup]],
+        uint3                  ntg3[[threads_per_threadgroup]],
         uint                   sgitg[[simdgroup_index_in_threadgroup]]) {
 
     const int32_t i02 = tgpig.z;
@@ -8242,24 +8243,86 @@ kernel void kernel_mul_mm_id(
 
     device const uchar * src0 = src0s + i02*nb02;
 
-    // row indices
-    threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192);
+    uint ntg = ntg3.x * ntg3.y * ntg3.z;
+    uint n   = nei0*nei1;
 
-    // TODO: parallelize this loop
-    int64_t _ne1 = 0;
-    for (ushort ii1 = 0; ii1 < nei1; ii1++) {
-        for (ushort ii0 = 0; ii0 < nei0; ii0++) {
-            int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
-            if (id == i02) {
-                //if (tiitg == 0) {
-                    rowids[_ne1] = ushort2(ii0, ii1);
-                //}
-                _ne1++;
-            }
-        }
+    //uint npt = (n + ntg - 1) / ntg;
+    //uint first = tiitg * npt;
+    //uint last  = first + npt <= n ? first + npt : n;
+
+    //uint nhave = 0;
+    //for (uint i = first; i < last; ++i) {
+    //    uint ii0 = i % nei0;
+    //    uint ii1 = i / nei0;
+    //    int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
+    //    if (id == i02) ++nhave;
+    //}
+    //threadgroup uint * nums = (threadgroup uint *)shared_memory;
+    //nums[tiitg] = nhave;
+    //threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    //uint nprev = 0;
+    //for (uint i = 0; i < tiitg; ++i) nprev += nums[i];
+    //int64_t _ne1 = nprev;
+    //for (uint i = tiitg; i < ntg; ++i) _ne1 += nums[i];
+
+    //threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192);
+    //for (uint i = first; i < last; ++i) {
+    //    uint ii0 = i % nei0;
+    //    uint ii1 = i / nei0;
+    //    int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
+    //    if (id == i02) rowids[nprev++] = ushort2(ii0, ii1);
+    //}
+
+    //threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    //
+    // The following is slightly faster than the commented out version above
+    //
+    uint nhave = 0;
+    for (uint i = tiitg; i < n; i += ntg) {
+        uint ii0 = i % nei0;
+        uint ii1 = i / nei0;
+        int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
+        if (id == i02) ++nhave;
     }
-
+    threadgroup uint * nums = (threadgroup uint *)shared_memory;
+    nums[tiitg] = nhave;
     threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    uint nprev = 0;
+    for (uint i = 0; i < tiitg; ++i) nprev += nums[i];
+    int64_t _ne1 = nprev;
+    for (uint i = tiitg; i < ntg; ++i) _ne1 += nums[i];
+
+    threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192);
+    for (uint i = tiitg; i < n; i += ntg) {
+        uint ii0 = i % nei0;
+        uint ii1 = i / nei0;
+        int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
+        if (id == i02) rowids[nprev++] = ushort2(ii0, ii1);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // This is the original version that is ridiculously slow.
+    //// row indices
+    //threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192);
+
+    //// TODO: parallelize this loop
+    //int64_t _ne1 = 0;
+    //for (ushort ii1 = 0; ii1 < nei1; ii1++) {
+    //    for (ushort ii0 = 0; ii0 < nei0; ii0++) {
+    //        int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
+    //        if (id == i02) {
+    //            //if (tiitg == 0) {
+    //                rowids[_ne1] = ushort2(ii0, ii1);
+    //            //}
+    //            _ne1++;
+    //        }
+    //    }
+    //}
+
+    //threadgroup_barrier(mem_flags::mem_threadgroup);
 
     kernel_mul_mm_id_impl<Dequantizer>(
         src0,

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -5132,7 +5132,7 @@ struct ggml_tensor * ggml_multi_add(
     }
 
     for (int i = 1; i < n_used; ++i) {
-        if (!ggml_are_same_shape(a_used[i], a[0])) {
+        if (!ggml_are_same_shape(a_used[i], a_used[0])) {
             GGML_ABORT("fayal error");
         }
     }
@@ -5141,7 +5141,7 @@ struct ggml_tensor * ggml_multi_add(
 
     result->op   = GGML_OP_MULTI_ADD;
     result->grad = is_node ? ggml_dup_tensor(ctx, result) : NULL;
-    for (int i = 1; i < n_used; ++i) {
+    for (int i = 0; i < n_used; ++i) {
         result->src[i] = a_used[i];
     }
     for (int i = n_used; i < GGML_MAX_SRC; ++i) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8358,44 +8358,33 @@ static struct ggml_tensor * llm_build_moe_ffn(
         return ggml_add(ctx, ggml_view_2d(ctx, experts, n_embd, n_tokens, experts->nb[2], 0),
                              ggml_view_2d(ctx, experts, n_embd, n_tokens, experts->nb[2], experts->nb[1]));
     }
-    if (n_expert_used <= GGML_MAX_SRC) {
-        ggml_tensor * src[GGML_MAX_SRC];
-        for (int i = 0; i < n_expert_used; ++i) {
-            src[i] = ggml_view_2d(ctx, experts, n_embd, n_tokens, experts->nb[2], i*experts->nb[1]);
-        }
-        for (int i = n_expert_used; i < GGML_MAX_SRC; ++i) src[i] = nullptr;
-        return ggml_multi_add(ctx, src);
-    }
+    return ggml_multi_add(ctx, ggml_view_2d(ctx, experts, n_embd, n_tokens, experts->nb[2], 0), n_expert_used);
 
-    GGML_ABORT("fatal error");
+    //// aggregate experts
+    //ggml_tensor * moe_out = nullptr;
+    ////ggml_tensor * first_expert = nullptr;
+    //for (int i = 0; i < n_expert_used; ++i) {
+    //    ggml_tensor * cur_expert = ggml_view_2d(ctx, experts, n_embd, n_tokens,
+    //            experts->nb[2], i*experts->nb[1]);
 
-    //int nloop = (n_expert_used + GGML_MAX_SRC - 1)/GGML_MAX_SRC;
+    //    if (i == 0) {
+    //        moe_out = cur_expert;
+    //        //first_expert = cur_expert;
+    //        //printf("%s: %d: %d x %d x %d x %d | %d x %d x %d x %d\n", __func__, ggml_is_contiguous(first_expert),
+    //        //        (int)cur_expert->ne[0], (int)cur_expert->ne[1], (int)cur_expert->ne[2], (int)cur_expert->ne[3],
+    //        //        (int)cur_expert->nb[0], (int)cur_expert->nb[1], (int)cur_expert->nb[2], (int)cur_expert->nb[3]);
+    //    } else {
+    //        moe_out = ggml_add(ctx, moe_out, cur_expert);
+    //        //printf("%s: %d  %d\n", __func__, ggml_is_contiguous(cur_expert), ggml_are_same_shape(cur_expert, first_expert));
+    //    }
+    //}
 
-    // aggregate experts
-    ggml_tensor * moe_out = nullptr;
-    //ggml_tensor * first_expert = nullptr;
-    for (int i = 0; i < n_expert_used; ++i) {
-        ggml_tensor * cur_expert = ggml_view_2d(ctx, experts, n_embd, n_tokens,
-                experts->nb[2], i*experts->nb[1]);
+    //if (n_expert_used == 1) {
+    //    // avoid returning a non-contiguous tensor
+    //    moe_out = ggml_cont(ctx, moe_out);
+    //}
 
-        if (i == 0) {
-            moe_out = cur_expert;
-            //first_expert = cur_expert;
-            //printf("%s: %d: %d x %d x %d x %d | %d x %d x %d x %d\n", __func__, ggml_is_contiguous(first_expert),
-            //        (int)cur_expert->ne[0], (int)cur_expert->ne[1], (int)cur_expert->ne[2], (int)cur_expert->ne[3],
-            //        (int)cur_expert->nb[0], (int)cur_expert->nb[1], (int)cur_expert->nb[2], (int)cur_expert->nb[3]);
-        } else {
-            moe_out = ggml_add(ctx, moe_out, cur_expert);
-            //printf("%s: %d  %d\n", __func__, ggml_is_contiguous(cur_expert), ggml_are_same_shape(cur_expert, first_expert));
-        }
-    }
-
-    if (n_expert_used == 1) {
-        // avoid returning a non-contiguous tensor
-        moe_out = ggml_cont(ctx, moe_out);
-    }
-
-    return moe_out;
+    //return moe_out;
 }
 
 static struct ggml_tensor * llm_build_kqv(


### PR DESCRIPTION

This PR
* Adds a new op `GGML_MULTI_ADD` used to sum up the contributions of the selected experts. It results in, e.g., a 7% improvement of token generation speed for Granite-1B-MoE on CUDA (RTX-4080).
* Fixes a massive inefficiency in the Metal implementation of MoE matrix multiplications (`kernel_mul_mm_id`). This leads to a nearly 6-fold prompt processing speedup for Granite-1B-MoE on Metal. But even for a much larger model such as Mixtral-8x7B the speedup is nearly a factor of 2 compared to current mainline `llama.cpp` (build: `8f275a7c (3989)`).   