### PR TITLE
More Flash Attention improvements

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12691,11 +12691,11 @@ struct HelperQ80 final : public BaseHelper<step> {
 template <int D, int step>
 struct HelperQ80R4 : public BaseHelper<step> {
     using Base = BaseHelper<step>;
-//#ifdef HAVE_FANCY_SIMD
+#ifdef __AVX2__
     using block_q8 = block_q8_1;
-//#else
-//    using block_q8 = block_q8_0;
-//#endif
+#else
+    using block_q8 = block_q8_0;
+#endif
     HelperQ80R4(int nk, const HelperQ80<D, step>& q8) : Base(q8.data, q8.stride) {
         r4 = repack(nk, q8);
         Base::data = (const char *)r4.data();

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12663,8 +12663,8 @@ struct HelperQ80 final : public BaseHelper<step> {
         v2 = _mm512_mul_ps(vd, _mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(_mm_loadu_si128((const __m128i *)dl->qs+1))));
 #else
         int ii = j%QK8_0;
-        v1 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(dl->qs+ii)+0))));
-        v2 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(dl->qs+ii)+1))));
+        v1 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(dl->qs+ii+0)))));
+        v2 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(dl->qs+ii+8)))));
 #endif
 #endif
     }
@@ -12691,11 +12691,11 @@ struct HelperQ80 final : public BaseHelper<step> {
 template <int D, int step>
 struct HelperQ80R4 : public BaseHelper<step> {
     using Base = BaseHelper<step>;
-#ifdef HAVE_FANCY_SIMD
+//#ifdef HAVE_FANCY_SIMD
     using block_q8 = block_q8_1;
-#else
-    using block_q8 = block_q8_0;
-#endif
+//#else
+//    using block_q8 = block_q8_0;
+//#endif
     HelperQ80R4(int nk, const HelperQ80<D, step>& q8) : Base(q8.data, q8.stride) {
         r4 = repack(nk, q8);
         Base::data = (const char *)r4.data();

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12730,8 +12730,28 @@ struct HelperQ80R4 : public BaseHelper<step> {
                 _mm256_storeu_si256((__m256i *)y[ib].qs + 1, m1);
                 _mm256_storeu_si256((__m256i *)y[ib].qs + 2, m2);
                 _mm256_storeu_si256((__m256i *)y[ib].qs + 3, m3);
+#elif defined __ARM_NEON
+                auto m0 = vld1q_s8_x2(x4[0][ib].qs);
+                auto m1 = vld1q_s8_x2(x4[1][ib].qs);
+                auto m2 = vld1q_s8_x2(x4[2][ib].qs);
+                auto m3 = vld1q_s8_x2(x4[3][ib].qs);
+                auto row01 = vtrnq_s32(vreinterpretq_s32_s8(m0.val[0]), vreinterpretq_s32_s8(m1.val[0]));
+                auto row23 = vtrnq_s32(vreinterpretq_s32_s8(m2.val[0]), vreinterpretq_s32_s8(m3.val[0]));
+                m0.val[0] = vreinterpretq_s8_s64(vtrn1q_s64(vreinterpretq_s64_s32(row01.val[0]), vreinterpretq_s64_s32(row23.val[0])));
+                m1.val[0] = vreinterpretq_s8_s64(vtrn1q_s64(vreinterpretq_s64_s32(row01.val[1]), vreinterpretq_s64_s32(row23.val[1])));
+                m2.val[0] = vreinterpretq_s8_s64(vtrn2q_s64(vreinterpretq_s64_s32(row01.val[0]), vreinterpretq_s64_s32(row23.val[0])));
+                m3.val[0] = vreinterpretq_s8_s64(vtrn2q_s64(vreinterpretq_s64_s32(row01.val[1]), vreinterpretq_s64_s32(row23.val[1])));
+                row01 = vtrnq_s32(vreinterpretq_s32_s8(m0.val[1]), vreinterpretq_s32_s8(m1.val[1]));
+                row23 = vtrnq_s32(vreinterpretq_s32_s8(m2.val[1]), vreinterpretq_s32_s8(m3.val[1]));
+                m0.val[1] = vreinterpretq_s8_s64(vtrn1q_s64(vreinterpretq_s64_s32(row01.val[0]), vreinterpretq_s64_s32(row23.val[0])));
+                m1.val[1] = vreinterpretq_s8_s64(vtrn1q_s64(vreinterpretq_s64_s32(row01.val[1]), vreinterpretq_s64_s32(row23.val[1])));
+                m2.val[1] = vreinterpretq_s8_s64(vtrn2q_s64(vreinterpretq_s64_s32(row01.val[0]), vreinterpretq_s64_s32(row23.val[0])));
+                m3.val[1] = vreinterpretq_s8_s64(vtrn2q_s64(vreinterpretq_s64_s32(row01.val[1]), vreinterpretq_s64_s32(row23.val[1])));
+                vst1q_s8_x2(y[ib].qs +  0, m0);
+                vst1q_s8_x2(y[ib].qs + 32, m1);
+                vst1q_s8_x2(y[ib].qs + 64, m2);
+                vst1q_s8_x2(y[ib].qs + 96, m3);
 #else
-                // TODO: optimize
                 for (int l = 0; l < 4; ++l) {
                     for (int k = 0; k < 4; ++k) for (int i = 0; i < 4; ++i) {
                         y[ib].qs[32*l+4*k+i+ 0] = x4[k][ib].qs[i+4*l+ 0];

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -48,7 +48,7 @@
 // For fp16/fp32 matri multiplications tiling is used to improve
 // performance.
 
-#define FA_TIMING 1
+#define FA_TIMING 0
 
 #include <utility>
 #include <array>

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12063,6 +12063,46 @@ void mul_mat_q8_0_r4_q8_0(int n, const void * vx, size_t bx, const DataInfo& inf
     }
 }
 
+template <int nrc_y>
+void mul_mat_q8_0_r4_q8_0_128(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    GGML_ASSERT(nrc_x%4 == 0);
+    GGML_ASSERT(n == 128);
+    int8x16x4_t qx[8];
+    float32x4_t scales[4];
+    float32x4_t scales_y[4];
+    for (int ix = 0; ix < nrc_x; ix += 4) {
+        const block_q8_0_x4 * iq8 = (const block_q8_0_x4 *)((const char *)vx + ix*bx);
+        for (int k = 0; k < 4; ++k) {
+            scales[k] = vcvt_f32_f16(vld1_f16((const float16_t *)iq8[k].d));
+            qx[2*k+0] = vld1q_s8_x4(iq8[k].qs);
+            qx[2*k+1] = vld1q_s8_x4(iq8[k].qs+64);
+        }
+        for (int iy = 0; iy < nrc_y; ++iy) {
+            auto by = (const block_q8_0_x4 *)info.src1_row(iy);
+            auto d8 = vcvt_f32_f16(vld1_f16((const float16_t *)by->d));
+            scales_y[0] = vmulq_laneq_f32(scales[0], d8, 0);
+            scales_y[1] = vmulq_laneq_f32(scales[1], d8, 1);
+            scales_y[2] = vmulq_laneq_f32(scales[2], d8, 2);
+            scales_y[3] = vmulq_laneq_f32(scales[3], d8, 3);
+            auto sumf = vdupq_n_f32(0.f);
+            for (int k = 0; k < 4; ++k) {
+                auto y = vld1q_s8_x2(by->qs+32*k);
+                auto sumi = vdupq_n_s32(0);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+0].val[0], y.val[0], 0);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+0].val[1], y.val[1], 0);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+0].val[2], y.val[0], 1);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+0].val[3], y.val[1], 1);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+1].val[0], y.val[0], 2);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+1].val[1], y.val[1], 2);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+1].val[2], y.val[0], 3);
+                sumi = vdotq_laneq_s32(sumi, qx[2*k+1].val[3], y.val[1], 3);
+                sumf = vfmaq_f32(sumf, scales_y[k], vcvtq_f32_s32(sumi));
+            }
+            info.store(ix, iy, sumf);
+        }
+    }
+}
+
 #define SET_MUL_MAT_FUNCTIONS_T(m, func, Dequantizer) \
             m.funcs[0] = func<Dequantizer, 1>;\
             m.funcs[1] = func<Dequantizer, 2>;\
@@ -13645,7 +13685,23 @@ struct FlashQKfp32 {
         }
         else if constexpr (std::is_same_v<KHelper, HelperQ80R4<D, k_step>>) {
 #ifdef __aarch64__
-            MAKE_FUNCS_ONLY_NRC(mul_mat_q8_0_r4_q8_0, nq);
+            if constexpr (D == 128) {
+                if (q_step >= 64 && nq >= 64) {
+                    return std::make_pair(mul_mat_q8_0_r4_q8_0_128<64>, 64);
+                }
+                else if (q_step >= 32 && nq >= 32) {
+                    return std::make_pair(mul_mat_q8_0_r4_q8_0_128<32>, 32);
+                }
+                else if (q_step >= 16 && nq >= 16) {
+                    return std::make_pair(mul_mat_q8_0_r4_q8_0_128<16>, 16);
+                }
+                else {
+                    MAKE_FUNCS_ONLY_NRC(mul_mat_q8_0_r4_q8_0_128, nq);
+                }
+            } else {
+                MAKE_FUNCS_ONLY_NRC(mul_mat_q8_0_r4_q8_0, nq);
+            }
+            //MAKE_FUNCS_ONLY_NRC(mul_mat_q8_0_r4_q8_0, nq);
 #else
 #ifdef HAVE_FANCY_SIMD
             if constexpr (D == 128) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -13029,41 +13029,6 @@ struct FlashQKV {
             }
         }
     }
-    //template <typename VHelper, int Nq = q_step, class = std::enable_if<Nq >= 2>>
-    //inline void accumulate_qkv(int nq1, const VHelper& vh, const FlashMS<q_step, k_step>& fms) {
-    //    F16::Data vk[2*q_step];
-    //    for (int i = 0; i < D/F16::block_size; i += 2) {
-    //        for (int j = 0; j < nq1; ++j) {
-    //            if (fms.need_scaling[j] == 2) {
-    //                vk[2*j+0] = vk[2*j+1] = F16::zero();
-    //            } else {
-    //                auto R = qkv_cache + D*j;
-    //                vk[2*j+0] = F16::load(R + F16::block_size*i);
-    //                vk[2*j+1] = F16::load(R + F16::block_size*(i + 1));
-    //                if (fms.need_scaling[j] == 1) {
-    //                    vk[2*j+0] = F16::mul(vk[2*j+0], fms.vms[j]);
-    //                    vk[2*j+1] = F16::mul(vk[2*j+1], fms.vms[j]);
-    //                }
-    //            }
-    //        }
-    //        F16::Data v1, v2, v3, v4;
-    //        for (int l1 = 0; l1 < k_step; l1 += 2) {
-    //            vh.load(l1+0, i, v1, v2);
-    //            vh.load(l1+1, i, v3, v4);
-    //            for (int j = 0; j < nq1; ++j) {
-    //                auto vs1 = F16::set1(fms.cache[k_step*j + l1+0]);
-    //                auto vs2 = F16::set1(fms.cache[k_step*j + l1+1]);
-    //                vk[2*j+0] = F16::fmadd(F16::fmadd(vk[2*j+0], v1, vs1), v3, vs2);
-    //                vk[2*j+1] = F16::fmadd(F16::fmadd(vk[2*j+1], v2, vs1), v4, vs2);
-    //            }
-    //        }
-    //        for (int j = 0; j < nq1; ++j) {
-    //            auto R = qkv_cache + D*j;
-    //            F16::store(R + F16::block_size*(i + 0), vk[2*j+0]);
-    //            F16::store(R + F16::block_size*(i + 1), vk[2*j+1]);
-    //        }
-    //    }
-    //}
 
     inline void normalize_and_store(const FlashMS<q_step, k_step>& fms, int j, const qkv_cache_t * R, float * qkv) const {
         GGML_ASSERT(fms.S[j] > 0);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12354,6 +12354,15 @@ struct F16 {
     static inline float reduce_add(Data data) { return _mm512_reduce_add_ps(data); }
     static inline Data max(Data v1, Data v2) { return _mm512_max_ps(v1, v2); }
     static inline Data add(Data v1, Data v2) { return _mm512_add_ps(v1, v2); }
+    static inline Data set4(const float * ptr) {
+        auto v128 = _mm_loadu_ps(ptr);
+        auto v256 = _mm256_set_m128(v128, v128);
+        return _mm512_insertf32x8(_mm512_castps256_ps512(v256), v256, 1);
+    }
+    static inline Data fmadd_lane0(Data prev, Data v1, Data v2) { return _mm512_fmadd_ps(v1, _mm512_shuffle_ps(v2, v2, 0x00), prev); }
+    static inline Data fmadd_lane1(Data prev, Data v1, Data v2) { return _mm512_fmadd_ps(v1, _mm512_shuffle_ps(v2, v2, 0x55), prev); }
+    static inline Data fmadd_lane2(Data prev, Data v1, Data v2) { return _mm512_fmadd_ps(v1, _mm512_shuffle_ps(v2, v2, 0xaa), prev); }
+    static inline Data fmadd_lane3(Data prev, Data v1, Data v2) { return _mm512_fmadd_ps(v1, _mm512_shuffle_ps(v2, v2, 0xff), prev); }
 #elif defined __AVX2__
     using Data = __m256;
     constexpr static int block_size = 8;
@@ -12371,6 +12380,14 @@ struct F16 {
     static inline float reduce_add(Data data) { return hsum_float_8(data); }
     static inline Data max(Data v1, Data v2) { return _mm256_max_ps(v1, v2); }
     static inline Data add(Data v1, Data v2) { return _mm256_add_ps(v1, v2); }
+    static inline Data set4(const float * ptr) {
+        auto v128 = _mm_loadu_ps(ptr);
+        return _mm256_set_m128(v128, v128);
+    }
+    static inline Data fmadd_lane0(Data prev, Data v1, Data v2) { return _mm256_fmadd_ps(v1, _mm256_shuffle_ps(v2, v2, 0x00), prev); }
+    static inline Data fmadd_lane1(Data prev, Data v1, Data v2) { return _mm256_fmadd_ps(v1, _mm256_shuffle_ps(v2, v2, 0x55), prev); }
+    static inline Data fmadd_lane2(Data prev, Data v1, Data v2) { return _mm256_fmadd_ps(v1, _mm256_shuffle_ps(v2, v2, 0xaa), prev); }
+    static inline Data fmadd_lane3(Data prev, Data v1, Data v2) { return _mm256_fmadd_ps(v1, _mm256_shuffle_ps(v2, v2, 0xff), prev); }
 #else
     using Data = float16x8_t;
     constexpr static int block_size = 8;
@@ -12402,6 +12419,15 @@ struct F16 {
     }
     static inline Data max(Data v1, Data v2) { return vmaxq_f16(v1, v2); }
     static inline Data add(Data v1, Data v2) { return vaddq_f16(v1, v2); }
+    static inline Data set4(const float * ptr) {
+        auto val32 = vld1q_f32(ptr);
+        auto val16 = vcvt_f16_f32(val32);
+        return vcombine_f16(val16, val16);
+    }
+    static inline Data fmadd_lane0(Data prev, Data v1, Data v2) { return vfmaq_laneq_f16(vfmaq_laneq_f16(prev, v1, v2, 0), v1, v2, 4); }
+    static inline Data fmadd_lane1(Data prev, Data v1, Data v2) { return vfmaq_laneq_f16(vfmaq_laneq_f16(prev, v1, v2, 1), v1, v2, 5); }
+    static inline Data fmadd_lane2(Data prev, Data v1, Data v2) { return vfmaq_laneq_f16(vfmaq_laneq_f16(prev, v1, v2, 2), v1, v2, 6); }
+    static inline Data fmadd_lane3(Data prev, Data v1, Data v2) { return vfmaq_laneq_f16(vfmaq_laneq_f16(prev, v1, v2, 3), v1, v2, 7); }
 #endif
     template <int k_step> static inline float reduce_max(const Data * data) {
         return reduce_T<k_step, &F16::max, &F16::reduce_max>(data);
@@ -12927,38 +12953,129 @@ struct FlashQKV {
     // Hence, for now, we will not handle head sizes of 80 and 112
     template <typename VHelper>
     inline void accumulate_qkv(const VHelper& vh, const FlashMS<q_step, k_step>& fms) {
-        F16::Data vk[2*q_step];
-        for (int i = 0; i < D/F16::block_size; i += 2) {
-            for (int j = 0; j < q_step; ++j) {
-                if (fms.need_scaling[j] == 2) {
-                    vk[2*j+0] = vk[2*j+1] = F16::zero();
-                } else {
-                    auto R = qkv_cache + D*j;
-                    vk[2*j+0] = F16::load(R + F16::block_size*i);
-                    vk[2*j+1] = F16::load(R + F16::block_size*(i + 1));
-                    if (fms.need_scaling[j] == 1) {
-                        vk[2*j+0] = F16::mul(vk[2*j+0], fms.vms[j]);
-                        vk[2*j+1] = F16::mul(vk[2*j+1], fms.vms[j]);
-                    }
-                }
+        F16::Data v[8];
+        for (int j = 0; j < q_step; ++j) {
+            auto R = qkv_cache + D*j;
+            if (fms.need_scaling[j] == 2) {
+                std::memset(R, 0, D*sizeof(qkv_cache_t));
             }
-            F16::Data v1, v2, v3, v4;
-            for (int l1 = 0; l1 < k_step; l1 += 2) {
-                vh.load(l1+0, i, v1, v2);
-                vh.load(l1+1, i, v3, v4);
-                for (int j = 0; j < q_step; ++j) {
-                    auto vs1 = F16::set1(fms.cache[k_step*j + l1+0]);
-                    auto vs2 = F16::set1(fms.cache[k_step*j + l1+1]);
-                    vk[2*j+0] = F16::fmadd(F16::fmadd(vk[2*j+0], v1, vs1), v3, vs2);
-                    vk[2*j+1] = F16::fmadd(F16::fmadd(vk[2*j+1], v2, vs1), v4, vs2);
+            else if (fms.need_scaling[j] == 1) {
+                for (int i = 0; i < D/F16::block_size; ++i) {
+                    F16::store(R + F16::block_size*i, F16::mul(fms.vms[j], F16::load(R + F16::block_size*i)));
                 }
-            }
-            for (int j = 0; j < q_step; ++j) {
-                auto R = qkv_cache + D*j;
-                F16::store(R + F16::block_size*(i + 0), vk[2*j+0]);
-                F16::store(R + F16::block_size*(i + 1), vk[2*j+1]);
             }
         }
+        for (int i = 0; i < D/F16::block_size; i += 2) {
+            for (int l = 0; l < k_step; l += 4) {
+                vh.load(l+0, i, v[0], v[4]);
+                vh.load(l+1, i, v[1], v[5]);
+                vh.load(l+2, i, v[2], v[6]);
+                vh.load(l+3, i, v[3], v[7]);
+                for (int j = 0; j < q_step; ++j) {
+                    auto R = qkv_cache + D*j;
+                    auto s1 = F16::load(R + F16::block_size*(i+0));
+                    auto s2 = F16::load(R + F16::block_size*(i+1));
+                    auto vs = F16::set4(fms.cache + k_step*j + l);
+                    s1 = F16::fmadd_lane0(s1, v[0], vs);
+                    s2 = F16::fmadd_lane0(s2, v[4], vs);
+                    s1 = F16::fmadd_lane1(s1, v[1], vs);
+                    s2 = F16::fmadd_lane1(s2, v[5], vs);
+                    s1 = F16::fmadd_lane2(s1, v[2], vs);
+                    s2 = F16::fmadd_lane2(s2, v[6], vs);
+                    s1 = F16::fmadd_lane3(s1, v[3], vs);
+                    s2 = F16::fmadd_lane3(s2, v[7], vs);
+                    F16::store(R + F16::block_size*(i+0), s1);
+                    F16::store(R + F16::block_size*(i+1), s2);
+                }
+            }
+        }
+        //F16::Data vk[2*q_step];
+        //for (int i = 0; i < D/F16::block_size; i += 2) {
+        //    for (int j = 0; j < q_step; ++j) {
+        //        if (fms.need_scaling[j] == 2) {
+        //            vk[2*j+0] = vk[2*j+1] = F16::zero();
+        //        } else {
+        //            auto R = qkv_cache + D*j;
+        //            vk[2*j+0] = F16::load(R + F16::block_size*i);
+        //            vk[2*j+1] = F16::load(R + F16::block_size*(i + 1));
+        //            if (fms.need_scaling[j] == 1) {
+        //                vk[2*j+0] = F16::mul(vk[2*j+0], fms.vms[j]);
+        //                vk[2*j+1] = F16::mul(vk[2*j+1], fms.vms[j]);
+        //            }
+        //        }
+        //    }
+        //    // R[j][i] += sum[l, V[l][i] * C[j][l] ]
+        //    // If we transpose V, we can accumulate as
+        //    // R[i][j] += sum [l, V[i][l] * C[j][l] ]
+        //    //   or
+        //    // R[j][i] += sum [l, V[i][l] * C[j][l] ]
+        //    // so
+        //    // for (int j = 0; j < q_step; ++j) {
+        //    //     for (int i = 0; i < D; ++i) {
+        //    //         for (int l = 0; l < k_step; ++k) {
+        //    //             R[j][i] += V[i][l] * C[j][l];
+        //    //         }
+        //    //     }
+        //    // }
+        //    // so
+        //    // for (int j = 0; j < q_step; ++j) {
+        //    //     for (int i = 0; i < D/F16::block_size; ++i) {
+        //    //         auto acc = F16::load(qkv_cache + D*j + F16::block_size*i);
+        //    //         for (int l = 0; l < k_step/F16::block_size; ++k) {
+        //    //             auto vk = vh.load1(j, l);
+        //    //             auto vs = F16::load(fms.cache(k_step*j + l*F16::block_size];
+        //    //             acc = F16::fmadd(acc, vk, vs);
+        //    //         }
+        //    //     }
+        //    // }
+        //    // but for k_step = 32, q_step = 8, F16::bloc = 32, we need only 16 registers to load the entire fms.cache
+        //    // F16::Data C[4*k_step/F16::block_size];
+        //    // F16::Data V[4*k_step/F16::block_size];
+        //    // F16::Data acc[4*k_step/F16::block_size];
+        //    // for (int j = 0; j < q_step; j += 4) {
+        //    //     for (int l = 0; l < k_step/F16::block_size; ++l) {
+        //    //         C[(k_step/F16::block_size)*(j+0) + l] = F16::load(fms.cache + k_step*(j+0) + l*F16::block_size);
+        //    //         C[(k_step/F16::block_size)*(j+1) + l] = F16::load(fms.cache + k_step*(j+1) + l*F16::block_size);
+        //    //         C[(k_step/F16::block_size)*(j+2) + l] = F16::load(fms.cache + k_step*(j+2) + l*F16::block_size);
+        //    //         C[(k_step/F16::block_size)*(j+3) + l] = F16::load(fms.cache + k_step*(j+3) + l*F16::block_size);
+        //    //         V[(k_step/F16::block_size)*(j+0) + l] = vh.load(j+0, l);
+        //    //         V[(k_step/F16::block_size)*(j+1) + l] = vh.load(j+1, l);
+        //    //         V[(k_step/F16::block_size)*(j+2) + l] = vh.load(j+2, l);
+        //    //         V[(k_step/F16::block_size)*(j+3) + l] = vh.load(j+3, l);
+        //    //     }
+        //    //     for (int i = 0; i < D/F16::block_size; ++i) {
+        //    //         auto acc = F16::load(qkv_cache + D*(j+0) + F16::block_size*i);
+        //    //         for (int l = 0; l < k_step/F16::block_size; ++l) {
+        //    //             acc = F16::fmadd(acc, C[(k_step/F16::block_size)*(j+0)+l], V[(k_step/F16::block_size)*(j+0)+l]);
+        //    //         acc1 = F16::fmadd(F16::fmadd(acc1, C[(k_step/F16::block_size)*(j+0), 
+        //    //         acc[0] = F16::load(qkv_cache + D*(j+0) + F16::block_size*(i+0));
+        //    //         acc[1] = F16::load(qkv_cache + D*(j+0) + F16::block_size*(i+1));
+        //    //         acc[2] = F16::load(qkv_cache + D*(j+1) + F16::block_size*(i+0));
+        //    //         acc[3] = F16::load(qkv_cache + D*(j+1) + F16::block_size*(i+1));
+        //    //         acc[4] = F16::load(qkv_cache + D*(j+2) + F16::block_size*(i+0));
+        //    //         acc[5] = F16::load(qkv_cache + D*(j+2) + F16::block_size*(i+1));
+        //    //         acc[6] = F16::load(qkv_cache + D*(j+3) + F16::block_size*(i+0));
+        //    //         acc[7] = F16::load(qkv_cache + D*(j+3) + F16::block_size*(i+1));
+        //    //
+        //    //     }
+        //    // }
+        //    F16::Data v1, v2, v3, v4;
+        //    for (int l1 = 0; l1 < k_step; l1 += 2) {
+        //        vh.load(l1+0, i, v1, v2);
+        //        vh.load(l1+1, i, v3, v4);
+        //        for (int j = 0; j < q_step; ++j) {
+        //            auto vs1 = F16::set1(fms.cache[k_step*j + l1+0]);
+        //            auto vs2 = F16::set1(fms.cache[k_step*j + l1+1]);
+        //            vk[2*j+0] = F16::fmadd(F16::fmadd(vk[2*j+0], v1, vs1), v3, vs2);
+        //            vk[2*j+1] = F16::fmadd(F16::fmadd(vk[2*j+1], v2, vs1), v4, vs2);
+        //        }
+        //    }
+        //    for (int j = 0; j < q_step; ++j) {
+        //        auto R = qkv_cache + D*j;
+        //        F16::store(R + F16::block_size*(i + 0), vk[2*j+0]);
+        //        F16::store(R + F16::block_size*(i + 1), vk[2*j+1]);
+        //    }
+        //}
     }
 
     template <typename VHelper, int Nq = q_step, class = std::enable_if<Nq >= 2>>

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12861,7 +12861,7 @@ struct FlashMS {
         if (smax > M[j]) {
             if (M[j] > -INFINITY) {
                 float m = expf(M[j] - smax);
-                vms[j] = F16::set1(m);
+                vms[j] = m;
                 need_scaling[j] = 1;
                 S[j] *= m;
             } else {
@@ -13043,7 +13043,7 @@ struct FlashMS {
     cache_t cache[q_step*k_step];
     float S[q_step], M[q_step];
     int need_scaling[q_step];
-    F16::Data vms[q_step];
+    float vms[q_step];
     const F16::Data vscale;
     const float  softcap;
     const ggml_half h_inf;
@@ -13070,8 +13070,9 @@ struct FlashQKV {
                 std::memset(R, 0, D*sizeof(qkv_cache_t));
             }
             else if (fms.need_scaling[j] == 1) {
+                auto vms = F16::set1(fms.vms[j]);
                 for (int i = 0; i < D/F16::block_size; ++i) {
-                    F16::store(R + F16::block_size*i, F16::mul(fms.vms[j], F16::load(R + F16::block_size*i)));
+                    F16::store(R + F16::block_size*i, F16::mul(vms, F16::load(R + F16::block_size*i)));
                 }
             }
         }
@@ -13110,8 +13111,9 @@ struct FlashQKV {
                 std::memset(R, 0, D*sizeof(qkv_cache_t));
             }
             else if (fms.need_scaling[j] == 1) {
+                auto vms = F16::set1(fms.vms[j]);
                 for (int i = 0; i < D/F16::block_size; ++i) {
-                    F16::store(R + F16::block_size*i, F16::mul(fms.vms[j], F16::load(R + F16::block_size*i)));
+                    F16::store(R + F16::block_size*i, F16::mul(vms, F16::load(R + F16::block_size*i)));
                 }
             }
         }


### PR DESCRIPTION

This PR further improves the Flash Attention implementation as follows:
* Slightly faster `V * softmax(K * Q)` implementation. This benefits all V-cache types
* Faster implementation when the K-cache is quantized with `Q8_0` via run-time-repacking to `Q8_0_R4`.

The following graph shows prompt processing speed as a function of prompt length for LLaMA-3.1-8B quantized with `IQ4_XS` on a Ryzem-7950X CPU. The PR results are shown with black (`BF16` KV-cache) and red (`Q8_0` KV-cache) triangles, circles are used for the main branch.  I have reused the graph from the last post in #25 by just adding the results for this PR, so mainline `llama.cpp` performance is shown as well. I'm particularly pleased with the fact that `Q8_0` KV-cache is now on per or even slightly better than the natively supported 16-bit float type as `Q8_0` quantized KV-cache is basically lossless while reducing required memory by 2X.

For reference, with a `Q8_K_R8`-quantized model we achieve 380 t/s for 512 tokens, and 150 t/s for 32k tokens.   

![pp512_vs_ctx](https://github.com/user-attachments/assets/cc1e7ce5-c596-47b0-a56a-912a196d2e38)
