### PR TITLE
IQ5_K_R4

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -61,6 +61,7 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     { "IQ4_K",    LLAMA_FTYPE_MOSTLY_IQ4_K,    " 4.5 bpw non-linear quantization",  },
     { "IQ4_K_R4", LLAMA_FTYPE_MOSTLY_IQ4_K_R4, "IQ4_K repacked",  },
     { "IQ5_K",    LLAMA_FTYPE_MOSTLY_IQ5_K,    " 5.5 bpw non-linear quantization",  },
+    { "IQ5_K_R4", LLAMA_FTYPE_MOSTLY_IQ5_K_R4, "IQ5_K repacked",  },
     { "IQ6_K",    LLAMA_FTYPE_MOSTLY_IQ6_K,    " 6.6 bpw non-linear quantization",  },
     { "Q4_K",     LLAMA_FTYPE_MOSTLY_Q4_K_M,   "alias for Q4_K_M", },
     { "Q4_K_R4",  LLAMA_FTYPE_MOSTLY_Q4_K_R4,  "Q4_K_S repacked", },

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -426,6 +426,7 @@ extern "C" {
         GGML_TYPE_IQ2_K_R4  = 337,
         GGML_TYPE_IQ3_K_R4  = 338,
         GGML_TYPE_IQ4_K_R4  = 339,
+        GGML_TYPE_IQ5_K_R4  = 340,
         GGML_TYPE_Q8_K_R8   = 399,
         GGML_TYPE_COUNT,
     };
@@ -502,6 +503,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_IQ2_K_R4  = 330, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ3_K_R4  = 331, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_K_R4  = 332, // except 1d tensors
+        GGML_FTYPE_MOSTLY_IQ5_K_R4  = 333, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q8_K_R8   = 399, // except 1d tensors
     };
 

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -585,6 +585,16 @@ typedef struct {
 static_assert(sizeof(block_iq5_k) == sizeof(ggml_half) + sizeof(uint16_t) + QK_K/2 + QK_K/8 + 3*QK_K/64, "wrong iq5_k block size/padding");
 
 typedef struct {
+    ggml_half d[4];
+    uint8_t  extra[8];
+    uint8_t  scales_h[QK_K/16];
+    uint8_t  scales_l[QK_K/8 ];
+    uint8_t  qs[QK_K*2];
+    uint8_t  qh[QK_K/2];
+} block_iq5_k_r4;
+static_assert(sizeof(block_iq5_k_r4) == 4*sizeof(block_iq5_k), "wrong iq5_k_r4 block size/padding");
+
+typedef struct {
     ggml_half d;
     uint16_t extra;
     int8_t   scales[QK_K/16];

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -15210,6 +15210,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_IQ2_K_R4: break;
         case GGML_TYPE_IQ3_K_R4: break;
         case GGML_TYPE_IQ4_K_R4: break;
+        case GGML_TYPE_IQ5_K_R4: break;
         case GGML_TYPE_Q8_K_R8: break;
         case GGML_TYPE_BF16_R16: break;
         case GGML_TYPE_Q4_0_4_4:

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -4335,7 +4335,6 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
     auto shuff = _mm256_loadu_si256((const __m256i *)k_shuff);
 #else
     auto s_shuffle = _mm256_set_epi64x(0x0f0e0f0e0d0c0d0c, 0x0b0a0b0a09080908, 0x0706070605040504, 0x0302030201000100);
-    auto m128 = _mm256_set1_epi8(-128);
 #endif
     int nbl = n / QK_K;
     __m256  acc[nrc_y] = {};
@@ -4405,25 +4404,22 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
                     qx[3] = _mm256_add_epi8(qx[3], shift);
                 }
 #else
-                auto qh = _mm256_and_si256(_mm256_slli_epi16(hb, 7), m128);
-                auto q5vl = _mm256_or_si256(qx[0], qh);
-                auto q5vh = _mm256_or_si256(qx[0], _mm256_xor_si256(qh, m128));
-                qx[0] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
 
-                qh = _mm256_and_si256(_mm256_slli_epi16(hb, 3), m128);
-                q5vl = _mm256_or_si256(qx[1], qh);
-                q5vh = _mm256_or_si256(qx[1], _mm256_xor_si256(qh, m128));
-                qx[1] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+                auto q5vl = _mm256_shuffle_epi8(values[0], qx[0]);
+                auto q5vh = _mm256_shuffle_epi8(values[1], qx[0]);
+                qx[0] = _mm256_blendv_epi8(q5vl, q5vh, _mm256_cmpeq_epi8(_mm256_and_si256(hb, _mm256_set1_epi8(0x01)), _mm256_set1_epi8(0x01)));
 
-                qh = _mm256_and_si256(_mm256_slli_epi16(hb, 6), m128);
-                q5vl = _mm256_or_si256(qx[2], qh);
-                q5vh = _mm256_or_si256(qx[2], _mm256_xor_si256(qh, m128));
-                qx[2] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+                q5vl = _mm256_shuffle_epi8(values[0], qx[1]);
+                q5vh = _mm256_shuffle_epi8(values[1], qx[1]);
+                qx[1] = _mm256_blendv_epi8(q5vl, q5vh, _mm256_cmpeq_epi8(_mm256_and_si256(hb, _mm256_set1_epi8(0x10)), _mm256_set1_epi8(0x10)));
 
-                qh = _mm256_and_si256(_mm256_slli_epi16(hb, 2), m128);
-                q5vl = _mm256_or_si256(qx[3], qh);
-                q5vh = _mm256_or_si256(qx[3], _mm256_xor_si256(qh, m128));
-                qx[3] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+                q5vl = _mm256_shuffle_epi8(values[0], qx[2]);
+                q5vh = _mm256_shuffle_epi8(values[1], qx[2]);
+                qx[2] = _mm256_blendv_epi8(q5vl, q5vh, _mm256_cmpeq_epi8(_mm256_and_si256(hb, _mm256_set1_epi8(0x02)), _mm256_set1_epi8(0x02)));
+
+                q5vl = _mm256_shuffle_epi8(values[0], qx[3]);
+                q5vh = _mm256_shuffle_epi8(values[1], qx[3]);
+                qx[3] = _mm256_blendv_epi8(q5vl, q5vh, _mm256_cmpeq_epi8(_mm256_and_si256(hb, _mm256_set1_epi8(0x20)), _mm256_set1_epi8(0x20)));
 
                 auto shift = _mm256_and_si256(ms, _mm256_slli_epi16(extra, 1)); extra = _mm256_srli_epi16(extra, 1);
                 shift = _mm256_shuffle_epi8(shift, shift_shuffle);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -4415,6 +4415,8 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
                 q5vl = _mm256_or_si256(qx[3], qh);
                 q5vh = _mm256_or_si256(qx[3], _mm256_xor_si256(qh, m128));
                 qx[3] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+
+#ifdef HAVE_FANCY_SIMD
                 if constexpr (nrc_y == 1) {
                     auto shift = _mm256_and_si256(ms, _mm256_slli_epi16(extra, 1)); extra = _mm256_srli_epi16(extra, 1);
                     shift = _mm256_shuffle_epi8(shift, shift_shuffle);
@@ -4423,8 +4425,7 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
                     qx[2] = _mm256_add_epi8(qx[2], shift);
                     qx[3] = _mm256_add_epi8(qx[3], shift);
                 }
-
-#ifndef HAVE_FANCY_SIMD
+#else
                 auto shift = _mm256_and_si256(ms, _mm256_slli_epi16(extra, 1)); extra = _mm256_srli_epi16(extra, 1);
                 shift = _mm256_shuffle_epi8(shift, shift_shuffle);
                 qx[0] = _mm256_add_epi8(qx[0], shift);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -1576,7 +1576,7 @@ struct DequantizerQ4K final : public BaseDequantizer<block_q4_K> {
 };
 
 struct DequantizerIQ4XS final : public BaseDequantizer<block_iq4_xs> {
-    DequantizerIQ4XS(const void * vx, size_t bx) :5BaseDequantizer(vx, bx), values(load_iq4nl_values_256()) {}
+    DequantizerIQ4XS(const void * vx, size_t bx) : BaseDequantizer(vx, bx), values(load_iq4nl_values_256()) {}
     template <typename Q8>
     inline __m256i new_block(int i, const Q8& q8, __m256 * accd) {
         d = GGML_FP16_TO_FP32(x[i].d);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -4335,8 +4335,8 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
     auto shuff = _mm256_loadu_si256((const __m256i *)k_shuff);
 #else
     auto s_shuffle = _mm256_set_epi64x(0x0f0e0f0e0d0c0d0c, 0x0b0a0b0a09080908, 0x0706070605040504, 0x0302030201000100);
-#endif
     auto m128 = _mm256_set1_epi8(-128);
+#endif
     int nbl = n / QK_K;
     __m256  acc[nrc_y] = {};
     __m256i qx[4];
@@ -4379,23 +4379,32 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
                 qx[2] = _mm256_and_si256(_mm256_srli_epi16(lbits1, 4), m4);
                 qx[3] = _mm256_and_si256(_mm256_srli_epi16(lbits2, 4), m4);
 
-                // 0, 4, 1, 5
+#ifdef HAVE_FANCY_SIMD
+                auto q5vl = _mm256_shuffle_epi8(values[0], qx[0]);
+                auto q5vh = _mm256_shuffle_epi8(values[1], qx[0]);
+                qx[0] = _mm256_mask_blend_epi8(_mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x01)), _mm256_set1_epi8(0x01)), q5vl, q5vh);
 
-                // This is slower
-//#ifdef HAVE_FANCY_SIMD
-//                auto mask1 = _mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x01)), _mm256_set1_epi8(0x01));
-//                auto mask2 = _mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x10)), _mm256_set1_epi8(0x10));
-//                auto mask3 = _mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x02)), _mm256_set1_epi8(0x02));
-//                auto mask4 = _mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x20)), _mm256_set1_epi8(0x20));
-//                qx[0] = _mm256_mask_shuffle_epi8(_mm256_maskz_shuffle_epi8(_knot_mask64(mask1), values[0], qx[0]), mask1, values[1], qx[0]);
-//                qx[1] = _mm256_mask_shuffle_epi8(_mm256_maskz_shuffle_epi8(_knot_mask64(mask2), values[0], qx[1]), mask2, values[1], qx[1]);
-//                qx[2] = _mm256_mask_shuffle_epi8(_mm256_maskz_shuffle_epi8(_knot_mask64(mask3), values[0], qx[2]), mask3, values[1], qx[2]);
-//                qx[3] = _mm256_mask_shuffle_epi8(_mm256_maskz_shuffle_epi8(_knot_mask64(mask4), values[0], qx[3]), mask4, values[1], qx[3]);
-//                qx[0] = _mm256_add_epi8(qx[0], shift);
-//                qx[1] = _mm256_add_epi8(qx[1], shift);
-//                qx[2] = _mm256_add_epi8(qx[2], shift);
-//                qx[3] = _mm256_add_epi8(qx[3], shift);
-//#else
+                q5vl = _mm256_shuffle_epi8(values[0], qx[1]);
+                q5vh = _mm256_shuffle_epi8(values[1], qx[1]);
+                qx[1] = _mm256_mask_blend_epi8(_mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x10)), _mm256_set1_epi8(0x10)), q5vl, q5vh);
+
+                q5vl = _mm256_shuffle_epi8(values[0], qx[2]);
+                q5vh = _mm256_shuffle_epi8(values[1], qx[2]);
+                qx[2] = _mm256_mask_blend_epi8(_mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x02)), _mm256_set1_epi8(0x02)), q5vl, q5vh);
+
+                q5vl = _mm256_shuffle_epi8(values[0], qx[3]);
+                q5vh = _mm256_shuffle_epi8(values[1], qx[3]);
+                qx[3] = _mm256_mask_blend_epi8(_mm256_cmpeq_epi8_mask(_mm256_and_si256(hb, _mm256_set1_epi8(0x20)), _mm256_set1_epi8(0x20)), q5vl, q5vh);
+
+                if constexpr (nrc_y == 1) {
+                    auto shift = _mm256_and_si256(ms, _mm256_slli_epi16(extra, 1)); extra = _mm256_srli_epi16(extra, 1);
+                    shift = _mm256_shuffle_epi8(shift, shift_shuffle);
+                    qx[0] = _mm256_add_epi8(qx[0], shift);
+                    qx[1] = _mm256_add_epi8(qx[1], shift);
+                    qx[2] = _mm256_add_epi8(qx[2], shift);
+                    qx[3] = _mm256_add_epi8(qx[3], shift);
+                }
+#else
                 auto qh = _mm256_and_si256(_mm256_slli_epi16(hb, 7), m128);
                 auto q5vl = _mm256_or_si256(qx[0], qh);
                 auto q5vh = _mm256_or_si256(qx[0], _mm256_xor_si256(qh, m128));
@@ -4416,16 +4425,6 @@ static void mul_mat_iq5_k_r4_q8_k(int n, const void * vx, size_t bx, const DataI
                 q5vh = _mm256_or_si256(qx[3], _mm256_xor_si256(qh, m128));
                 qx[3] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
 
-#ifdef HAVE_FANCY_SIMD
-                if constexpr (nrc_y == 1) {
-                    auto shift = _mm256_and_si256(ms, _mm256_slli_epi16(extra, 1)); extra = _mm256_srli_epi16(extra, 1);
-                    shift = _mm256_shuffle_epi8(shift, shift_shuffle);
-                    qx[0] = _mm256_add_epi8(qx[0], shift);
-                    qx[1] = _mm256_add_epi8(qx[1], shift);
-                    qx[2] = _mm256_add_epi8(qx[2], shift);
-                    qx[3] = _mm256_add_epi8(qx[3], shift);
-                }
-#else
                 auto shift = _mm256_and_si256(ms, _mm256_slli_epi16(extra, 1)); extra = _mm256_srli_epi16(extra, 1);
                 shift = _mm256_shuffle_epi8(shift, shift_shuffle);
                 qx[0] = _mm256_add_epi8(qx[0], shift);

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -139,6 +139,12 @@ size_t quantize_q6_k_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT ds
 void   dequantize_row_q6_k_r4(const block_q6_k_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 void   vec_dot_q6_k_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
+void   quantize_row_iq5_k_r4_ref(const float * GGML_RESTRICT x, block_iq5_k_r4  * GGML_RESTRICT y, int64_t k);
+void   quantize_row_iq5_k_r4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+size_t quantize_iq5_k_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+void   dequantize_row_iq5_k_r4(const block_iq5_k_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void   vec_dot_iq5_k_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 void   quantize_row_iq4_k_r4_ref(const float * GGML_RESTRICT x, block_iq4_k_r4  * GGML_RESTRICT y, int64_t k);
 void   quantize_row_iq4_k_r4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 size_t quantize_iq4_k_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);

--- a/include/llama.h
+++ b/include/llama.h
@@ -196,6 +196,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_IQ2_K_R4      = 338, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ3_K_R4      = 339, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_K_R4      = 340, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_IQ5_K_R4      = 341, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q8_K_R8       = 399, // except 1d tensors
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3876,6 +3876,7 @@ struct llama_model_loader {
                 case GGML_TYPE_IQ4_K:   ftype = LLAMA_FTYPE_MOSTLY_IQ4_K;   break;
                 case GGML_TYPE_IQ4_K_R4:ftype = LLAMA_FTYPE_MOSTLY_IQ4_K_R4;break;
                 case GGML_TYPE_IQ5_K:   ftype = LLAMA_FTYPE_MOSTLY_IQ5_K;   break;
+                case GGML_TYPE_IQ5_K_R4:ftype = LLAMA_FTYPE_MOSTLY_IQ5_K_R4;break;
                 case GGML_TYPE_IQ6_K:   ftype = LLAMA_FTYPE_MOSTLY_IQ6_K;   break;
                 case GGML_TYPE_IQ3_S:   ftype = LLAMA_FTYPE_MOSTLY_IQ3_S;   break;
                 case GGML_TYPE_Q4_0_4_4: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_4_4; break;
@@ -4601,6 +4602,7 @@ static std::string llama_model_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_IQ4_K:    return "IQ4_K - 4.5 bpw";
         case LLAMA_FTYPE_MOSTLY_IQ4_K_R4: return "IQ4_K_R4 - 4.5 bpw";
         case LLAMA_FTYPE_MOSTLY_IQ5_K:    return "IQ5_K - 5.5 bpw";
+        case LLAMA_FTYPE_MOSTLY_IQ5_K_R4: return "IQ5_K_R4 - 5.5 bpw";
         case LLAMA_FTYPE_MOSTLY_IQ6_K:    return "IQ6_K - 6.6 bpw";
         case LLAMA_FTYPE_MOSTLY_IQ1_BN:   return "IQ1_BN - 1.625 bpw Bitnet";
         case LLAMA_FTYPE_MOSTLY_IQ2_BN:   return "IQ2_BN - 2.00 bpw Bitnet";
@@ -15854,6 +15856,9 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
             else if (new_type == GGML_TYPE_IQ4_K_R4) {
                 new_type = GGML_TYPE_IQ4_K;
             }
+            else if (new_type == GGML_TYPE_IQ5_K_R4) {
+                new_type = GGML_TYPE_IQ5_K;
+            }
             else if (new_type == GGML_TYPE_Q4_0_R4) {
                 new_type = GGML_TYPE_Q4_0;
             }
@@ -16150,7 +16155,7 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
         new_type == GGML_TYPE_IQ2_KS  || new_type == GGML_TYPE_IQ4_KSS || new_type == GGML_TYPE_Q6_K_R4 ||
         new_type == GGML_TYPE_Q5_K_R4 || new_type == GGML_TYPE_Q3_K_R4 || new_type == GGML_TYPE_Q2_K_R4 ||
         new_type == GGML_TYPE_IQ4_K_R4|| new_type == GGML_TYPE_Q8_K_R8 || new_type == GGML_TYPE_IQ3_K_R4||
-        new_type == GGML_TYPE_IQ2_K_R4) {
+        new_type == GGML_TYPE_IQ2_K_R4|| new_type == GGML_TYPE_IQ5_K_R4) {
         int nx = tensor->ne[0];
         int ny = tensor->ne[1];
         if (nx % QK_K != 0) {
@@ -16193,6 +16198,7 @@ static ggml_type llama_tensor_get_type(quantize_state_internal & qs, ggml_type n
             case GGML_TYPE_Q4_K_R4:
             case GGML_TYPE_Q4_K:   new_type = GGML_TYPE_Q5_0;   break;
             case GGML_TYPE_IQ5_K:
+            case GGML_TYPE_IQ5_K_R4:
             case GGML_TYPE_Q5_K_R4:
             case GGML_TYPE_Q5_K:   new_type = GGML_TYPE_Q6_0;   break;
             case GGML_TYPE_IQ6_K:
@@ -16325,6 +16331,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
         case LLAMA_FTYPE_MOSTLY_IQ4_K:   default_type = GGML_TYPE_IQ4_K;   break;
         case LLAMA_FTYPE_MOSTLY_IQ4_K_R4:default_type = GGML_TYPE_IQ4_K_R4;break;
         case LLAMA_FTYPE_MOSTLY_IQ5_K:   default_type = GGML_TYPE_IQ5_K;   break;
+        case LLAMA_FTYPE_MOSTLY_IQ5_K_R4:default_type = GGML_TYPE_IQ5_K_R4;break;
         case LLAMA_FTYPE_MOSTLY_IQ6_K:   default_type = GGML_TYPE_IQ6_K;   break;
         case LLAMA_FTYPE_MOSTLY_IQ3_S:   default_type = GGML_TYPE_IQ3_S;   break;
         case LLAMA_FTYPE_MOSTLY_IQ3_M:   default_type = GGML_TYPE_IQ3_S;   break;
@@ -16739,6 +16746,10 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
             }
             else if (new_type == GGML_TYPE_IQ4_K_R4) {
                 if (tensor->ne[1] % 4 != 0) new_type = GGML_TYPE_IQ4_K;
+                else chunk_size_multiplier = 4;
+            }
+            else if (new_type == GGML_TYPE_IQ5_K_R4) {
+                if (tensor->ne[1] % 4 != 0) new_type = GGML_TYPE_IQ5_K;
                 else chunk_size_multiplier = 4;
             }
             else if (new_type == GGML_TYPE_BF16_R16) {


### PR DESCRIPTION

Adding `IQ5_K` with 4 interleaved rows.

We get very signifiant performance gains on `ARM_NEON` and more modest gains on `AVX2/Zen4`. 

Here is `PP-512` for LLaMA-3.1-8B on `Zen4` (Ryzen-7950X), `ARM_NEON` (M2-Max) and `AVX2` (Ryzen-5975WX)

| Platform |  Threads | IQ5_K | IQ5_K_R4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON |  8 |  53.80 ± 1.08  |  93.33 ± 2.02 | 1.735 |
| Zen4            | 16 | 168.09 ± 0.58 | 230.23 ± 0.23    | 1.370 |
| AVX2           | 32 | 177.16 ± 0.31 |  231.50 ± 0.43   | 1.307 |

TG does not look good on AVX2/Zen4. On ARM_NEON we get a decent performance gain.
Here results for TG-128 on LLaMA-3.1-8B with different numbers of threads:

| Platform |  Threads | IQ5_K | IQ5_K_R4 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| ARM_NEON | 2 |  5.92 ± 0.07 | 6.98 ± 0.00 | 1.179 |
|                      | 4 | 11.53 ± 0.01  | 13.35 ± 0.01 | 1.158 |
|                      | 8 | 20.29 ± 0.46 | 21.17 ± 0.18  | 1.043 |

