### PR TITLE
Q4_K_R4

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -58,6 +58,7 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     { "IQ5_K",    LLAMA_FTYPE_MOSTLY_IQ5_K,    " 5.5 bpw non-linear quantization",  },
     { "IQ6_K",    LLAMA_FTYPE_MOSTLY_IQ6_K,    " 6.6 bpw non-linear quantization",  },
     { "Q4_K",     LLAMA_FTYPE_MOSTLY_Q4_K_M,   "alias for Q4_K_M", },
+    { "Q4_K_R4",  LLAMA_FTYPE_MOSTLY_Q4_K_R4,  "Q4_K_S repacked", },
     { "Q4_K_S",   LLAMA_FTYPE_MOSTLY_Q4_K_S,   " 3.59G, +0.0992 ppl @ LLaMA-v1-7B", },
     { "Q4_K_M",   LLAMA_FTYPE_MOSTLY_Q4_K_M,   " 3.80G, +0.0532 ppl @ LLaMA-v1-7B", },
     { "Q5_K",     LLAMA_FTYPE_MOSTLY_Q5_K_M,   "alias for Q5_K_M", },

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -412,6 +412,7 @@ extern "C" {
         GGML_TYPE_Q4_0_R4   = 202,
         GGML_TYPE_Q5_0_R4   = 206,
         GGML_TYPE_Q8_0_R4   = 208,
+        GGML_TYPE_Q4_K_R4   = 212,
         GGML_TYPE_IQ4_NL_R4 = 220,
         GGML_TYPE_IQ4_XS_R4 = 223,
         GGML_TYPE_Q6_0_R4   = 233,
@@ -478,6 +479,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_Q4_0_R4   = 202, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q8_0_R4   = 207, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q5_0_R4   = 208, // except 1d tensors
+        GGML_FTYPE_MOSTLY_Q4_K_R4   = 212, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_NL_R4 = 219, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_XS_R4 = 222, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q6_0_R4   = 227, // except 1d tensors

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -299,6 +299,14 @@ typedef struct {
 } block_q4_K;
 static_assert(sizeof(block_q4_K) == 2*sizeof(ggml_half) + K_SCALE_SIZE + QK_K/2, "wrong q4_K block size/padding");
 
+typedef struct {
+    ggml_half d[8];
+    uint8_t scales_h[QK_K/16];// scales and mins, quantized with 6 bits
+    uint8_t scales_l[QK_K/8]; // scales and mins, quantized with 6 bits
+    uint8_t qs[QK_K*2];           // 4--bit quants
+} block_q4_k_r4;
+static_assert(sizeof(block_q4_k_r4) == 8*sizeof(ggml_half) + QK_K/16 + QK_K/8 + QK_K*2, "wrong q4_k_r4 block size/padding");
+
 // 5-bit quantization
 // 8 blocks of 32 elements each
 // weight is represented as x = a * q + b

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -15202,6 +15202,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_Q5_0_R4: break;
         case GGML_TYPE_Q6_0_R4: break;
         case GGML_TYPE_Q8_0_R4: break;
+        case GGML_TYPE_Q4_K_R4: break;
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
             {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3117,9 +3117,9 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
                     sumi = _mm256_dpbusd_epi32(sumi, qx[2], _mm256_shuffle_epi32(y, 0xaa));
                     sumi = _mm256_dpbusd_epi32(sumi, qx[3], _mm256_shuffle_epi32(y, 0xff));
 #else
-                    auto sumi1 = _mm256_add_api16(_mm256_maddubs_epi16(qx[0], _mm256_shuffle_epi32(y, 0x00)),
+                    auto sumi1 = _mm256_add_epi16(_mm256_maddubs_epi16(qx[0], _mm256_shuffle_epi32(y, 0x00)),
                                                   _mm256_maddubs_epi16(qx[1], _mm256_shuffle_epi32(y, 0x55)));
-                    auto sumi2 = _mm256_add_api16(_mm256_maddubs_epi16(qx[2], _mm256_shuffle_epi32(y, 0xaa)),
+                    auto sumi2 = _mm256_add_epi16(_mm256_maddubs_epi16(qx[2], _mm256_shuffle_epi32(y, 0xaa)),
                                                   _mm256_maddubs_epi16(qx[3], _mm256_shuffle_epi32(y, 0xff)));
                     auto sumi = _mm256_madd_epi16(m1, _mm256_add_epi16(sumi1, sumi2));
 #endif
@@ -3138,6 +3138,7 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
     }
 }
 
+#ifdef HAVE_FANCY_SIMD
 template <int nrc_y>
 static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     //mul_mat_q4_k_r4_q8_k_avx2<nrc_y>(n, vx, bx, info, nrc_x);
@@ -3224,6 +3225,12 @@ static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
     }
     }
 }
+#else
+template <int nrc_y>
+static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    mul_mat_q4_k_r4_q8_k_avx2<nrc_y>(n, vx, bx, info, nrc_x);
+}
+#endif
 
 template <typename Bits>
 inline void multiply_add_1(int j, const Bits& bits, const __m256i * scales, const __m256i * q8, __m256i * sumi) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3073,6 +3073,91 @@ static void mul_mat_iq4_xs_r4_q8_k(int n, const void * vx, size_t bx, const Data
 }
 #endif
 
+template <int nrc_y>
+static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    //if constexpr (nrc_y == 1){
+    //    mul_mat_iq4_xs_r4_q8_k_avx2<1>(n, vx, bx, info, nrc_x);
+    //} else {
+    GGML_ASSERT(nrc_x%8 == 0);
+    Q8<nrc_y, block_q8_K> q8(info);
+    auto mf = _mm512_set1_epi8(0xf);
+    int nbl = n / QK_K;
+    using helper_t = union { __m512i vec; uint32_t val[16]; };
+    helper_t hd, hm;
+    __m512  acc[2*nrc_y] = {};
+    __m512i qx[4];
+    for (int ix = 0; ix < nrc_x; ix += 8) {
+        const block_q4_k_r4 * iq4l = (const block_q4_k_r4 *)((const char *)vx + (ix+0)*bx);
+        const block_q4_k_r4 * iq4h = (const block_q4_k_r4 *)((const char *)vx + (ix+4)*bx);
+        for (int ibl = 0; ibl < nbl; ++ibl) { // Block of 256
+            auto d1 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq4l[ibl].d));
+            auto d2 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq4h[ibl].d));
+            auto dl = _mm256_castps256_ps128(d1);
+            auto ml = _mm256_extractf128_ps(d1, 1);
+            auto dh = _mm256_castps256_ps128(d2);
+            auto mh = _mm256_extractf128_ps(d2, 1);
+            auto d4 = _mm512_insertf32x8(_mm512_castps256_ps512(_mm256_set_m128(dl, dl)), _mm256_set_m128(dh, dh), 1);
+            auto m4 = _mm512_insertf32x8(_mm512_castps256_ps512(_mm256_set_m128(ml, ml)), _mm256_set_m128(mh, mh), 1);
+            auto slbits_l = _mm256_loadu_si256((const __m256i *)iq4l[ibl].scales_l);
+            auto shbits_l = _mm256_loadu_si256((const __m256i *)iq4h[ibl].scales_l);
+            auto slb = _mm512_inserti32x8(_mm512_castsi256_si512(slbits_l), shbits_l, 1);
+            auto sld = _mm512_and_si512(slb, mf);
+            auto slm = _mm512_and_si512(_mm512_srli_epi16(slb, 4), mf);
+            auto slbits_h = _mm_loadu_si128((const __m128i *)iq4l[ibl].scales_h);
+            auto shbits_h = _mm_loadu_si128((const __m128i *)iq4h[ibl].scales_h);
+            auto slbits_h2 = MM256_SET_M128I(_mm_srli_epi16(slbits_h, 4), slbits_h);
+            auto shbits_h2 = MM256_SET_M128I(_mm_srli_epi16(shbits_h, 4), shbits_h);
+            auto shb = _mm512_inserti32x8(_mm512_castsi256_si512(slbits_h2), shbits_h2, 1);
+            auto shd = _mm512_and_si512(_mm512_slli_epi16(shb, 4), _mm512_set1_epi8(0x30));
+            auto shm = _mm512_and_si512(_mm512_slli_epi16(shb, 2), _mm512_set1_epi8(0x30));
+            hd.vec = _mm512_or_si512(sld, shd);
+            hm.vec = _mm512_or_si512(slm, shm);
+            for (int ib = 0; ib < QK_K/32; ++ib) {
+                //auto iscales = _mm512_cvtepi8_epi32(_mm_set_epi32(hd.val[ib+8], hd.val[ib+8], hd.val[ib], hd.val[ib]));
+                auto scales1 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hd.val[ib+0]));
+                auto scales2 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hd.val[ib+8]));
+                auto iscales = _mm512_inserti32x8(_mm512_castsi256_si512(scales1), scales2, 1);
+                auto scales  = _mm512_mul_ps(d4, _mm512_cvtepi32_ps(iscales));
+                //iscales = _mm512_cvtepi8_epi32(_mm_set_epi32(hm.val[ib+8], hm.val[ib+8], hm.val[ib], hm.val[ib]));
+                scales1 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hm.val[ib+0]));
+                scales2 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hm.val[ib+8]));
+                iscales = _mm512_inserti32x8(_mm512_castsi256_si512(scales1), scales2, 1);
+                auto scales_m  = _mm512_mul_ps(m4, _mm512_cvtepi32_ps(iscales));
+                auto bits1 = _mm512_inserti32x8(_mm512_castsi256_si512(_mm256_loadu_si256((const __m256i *)iq4l[ibl].qs+2*ib+0)),
+                                                                       _mm256_loadu_si256((const __m256i *)iq4h[ibl].qs+2*ib+0), 1);
+                auto bits2 = _mm512_inserti32x8(_mm512_castsi256_si512(_mm256_loadu_si256((const __m256i *)iq4l[ibl].qs+2*ib+1)),
+                                                                       _mm256_loadu_si256((const __m256i *)iq4h[ibl].qs+2*ib+1), 1);
+                qx[0] = _mm512_and_si512(bits1, mf);
+                qx[1] = _mm512_and_si512(bits2, mf);
+                qx[2] = _mm512_and_si512(_mm512_srli_epi16(bits1, 4), mf);
+                qx[3] = _mm512_and_si512(_mm512_srli_epi16(bits2, 4), mf);
+                for (int iy = 0; iy < nrc_y; ++iy) {
+                    auto y8 = _mm256_loadu_si256((const __m256i*)q8.y[iy][ibl].qs+ib);
+                    auto y = _mm512_inserti32x8(_mm512_castsi256_si512(y8), y8, 1);
+                    auto sumi = _mm512_setzero_si512();
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[0], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0x00)));
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[1], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0x55)));
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[2], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0xaa)));
+                    sumi = _mm512_dpbusd_epi32(sumi, qx[3], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0xff)));
+                    float d8 = q8.scale(iy, ibl);
+                    float m8 = ((const float *)q8.y[iy][ibl].bsums)[ib];
+                    acc[2*iy+0] = _mm512_fmadd_ps(_mm512_mul_ps(scales, _mm512_set1_ps(d8)), _mm512_cvtepi32_ps(sumi), acc[2*iy+0]);
+                    acc[2*iy+1] = _mm512_fmadd_ps(scales_m, _mm512_set1_ps(m8), acc[2*iy+1]);
+                }
+            }
+        }
+        for (int iy = 0; iy < nrc_y; ++iy) {
+            auto sum512 = _mm512_fmadd_ps(_mm512_set1_ps(-0.5f), acc[2*iy+1], acc[2*iy+0]);
+            acc[2*iy+0] = acc[2*iy+1] =  _mm512_setzero_ps();
+            auto sum1 = _mm_add_ps(_mm512_extractf32x4_ps(sum512, 0), _mm512_extractf32x4_ps(sum512, 1));
+            auto sum2 = _mm_add_ps(_mm512_extractf32x4_ps(sum512, 2), _mm512_extractf32x4_ps(sum512, 3));
+            info.store(ix+0, iy, sum1);
+            info.store(ix+4, iy, sum2);
+        }
+    }
+    //}
+}
+
 template <typename Bits>
 inline void multiply_add_1(int j, const Bits& bits, const __m256i * scales, const __m256i * q8, __m256i * sumi) {
     if (j == 0) {
@@ -5066,6 +5151,18 @@ bool MulMat::prepare(int typeA, int typeB, int ne00, MulMat& mm, int Ny) {
             mm.funcs[5] = mul_mat_iq4_xs_r4_q8_k<6>;
             mm.funcs[6] = mul_mat_iq4_xs_r4_q8_k<7>;
             mm.funcs[7] = mul_mat_iq4_xs_r4_q8_k<8>;
+            expected_typeB = GGML_TYPE_Q8_K32;
+            break;
+        case GGML_TYPE_Q4_K_R4:
+            assert (ne00 % QK_K == 0);
+            mm.funcs[0] = mul_mat_q4_k_r4_q8_k<1>;
+            mm.funcs[1] = mul_mat_q4_k_r4_q8_k<2>;
+            mm.funcs[2] = mul_mat_q4_k_r4_q8_k<3>;
+            mm.funcs[3] = mul_mat_q4_k_r4_q8_k<4>;
+            mm.funcs[4] = mul_mat_q4_k_r4_q8_k<5>;
+            mm.funcs[5] = mul_mat_q4_k_r4_q8_k<6>;
+            mm.funcs[6] = mul_mat_q4_k_r4_q8_k<7>;
+            mm.funcs[7] = mul_mat_q4_k_r4_q8_k<8>;
             expected_typeB = GGML_TYPE_Q8_K32;
             break;
         case GGML_TYPE_Q4_0_R4:

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3161,7 +3161,6 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
 template <int nrc_y>
 static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     //mul_mat_q4_k_r4_q8_k_avx2<nrc_y>(n, vx, bx, info, nrc_x);
-    //return;
     if constexpr (nrc_y == 1){
         mul_mat_q4_k_r4_q8_k_avx2<1>(n, vx, bx, info, nrc_x);
     } else {
@@ -3200,12 +3199,10 @@ static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
             hd.vec = _mm512_or_si512(sld, shd);
             hm.vec = _mm512_or_si512(slm, shm);
             for (int ib = 0; ib < QK_K/32; ++ib) {
-                //auto iscales = _mm512_cvtepi8_epi32(_mm_set_epi32(hd.val[ib+8], hd.val[ib+8], hd.val[ib], hd.val[ib]));
                 auto scales1 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hd.val[ib+0]));
                 auto scales2 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hd.val[ib+8]));
                 auto iscales = _mm512_inserti32x8(_mm512_castsi256_si512(scales1), scales2, 1);
                 auto scales  = _mm512_mul_ps(d4, _mm512_cvtepi32_ps(iscales));
-                //iscales = _mm512_cvtepi8_epi32(_mm_set_epi32(hm.val[ib+8], hm.val[ib+8], hm.val[ib], hm.val[ib]));
                 scales1 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hm.val[ib+0]));
                 scales2 = _mm256_cvtepi8_epi32(_mm_set1_epi32(hm.val[ib+8]));
                 iscales = _mm512_inserti32x8(_mm512_castsi256_si512(scales1), scales2, 1);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -7897,6 +7897,86 @@ void mul_mat_iq4_xs_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& i
     }
 }
 
+IQK_ALWAYS_INLINE void prepare_q4_k_quants(const uint8x16_t& m4, const uint8x16x4_t& bits, int8x16_t * qx) {
+    qx[0] = vandq_u8(bits.val[0], m4);   //  0...3 from the 4 rows
+    qx[1] = vandq_u8(bits.val[1], m4);   // 16..19
+    qx[2] = vandq_u8(bits.val[2], m4);   //  4...7
+    qx[3] = vandq_u8(bits.val[3], m4);   // 20..23
+    qx[4] = vshrq_n_u8(bits.val[0], 4);  //  8..11
+    qx[5] = vshrq_n_u8(bits.val[1], 4);  // 24..27
+    qx[6] = vshrq_n_u8(bits.val[2], 4);  // 12..15
+    qx[7] = vshrq_n_u8(bits.val[3], 4);  // 28..31
+}
+
+template <int nrc_y>
+void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    GGML_ASSERT(nrc_x%4 == 0);
+    Q8<nrc_y, block_q8_K> q8(info);
+    auto mf = vdupq_n_u8(0xf);
+    auto m3 = vdupq_n_u8(0x30);
+    int nbl = n / QK_K;
+    int8x16_t qx[8];
+    int8x16x4_t iscales;
+    float32x4x4_t scales;
+    float32x4_t acc[nrc_y] = {};
+    for (int ix = 0; ix < nrc_x; ix += 4) {
+        const block_q4_k_r4 * iq4 = (const block_q4_k_r4 *)((const char *)vx + ix*bx);
+        for (int ibl = 0; ibl < nbl; ++ibl) {
+            auto d4 = vcvt_f32_f16(vld1_f16((const float16_t *)iq4[ibl].d));
+            auto m4 = vcvt_f32_f16(vld1_f16((const float16_t *)iq4[ibl].d+4));
+            m4 = vmulq_f32(m4, vdupq_n_f32(-1.f));
+            if constexpr (nrc_y == 1) {
+                d4 = vmulq_f32(d4, vdupq_n_f32(q8.scale(0, ibl)));
+            }
+            auto sl = vld1q_u8_x2(iq4[ibl].scales_l);
+            auto sh = vld1q_u8(iq4[ibl].scales_h);
+            iscales.val[0] = vorrq_u8(vandq_u8(sl.val[0], mf), vandq_u8(vshlq_n_u8(sh, 4), m3));
+            iscales.val[1] = vorrq_u8(vandq_u8(sl.val[1], mf), vandq_u8(sh, m3));
+            iscales.val[2] = vorrq_u8(vshrq_n_u8(sl.val[0], 4), vandq_u8(vshlq_n_u8(sh, 2), m3));
+            iscales.val[3] = vorrq_u8(vshrq_n_u8(sl.val[1], 4), vandq_u8(vshrq_n_u8(sh, 2), m3));
+            for (int is = 0; is < 2; ++is) {
+                auto iscales16_1 = vmovl_s8(vget_low_s8(iscales.val[is+2]));
+                auto iscales16_2 = vmovl_s8(vget_high_s8(iscales.val[is+2]));
+                scales.val[0] = vmulq_f32(m4, vcvtq_f32_s32(vmovl_s16(vget_low_s16(iscales16_1))));
+                scales.val[1] = vmulq_f32(m4, vcvtq_f32_s32(vmovl_s16(vget_high_s16(iscales16_1))));
+                scales.val[2] = vmulq_f32(m4, vcvtq_f32_s32(vmovl_s16(vget_low_s16(iscales16_2))));
+                scales.val[3] = vmulq_f32(m4, vcvtq_f32_s32(vmovl_s16(vget_high_s16(iscales16_2))));
+                for (int iy = 0; iy < nrc_y; ++iy) {
+                    auto m8 = vld1q_f32((const float *)q8.y[iy][ibl].bsums + 4*is);
+                    acc[iy] = vmlaq_laneq_f32(acc[iy], scales.val[0], m8, 0);
+                    acc[iy] = vmlaq_laneq_f32(acc[iy], scales.val[1], m8, 1);
+                    acc[iy] = vmlaq_laneq_f32(acc[iy], scales.val[2], m8, 2);
+                    acc[iy] = vmlaq_laneq_f32(acc[iy], scales.val[3], m8, 3);
+                }
+                iscales16_1 = vmovl_s8(vget_low_s8(iscales.val[is]));
+                iscales16_2 = vmovl_s8(vget_high_s8(iscales.val[is]));
+                scales.val[0] = vmulq_f32(d4, vcvtq_f32_s32(vmovl_s16(vget_low_s16(iscales16_1))));
+                scales.val[1] = vmulq_f32(d4, vcvtq_f32_s32(vmovl_s16(vget_high_s16(iscales16_1))));
+                scales.val[2] = vmulq_f32(d4, vcvtq_f32_s32(vmovl_s16(vget_low_s16(iscales16_2))));
+                scales.val[3] = vmulq_f32(d4, vcvtq_f32_s32(vmovl_s16(vget_high_s16(iscales16_2))));
+                for (int ib = 0; ib < 4; ++ib) {
+                    auto bits = vld1q_u8_x4(iq4[ibl].qs + 256*is + 64*ib);
+                    prepare_q4_k_quants(mf, bits, qx);
+                    for (int iy = 0; iy < nrc_y; ++iy) {
+                        auto y = vld1q_s8_x2(q8.y[iy][ibl].qs+128*is+32*ib);
+                        auto sumi = interleaved_dotq(qx, y);
+                        if constexpr (nrc_y == 1) {
+                            acc[iy] = vfmaq_f32(acc[iy], scales.val[ib], vcvtq_f32_s32(sumi));
+                        } else {
+                            auto d4d8 = vmulq_f32(scales.val[ib], vdupq_n_f32(q8.scale(iy, ibl)));
+                            acc[iy] = vfmaq_f32(acc[iy], d4d8, vcvtq_f32_s32(sumi));
+                        }
+                    }
+                }
+            }
+        }
+        for (int iy = 0; iy < nrc_y; ++iy) {
+            info.store(ix, iy, acc[iy]);
+            acc[iy] = vdupq_n_f32(0.f);
+        }
+    }
+}
+
 void mul_mat_iq4_nl_r4_q8_0_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     GGML_ASSERT(nrc_x%4 == 0);
     Q8<1, block_q8_0_x4> q8(info);
@@ -8293,6 +8373,10 @@ bool MulMat::prepare(int typeA, int typeB, int ne00, MulMat& m, int /*Ny*/) {
         case GGML_TYPE_IQ4_XS_R4:
             SET_MUL_MAT_FUNCTIONS(m, mul_mat_iq4_xs_r4_q8_k);
             expected_Btype = GGML_TYPE_Q8_K;
+            break;
+        case GGML_TYPE_Q4_K_R4:
+            SET_MUL_MAT_FUNCTIONS(m, mul_mat_q4_k_r4_q8_k);
+            expected_Btype = GGML_TYPE_Q8_K32;
             break;
         case GGML_TYPE_Q4_0_R4:
             SET_MUL_MAT_FUNCTIONS_T(m, mul_mat_qx_r4_q8_0, Q4_0_R4_Dequantizer);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3093,15 +3093,34 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
         for (int ibl = 0; ibl < nbl; ++ibl) { // Block of 256
             auto dl = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq4[ibl].d));
             auto d4 = _mm256_set_m128(_mm256_castps256_ps128(dl), _mm256_castps256_ps128(dl));
-            auto m4 = _mm256_mul_ps(_mm256_set1_ps(-0.5f), _mm256_set_m128(_mm256_extractf128_ps(dl, 1), _mm256_extractf128_ps(dl, 1)));
+            auto m4 = _mm256_set_m128(_mm256_extractf128_ps(dl, 1), _mm256_extractf128_ps(dl, 1));
+            if constexpr (nrc_y == 1) {
+                d4 = _mm256_mul_ps(d4, _mm256_set1_ps(q8.scale(0, ibl)));
+            }
             auto lbits = _mm256_loadu_si256((const __m256i *)iq4[ibl].scales_l);
             auto hbits128 = _mm_loadu_si128((const __m128i *)iq4[ibl].scales_h);
             auto hbits = MM256_SET_M128I(hbits128, _mm_slli_epi16(hbits128, 4));
             hd.vec = _mm256_or_si256(_mm256_and_si256(lbits, mf), _mm256_and_si256(hbits, m3));
             hm.vec = _mm256_or_si256(_mm256_and_si256(_mm256_srli_epi16(lbits, 4), mf), _mm256_and_si256(_mm256_srli_epi16(hbits, 2), m3));
+            //if constexpr (nrc_y > 2) {
+                m4 = _mm256_mul_ps(_mm256_set1_ps(-1.0f), m4);
+                auto c1 = _mm256_mul_ps(m4, _mm256_cvtepi32_ps(MM256_SET_M128I(_mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[4])), _mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[0])))));
+                auto c2 = _mm256_mul_ps(m4, _mm256_cvtepi32_ps(MM256_SET_M128I(_mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[5])), _mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[1])))));
+                auto c3 = _mm256_mul_ps(m4, _mm256_cvtepi32_ps(MM256_SET_M128I(_mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[6])), _mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[2])))));
+                auto c4 = _mm256_mul_ps(m4, _mm256_cvtepi32_ps(MM256_SET_M128I(_mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[7])), _mm_cvtepi8_epi32(_mm_set1_epi32(hm.val[3])))));
+                for (int iy = 0; iy < nrc_y; ++iy) {
+                    auto bs = _mm256_loadu_ps((const float *)q8.y[iy][ibl].bsums);
+                    acc[iy] = _mm256_fmadd_ps(c1, _mm256_shuffle_ps(bs, bs, 0x00), acc[iy]);
+                    acc[iy] = _mm256_fmadd_ps(c2, _mm256_shuffle_ps(bs, bs, 0x55), acc[iy]);
+                    acc[iy] = _mm256_fmadd_ps(c3, _mm256_shuffle_ps(bs, bs, 0xaa), acc[iy]);
+                    acc[iy] = _mm256_fmadd_ps(c4, _mm256_shuffle_ps(bs, bs, 0xff), acc[iy]);
+                }
+            //} else {
+            //    m4 = _mm256_mul_ps(_mm256_set1_ps(-0.5f), m4);
+            //}
             for (int ib = 0; ib < QK_K/32; ++ib) {
                 auto scales_d = _mm256_mul_ps(d4, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_set1_epi32(hd.val[ib]))));
-                auto scales_m = _mm256_mul_ps(m4, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_set1_epi32(hm.val[ib]))));
+                //auto scales_m = _mm256_mul_ps(m4, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_set1_epi32(hm.val[ib]))));
                 auto bits1 = _mm256_loadu_si256((const __m256i *)iq4[ibl].qs+2*ib+0);
                 auto bits2 = _mm256_loadu_si256((const __m256i *)iq4[ibl].qs+2*ib+1);
                 qx[0] = _mm256_and_si256(bits1, mf);
@@ -3123,10 +3142,16 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
                                                   _mm256_maddubs_epi16(qx[3], _mm256_shuffle_epi32(y, 0xff)));
                     auto sumi = _mm256_madd_epi16(m1, _mm256_add_epi16(sumi1, sumi2));
 #endif
-                    float d8 = q8.scale(iy, ibl);
-                    float m8 = ((const float *)q8.y[iy][ibl].bsums)[ib];
-                    acc[iy] = _mm256_fmadd_ps(_mm256_mul_ps(scales_d, _mm256_set1_ps(d8)), _mm256_cvtepi32_ps(sumi), acc[iy]);
-                    acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(m8), acc[iy]);
+                    if constexpr (nrc_y == 1) {
+                        acc[iy] = _mm256_fmadd_ps(scales_d, _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    } else {
+                        float d8 = q8.scale(iy, ibl);
+                        acc[iy] = _mm256_fmadd_ps(_mm256_mul_ps(scales_d, _mm256_set1_ps(d8)), _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    }
+                    //if constexpr (nrc_y <= 2) {
+                    //    float m8 = ((const float *)q8.y[iy][ibl].bsums)[ib];
+                    //    acc[iy] = _mm256_fmadd_ps(scales_m, _mm256_set1_ps(m8), acc[iy]);
+                    //}
                 }
             }
         }

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3085,27 +3085,6 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
     auto m1 = _mm256_set1_epi16(1);
 #endif
     int nbl = n / QK_K;
-    //float q4[1024];
-    //float a[4*nrc_y];
-    //for (int ix = 0; ix < nrc_x; ix += 4) {
-    //    std::memset(a, 0, 4*nrc_y*sizeof(float));
-    //    const block_q4_k_r4 * iq4 = (const block_q4_k_r4 *)((const char *)vx + (ix+0)*bx);
-    //    for (int ibl = 0; ibl < nbl; ++ibl) { // Block of 256
-    //        dequantize_row_q4_k_r4(iq4 + ibl, q4, 1024);
-    //        for (int iy = 0; iy < nrc_y; ++iy) {
-    //            float d8 = q8.scale(iy, ibl);
-    //            for (int j = 0; j < 256; ++j) {
-    //                float v = d8*q8.y[iy][ibl].qs[j];
-    //                a[4*iy+0] += v * q4[j+  0];
-    //                a[4*iy+1] += v * q4[j+256];
-    //                a[4*iy+2] += v * q4[j+512];
-    //                a[4*iy+3] += v * q4[j+768];
-    //            }
-    //        }
-    //    }
-    //    for (int iy = 0; iy < nrc_y; ++iy) for (int k = 0; k < 4; ++k) info.store(ix+k, iy, a[4*iy+k]);
-    //}
-    //return;
     union { __m256i vec; uint32_t val[8]; } hd, hm;
     __m256  acc[nrc_y] = {};
     __m256i qx[4];
@@ -3161,11 +3140,11 @@ static void mul_mat_q4_k_r4_q8_k_avx2(int n, const void * vx, size_t bx, const D
 
 template <int nrc_y>
 static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
-    mul_mat_q4_k_r4_q8_k_avx2<nrc_y>(n, vx, bx, info, nrc_x);
-    return;
-    //if constexpr (nrc_y == 1){
-    //    mul_mat_iq4_xs_r4_q8_k_avx2<1>(n, vx, bx, info, nrc_x);
-    //} else {
+    //mul_mat_q4_k_r4_q8_k_avx2<nrc_y>(n, vx, bx, info, nrc_x);
+    //return;
+    if constexpr (nrc_y == 1){
+        mul_mat_q4_k_r4_q8_k_avx2<1>(n, vx, bx, info, nrc_x);
+    } else {
     GGML_ASSERT(nrc_x%8 == 0);
     Q8<nrc_y, block_q8_K> q8(info);
     auto mf = _mm512_set1_epi8(0xf);
@@ -3243,7 +3222,7 @@ static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
             info.store(ix+4, iy, sum2);
         }
     }
-    //}
+    }
 }
 
 template <typename Bits>

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -4002,22 +4002,6 @@ static void repack_q4_k(int nrows, int n_per_row, const block_q4_K * x, block_q4
                     }
                 }
             }
-            //for (int ib = 0; ib < QK_K/32; ++ib) {
-            //    for (int k = 0; k < 4; ++k) for (int i = 0; i < 4; ++i) {
-            //        uint8_t l1 = (x4[k][ibl].qs[32*(ib/2)+i+ 0] >> 4*(ib%2)) & 0xf;
-            //        uint8_t l2 = (x4[k][ibl].qs[32*(ib/2)+i+ 8] >> 4*(ib%2)) & 0xf;
-            //        y[ibl].qs[64*ib+4*k+i+ 0] = l1 | (l2 << 4);
-            //        l1 = (x4[k][ibl].qs[32*(ib/2)+i+16] >> 4*(ib%2)) & 0xf;
-            //        l2 = (x4[k][ibl].qs[32*(ib/2)+i+24] >> 4*(ib%2)) & 0xf;
-            //        y[ibl].qs[64*ib+4*k+i+16] = l1 | (l2 << 4);
-            //        l1 = (x4[k][ibl].qs[32*(ib/2)+i+ 4] >> 4*(ib%2)) & 0xf;
-            //        l2 = (x4[k][ibl].qs[32*(ib/2)+i+12] >> 4*(ib%2)) & 0xf;
-            //        y[ibl].qs[64*ib+4*k+i+32] = l1 | (l2 << 4);
-            //        l1 = (x4[k][ibl].qs[32*(ib/2)+i+20] >> 4*(ib%2)) & 0xf;
-            //        l2 = (x4[k][ibl].qs[32*(ib/2)+i+28] >> 4*(ib%2)) & 0xf;
-            //        y[ibl].qs[64*ib+4*k+i+48] = l1 | (l2 << 4);
-            //    }
-            //}
         }
         x += 4*nblock;
         y += nblock;

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -3942,3 +3942,124 @@ void vec_dot_iq2_bn_r4_q8_K64(int n, float * s, size_t bs, const void * vx, size
     GGML_UNUSED(by);
 }
 
+//
+// ========================================= q4_k_r4
+//
+
+void quantize_row_q4_k_r4_ref(const float * x, block_q4_k_r4 * y, int64_t k) {
+    quantize_q4_k_r4(x, (void *)y, 4, k/4, nullptr);
+}
+
+void quantize_row_q4_k_r4(const float * x, void * y, int64_t k) {
+    quantize_q4_k_r4(x, y, 4, k/4, nullptr);
+}
+
+namespace {
+inline void get_scale_min_k4(int j, const uint8_t * q, uint8_t& d, uint8_t& m) {
+    if (j < 4) {
+        d = q[j] & 63; m = q[j + 4] & 63;
+    } else {
+        d = (q[j+4] & 0xF) | ((q[j-4] >> 6) << 4);
+        m = (q[j+4] >>  4) | ((q[j-0] >> 6) << 4);
+    }
+}
+}
+
+static void repack_q4_k(int nrows, int n_per_row, const block_q4_K * x, block_q4_k_r4 * y) {
+    GGML_ASSERT(nrows%4 == 0);
+    GGML_ASSERT(n_per_row%QK_K == 0);
+    int nblock = n_per_row/QK_K;
+    const block_q4_K * x4[4];
+    uint8_t ld, lm;
+    for (int row = 0; row < nrows; row += 4) {
+        for (int k = 0; k < 4; ++k) x4[k] = x + nblock*k;
+        for (int ibl = 0; ibl < nblock; ++ibl) {
+            std::memset(y[ibl].scales_l, 0, QK_K/8);
+            std::memset(y[ibl].scales_h, 0, QK_K/16);
+            for (int k = 0; k < 4; ++k) {
+                y[ibl].d[k+0] = x4[k][ibl].d;
+                y[ibl].d[k+4] = x4[k][ibl].dmin;
+                for (int ib = 0; ib < QK_K/32; ++ib) {
+                    get_scale_min_k4(ib, x4[k][ibl].scales, ld, lm);
+                    y[ibl].scales_l[4*ib+k] = (ld & 0xf) | ((lm & 0xf) << 4);
+                    uint8_t h = (ld >> 4) | ((lm >> 4) << 2);
+                    y[ibl].scales_h[(4*ib+k)%16] |= (h << 4*((4*ib+k)/16));
+                }
+            }
+            for (int ib = 0; ib < QK_K/32; ++ib) {
+                for (int k = 0; k < 4; ++k) for (int i = 0; i < 4; ++i) {
+                    uint8_t l1 = (x4[k][ibl].qs[32*(ib/2)+i+ 0] >> 4*(ib%2)) & 0xf;
+                    uint8_t l2 = (x4[k][ibl].qs[32*(ib/2)+i+ 8] >> 4*(ib%2)) & 0xf;
+                    y[ibl].qs[64*ib+4*k+i+ 0] = l1 | (l2 << 4);
+                    l1 = (x4[k][ibl].qs[32*(ib/2)+i+16] >> 4*(ib%2)) & 0xf;
+                    l2 = (x4[k][ibl].qs[32*(ib/2)+i+24] >> 4*(ib%2)) & 0xf;
+                    y[ibl].qs[64*ib+4*k+i+16] = l1 | (l2 << 4);
+                    l1 = (x4[k][ibl].qs[32*(ib/2)+i+ 4] >> 4*(ib%2)) & 0xf;
+                    l2 = (x4[k][ibl].qs[32*(ib/2)+i+12] >> 4*(ib%2)) & 0xf;
+                    y[ibl].qs[64*ib+4*k+i+32] = l1 | (l2 << 4);
+                    l1 = (x4[k][ibl].qs[32*(ib/2)+i+20] >> 4*(ib%2)) & 0xf;
+                    l2 = (x4[k][ibl].qs[32*(ib/2)+i+28] >> 4*(ib%2)) & 0xf;
+                    y[ibl].qs[64*ib+4*k+i+48] = l1 | (l2 << 4);
+                }
+            }
+        }
+        x += 4*nblock;
+        y += nblock;
+    }
+}
+
+size_t quantize_q4_k_r4(const float * src, void * dst, int64_t nrows, int64_t n_per_row, const float * imatrix) {
+    GGML_ASSERT(nrows%4 == 0);
+    GGML_ASSERT(n_per_row%QK_K == 0);
+    char * qcur = (char *)dst;
+    auto row_size = ggml_row_size(GGML_TYPE_Q4_K, n_per_row);
+    std::vector<char> qtmp(4*row_size);
+    for (int row = 0; row < nrows; row += 4) {
+        quantize_q4_K(src, (void *)qtmp.data(), 4, n_per_row, imatrix);
+        repack_q4_k(4, n_per_row, (const block_q4_K *)qtmp.data(), (block_q4_k_r4 *)qcur);
+        qcur += 4*row_size;
+        src += 4*n_per_row;
+    }
+    return nrows*row_size;
+}
+
+void dequantize_row_q4_k_r4(const block_q4_k_r4 * x, float * y, int64_t k) {
+    auto n_per_row = k/4;
+    float * y4[4] = {y, y + n_per_row, y + 2*n_per_row, y + 3*n_per_row};
+    int nblock = n_per_row/QK_K;
+    for (int ibl = 0; ibl < nblock; ++ibl) {
+        for (int k = 0; k < 4; ++k) {
+            const float d = GGML_FP16_TO_FP32(x[ibl].d[k+0]);
+            const float m = GGML_FP16_TO_FP32(x[ibl].d[k+4]);
+            for (int ib = 0; ib < QK_K/32; ++ib) {
+                int is = 4*ib + k;
+                float dl = d * ((x[ibl].scales_l[is] & 0xf) | (((x[ibl].scales_h[is%16] >> 4*(is/16)) & 0x03) << 4));
+                float ml = m * ((x[ibl].scales_l[is] >>  4) | (((x[ibl].scales_h[is%16] >> 4*(is/16)) & 0x0c) << 2));
+                for (int i = 0; i < 4; ++i) {
+                    y4[k][QK_K*ibl+32*ib+i+ 0] = dl * (x[ibl].qs[64*ib+4*k+i+ 0] & 0xf) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+ 8] = dl * (x[ibl].qs[64*ib+4*k+i+ 0] >>  4) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+16] = dl * (x[ibl].qs[64*ib+4*k+i+16] & 0xf) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+24] = dl * (x[ibl].qs[64*ib+4*k+i+16] >>  4) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+ 4] = dl * (x[ibl].qs[64*ib+4*k+i+32] & 0xf) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+12] = dl * (x[ibl].qs[64*ib+4*k+i+32] >>  4) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+20] = dl * (x[ibl].qs[64*ib+4*k+i+48] & 0xf) - ml;
+                    y4[k][QK_K*ibl+32*ib+i+28] = dl * (x[ibl].qs[64*ib+4*k+i+48] >>  4) - ml;
+                }
+            }
+        }
+    }
+}
+
+void vec_dot_q4_k_r4_q8_k(int n, float * s, size_t bs, const void * vx, size_t bx, const void * vy, size_t by, int nrc) {
+#if GGML_USE_IQK_MULMAT
+    if (iqk_mul_mat(1, 1, n, GGML_TYPE_Q4_K_R4, vx, 0, GGML_TYPE_Q8_K, vy, 0, s, 0, 0, 1)) {
+        return;
+    }
+#endif
+    GGML_ASSERT(n%QK4_NL == 0);
+    GGML_ASSERT(nrc == 1);
+    GGML_UNUSED(bs);
+    GGML_UNUSED(bx);
+    GGML_UNUSED(by);
+}
+

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -109,6 +109,12 @@ void   dequantize_row_iq2_bn_r4(const block_iq2_bn * GGML_RESTRICT x, float * GG
 size_t quantize_iq2_bn_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 void   vec_dot_iq2_bn_r4_q8_K64(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
+void   quantize_row_q4_k_r4_ref(const float * GGML_RESTRICT x, block_q4_k_r4  * GGML_RESTRICT y, int64_t k);
+void   quantize_row_q4_k_r4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+size_t quantize_q4_k_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+void   dequantize_row_q4_k_r4(const block_q4_k_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void   vec_dot_q4_k_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 void iqk_quantize_row_q8_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k);
 void quantize_row_q8_K64_ref(const float * GGML_RESTRICT x, block_q8_K64 * GGML_RESTRICT y, int64_t k);
 void quantize_row_q8_K64(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);

--- a/include/llama.h
+++ b/include/llama.h
@@ -183,6 +183,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q4_0_R4       = 202, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q8_0_R4       = 207, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q5_0_R4       = 208, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_Q4_K_R4       = 214, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_NL_R4     = 225, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_XS_R4     = 230, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q6_0_R4       = 235, // except 1d tensors

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4546,6 +4546,7 @@ static std::string llama_model_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q3_K_M:   return "Q3_K - Medium";
         case LLAMA_FTYPE_MOSTLY_Q3_K_L:   return "Q3_K - Large";
         case LLAMA_FTYPE_MOSTLY_Q4_K_S:   return "Q4_K - Small";
+        case LLAMA_FTYPE_MOSTLY_Q4_K_R4:  return "Q4_K_R4";
         case LLAMA_FTYPE_MOSTLY_Q4_K_M:   return "Q4_K - Medium";
         case LLAMA_FTYPE_MOSTLY_Q5_K_S:   return "Q5_K - Small";
         case LLAMA_FTYPE_MOSTLY_Q5_K_M:   return "Q5_K - Medium";
@@ -15870,6 +15871,7 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
         else if ((ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M || ftype == LLAMA_FTYPE_MOSTLY_Q5_K_M) &&
                 use_more_bits(qs.i_attention_wv, qs.n_attention_wv)) new_type = GGML_TYPE_Q6_K;
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S && qs.i_attention_wv < 4) new_type = GGML_TYPE_Q5_K;
+        else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_R4 && qs.i_attention_wv < 4) new_type = GGML_TYPE_Q5_K;
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q5_K_S) {
             if (qs.model.hparams.n_vocab >= 127999 && (qs.model.type == MODEL_8B || qs.model.type == MODEL_70B))
                 new_type = GGML_TYPE_Q6_K;
@@ -15964,6 +15966,9 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
         else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S && arch != LLM_ARCH_FALCON && i_layer < n_layer/8) {
             new_type = GGML_TYPE_Q5_K;
         }
+        else if (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_R4 && arch != LLM_ARCH_FALCON && i_layer < n_layer/8) {
+            new_type = GGML_TYPE_Q5_K;
+        }
         else if ((ftype == LLAMA_FTYPE_MOSTLY_Q4_0 || ftype == LLAMA_FTYPE_MOSTLY_Q5_0)
                 && qs.has_imatrix && i_layer < n_layer/8) {
             // Guard against craziness in the first few ffn_down layers that can happen even with imatrix for Q4_0/Q5_0.
@@ -15983,7 +15988,7 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
                     ftype == LLAMA_FTYPE_MOSTLY_Q3_K_S || ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M || ftype == LLAMA_FTYPE_MOSTLY_IQ4_NL  ||
                     ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S || ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M || ftype == LLAMA_FTYPE_MOSTLY_IQ3_S   ||
                     ftype == LLAMA_FTYPE_MOSTLY_IQ3_M  || ftype == LLAMA_FTYPE_MOSTLY_IQ4_XS || ftype == LLAMA_FTYPE_MOSTLY_IQ4_K   ||
-                    ftype == LLAMA_FTYPE_MOSTLY_IQ2_K  || ftype == LLAMA_FTYPE_MOSTLY_IQ3_K  ||
+                    ftype == LLAMA_FTYPE_MOSTLY_IQ2_K  || ftype == LLAMA_FTYPE_MOSTLY_IQ3_K  || ftype == LLAMA_FTYPE_MOSTLY_Q4_K_R4 ||
                     ftype == LLAMA_FTYPE_MOSTLY_IQ4_NL_R4 || ftype == LLAMA_FTYPE_MOSTLY_IQ4_XS_R4) {
                     new_type = GGML_TYPE_Q5_K;
                 }
@@ -16051,8 +16056,8 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
         new_type == GGML_TYPE_IQ2_XS  || new_type == GGML_TYPE_IQ2_XXS || new_type == GGML_TYPE_IQ2_S  ||
         new_type == GGML_TYPE_IQ3_XXS || new_type == GGML_TYPE_IQ1_S   || new_type == GGML_TYPE_IQ3_S  ||
         new_type == GGML_TYPE_IQ1_M   || new_type == GGML_TYPE_IQ4_K   || new_type == GGML_TYPE_IQ2_K  ||
-        new_type == GGML_TYPE_IQ5_K   || new_type == GGML_TYPE_IQ3_K   ||
-        new_type == GGML_TYPE_IQ6_K   || new_type == GGML_TYPE_IQ4_KS  ||
+        new_type == GGML_TYPE_IQ5_K   || new_type == GGML_TYPE_IQ3_K   || new_type == GGML_TYPE_Q4_K_R4 ||
+        new_type == GGML_TYPE_IQ6_K   || new_type == GGML_TYPE_IQ4_KS  || new_type == GGML_TYPE_IQ4_XS_R4 ||
         new_type == GGML_TYPE_IQ2_KS  || new_type == GGML_TYPE_IQ4_KSS) {
         int nx = tensor->ne[0];
         int ny = tensor->ne[1];
@@ -16085,8 +16090,10 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
             case GGML_TYPE_IQ3_K:
             case GGML_TYPE_IQ4_KSS:
             case GGML_TYPE_IQ4_KS:
+            case GGML_TYPE_IQ4_XS_R4:
             case GGML_TYPE_IQ4_XS: new_type = GGML_TYPE_IQ4_NL; break;
             case GGML_TYPE_IQ4_K:
+            case GGML_TYPE_Q4_K_R4:
             case GGML_TYPE_Q4_K:   new_type = GGML_TYPE_Q5_0;   break;
             case GGML_TYPE_IQ5_K:
             case GGML_TYPE_Q5_K:   new_type = GGML_TYPE_Q6_0;   break;
@@ -16179,6 +16186,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
         case LLAMA_FTYPE_MOSTLY_Q3_K_L:  default_type = GGML_TYPE_Q3_K;    break;
         case LLAMA_FTYPE_MOSTLY_Q4_K_S:
         case LLAMA_FTYPE_MOSTLY_Q4_K_M:  default_type = GGML_TYPE_Q4_K;    break;
+        case LLAMA_FTYPE_MOSTLY_Q4_K_R4: default_type = GGML_TYPE_Q4_K_R4; break;
         case LLAMA_FTYPE_MOSTLY_Q5_K_S:
         case LLAMA_FTYPE_MOSTLY_Q5_K_M:  default_type = GGML_TYPE_Q5_K;    break;
         case LLAMA_FTYPE_MOSTLY_Q6_K:    default_type = GGML_TYPE_Q6_K;    break;
@@ -16579,6 +16587,10 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
             }
             else if (new_type == GGML_TYPE_Q8_0_R4) {
                 if (tensor->ne[1] % 4 != 0) new_type = GGML_TYPE_Q8_0;
+                else chunk_size_multiplier = 4;
+            }
+            else if (new_type == GGML_TYPE_Q4_K_R4) {
+                if (tensor->ne[1] % 4 != 0) new_type = GGML_TYPE_Q4_K;
                 else chunk_size_multiplier = 4;
             }
             else if (new_type == GGML_TYPE_IQ2_BN_R4) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3837,6 +3837,7 @@ struct llama_model_loader {
                 case GGML_TYPE_Q2_K:    ftype = LLAMA_FTYPE_MOSTLY_Q2_K;    break;
                 case GGML_TYPE_Q3_K:    ftype = LLAMA_FTYPE_MOSTLY_Q3_K_M;  break;
                 case GGML_TYPE_Q4_K:    ftype = LLAMA_FTYPE_MOSTLY_Q4_K_M;  break;
+                case GGML_TYPE_Q4_K_R4: ftype = LLAMA_FTYPE_MOSTLY_Q4_K_R4; break;
                 case GGML_TYPE_Q5_K:    ftype = LLAMA_FTYPE_MOSTLY_Q5_K_M;  break;
                 case GGML_TYPE_Q6_K:    ftype = LLAMA_FTYPE_MOSTLY_Q6_K;    break;
                 case GGML_TYPE_IQ2_XXS: ftype = LLAMA_FTYPE_MOSTLY_IQ2_XXS; break;
@@ -15786,6 +15787,9 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
             }
             else if (new_type == GGML_TYPE_IQ4_XS_R4) {
                 new_type = GGML_TYPE_IQ4_XS;
+            }
+            else if (new_type == GGML_TYPE_Q4_K_R4) {
+                new_type = GGML_TYPE_Q4_K;
             }
             else if (new_type == GGML_TYPE_Q4_0_R4) {
                 new_type = GGML_TYPE_Q4_0;


### PR DESCRIPTION

Follow up of #118, #119, #120, #121, #122, #123  for `Q4_K`.

After having demonstrated interleaved rows with blocks and super-blocks for `IQ4_XS` in #123, here the corresponding implementation for `Q4_K`. To not have an explosion of quantization types, `Q4_K_R4` corresponds to `Q4_K_S` (and there is no `_R4` variant for `Q4_K_M`).

We get a massive speedup on `ARM_NEON` and quite significant gain on `AVX2/Zen4`. The `Zen4` implementation could probably be optimized further. Here is `PP-512` for LLaMA-3.1-8B on `Zen4` (Ryzen-7950X), `ARM_NEON` (M2-Max) and `AVX2` (Ryzen-5975WX)

| Platform |  Threads | Q4_K_S | Q4_K_R4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON |  8 |  68.73 ± 0.88  | 110.02 ± 1.31  | 1.601 |
| Zen4            | 16 | 198.92 ± 0.69  | 259.19 ± 0.24  | 1.303 |
| AVX2           | 32 | 206.39 ± 0.28  | 282.78 ± 0.54  | 1.370 |

Here we gain even for TG. Here results for TG-128 on LLaMA-3.1-8B with different numbers of threads:

| Platform |  Threads | Q4_K_S | Q4_K_R4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON |  2 |  11.38 ± 0.00  | 12.17 ± 0.01  | 1.069 |
|                       |  4 |  18.08 ± 0.44  | 21.56 ± 0.06  | 1.192 |
|                       |  8 |  25.02 ± 0.17   | 25.39 ± 0.14  | 1.015 |
| Zen4            | 1 |  5.73 ± 0.01  | 8.95 ± 0.00  |  1.562 |
|                      | 2 |  10.47 ± 0.01  | 13.37 ± 0.00  |  1.277 |
|                      | 4 |  13.38 ± 0.63  | 14.03 ± 0.01  |  1.049 |
| AVX2           | 2 | 4.60 ± 0.00   | 7.61 ± 0.00  | 1.370 |
|                     | 4 | 8.55 ± 0.00    | 12.01 ± 0.00  | 1.403 |
|                     | 8 |  11.67 ± 0.00   | 13.83 ± 0.00  | 1.185 |


