### PR TITLE
IQ4_NL_X4

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -40,6 +40,7 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     { "Q3_K_M",   LLAMA_FTYPE_MOSTLY_Q3_K_M,   " 3.07G, +0.2496 ppl @ LLaMA-v1-7B", },
     { "Q3_K_L",   LLAMA_FTYPE_MOSTLY_Q3_K_L,   " 3.35G, +0.1764 ppl @ LLaMA-v1-7B", },
     { "IQ4_NL",   LLAMA_FTYPE_MOSTLY_IQ4_NL,   " 4.50 bpw non-linear quantization", },
+    { "IQ4_NL_X4",LLAMA_FTYPE_MOSTLY_IQ4_NL_X4," 4.50 bpw non-linear quantization", },
     { "IQ4_XS",   LLAMA_FTYPE_MOSTLY_IQ4_XS,   " 4.25 bpw non-linear quantization", },
     { "IQ4_KS",   LLAMA_FTYPE_MOSTLY_IQ4_KS,   " 4.25 bpw non-linear quantization", },
     { "IQ4_KSS",  LLAMA_FTYPE_MOSTLY_IQ4_KSS,  " 4.0 bpw non-linear quantization",  },

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -406,6 +406,8 @@ extern "C" {
         GGML_TYPE_IQ4_KS  = 144,
         GGML_TYPE_IQ2_KS  = 145,
         GGML_TYPE_IQ4_KSS = 146,
+
+        GGML_TYPE_IQ4_NL_X4 = 220,
         GGML_TYPE_COUNT,
     };
 
@@ -464,6 +466,8 @@ extern "C" {
         GGML_FTYPE_MOSTLY_IQ4_KS  = 137, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ2_KS  = 138, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_KSS = 139, // except 1d tensors
+                                         //
+        GGML_FTYPE_MOSTLY_IQ4_NL_X4 = 219, // except 1d tensors
     };
 
     // available tensor operations:

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -419,6 +419,11 @@ typedef struct {
     uint8_t qs[QK4_NL/2];
 } block_iq4_nl;
 static_assert(sizeof(block_iq4_nl) == sizeof(ggml_half) + QK4_NL/2, "wrong iq4_nl block size/padding");
+typedef struct {
+    ggml_half d[4];
+    uint8_t qs[2*QK4_NL];
+} block_iq4_nl_x4;
+static_assert(sizeof(block_iq4_nl_x4) == 4*sizeof(ggml_half) + 2*QK4_NL, "wrong iq4_nl_x4 block size/padding");
 
 typedef struct {
     ggml_half d;

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -15196,6 +15196,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_IQ6_K: break;
         case GGML_TYPE_IQ4_KS: break;
         case GGML_TYPE_IQ4_KSS: break;
+        case GGML_TYPE_IQ4_NL_X4: break;
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
             {

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1245,6 +1245,23 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .nrows                    = 1,
         .row_meta_size            = 0,
     },
+    [GGML_TYPE_IQ4_NL_X4] = {
+        .type_name                = "iq4_nl_x4",
+        .blck_size                = QK4_NL,
+        .type_size                = sizeof(block_iq4_nl),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_iq4_nl_x4,
+        .from_float               = quantize_row_iq4_nl_x4,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_iq4_nl_x4_ref,
+        .vec_dot                  = vec_dot_iq4_nl_x4_q8_0,
+#if GGML_USE_IQK_MULMAT && defined __AVX2__
+        .vec_dot_type             = GGML_TYPE_Q8_1,
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+#endif
+        .nrows                    = 1,
+        .row_meta_size            = 0,
+    },
 };
 
 // For internal test use
@@ -3903,6 +3920,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_IQ1_BN:        wtype = GGML_TYPE_IQ1_BN;   break;
         case GGML_FTYPE_MOSTLY_IQ2_BN:        wtype = GGML_TYPE_IQ2_BN;   break;
         case GGML_FTYPE_MOSTLY_IQ4_NL:        wtype = GGML_TYPE_IQ4_NL;   break;
+        case GGML_FTYPE_MOSTLY_IQ4_NL_X4:     wtype = GGML_TYPE_IQ4_NL_X4;break;
         case GGML_FTYPE_MOSTLY_IQ4_XS:        wtype = GGML_TYPE_IQ4_XS;   break;
         case GGML_FTYPE_MOSTLY_IQ4_KS:        wtype = GGML_TYPE_IQ4_KS;   break;
         case GGML_FTYPE_MOSTLY_IQ4_KSS:       wtype = GGML_TYPE_IQ4_KSS;  break;
@@ -10426,6 +10444,7 @@ static void ggml_compute_forward_add(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -10868,6 +10887,7 @@ static void ggml_compute_forward_add1(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -11007,6 +11027,7 @@ static void ggml_compute_forward_acc(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -14192,6 +14213,7 @@ static void ggml_compute_forward_out_prod(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -14571,6 +14593,7 @@ static void ggml_compute_forward_set(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -14844,6 +14867,7 @@ static void ggml_compute_forward_get_rows(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -15444,6 +15468,7 @@ static void ggml_compute_forward_clamp(
         case GGML_TYPE_IQ1_BN:
         case GGML_TYPE_IQ2_BN:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_NL_X4:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_KSS:
@@ -22270,6 +22295,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_IQ1_BN:  result = quantize_iq1_bn (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ2_BN:  result = quantize_iq2_bn (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ4_NL:  result = quantize_iq4_nl (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_IQ4_NL_X4: result = quantize_iq4_nl_x4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ4_XS:  result = quantize_iq4_xs (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ4_KS:  result = quantize_iq4_ks (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ4_KSS: result = quantize_iq4_kss(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -6565,9 +6565,8 @@ void mul_mat_iq4_nl_x4_q8_0(int n, const void * vx, size_t bx, const DataInfo& i
     int nb = n / QK4_NL;
     GGML_ASSERT(nb%4 == 0);
     int8x16_t qx[8];
-    float32x4_t acc[nrc_y]; // = {};
+    float32x4_t acc[nrc_y] = {};
     for (int ix = 0; ix < nrc_x; ix += 4) {
-        for (int iy = 0; iy < nrc_y; ++iy) acc[iy] = vdupq_n_f32(0.f);
         const block_iq4_nl_x4 * iq4 = (const block_iq4_nl_x4 *)((const char *)vx + ix*bx);
         for (int ib4 = 0; ib4 < nb/4; ++ib4) {
             for (int k = 0; k < 4; ++k) {
@@ -6583,18 +6582,6 @@ void mul_mat_iq4_nl_x4_q8_0(int n, const void * vx, size_t bx, const DataInfo& i
                 qx[7] = vqtbl1q_s8(values, vshrq_n_u8(bits.val[3], 4));  // 28..31
                 for (int iy = 0; iy < nrc_y; ++iy) {
                     auto y = vld1q_s8_x2(q8.y[iy][ib4].qs+32*k);
-                    //auto sumi1 = vdupq_n_s32(0);
-                    //auto sumi2 = vdupq_n_s32(0);
-                    //sumi1 = vdotq_laneq_s32(sumi1, qx[0], y.val[0], 0);
-                    //sumi2 = vdotq_laneq_s32(sumi2, qx[1], y.val[1], 0);
-                    //sumi1 = vdotq_laneq_s32(sumi1, qx[2], y.val[0], 1);
-                    //sumi2 = vdotq_laneq_s32(sumi2, qx[3], y.val[1], 1);
-                    //sumi1 = vdotq_laneq_s32(sumi1, qx[4], y.val[0], 2);
-                    //sumi2 = vdotq_laneq_s32(sumi2, qx[5], y.val[1], 2);
-                    //sumi1 = vdotq_laneq_s32(sumi1, qx[6], y.val[0], 3);
-                    //sumi2 = vdotq_laneq_s32(sumi2, qx[7], y.val[1], 3);
-                    //auto d4d8 = vmulq_f32(scales, vdupq_n_f32(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k])));
-                    //acc[iy] = vfmaq_f32(acc[iy], d4d8, vcvtq_f32_s32(vaddq_s32(sumi1, sumi2)));
                     auto sumi = vdupq_n_s32(0);
                     sumi = vdotq_laneq_s32(sumi, qx[0], y.val[0], 0);
                     sumi = vdotq_laneq_s32(sumi, qx[1], y.val[1], 0);
@@ -6611,7 +6598,7 @@ void mul_mat_iq4_nl_x4_q8_0(int n, const void * vx, size_t bx, const DataInfo& i
         }
         for (int iy = 0; iy < nrc_y; ++iy) {
             info.store(ix, iy, acc[iy]);
-            //acc[iy] = vdupq_n_f32(0.f);
+            acc[iy] = vdupq_n_f32(0.f);
         }
     }
 }

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -2074,189 +2074,109 @@ static void mul_mat_qX_K_q8_K_T(int n, const void * vx, size_t bx, const DataInf
 
 #endif  // Zen4 or vanilla AVX2
 
-
-template <int nrc_y>
-static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
-    GGML_ASSERT(nrc_x%4 == 0);
-    //printf("%s: n = %d, nrc_x = %d, bx = %zu\n", __func__, n, nrc_x, bx);
-    Q8<nrc_y, block_q8_1_x4> q8(info);
-    auto m4 = _mm256_set1_epi8(0xf);
-    auto values = load_iq4nl_values_256();
-    int nb = n / QK4_NL;
-    //float dequant[128], stored[4], s[4*nrc_y];
-    //float dequant[128], s[4*nrc_y];
-    GGML_ASSERT(nb%4 == 0);
-    __m256 acc[nrc_y] = {};
-    for (int ix = 0; ix < nrc_x; ix += 4) {
-        const block_iq4_nl_x4 * iq4 = (const block_iq4_nl_x4 *)((const char *)vx + ix*bx);
-        //for (int iy = 0; iy < nrc_y; ++iy) acc[iy] = _mm256_setzero_ps();
-        //for (int j = 0; j < 4*nrc_y; ++j) s[j] = 0;
-        for (int ib4 = 0; ib4 < nb/4; ++ib4) {
-            for (int k = 0; k < 4; ++k) {
-                //dequantize_row_iq4_nl_x4(iq4+4*ib4+k, dequant, 128);
-                auto scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4[4*ib4+k].d));
-                auto scales = _mm256_set_m128(scales128, scales128);
-                auto scales_m = _mm256_mul_ps(scales, _mm256_set1_ps(-64.f));
-                //auto scales_m = _mm256_mul_ps(scales, _mm256_set1_ps(-128.f));
-                auto bits1 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+0);
-                auto bits2 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+1);
-                auto q1 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits1, m4));
-                auto q2 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits2, m4));
-                auto q3 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits1, 4), m4));
-                auto q4 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits2, 4), m4));
-                __m256i sumi;
-                for (int iy = 0; iy < nrc_y; ++iy) {
-                    //float d8 = GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k]);
-                    //const int8_t * qs = q8.y[iy][ib4].qs+32*k;
-                    ////s[0] = s[1] = s[2] = s[3] = 0;
-                    //for (int j = 0; j < 32; ++j) {
-                    //    s[4*iy+0] += d8*dequant[j+ 0]*qs[j];
-                    //    s[4*iy+1] += d8*dequant[j+32]*qs[j];
-                    //    s[4*iy+2] += d8*dequant[j+64]*qs[j];
-                    //    s[4*iy+3] += d8*dequant[j+96]*qs[j];
-                    //}
-                    ////s[0] *= d8; s[1] *= d8; s[2] *= d8; s[3] *= d8;
-                    auto y = _mm256_loadu_si256((const __m256i*)q8.y[iy][ib4].qs+k);
-                    sumi = _mm256_dpbusd_epi32(_mm256_setzero_si256(), q1, _mm256_shuffle_epi32(y, 0x00));
-                    sumi = _mm256_dpbusd_epi32(sumi, q2, _mm256_shuffle_epi32(y, 0x55));
-                    sumi = _mm256_dpbusd_epi32(sumi, q3, _mm256_shuffle_epi32(y, 0xaa));
-                    sumi = _mm256_dpbusd_epi32(sumi, q4, _mm256_shuffle_epi32(y, 0xff));
-                    //auto d4d8 = _mm256_mul_ps(scales, _mm256_cvtph_ps(_mm_set1_epi16(q8.y[iy][ib4].d[k])));
-                    auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k])));
-                    //auto check = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), _mm256_setzero_ps());
-                    //check = _mm256_fmadd_ps(scales_m, _mm256_cvtph_ps(_mm_set1_epi16(q8.y[iy][ib4].d[k+4])), check);
-                    //auto check128 = _mm_add_ps(_mm256_castps256_ps128(check), _mm256_extractf128_ps(check, 1));
-                    //_mm_storeu_ps(stored, check128);
-                    //bool is_good = true;
-                    //for (int j = 0; j < 4; ++j) {
-                    //    if (std::abs(stored[j] - s[j]) > 1e-1*(std::abs(s[j])+std::abs(stored[j]))) is_good = false;
-                    //}
-                    //if (!is_good) {
-                    //    static int ncount = 0;
-                    //    printf("Oops\n");
-                    //    for (int j = 0; j < 4; ++j) printf("%g vs %g, diff = %g, thresh = %g\n", s[j], stored[j], std::abs(stored[j] - s[j]), 1e-2f*std::abs(s[j]));
-                    //    _mm_storeu_ps(stored, scales128);
-                    //    printf("iq4_nl scales: %g, %g, %g, %g\n", stored[0], stored[1], stored[2], stored[3]);
-                    //    printf("d8 = %g, %g\n", d8, GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4]));
-                    //    _mm_storeu_ps(stored, _mm256_castps256_ps128(d4d8));
-                    //    printf("iq4_nl scales x q8: %g, %g, %g, %g", stored[0], stored[1], stored[2], stored[3]);
-                    //    _mm_storeu_ps(stored, _mm256_extractf128_ps(d4d8, 1));
-                    //    printf(" %g, %g, %g, %g\n", stored[0], stored[1], stored[2], stored[3]);
-                    //    check = _mm256_mul_ps(scales_m, _mm256_cvtph_ps(_mm_set1_epi16(q8.y[iy][ib4].d[k+4])));
-                    //    check128 = _mm_add_ps(_mm256_castps256_ps128(check), _mm256_extractf128_ps(check, 1));
-                    //    _mm_storeu_ps(stored, check128);
-                    //    printf("minus: %g, %g, %g, %g\n", stored[0], stored[1], stored[2], stored[3]);
-                    //    check = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), _mm256_setzero_ps());
-                    //    check128 = _mm_add_ps(_mm256_castps256_ps128(check), _mm256_extractf128_ps(check, 1));
-                    //    _mm_storeu_ps(stored, check128);
-                    //    printf("plus: %g, %g, %g, %g\n", stored[0], stored[1], stored[2], stored[3]);
-                    //    auto sumi128 = _mm_add_epi32(_mm256_castsi256_si128(sumi), _mm256_extractf128_si256(sumi, 1));
-                    //    _mm_storeu_si128((__m128i *)stored, sumi128);
-                    //    const int32_t * aux32 = (const int32_t *)stored;
-                    //    printf("sumi: %d, %d, %d, %d\n", aux32[0], aux32[1], aux32[2], aux32[3]);
-                    //    //uint8_t aux[32];
-                    //    //_mm256_storeu_si256((__m256i *)aux, q1);
-                    //    //printf("=== q1\n");
-                    //    //for (int j = 0; j < 32; ++j) printf("%d  %u\n", j, aux[j]);
-                    //    //_mm256_storeu_si256((__m256i *)aux, q2);
-                    //    //printf("=== q2\n");
-                    //    //for (int j = 0; j < 32; ++j) printf("%d  %u\n", j, aux[j]);
-                    //    //_mm256_storeu_si256((__m256i *)aux, q3);
-                    //    //printf("=== q3\n");
-                    //    //for (int j = 0; j < 32; ++j) printf("%d  %u\n", j, aux[j]);
-                    //    //_mm256_storeu_si256((__m256i *)aux, q4);
-                    //    //printf("=== q4\n");
-                    //    //for (int j = 0; j < 32; ++j) printf("%d  %u\n", j, aux[j]);
-                    //    if (++ncount > 10) GGML_ABORT("fatal error");
-                    //}
-                    acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
-                    //acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_cvtph_ps(_mm_set1_epi16(q8.y[iy][ib4].d[k+4])), acc[iy]);
-                    acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[iy]);
-                }
-            }
-        }
-        for (int iy = 0; iy < nrc_y; ++iy) {
-            auto sum = _mm_add_ps(_mm256_castps256_ps128(acc[iy]), _mm256_extractf128_ps(acc[iy], 1));
-            //_mm_storeu_ps(stored, sum);
-            //bool is_good = true;
-            //for (int j = 0; j < 4; ++j) {
-            //    if (std::abs(stored[j] - s[j]) > 1e-4f) { printf("Oops: %g vs %g\n", stored[j], s[j]); is_good = false; }
-            //}
-            //if (!is_good) GGML_ABORT("fatal error");
-            info.store(ix, iy, sum);
-            //for (int k = 0; k < 4; ++k) info.store(ix+k, iy, s[4*iy+k]);
-            acc[iy] = _mm256_setzero_ps();
-        }
-    }
-}
-
 //template <int nrc_y>
 //static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
-//    GGML_ASSERT(nrc_x%8 == 0);
-//    //printf("%s: n = %d, nrc_x = %d, bx = %zu\n", __func__, n, nrc_x, bx);
+//    GGML_ASSERT(nrc_x%4 == 0);
 //    Q8<nrc_y, block_q8_1_x4> q8(info);
 //    auto m4 = _mm256_set1_epi8(0xf);
 //    auto values = load_iq4nl_values_256();
 //    int nb = n / QK4_NL;
 //    GGML_ASSERT(nb%4 == 0);
-//    __m256  acc[2*nrc_y] = {};
-//    __m256i qx[8];
-//    for (int ix = 0; ix < nrc_x; ix += 8) {
-//        const block_iq4_nl_x4 * iq4l = (const block_iq4_nl_x4 *)((const char *)vx + (ix+0)*bx);
-//        const block_iq4_nl_x4 * iq4h = (const block_iq4_nl_x4 *)((const char *)vx + (ix+4)*bx);
+//    //__m256 acc[nrc_y] = {};
+//    __m256 acc[2*nrc_y] = {};
+//    for (int ix = 0; ix < nrc_x; ix += 4) {
+//        const block_iq4_nl_x4 * iq4 = (const block_iq4_nl_x4 *)((const char *)vx + ix*bx);
 //        for (int ib4 = 0; ib4 < nb/4; ++ib4) {
 //            for (int k = 0; k < 4; ++k) {
-//                auto scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4l[4*ib4+k].d));
-//                auto scales1 = _mm256_set_m128(scales128, scales128);
-//                auto scales1_m = _mm256_mul_ps(scales1, _mm256_set1_ps(-64.f));
-//                auto bits1 = _mm256_loadu_si256((const __m256i *)iq4l[4*ib4+k].qs+0);
-//                auto bits2 = _mm256_loadu_si256((const __m256i *)iq4l[4*ib4+k].qs+1);
-//                qx[0] = _mm256_shuffle_epi8(values, _mm256_and_si256(bits1, m4));
-//                qx[1] = _mm256_shuffle_epi8(values, _mm256_and_si256(bits2, m4));
-//                qx[2] = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits1, 4), m4));
-//                qx[3] = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits2, 4), m4));
-//                scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4h[4*ib4+k].d));
-//                auto scales2 = _mm256_set_m128(scales128, scales128);
-//                auto scales2_m = _mm256_mul_ps(scales2, _mm256_set1_ps(-64.f));
-//                bits1 = _mm256_loadu_si256((const __m256i *)iq4h[4*ib4+k].qs+0);
-//                bits2 = _mm256_loadu_si256((const __m256i *)iq4h[4*ib4+k].qs+1);
-//                qx[4] = _mm256_shuffle_epi8(values, _mm256_and_si256(bits1, m4));
-//                qx[5] = _mm256_shuffle_epi8(values, _mm256_and_si256(bits2, m4));
-//                qx[6] = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits1, 4), m4));
-//                qx[7] = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits2, 4), m4));
-//                __m256i sumi1, sumi2;
+//                auto scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4[4*ib4+k].d));
+//                auto scales = _mm256_set_m128(scales128, scales128);
+//                auto scales_m = _mm256_mul_ps(scales, _mm256_set1_ps(-64.f));
+//                auto bits1 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+0);
+//                auto bits2 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+1);
+//                auto q1 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits1, m4));
+//                auto q2 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits2, m4));
+//                auto q3 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits1, 4), m4));
+//                auto q4 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits2, 4), m4));
+//                __m256i sumi;
 //                for (int iy = 0; iy < nrc_y; ++iy) {
 //                    auto y = _mm256_loadu_si256((const __m256i*)q8.y[iy][ib4].qs+k);
-//                    auto sy = _mm256_shuffle_epi32(y, 0x00);
-//                    sumi1 = _mm256_dpbusd_epi32(qx[0], sy, _mm256_setzero_si256());
-//                    sumi2 = _mm256_dpbusd_epi32(qx[4], sy, _mm256_setzero_si256());
-//                    sy = _mm256_shuffle_epi32(y, 0x55);
-//                    sumi1 = _mm256_dpbusd_epi32(qx[1], sy, sumi1);
-//                    sumi2 = _mm256_dpbusd_epi32(qx[5], sy, sumi2);
-//                    sy = _mm256_shuffle_epi32(y, 0xaa);
-//                    sumi1 = _mm256_dpbusd_epi32(qx[2], sy, sumi1);
-//                    sumi2 = _mm256_dpbusd_epi32(qx[6], sy, sumi2);
-//                    sy = _mm256_shuffle_epi32(y, 0xff);
-//                    sumi1 = _mm256_dpbusd_epi32(qx[3], sy, sumi1);
-//                    sumi2 = _mm256_dpbusd_epi32(qx[7], sy, sumi2);
-//                    auto dy = _mm256_cvtph_ps(_mm_set1_epi16(q8.y[iy][ib4].d[k]));
-//                    acc[2*iy+0] = _mm256_fmadd_ps(_mm256_mul_ps(scales1, dy), _mm256_cvtepi32_ps(sumi1), acc[2*iy+0]);
-//                    acc[2*iy+1] = _mm256_fmadd_ps(_mm256_mul_ps(scales2, dy), _mm256_cvtepi32_ps(sumi2), acc[2*iy+1]);
-//                    dy = _mm256_cvtph_ps(_mm_set1_epi16(q8.y[iy][ib4].d[k+4]));
-//                    acc[2*iy+0] = _mm256_fmadd_ps(scales1_m, dy, acc[2*iy+0]);
-//                    acc[2*iy+1] = _mm256_fmadd_ps(scales2_m, dy, acc[2*iy+1]);
+//                    sumi = _mm256_dpbusd_epi32(_mm256_setzero_si256(), q1, _mm256_shuffle_epi32(y, 0x00));
+//                    sumi = _mm256_dpbusd_epi32(sumi, q2, _mm256_shuffle_epi32(y, 0x55));
+//                    sumi = _mm256_dpbusd_epi32(sumi, q3, _mm256_shuffle_epi32(y, 0xaa));
+//                    sumi = _mm256_dpbusd_epi32(sumi, q4, _mm256_shuffle_epi32(y, 0xff));
+//                    auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k])));
+//                    //acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
+//                    //acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[iy]);
+//                    acc[2*iy+0] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[2*iy+0]);
+//                    acc[2*iy+1] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[2*iy+1]);
 //                }
 //            }
 //        }
 //        for (int iy = 0; iy < nrc_y; ++iy) {
-//            auto sum = _mm_add_ps(_mm256_castps256_ps128(acc[2*iy+0]), _mm256_extractf128_ps(acc[2*iy+0], 1));
-//            info.store(ix+0, iy, sum);
-//            sum = _mm_add_ps(_mm256_castps256_ps128(acc[2*iy+1]), _mm256_extractf128_ps(acc[2*iy+1], 1));
-//            info.store(ix+4, iy, sum);
+//            auto sum256 = _mm256_add_ps(acc[2*iy+0], acc[2*iy+1]);
 //            acc[2*iy+0] = acc[2*iy+1] = _mm256_setzero_ps();
+//            auto sum = _mm_add_ps(_mm256_castps256_ps128(sum256), _mm256_extractf128_ps(sum256, 1));
+//            info.store(ix, iy, sum);
+//            //auto sum = _mm_add_ps(_mm256_castps256_ps128(acc[iy]), _mm256_extractf128_ps(acc[iy], 1));
+//            //info.store(ix, iy, sum);
+//            //acc[iy] = _mm256_setzero_ps();
 //        }
 //    }
 //}
+
+template <int nrc_y>
+static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    GGML_ASSERT(nrc_x%8 == 0);
+    Q8<nrc_y, block_q8_1_x4> q8(info);
+    auto m4 = _mm512_set1_epi8(0xf);
+    auto values = load_iq4nl_values_512();
+    int nb = n / QK4_NL;
+    GGML_ASSERT(nb%4 == 0);
+    __m512  acc[2*nrc_y] = {};
+    __m512i qx[4];
+    for (int ix = 0; ix < nrc_x; ix += 8) {
+        const block_iq4_nl_x4 * iq4l = (const block_iq4_nl_x4 *)((const char *)vx + (ix+0)*bx);
+        const block_iq4_nl_x4 * iq4h = (const block_iq4_nl_x4 *)((const char *)vx + (ix+4)*bx);
+        for (int ib4 = 0; ib4 < nb/4; ++ib4) {
+            for (int k = 0; k < 4; ++k) {
+                auto scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4l[4*ib4+k].d));
+                auto scales1 = _mm256_set_m128(scales128, scales128);
+                scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4h[4*ib4+k].d));
+                auto scales2 = _mm256_set_m128(scales128, scales128);
+                auto scales = _mm512_insertf32x8(_mm512_castps256_ps512(scales1), scales2, 1);
+                auto scales_m = _mm512_mul_ps(scales, _mm512_set1_ps(-64.f));
+                auto bits1 = _mm512_inserti32x8(_mm512_castsi256_si512(_mm256_loadu_si256((const __m256i *)iq4l[4*ib4+k].qs+0)),
+                                                                       _mm256_loadu_si256((const __m256i *)iq4h[4*ib4+k].qs+0), 1);
+                auto bits2 = _mm512_inserti32x8(_mm512_castsi256_si512(_mm256_loadu_si256((const __m256i *)iq4l[4*ib4+k].qs+1)),
+                                                                       _mm256_loadu_si256((const __m256i *)iq4h[4*ib4+k].qs+1), 1);
+                qx[0] = _mm512_shuffle_epi8(values, _mm512_and_si512(bits1, m4));
+                qx[1] = _mm512_shuffle_epi8(values, _mm512_and_si512(bits2, m4));
+                qx[2] = _mm512_shuffle_epi8(values, _mm512_and_si512(_mm512_srli_epi16(bits1, 4), m4));
+                qx[3] = _mm512_shuffle_epi8(values, _mm512_and_si512(_mm512_srli_epi16(bits2, 4), m4));
+                for (int iy = 0; iy < nrc_y; ++iy) {
+                    auto y8 = _mm256_loadu_si256((const __m256i*)q8.y[iy][ib4].qs+k);
+                    auto y = _mm512_inserti32x8(_mm512_castsi256_si512(y8), y8, 1);
+                    auto sumi = _mm512_setzero_si512();
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[0], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0x00)));
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[1], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0x55)));
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[2], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0xaa)));
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[3], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0xff)));
+                    auto dy = _mm512_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k]));
+                    acc[2*iy+0] = _mm512_fmadd_ps(_mm512_mul_ps(scales, dy), _mm512_cvtepi32_ps(sumi), acc[2*iy+0]);
+                    acc[2*iy+1] = _mm512_fmadd_ps(scales_m, _mm512_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[2*iy+1]);
+                }
+            }
+        }
+        for (int iy = 0; iy < nrc_y; ++iy) {
+            auto sum512 = _mm512_add_ps(acc[2*iy+0], acc[2*iy+1]);
+            acc[2*iy+0] = acc[2*iy+1] = _mm512_setzero_ps();
+            auto sum1 = _mm_add_ps(_mm512_extractf32x4_ps(sum512, 0), _mm512_extractf32x4_ps(sum512, 1));
+            auto sum2 = _mm_add_ps(_mm512_extractf32x4_ps(sum512, 2), _mm512_extractf32x4_ps(sum512, 3));
+            info.store(ix+0, iy, sum1);
+            info.store(ix+4, iy, sum2);
+        }
+    }
+}
 
 template <typename Bits>
 inline void multiply_add_1(int j, const Bits& bits, const __m256i * scales, const __m256i * q8, __m256i * sumi) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -2074,56 +2074,7 @@ static void mul_mat_qX_K_q8_K_T(int n, const void * vx, size_t bx, const DataInf
 
 #endif  // Zen4 or vanilla AVX2
 
-//template <int nrc_y>
-//static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
-//    GGML_ASSERT(nrc_x%4 == 0);
-//    Q8<nrc_y, block_q8_1_x4> q8(info);
-//    auto m4 = _mm256_set1_epi8(0xf);
-//    auto values = load_iq4nl_values_256();
-//    int nb = n / QK4_NL;
-//    GGML_ASSERT(nb%4 == 0);
-//    //__m256 acc[nrc_y] = {};
-//    __m256 acc[2*nrc_y] = {};
-//    for (int ix = 0; ix < nrc_x; ix += 4) {
-//        const block_iq4_nl_x4 * iq4 = (const block_iq4_nl_x4 *)((const char *)vx + ix*bx);
-//        for (int ib4 = 0; ib4 < nb/4; ++ib4) {
-//            for (int k = 0; k < 4; ++k) {
-//                auto scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4[4*ib4+k].d));
-//                auto scales = _mm256_set_m128(scales128, scales128);
-//                auto scales_m = _mm256_mul_ps(scales, _mm256_set1_ps(-64.f));
-//                auto bits1 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+0);
-//                auto bits2 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+1);
-//                auto q1 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits1, m4));
-//                auto q2 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits2, m4));
-//                auto q3 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits1, 4), m4));
-//                auto q4 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits2, 4), m4));
-//                __m256i sumi;
-//                for (int iy = 0; iy < nrc_y; ++iy) {
-//                    auto y = _mm256_loadu_si256((const __m256i*)q8.y[iy][ib4].qs+k);
-//                    sumi = _mm256_dpbusd_epi32(_mm256_setzero_si256(), q1, _mm256_shuffle_epi32(y, 0x00));
-//                    sumi = _mm256_dpbusd_epi32(sumi, q2, _mm256_shuffle_epi32(y, 0x55));
-//                    sumi = _mm256_dpbusd_epi32(sumi, q3, _mm256_shuffle_epi32(y, 0xaa));
-//                    sumi = _mm256_dpbusd_epi32(sumi, q4, _mm256_shuffle_epi32(y, 0xff));
-//                    auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k])));
-//                    //acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
-//                    //acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[iy]);
-//                    acc[2*iy+0] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[2*iy+0]);
-//                    acc[2*iy+1] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[2*iy+1]);
-//                }
-//            }
-//        }
-//        for (int iy = 0; iy < nrc_y; ++iy) {
-//            auto sum256 = _mm256_add_ps(acc[2*iy+0], acc[2*iy+1]);
-//            acc[2*iy+0] = acc[2*iy+1] = _mm256_setzero_ps();
-//            auto sum = _mm_add_ps(_mm256_castps256_ps128(sum256), _mm256_extractf128_ps(sum256, 1));
-//            info.store(ix, iy, sum);
-//            //auto sum = _mm_add_ps(_mm256_castps256_ps128(acc[iy]), _mm256_extractf128_ps(acc[iy], 1));
-//            //info.store(ix, iy, sum);
-//            //acc[iy] = _mm256_setzero_ps();
-//        }
-//    }
-//}
-
+#ifdef HAVE_FANCY_SIMD
 template <int nrc_y>
 static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     GGML_ASSERT(nrc_x%8 == 0);
@@ -2177,6 +2128,57 @@ static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const Data
         }
     }
 }
+#else
+template <int nrc_y>
+static void mul_mat_iq4_nl_x4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    GGML_ASSERT(nrc_x%4 == 0);
+    Q8<nrc_y, block_q8_1_x4> q8(info);
+    auto m4 = _mm256_set1_epi8(0xf);
+    auto m1 = _mm256_set1_epi16(1);
+    auto values = load_iq4nl_values_256();
+    int nb = n / QK4_NL;
+    GGML_ASSERT(nb%4 == 0);
+    __m256 acc[nrc_y] = {};
+    //__m256 acc[2*nrc_y] = {};
+    for (int ix = 0; ix < nrc_x; ix += 4) {
+        const block_iq4_nl_x4 * iq4 = (const block_iq4_nl_x4 *)((const char *)vx + ix*bx);
+        for (int ib4 = 0; ib4 < nb/4; ++ib4) {
+            for (int k = 0; k < 4; ++k) {
+                auto scales128 = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq4[4*ib4+k].d));
+                auto scales = _mm256_set_m128(scales128, scales128);
+                auto scales_m = _mm256_mul_ps(scales, _mm256_set1_ps(-64.f));
+                auto bits1 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+0);
+                auto bits2 = _mm256_loadu_si256((const __m256i *)iq4[4*ib4+k].qs+1);
+                auto q1 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits1, m4));
+                auto q2 = _mm256_shuffle_epi8(values, _mm256_and_si256(bits2, m4));
+                auto q3 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits1, 4), m4));
+                auto q4 = _mm256_shuffle_epi8(values, _mm256_and_si256(_mm256_srli_epi16(bits2, 4), m4));
+                for (int iy = 0; iy < nrc_y; ++iy) {
+                    auto y = _mm256_loadu_si256((const __m256i*)q8.y[iy][ib4].qs+k);
+                    auto sumi1 = _mm256_add_epi32(_mm256_madd_epi16(m1, _mm256_maddubs_epi16(q1, _mm256_shuffle_epi32(y, 0x00))),
+                                                  _mm256_madd_epi16(m1, _mm256_maddubs_epi16(q2, _mm256_shuffle_epi32(y, 0x55))));
+                    auto sumi2 = _mm256_add_epi32(_mm256_madd_epi16(m1, _mm256_maddubs_epi16(q3, _mm256_shuffle_epi32(y, 0xaa))),
+                                                  _mm256_madd_epi16(m1, _mm256_maddubs_epi16(q4, _mm256_shuffle_epi32(y, 0xff))));
+                    auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k])));
+                    acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(_mm256_add_epi32(sumi1, sumi2)), acc[iy]);
+                    acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[iy]);
+                    //acc[2*iy+0] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(_mm256_add_epi32(sumi1, sumi2)), acc[2*iy+0]);
+                    //acc[2*iy+1] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(GGML_FP16_TO_FP32(q8.y[iy][ib4].d[k+4])), acc[2*iy+1]);
+                }
+            }
+        }
+        for (int iy = 0; iy < nrc_y; ++iy) {
+            //auto sum256 = _mm256_add_ps(acc[2*iy+0], acc[2*iy+1]);
+            //acc[2*iy+0] = acc[2*iy+1] = _mm256_setzero_ps();
+            //auto sum = _mm_add_ps(_mm256_castps256_ps128(sum256), _mm256_extractf128_ps(sum256, 1));
+            //info.store(ix, iy, sum);
+            auto sum = _mm_add_ps(_mm256_castps256_ps128(acc[iy]), _mm256_extractf128_ps(acc[iy], 1));
+            info.store(ix, iy, sum);
+            acc[iy] = _mm256_setzero_ps();
+        }
+    }
+}
+#endif
 
 template <typename Bits>
 inline void multiply_add_1(int j, const Bits& bits, const __m256i * scales, const __m256i * q8, __m256i * sumi) {

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -63,6 +63,12 @@ void   vec_dot_iq2_ks_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void
 
 void iqk_quantize_row_q8_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k);
 
+void   quantize_row_iq4_nl_x4_ref(const float * GGML_RESTRICT x, block_iq4_nl_x4  * GGML_RESTRICT y, int64_t k);
+void   quantize_row_iq4_nl_x4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+size_t quantize_iq4_nl_x4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+void   dequantize_row_iq4_nl_x4(const block_iq4_nl_x4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void   vec_dot_iq4_nl_x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/llama.h
+++ b/include/llama.h
@@ -179,6 +179,8 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_IQ3_KL        = 146, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ2_KS        = 147, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_KSS       = 148, // except 1d tensors
+                                                //
+        LLAMA_FTYPE_MOSTLY_IQ4_NL_X4     = 225, // except 1d tensors
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };


### PR DESCRIPTION

In mainline `llama.cpp` they have added various types where `Q4_0` or `IQ4_NL` are repacked by interleaving quants from 4 or 8 consecutive rows. They get significant improvement in prompt processing speed on `ARM`, so I decided to see if interleaved rows can further improve the `iqk_mul_mat` matrix-matrix multiplication speed.

This PR adds `IQ4_NL_X4`, a repacked variant of `IQ4_NL`.  The table below shows `PP-512`comparison between `IQ4_NL` and `IQ4_NL_X4` for LLaMA-3.1-8B-Instruct on `ARM` (M2-Max), `Zen4` (Ryzen-7950X) and `AVX2` (Ryzen-5975WX). Somewhat surprisingly the speedup on Zen4 is larger than the speedup on M2-Max. On `Zen4` `IQ4_NL_X4` is now the fastest quantization type for prompt processing, beating even `bf16` (237 t/s on the Ryzen-7950X CPU, which has native `bf16` support).   

| Platform |  Threads | IQ4_NL | IQ4_NL_X4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON |  8 |   85.11 ± 0.47 | 110.32  ± 0.53 | 1.296 |
| Zen4            | 16 | 168.21 ± 0.60 | 262.69 ± 0.65 | 1.562 |
| AVX2.          | 32 | 186.81 ± 0.17 | 231.45 ± 0.61 | 1.240 |

For reference:  On my M2-Max mainline `llama.cpp` (build: `3420909d`) achieves 92.3 t/s for `IQ4_NL_4_4`.