### PR TITLE
MoE fix for R4 quants

### DIFF
--- a/examples/batched-bench/batched-bench.cpp
+++ b/examples/batched-bench/batched-bench.cpp
@@ -139,6 +139,8 @@ int main(int argc, char ** argv) {
                 const int n_ctx_req = is_pp_shared ? pp + pl*tg : pl*(pp + tg);
 
                 if (n_ctx_req > n_kv_max) {
+                    printf("n_ctx_req = %d is greater than n_kv_max = %d for pp = %d, tg = %d, pl = %d\n",
+                            n_ctx_req, n_kv_max, pp, tg, pl);
                     continue;
                 }
 

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -142,13 +142,14 @@ struct MulMat {
         }
         int ny = funcs.size();
         while (!funcs[ny-1] && ny > 0) --ny;
-        int n_step = (nrc_y - info.cur_y)/ny;
+        int n_left = nrc_y - info.cur_y;
+        int n_step = n_left/ny;
         if (n_step > 0) {
-            if (n_step*ny != nrc_y) {
+            if (n_step*ny != n_left) {
                 ++n_step;
-                int ny1 = nrc_y/n_step;
+                int ny1 = n_left/n_step;
                 int ny2 = ny1 + 1;
-                int my1 = n_step*ny2 - nrc_y;
+                int my1 = n_step*ny2 - n_left;
                 int my2 = n_step - my1;
                 for (int ix = 0; ix < nrc_x; ix += k_x_step) {
                     auto this_info = info;
@@ -163,7 +164,7 @@ struct MulMat {
                         this_info.cur_y += ny2;
                     }
                 }
-                info.cur_y += nrc_y;
+                info.cur_y += n_left;
             }
             else {
                 for (int ix = 0; ix < nrc_x; ix += k_x_step) {
@@ -178,7 +179,7 @@ struct MulMat {
                 info.cur_y += ny * n_step;
             }
         }
-        int n_left = nrc_y - info.cur_y;
+        n_left = nrc_y - info.cur_y;
         if (n_left > 0) {
             funcs[n_left-1](n, vx, bx, info, nrc_x);
         }
@@ -13597,6 +13598,7 @@ void compute_helper(KHelper& kh, VHelper& vh, int nq1, int nk1, int stride_q, in
 #ifdef __aarch64__
     float16_t q_f16[D*q_step];
 #endif
+
     for (int i1 = 0; i1 < nq1/q_step; ++i1) {
         fms.init_qstep();
         kh.reset_block();


### PR DESCRIPTION

This PR adds two fixes:
* Make sure number of tensor rows being processed by one thread is a multiple of the number of interleaved rows when using `R4` quants also in `iqk_mul_mat_mow`
* Fix logic when we have a matrix multiplication kernel that processes 16 columns of the right matrix per kernel call (introduced on 907cde6be). The bug shows up when the number of columns in the right matrix is greater than 16 (so this kernel gets used), and the number of columns is not divisible by 16 (so there are leftover columns to be processed), so did not get caught by the usual `TG-128` and `PP-512` testing.

If quantized to `R4` quants, MoE models now work. But if run-time-repacking is used (`-rtr` command line option) to repack non-`R4` quants to `R4`, something goes wrong for MoE models that I'm not able to figure out. It is really bizarre because in the former case (quantize directly into `R4`) four rows are quantized to the corresponding non-`R4` quant in a temporary buffer and then repacked to `R4`. In the later case, 4 rows are copied into a temporary buffer and then repacked, storrng the repacked data into the memory from where the data was copied. The exact same repacking function is used in both cases, so I don't see how `rtr` can fail. What is even more bizarre is that `rtr` always works for non-MoE models, and also works for some quantization types for MoE models.