### PR TITLE
Q6_K_R4

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -65,6 +65,7 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     { "Q5_K_S",   LLAMA_FTYPE_MOSTLY_Q5_K_S,   " 4.33G, +0.0400 ppl @ LLaMA-v1-7B", },
     { "Q5_K_M",   LLAMA_FTYPE_MOSTLY_Q5_K_M,   " 4.45G, +0.0122 ppl @ LLaMA-v1-7B", },
     { "Q6_K",     LLAMA_FTYPE_MOSTLY_Q6_K,     " 5.15G, +0.0008 ppl @ LLaMA-v1-7B", },
+    { "Q6_K_R4",  LLAMA_FTYPE_MOSTLY_Q6_K_R4,  "Q6_K repacked", },
     { "Q8_0",     LLAMA_FTYPE_MOSTLY_Q8_0,     " 6.70G, +0.0004 ppl @ LLaMA-v1-7B", },
     { "Q4_0_4_4", LLAMA_FTYPE_MOSTLY_Q4_0_4_4, " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_0_4_8", LLAMA_FTYPE_MOSTLY_Q4_0_4_8, " 4.34G, +0.4685 ppl @ Llama-3-8B",  },

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -413,6 +413,7 @@ extern "C" {
         GGML_TYPE_Q5_0_R4   = 206,
         GGML_TYPE_Q8_0_R4   = 208,
         GGML_TYPE_Q4_K_R4   = 212,
+        GGML_TYPE_Q6_K_R4   = 214,
         GGML_TYPE_IQ4_NL_R4 = 220,
         GGML_TYPE_IQ4_XS_R4 = 223,
         GGML_TYPE_Q6_0_R4   = 233,
@@ -480,6 +481,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_Q8_0_R4   = 207, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q5_0_R4   = 208, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q4_K_R4   = 212, // except 1d tensors
+        GGML_FTYPE_MOSTLY_Q6_K_R4   = 214, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_NL_R4 = 219, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_XS_R4 = 222, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q6_0_R4   = 227, // except 1d tensors

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -331,6 +331,14 @@ typedef struct {
 } block_q6_K;
 static_assert(sizeof(block_q6_K) == sizeof(ggml_half) + QK_K / 16 + 3*QK_K/4, "wrong q6_K block size/padding");
 
+typedef struct {
+    ggml_half d[4];          // super-block scale
+    int8_t  scales[QK_K/4];  // scales, quantized with 8 bits
+    uint8_t qh[QK_K];        // quants, upper 2 bits
+    uint8_t ql[QK_K*2];      // quants, lower 4 bits
+} block_q6_k_r4;
+static_assert(sizeof(block_q6_k_r4) == 4*sizeof(ggml_half) + QK_K/4 + 3*QK_K, "wrong q6_k_r4 block size/padding");
+
 // This is only used for intermediate quantization and dot products
 typedef struct {
     float   d;              // delta

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -15203,6 +15203,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_Q6_0_R4: break;
         case GGML_TYPE_Q8_0_R4: break;
         case GGML_TYPE_Q4_K_R4: break;
+        case GGML_TYPE_Q6_K_R4: break;
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
             {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3248,6 +3248,71 @@ static void mul_mat_q4_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
 }
 #endif
 
+template <int nrc_y>
+static void mul_mat_q6_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    GGML_ASSERT(nrc_x%4 == 0);
+    Q8<nrc_y, block_q8_K> q8(info);
+    auto m4 = _mm256_set1_epi8(0xf);
+    auto m3 = _mm256_set1_epi8(0x30);
+    auto m32 = _mm256_set1_epi8(-32);
+#ifndef HAVE_FANCY_SIMD
+    auto m1 = _mm256_set1_epi16(1);
+#endif
+    int nbl = n / QK_K;
+    __m256  acc[nrc_y] = {};
+    __m256i qx[4];
+    for (int ix = 0; ix < nrc_x; ix += 4) {
+        const block_q6_k_r4 * iq6 = (const block_q6_k_r4 *)((const char *)vx + (ix+0)*bx);
+        for (int ibl = 0; ibl < nbl; ++ibl) { // Block of 256
+            auto dl = _mm_cvtph_ps(_mm_loadl_epi64((const __m128i *)iq6[ibl].d));
+            auto d4 = _mm256_set_m128(dl, dl);
+            const uint32_t * scales = (const uint32_t *)iq6[ibl].scales;
+            for (int ib = 0; ib < QK_K/32; ++ib) {
+                auto iscales = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(scales + 2*ib)));
+                auto scales  = _mm256_mul_ps(d4, _mm256_cvtepi32_ps(iscales));
+//#ifdef HAVE_FANCY_SIMD
+//                auto scales_m = _mm256_mul_ps(scales, _mm256_set1_ps(-64.f));
+//#endif
+                auto lbits1 = _mm256_loadu_si256((const __m256i *)iq6[ibl].ql+2*ib+0);
+                auto lbits2 = _mm256_loadu_si256((const __m256i *)iq6[ibl].ql+2*ib+1);
+                auto hbits  = _mm256_loadu_si256((const __m256i *)iq6[ibl].qh+ib);
+                qx[0] = _mm256_add_epi8(_mm256_or_si256(_mm256_and_si256(lbits1, m4), _mm256_and_si256(m3, _mm256_slli_epi16(hbits, 4))), m32);
+                qx[1] = _mm256_add_epi8(_mm256_or_si256(_mm256_and_si256(lbits2, m4), _mm256_and_si256(m3, hbits)), m32);
+                qx[2] = _mm256_add_epi8(_mm256_or_si256(_mm256_and_si256(_mm256_srli_epi16(lbits1, 4), m4), _mm256_and_si256(m3, _mm256_slli_epi16(hbits, 2))), m32);
+                qx[3] = _mm256_add_epi8(_mm256_or_si256(_mm256_and_si256(_mm256_srli_epi16(lbits2, 4), m4), _mm256_and_si256(m3, _mm256_srli_epi16(hbits, 2))), m32);
+//#ifndef HAVE_FANCY_SIMD
+                auto s1 = _mm256_sign_epi8(qx[0], qx[0]);
+                auto s2 = _mm256_sign_epi8(qx[1], qx[1]);
+                auto s3 = _mm256_sign_epi8(qx[2], qx[2]);
+                auto s4 = _mm256_sign_epi8(qx[3], qx[3]);
+//#endif
+                for (int iy = 0; iy < nrc_y; ++iy) {
+                    auto y = _mm256_loadu_si256((const __m256i*)q8.y[iy][ibl].qs+ib);
+#ifdef HAVE_FANCY_SIMD
+                    auto sumi = _mm256_setzero_si256();
+                    sumi = _mm256_dpbusd_epi32(sumi, s1, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x00), qx[0]));
+                    sumi = _mm256_dpbusd_epi32(sumi, s2, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x55), qx[1]));
+                    sumi = _mm256_dpbusd_epi32(sumi, s3, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xaa), qx[2]));
+                    sumi = _mm256_dpbusd_epi32(sumi, s4, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xff), qx[3]));
+#else
+                    auto sumi1 = _mm256_add_epi16(_mm256_maddubs_epi16(s1, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x00), qx[0])),
+                                                  _mm256_maddubs_epi16(s2, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x55), qx[1])));
+                    auto sumi2 = _mm256_add_epi16(_mm256_maddubs_epi16(s3, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xaa), qx[2])),
+                                                  _mm256_maddubs_epi16(s4, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xff), qx[3])));
+                    auto sumi = _mm256_add_epi32(_mm256_madd_epi16(m1, sumi1), _mm256_madd_epi16(m1, sumi2));
+#endif
+                    acc[iy] = _mm256_fmadd_ps(_mm256_mul_ps(scales, _mm256_set1_ps(q8.scale(iy, ibl))), _mm256_cvtepi32_ps(sumi), acc[iy]);
+                }
+            }
+        }
+        for (int iy = 0; iy < nrc_y; ++iy) {
+            auto sum = _mm_add_ps(_mm256_castps256_ps128(acc[iy]), _mm256_extractf128_ps(acc[iy], 1));
+            acc[iy] = _mm256_setzero_ps();
+            info.store(ix+0, iy, sum);
+        }
+    }
+}
+
 template <typename Bits>
 inline void multiply_add_1(int j, const Bits& bits, const __m256i * scales, const __m256i * q8, __m256i * sumi) {
     if (j == 0) {
@@ -5254,6 +5319,18 @@ bool MulMat::prepare(int typeA, int typeB, int ne00, MulMat& mm, int Ny) {
             mm.funcs[6] = mul_mat_q4_k_r4_q8_k<7>;
             mm.funcs[7] = mul_mat_q4_k_r4_q8_k<8>;
             expected_typeB = GGML_TYPE_Q8_K32;
+            break;
+        case GGML_TYPE_Q6_K_R4:
+            assert (ne00 % QK_K == 0);
+            mm.funcs[0] = mul_mat_q6_k_r4_q8_k<1>;
+            mm.funcs[1] = mul_mat_q6_k_r4_q8_k<2>;
+            mm.funcs[2] = mul_mat_q6_k_r4_q8_k<3>;
+            mm.funcs[3] = mul_mat_q6_k_r4_q8_k<4>;
+            mm.funcs[4] = mul_mat_q6_k_r4_q8_k<5>;
+            mm.funcs[5] = mul_mat_q6_k_r4_q8_k<6>;
+            mm.funcs[6] = mul_mat_q6_k_r4_q8_k<7>;
+            mm.funcs[7] = mul_mat_q6_k_r4_q8_k<8>;
+            expected_typeB = GGML_TYPE_Q8_K;
             break;
         case GGML_TYPE_Q4_0_R4:
             assert (ne00 % QK4_NL == 0);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -163,11 +163,14 @@ struct MulMat {
     static bool prepare(int typeA, int typeB, int ne00, MulMat& mm, int Ny);
     static inline int num_rows(ggml_type type) {
         switch (type) {
+            case GGML_TYPE_Q4_K_R4:
+            case GGML_TYPE_Q6_K_R4:
             case GGML_TYPE_Q4_0_R4:
             case GGML_TYPE_Q5_0_R4:
             case GGML_TYPE_Q6_0_R4:
             case GGML_TYPE_Q8_0_R4:
             case GGML_TYPE_IQ4_NL_R4:
+            case GGML_TYPE_IQ4_XS_R4:
             case GGML_TYPE_IQ2_BN_R4: return 4;
             default: return 1;
         }
@@ -7968,6 +7971,15 @@ IQK_ALWAYS_INLINE int32x4x2_t interleaved_dotq_b16(const int8x16_t * qx, const i
     return sumi;
 }
 
+IQK_ALWAYS_INLINE int32x4_t interleaved_dotq(const int8x16_t * qx, const int8x16_t& y) {
+    auto sumi = vdupq_n_s32(0);
+    sumi = vdotq_laneq_s32(sumi, qx[0], y, 0);
+    sumi = vdotq_laneq_s32(sumi, qx[1], y, 1);
+    sumi = vdotq_laneq_s32(sumi, qx[2], y, 2);
+    sumi = vdotq_laneq_s32(sumi, qx[3], y, 3);
+    return sumi;
+}
+
 IQK_ALWAYS_INLINE void prepare_iq4_nl_quants(const int8x16_t& values, const uint8x16_t& m4, const uint8x16x4_t& bits, int8x16_t * qx) {
     qx[0] = vqtbl1q_s8(values, vandq_u8(bits.val[0], m4));   //  0...3 from the 4 rows
     qx[1] = vqtbl1q_s8(values, vandq_u8(bits.val[1], m4));   // 16..19
@@ -8121,48 +8133,43 @@ void mul_mat_q6_k_r4_q8_k(int n, const void * vx, size_t bx, const DataInfo& inf
     auto mf = vdupq_n_u8(0x0f);
     auto m3 = vdupq_n_u8(0x30);
     auto m32 = vdupq_n_s8(-32);
-    //auto mx = vdupq_n_u8(0xaa);
     int nbl = n / QK_K;
-    int8x16_t qx[8];
+    int8x16_t qx[4];
     float32x4x2_t scales;
     float32x4_t acc[nrc_y] = {};
+    float32x4_t d4[nrc_y] = {};
     for (int ix = 0; ix < nrc_x; ix += 4) {
         const block_q6_k_r4 * iq6 = (const block_q6_k_r4 *)((const char *)vx + ix*bx);
         for (int ibl = 0; ibl < nbl; ++ibl) {
-            auto d4 = vcvt_f32_f16(vld1_f16((const float16_t *)iq6[ibl].d));
-            if constexpr (nrc_y == 1) {
-                d4 = vmulq_f32(d4, vdupq_n_f32(q8.scale(0, ibl)));
+            auto dtmp = vcvt_f32_f16(vld1_f16((const float16_t *)iq6[ibl].d));
+            for (int iy = 0; iy < nrc_y; ++iy) {
+                d4[iy] = vmulq_f32(dtmp, vdupq_n_f32(q8.scale(iy, ibl)));
             }
             for (int is = 0; is < 2; ++is) {
                 for (int ib = 0; ib < 4; ++ib) {
                     auto lbits = vld1q_u8_x4(iq6[ibl].ql + 256*is + 64*ib);
-                    auto hbits = vld1q_u8_x2(iq6[ibl].qh + 128*is + 32*ib);
+                    auto hbits = vld1q_u8(iq6[ibl].qh + 128*is + 32*ib);
                     auto iscales = vmovl_s8(vld1_s8(iq6[ibl].scales + 32*is + 8*ib));
-                    scales.val[0] = vmulq_f32(d4, vcvtq_f32_s32(vmovl_s16(vget_low_s16(iscales))));
-                    scales.val[1] = vmulq_f32(d4, vcvtq_f32_s32(vmovl_s16(vget_high_s16(iscales))));
-                    //hbits.val[0] = veorq_u8(hbits.val[0], mx);
-                    //hbits.val[1] = veorq_u8(hbits.val[1], mx);
-                    //qx[0] = vorrq_u8(vandq_u8(vshlq_n_u8(hbits.val[0], 6), m3), vandq_u8(vshlq_n_u8(lbits.val[0], 4), mf));
-                    prepare_q4_k_quants(mf, lbits, qx);
-                    qx[0] = vaddq_s8(m32, vorrq_u8(qx[0], vandq_u8(m3, vshlq_n_u8(hbits.val[0], 4))));
-                    qx[1] = vaddq_s8(m32, vorrq_u8(qx[1], vandq_u8(m3, vshlq_n_u8(hbits.val[1], 4))));
-                    qx[2] = vaddq_s8(m32, vorrq_u8(qx[2], vandq_u8(m3, hbits.val[0])));
-                    qx[3] = vaddq_s8(m32, vorrq_u8(qx[3], vandq_u8(m3, hbits.val[1])));
-                    qx[4] = vaddq_s8(m32, vorrq_u8(qx[4], vandq_u8(m3, vshlq_n_u8(hbits.val[0], 2))));
-                    qx[5] = vaddq_s8(m32, vorrq_u8(qx[5], vandq_u8(m3, vshlq_n_u8(hbits.val[1], 2))));
-                    qx[6] = vaddq_s8(m32, vorrq_u8(qx[6], vandq_u8(m3, vshrq_n_u8(hbits.val[0], 2))));
-                    qx[7] = vaddq_s8(m32, vorrq_u8(qx[7], vandq_u8(m3, vshrq_n_u8(hbits.val[1], 2))));
+                    scales.val[0] = vcvtq_f32_s32(vmovl_s16(vget_low_s16(iscales)));
+                    scales.val[1] = vcvtq_f32_s32(vmovl_s16(vget_high_s16(iscales)));
+                    qx[0] = vaddq_s8(m32, vorrq_u8(vandq_u8 (lbits.val[0], mf), vandq_u8(m3, vshlq_n_u8(hbits, 4))));
+                    qx[1] = vaddq_s8(m32, vorrq_u8(vandq_u8 (lbits.val[2], mf), vandq_u8(m3, hbits)));
+                    qx[2] = vaddq_s8(m32, vorrq_u8(vshrq_n_u8(lbits.val[0], 4), vandq_u8(m3, vshlq_n_u8(hbits, 2))));
+                    qx[3] = vaddq_s8(m32, vorrq_u8(vshrq_n_u8(lbits.val[2], 4), vandq_u8(m3, vshrq_n_u8(hbits, 2))));
                     for (int iy = 0; iy < nrc_y; ++iy) {
-                        auto y = vld1q_s8_x2(q8.y[iy][ibl].qs+128*is+32*ib);
-                        auto sumi = interleaved_dotq_b16(qx, y);
-                        if constexpr (nrc_y == 1) {
-                            acc[iy] = vfmaq_f32(acc[iy], scales.val[0], vcvtq_f32_s32(sumi.val[0]));
-                            acc[iy] = vfmaq_f32(acc[iy], scales.val[1], vcvtq_f32_s32(sumi.val[1]));
-                        } else {
-                            auto d8 = vdupq_n_f32(q8.scale(iy, ibl));
-                            acc[iy] = vfmaq_f32(acc[iy], vmulq_f32(scales.val[0], d8), vcvtq_f32_s32(sumi.val[0]));
-                            acc[iy] = vfmaq_f32(acc[iy], vmulq_f32(scales.val[1], d8), vcvtq_f32_s32(sumi.val[1]));
-                        }
+                        auto y = vld1q_s8(q8.y[iy][ibl].qs+128*is+32*ib);
+                        auto sumi = interleaved_dotq(qx, y);
+                        acc[iy] = vfmaq_f32(acc[iy], vmulq_f32(scales.val[0], d4[iy]), vcvtq_f32_s32(sumi));
+                    }
+                    hbits = vld1q_u8(iq6[ibl].qh + 128*is + 32*ib + 16);
+                    qx[0] = vaddq_s8(m32, vorrq_u8(vandq_u8 (lbits.val[1], mf), vandq_u8(m3, vshlq_n_u8(hbits, 4))));
+                    qx[1] = vaddq_s8(m32, vorrq_u8(vandq_u8 (lbits.val[3], mf), vandq_u8(m3, hbits)));
+                    qx[2] = vaddq_s8(m32, vorrq_u8(vshrq_n_u8(lbits.val[1], 4), vandq_u8(m3, vshlq_n_u8(hbits, 2))));
+                    qx[3] = vaddq_s8(m32, vorrq_u8(vshrq_n_u8(lbits.val[3], 4), vandq_u8(m3, vshrq_n_u8(hbits, 2))));
+                    for (int iy = 0; iy < nrc_y; ++iy) {
+                        auto y = vld1q_s8(q8.y[iy][ibl].qs+128*is+32*ib+16);
+                        auto sumi = interleaved_dotq(qx, y);
+                        acc[iy] = vfmaq_f32(acc[iy], vmulq_f32(scales.val[1], d4[iy]), vcvtq_f32_s32(sumi));
                     }
                 }
             }

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -115,6 +115,12 @@ size_t quantize_q4_k_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT ds
 void   dequantize_row_q4_k_r4(const block_q4_k_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 void   vec_dot_q4_k_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
+void   quantize_row_q6_k_r4_ref(const float * GGML_RESTRICT x, block_q6_k_r4  * GGML_RESTRICT y, int64_t k);
+void   quantize_row_q6_k_r4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+size_t quantize_q6_k_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+void   dequantize_row_q6_k_r4(const block_q6_k_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void   vec_dot_q6_k_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 void iqk_quantize_row_q8_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k);
 void quantize_row_q8_K64_ref(const float * GGML_RESTRICT x, block_q8_K64 * GGML_RESTRICT y, int64_t k);
 void quantize_row_q8_K64(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);

--- a/include/llama.h
+++ b/include/llama.h
@@ -184,6 +184,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q8_0_R4       = 207, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q5_0_R4       = 208, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q4_K_R4       = 214, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_Q6_K_R4       = 218, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_NL_R4     = 225, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_XS_R4     = 230, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q6_0_R4       = 235, // except 1d tensors


### PR DESCRIPTION

Follow up of #118, #119, #120, #121, #122, #123, #129  for `Q6_K`. 

If nothing else `Q6_K` is routinely used for the output tensor, so having a better `Q6_K` performance would be useful.

We get a large speedup on `ARM_NEON` and non-negligible gains on `AVX2/Zen4`.  Here is `PP-512` for LLaMA-3.1-8B on `Zen4` (Ryzen-7950X), `ARM_NEON` (M2-Max) and `AVX2` (Ryzen-5975WX)

| Platform |  Threads | Q6_K | Q6_K_R4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON |  8 |  57.57 ± 0.61  | 83.25 ± 0.81  | 1.446 |
| Zen4            | 16 | 195.20 ± 0.74  | 243.25 ± 0.31  | 1.246 |
| AVX2           | 32 | 194.51 ± 0.35  | 264.16 ± 0.44  | 1.358 |

Except on `ARM_NEON`, where TG performance is slightly lower for small numbers of threads, we gain even for TG. Here results for TG-128 on LLaMA-3.1-8B with different numbers of threads:

| Platform |  Threads | Q6_K | Q6_K_R4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON |  2 |  7.46 ± 0.03  | 7.35 ± 0.01  | 0.985 |
|                       |  4 |  13.88 ± 0.02  | 13.80 ± 0.01  | 0.994 |
|                       |  8 |  18.31 ± 0.16   |  18.57 ± 0.14  | 1.014 |
| Zen4            | 1 |  5.38 ± 0.00  | 7.94 ± 0.00  |  1.476 |
|                      | 2 |  8.93 ± 0.00 | 10.38 ± 0.00  |  1.162 |
|                      | 4 |  9.97 ± 0.27  | 10.18 ± 0.01  |  1.021 |
| AVX2           | 2 | 4.75 ± 0.00    | 5.78 ± 0.01  | 1.217 |
|                     | 4 | 7.57 ± 0.00    | 8.47 ± 0.00  | 1.119 |
|                     | 8 |  8.23 ± 0.00   | 9.14 ± 0.00  | 1.111 |

With this Zen4 implementation, for TG the available memory bandwidth is fully saturated with just 2 threads!