### PR TITLE
Various

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -220,6 +220,7 @@ struct cmd_params {
     std::vector<int> n_prompt;
     std::vector<int> n_gen;
     std::vector<std::pair<int, int>> n_pg;
+    std::vector<std::pair<int, int>> n_gp;
     std::vector<int> n_batch;
     std::vector<int> n_ubatch;
     std::vector<ggml_type> type_k;
@@ -248,6 +249,7 @@ static const cmd_params cmd_params_defaults = {
     /* n_prompt             */ {512},
     /* n_gen                */ {128},
     /* n_pg                 */ {},
+    /* n_gp                 */ {},
     /* n_batch              */ {2048},
     /* n_ubatch             */ {512},
     /* type_k               */ {GGML_TYPE_F16},
@@ -280,6 +282,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -p, --n-prompt <n>                  (default: %s)\n", join(cmd_params_defaults.n_prompt, ",").c_str());
     printf("  -n, --n-gen <n>                     (default: %s)\n", join(cmd_params_defaults.n_gen, ",").c_str());
     printf("  -pg <pp,tg>                         (default: %s)\n", join(transform_to_str(cmd_params_defaults.n_pg, pair_str), ",").c_str());
+    printf("  -gp <pp,tg>                         (default: %s)\n", join(transform_to_str(cmd_params_defaults.n_gp, pair_str), ",").c_str());
     printf("  -b, --batch-size <n>                (default: %s)\n", join(cmd_params_defaults.n_batch, ",").c_str());
     printf("  -ub, --ubatch-size <n>              (default: %s)\n", join(cmd_params_defaults.n_ubatch, ",").c_str());
     printf("  -ctk, --cache-type-k <t>            (default: %s)\n", join(transform_to_str(cmd_params_defaults.type_k, ggml_type_name), ",").c_str());
@@ -393,6 +396,17 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 break;
             }
             params.n_pg.push_back({std::stoi(p[0]), std::stoi(p[1])});
+        } else if (arg == "-gp") {
+            if (++i >= argc) {
+                invalid_param = true;
+                break;
+            }
+            auto p = string_split<std::string>(argv[i], ',');
+            if (p.size() != 2) {
+                invalid_param = true;
+                break;
+            }
+            params.n_gp.push_back({ std::stoi(p[0]), std::stoi(p[1]) });
         } else if (arg == "-b" || arg == "--batch-size") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -596,6 +610,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     if (params.n_prompt.empty())     { params.n_prompt = cmd_params_defaults.n_prompt; }
     if (params.n_gen.empty())        { params.n_gen = cmd_params_defaults.n_gen; }
     if (params.n_pg.empty())         { params.n_pg = cmd_params_defaults.n_pg; }
+    if (params.n_gp.empty())         { params.n_gp = cmd_params_defaults.n_gp; }
     if (params.n_batch.empty())      { params.n_batch = cmd_params_defaults.n_batch; }
     if (params.n_ubatch.empty())     { params.n_ubatch = cmd_params_defaults.n_ubatch; }
     if (params.type_k.empty())       { params.type_k = cmd_params_defaults.type_k; }
@@ -614,7 +629,19 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     return params;
 }
 
+enum test_kind_type {
+    // measure mean prompt processing rate without token generation
+    TEST_KIND_PP,
+    // measure mean token generation rate without prompt processing
+    TEST_KIND_TG,
+    // measure mean prompt processing and token generation rate
+    TEST_KIND_PG,
+    // measure mean token generation rate after processing prompt of given length
+    TEST_KIND_GP,
+};
+
 struct cmd_params_instance {
+    test_kind_type test_kind;
     std::string model;
     int n_prompt;
     int n_gen;
@@ -701,6 +728,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 continue;
             }
             cmd_params_instance instance = {
+                /* .test_kind    = */ TEST_KIND_PP,
                 /* .model        = */ m,
                 /* .n_prompt     = */ n_prompt,
                 /* .n_gen        = */ 0,
@@ -728,6 +756,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 continue;
             }
             cmd_params_instance instance = {
+                /* .test_kind    = */ TEST_KIND_PP,
                 /* .model        = */ m,
                 /* .n_prompt     = */ 0,
                 /* .n_gen        = */ n_gen,
@@ -755,9 +784,38 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 continue;
             }
             cmd_params_instance instance = {
+                /* .test_kind    = */ TEST_KIND_PP,
                 /* .model        = */ m,
                 /* .n_prompt     = */ n_pg.first,
                 /* .n_gen        = */ n_pg.second,
+                /* .n_batch      = */ nb,
+                /* .n_ubatch     = */ nub,
+                /* .type_k       = */ tk,
+                /* .type_v       = */ tv,
+                /* .n_threads    = */ nt,
+                /* .n_gpu_layers = */ nl,
+                /* .rpc_servers  = */ rpc,
+                /* .split_mode   = */ sm,
+                /* .main_gpu     = */ mg,
+                /* .no_kv_offload= */ nkvo,
+                /* .flash_attn   = */ fa,
+                /* .tensor_split = */ ts,
+                /* .use_mmap     = */ mmp,
+                /* .embeddings   = */ embd,
+                /* .repack       = */ params.repack,
+            };
+            instances.push_back(instance);
+        }
+
+        for (const auto & n_gp : params.n_gp) {
+            if (n_gp.first == 0 && n_gp.second == 0) {
+                continue;
+            }
+            cmd_params_instance instance = {
+                /* .test_kind    = */ TEST_KIND_GP,
+                /* .model        = */ m,
+                /* .n_prompt     = */ n_gp.first,
+                /* .n_gen        = */ n_gp.second,
                 /* .n_batch      = */ nb,
                 /* .n_ubatch     = */ nub,
                 /* .type_k       = */ tk,
@@ -816,6 +874,8 @@ struct test {
     int n_gen;
     std::string test_time;
     std::vector<uint64_t> samples_ns;
+    test_kind_type  test_kind;
+    std::string     test_label;
 
     test(const cmd_params_instance & inst, const llama_model * lmodel, const llama_context * ctx) {
         model_filename = inst.model;
@@ -841,10 +901,31 @@ struct test {
         repack = inst.repack;
         n_prompt = inst.n_prompt;
         n_gen = inst.n_gen;
+        test_kind = inst.test_kind;
         // RFC 3339 date-time format
         time_t t = time(NULL);
         std::strftime(buf, sizeof(buf), "%FT%TZ", gmtime(&t));
         test_time = buf;
+
+        // prepare test label for printing
+        switch (test_kind) {
+            case TEST_KIND_PP:
+                snprintf(buf, sizeof(buf), "pp%d", n_prompt);
+                break;
+            case TEST_KIND_TG:
+                snprintf(buf, sizeof(buf), "tg%d", n_gen);
+                break;
+            case TEST_KIND_PG:
+                snprintf(buf, sizeof(buf), "pp%d+tg%d", n_prompt, n_gen);
+                break;
+            case TEST_KIND_GP:
+                snprintf(buf, sizeof(buf), "tg%d@pp%d", n_gen, n_prompt);
+                break;
+            default:
+                snprintf(buf, sizeof(buf), "unknown");
+                break;
+        }
+        test_label = buf;
 
         (void) ctx;
     }
@@ -858,7 +939,7 @@ struct test {
     }
 
     std::vector<double> get_ts() const {
-        int n_tokens = n_prompt + n_gen;
+        int n_tokens = (test_kind == TEST_KIND_GP ? 0 : n_prompt) + n_gen;
         std::vector<double> ts;
         std::transform(samples_ns.begin(), samples_ns.end(), std::back_inserter(ts), [n_tokens](uint64_t t) { return 1e9 * n_tokens / t; });
         return ts;
@@ -911,7 +992,7 @@ struct test {
             "tensor_split", "use_mmap", "embeddings", "repack",
             "n_prompt", "n_gen", "test_time",
             "avg_ns", "stddev_ns",
-            "avg_ts", "stddev_ts"
+            "avg_ts", "stddev_ts", "test",
         };
         return fields;
     }
@@ -967,7 +1048,8 @@ struct test {
             tensor_split_str, std::to_string(use_mmap), std::to_string(embeddings), std::to_string(repack),
             std::to_string(n_prompt), std::to_string(n_gen), test_time,
             std::to_string(avg_ns()), std::to_string(stdev_ns()),
-            std::to_string(avg_ts()), std::to_string(stdev_ts())
+            std::to_string(avg_ts()), std::to_string(stdev_ts()),
+            test_label
         };
         return values;
     }
@@ -1269,14 +1351,15 @@ struct markdown_printer : public printer {
                     value += "+RPC";
                 }
             } else if (field == "test") {
-                if (t.n_prompt > 0 && t.n_gen == 0) {
-                    snprintf(buf, sizeof(buf), "pp%d", t.n_prompt);
-                } else if (t.n_gen > 0 && t.n_prompt == 0) {
-                    snprintf(buf, sizeof(buf), "tg%d", t.n_gen);
-                } else {
-                    snprintf(buf, sizeof(buf), "pp%d+tg%d", t.n_prompt, t.n_gen);
-                }
-                value = buf;
+                //if (t.n_prompt > 0 && t.n_gen == 0) {
+                //    snprintf(buf, sizeof(buf), "pp%d", t.n_prompt);
+                //} else if (t.n_gen > 0 && t.n_prompt == 0) {
+                //    snprintf(buf, sizeof(buf), "tg%d", t.n_gen);
+                //} else {
+                //    snprintf(buf, sizeof(buf), "pp%d+tg%d", t.n_prompt, t.n_gen);
+                //}
+                //value = buf;
+                value = t.test_label;
             } else if (field == "t/s") {
                 snprintf(buf, sizeof(buf), "%.2f ± %.2f", t.avg_ts(), t.stdev_ts());
                 value = buf;
@@ -1489,6 +1572,7 @@ int main(int argc, char ** argv) {
             if (t.n_prompt > 0) {
                 test_prompt(ctx, t.n_prompt, 0, t.n_batch, t.n_threads);
             }
+            if (t.test_kind == TEST_KIND_GP) t_start = get_time_ns();
             if (t.n_gen > 0) {
                 test_gen(ctx, t.n_gen, t.n_prompt, t.n_threads);
             }

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3013,12 +3013,56 @@ static void mul_mat_q6_0_r4_q8_1(int n, const void * vx, size_t bx, const DataIn
 #endif
 
 #ifdef HAVE_FANCY_SIMD
+inline __m512i qx_r8_q8_dot_product(const __m512i * qx, const int8_t * y) {
+    auto y4l = _mm_loadu_si128((const __m128i*)y+0);
+    auto y4h = _mm_loadu_si128((const __m128i*)y+1);
+    auto y8l = MM256_SET_M128I(y4l, y4l);
+    auto y8h = MM256_SET_M128I(y4h, y4h);
+    auto yl  = _mm512_inserti32x8(_mm512_castsi256_si512(y8l), y8l, 1);
+    auto yh  = _mm512_inserti32x8(_mm512_castsi256_si512(y8h), y8h, 1);
+    auto sumi = _mm512_setzero_si512();
+    sumi = _mm512_dpbusd_epi32(sumi, qx[0], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0x00)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[1], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0x55)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[2], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0xaa)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[3], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0xff)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[4], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0x00)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[5], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0x55)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[6], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0xaa)));
+    sumi = _mm512_dpbusd_epi32(sumi, qx[7], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0xff)));
+    return sumi;
+}
+inline __m256i qx_r8_q8_dot_product(const __m256i * qx, const int8_t * y) {
+    auto y4l = _mm_loadu_si128((const __m128i*)y+0);
+    auto y4h = _mm_loadu_si128((const __m128i*)y+1);
+    auto yl  = MM256_SET_M128I(y4l, y4l);
+    auto yh  = MM256_SET_M128I(y4h, y4h);
+    auto sumi = _mm256_setzero_si256();
+    sumi = _mm256_dpbusd_epi32(sumi, qx[0], _mm256_shuffle_epi32(yl, 0x00));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[1], _mm256_shuffle_epi32(yl, 0x55));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[2], _mm256_shuffle_epi32(yl, 0xaa));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[3], _mm256_shuffle_epi32(yl, 0xff));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[4], _mm256_shuffle_epi32(yh, 0x00));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[5], _mm256_shuffle_epi32(yh, 0x55));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[6], _mm256_shuffle_epi32(yh, 0xaa));
+    sumi = _mm256_dpbusd_epi32(sumi, qx[7], _mm256_shuffle_epi32(yh, 0xff));
+    return sumi;
+}
+inline __m256i q8_0_r8_dot_product(const uint8_t * x, const int8_t * y, __m256i * qx) {
+    qx[0] = _mm256_loadu_si256((const __m256i *)x+0);
+    qx[1] = _mm256_loadu_si256((const __m256i *)x+1);
+    qx[2] = _mm256_loadu_si256((const __m256i *)x+2);
+    qx[3] = _mm256_loadu_si256((const __m256i *)x+3);
+    qx[4] = _mm256_loadu_si256((const __m256i *)x+4);
+    qx[5] = _mm256_loadu_si256((const __m256i *)x+5);
+    qx[6] = _mm256_loadu_si256((const __m256i *)x+6);
+    qx[7] = _mm256_loadu_si256((const __m256i *)x+7);
+    return qx_r8_q8_dot_product(qx, y);
+}
 template <int nrc_y>
 static void mul_mat_q8_0_r4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     GGML_ASSERT(nrc_x%16 == 0);
     Q8<nrc_y, block_q8_1_x4> q8(info);
     int nb = n / QK8_0;
-    GGML_ASSERT(nb%4 == 0);
     if constexpr (nrc_y == 1) {
         __m256 acc[2] = {};
         __m256i qx[8];
@@ -3029,30 +3073,20 @@ static void mul_mat_q8_0_r4_q8_1(int n, const void * vx, size_t bx, const DataIn
                 _mm256_storeu_ps(d8, _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)q8.y[0][ib4].d)));
                 for (int k = 0; k < 4; ++k) {
                     auto scales = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq8[4*ib4+k].d));
-                    qx[0] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+0);
-                    qx[1] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+1);
-                    qx[2] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+2);
-                    qx[3] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+3);
-                    qx[4] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+4);
-                    qx[5] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+5);
-                    qx[6] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+6);
-                    qx[7] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+7);
-                    auto y4l = _mm_loadu_si128((const __m128i*)q8.y[0][ib4].qs+2*k+0);
-                    auto y4h = _mm_loadu_si128((const __m128i*)q8.y[0][ib4].qs+2*k+1);
-                    auto yl  = MM256_SET_M128I(y4l, y4l);
-                    auto yh  = MM256_SET_M128I(y4h, y4h);
-                    auto sumi = _mm256_setzero_si256();
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[0], _mm256_shuffle_epi32(yl, 0x00));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[1], _mm256_shuffle_epi32(yl, 0x55));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[2], _mm256_shuffle_epi32(yl, 0xaa));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[3], _mm256_shuffle_epi32(yl, 0xff));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[4], _mm256_shuffle_epi32(yh, 0x00));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[5], _mm256_shuffle_epi32(yh, 0x55));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[6], _mm256_shuffle_epi32(yh, 0xaa));
-                    sumi = _mm256_dpbusd_epi32(sumi, qx[7], _mm256_shuffle_epi32(yh, 0xff));
+                    auto sumi = q8_0_r8_dot_product((const uint8_t *)iq8[4*ib4+k].qs, q8.y[0][ib4].qs+32*k, qx);
                     auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(d8[k]));
                     acc[0] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[0]);
                     acc[1] = _mm256_fmadd_ps(scales, _mm256_set1_ps(d8[k+4]), acc[1]);
+                }
+            }
+            if (4*(nb/4) < nb) {
+                auto qy = (const block_q8_1 *)q8.y[0];
+                for (int ib = 4*(nb/4); ib < nb; ++ib) {
+                    auto scales = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq8[ib].d));
+                    auto sumi = q8_0_r8_dot_product((const uint8_t *)iq8[ib].qs, qy[ib].qs, qx);
+                    auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_FP16_TO_FP32(qy[ib].d)));
+                    acc[0] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[0]);
+                    acc[1] = _mm256_fmadd_ps(scales, _mm256_set1_ps(qy[ib].s), acc[1]);
                 }
             }
             info.store(ix, 0, _mm256_fmadd_ps(_mm256_set1_ps(-127.f), acc[1], acc[0]));
@@ -3078,24 +3112,28 @@ static void mul_mat_q8_0_r4_q8_1(int n, const void * vx, size_t bx, const DataIn
                                                                           _mm256_loadu_si256((const __m256i *)q8h[4*ib4+k].qs+j), 1);
                     }
                     for (int iy = 0; iy < nrc_y; ++iy) {
-                        auto y4l = _mm_loadu_si128((const __m128i*)q8.y[iy][ib4].qs+2*k+0);
-                        auto y4h = _mm_loadu_si128((const __m128i*)q8.y[iy][ib4].qs+2*k+1);
-                        auto y8l = MM256_SET_M128I(y4l, y4l);
-                        auto y8h = MM256_SET_M128I(y4h, y4h);
-                        auto yl  = _mm512_inserti32x8(_mm512_castsi256_si512(y8l), y8l, 1);
-                        auto yh  = _mm512_inserti32x8(_mm512_castsi256_si512(y8h), y8h, 1);
-                        auto sumi = _mm512_setzero_si512();
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[0], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0x00)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[1], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0x55)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[2], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0xaa)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[3], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0xff)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[4], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0x00)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[5], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0x55)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[6], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0xaa)));
-                        sumi = _mm512_dpbusd_epi32(sumi, qx[7], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0xff)));
+                        auto sumi = qx_r8_q8_dot_product(qx, q8.y[iy][ib4].qs+32*k);
                         auto dy = _mm512_set1_ps(d8[8*iy+k]);
                         acc[2*iy+0] = _mm512_fmadd_ps(_mm512_mul_ps(scales, dy), _mm512_cvtepi32_ps(sumi), acc[2*iy+0]);
                         acc[2*iy+1] = _mm512_fmadd_ps(scales, _mm512_set1_ps(d8[8*iy+k+4]), acc[2*iy+1]);
+                    }
+                }
+            }
+            if (4*(nb/4) < nb) {
+                for (int ib = 4*(nb/4); ib < nb; ++ib) {
+                    auto scales1  = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)q8l[ib].d));
+                    auto scales2  = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)q8h[ib].d));
+                    auto scales   = _mm512_insertf32x8(_mm512_castps256_ps512(scales1), scales2, 1);
+                    for (int j = 0; j < 8; ++j) {
+                        qx[j] = _mm512_inserti32x8(_mm512_castsi256_si512(_mm256_loadu_si256((const __m256i *)q8l[ib].qs+j)),
+                                                                          _mm256_loadu_si256((const __m256i *)q8h[ib].qs+j), 1);
+                    }
+                    for (int iy = 0; iy < nrc_y; ++iy) {
+                        auto qy = (const block_q8_1 *)q8.y[iy];
+                        auto sumi = qx_r8_q8_dot_product(qx, qy[ib].qs);
+                        auto dy = _mm512_set1_ps(GGML_FP16_TO_FP32(qy[ib].d));
+                        acc[2*iy+0] = _mm512_fmadd_ps(_mm512_mul_ps(scales, dy), _mm512_cvtepi32_ps(sumi), acc[2*iy+0]);
+                        acc[2*iy+1] = _mm512_fmadd_ps(scales, _mm512_set1_ps(GGML_FP16_TO_FP32(qy[ib].s)), acc[2*iy+1]);
                     }
                 }
             }
@@ -7112,6 +7150,7 @@ struct QFBase {
     static inline Acc acc_first(const Data& y, const Data& x) {
         return _mm512_mul_ps(y, x);
     }
+    static inline Acc add(Acc x, Acc y) { return _mm512_add_ps(x, y); }
     static inline float hsum(Acc acc) {
         return _mm512_reduce_add_ps(acc);
     }
@@ -7150,6 +7189,7 @@ struct QFBase {
     static inline Acc acc(Acc prev, const Data& y, const Data& x) {
         return _mm256_fmadd_ps(y, x, prev);
     }
+    static inline Acc add(Acc x, Acc y) { return _mm256_add_ps(x, y); }
     static inline Acc acc_r4(Acc acc, const Data * xv, const Data& yv) {
         acc = _mm256_fmadd_ps(xv[0], _mm256_shuffle_ps(yv, yv, 0x00), acc);
         acc = _mm256_fmadd_ps(xv[1], _mm256_shuffle_ps(yv, yv, 0x55), acc);
@@ -7221,6 +7261,44 @@ template <typename Float, int nrc_in> struct QFT final : public QFBase {
     }
     const Float * y[nrc];
 };
+
+// TBD if we want this
+//template <typename Qy, typename Qx>
+//IQK_NOINLINE void mul_mat_Qx_Qy_Mx1(int n, const char * cx, size_t bx, int ix0, const DataInfo& info) {
+//    static_assert(Qy::nrc == 1);
+//    int nb = n/QFBase::k_step;
+//    int nb4 = n/4;
+//    Qy y(info);
+//    Qx x(cx + ix0*bx, bx);
+//    QFBase::Data xv[2*Qx::nrc];
+//    QFBase::Acc  acc[2*Qx::nrc];
+//    auto yv1 = y.load1(0, 0);
+//    auto yv2 = y.load1(0, 1);
+//    for (int ix = 0; ix < Qx::nrc; ++ix) {
+//        xv[2*ix+0] = x.load1(ix, 0);
+//        xv[2*ix+1] = x.load1(ix, 1);
+//        acc[2*ix+0] = QFBase::acc_first(yv1, xv[2*ix+0]);
+//        acc[2*ix+1] = QFBase::acc_first(yv2, xv[2*ix+1]);
+//    }
+//    for (int i = 1; i < nb/2; ++i) {
+//        yv1 = y.load1(0, 2*i+0);
+//        yv2 = y.load1(0, 2*i+1);
+//        for (int ix = 0; ix < Qx::nrc; ++ix) {
+//            xv[2*ix+0] = x.load1(ix, 2*i+0);
+//            xv[2*ix+1] = x.load1(ix, 2*i+1);
+//            acc[2*ix+0] = QFBase::acc(acc[2*ix+0], yv1, xv[2*ix+0]);
+//            acc[2*ix+1] = QFBase::acc(acc[2*ix+1], yv2, xv[2*ix+1]);
+//        }
+//    }
+//    for (int i = (QFBase::k_step/4)*nb; i < nb4; ++i) {
+//        yv1 = y.load_tail(0, i);
+//        for (int ix = 0; ix < Qx::nrc; ++ix) {
+//            xv[ix] = x.load_tail(ix, i);
+//            acc[2*ix+0] = QFBase::acc(acc[2*ix+0], yv1, xv[ix]);
+//        }
+//    }
+//    for (int ix = 0; ix < Qx::nrc; ++ix) info.store(ix0+ix, 0, QFBase::hsum(QFBase::add(acc[2*ix+0], acc[2*ix+1])));
+//}
 
 template <typename Qy, typename Qx>
 IQK_NOINLINE void mul_mat_Qx_Qy_MxN(int n, const char * cx, size_t bx, int ix0, const DataInfo& info) {
@@ -7319,12 +7397,29 @@ inline void mul_mat_Qx_Qy_MxN_fa4(int D, const char * cx, size_t bx, int ix0, co
 // f16, but I don't have a CPU capable of f16 vector arithmetic, so not doing it for now.
 template <int nrc_y, typename FloatX, typename FloatY>
 void mul_mat_fX_fY_T(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+    const char * cx = (const char *)vx;
+    // TBD if we want this
+    //if constexpr (nrc_y == 1) {
+    //    constexpr int k_nx = 2;
+    //    for (int ix = 0; ix < nrc_x/k_nx; ++ix) {
+    //        mul_mat_Qx_Qy_Mx1<QFT<FloatY, nrc_y>, QFT<FloatX, k_nx>>(n, cx, bx, ix*k_nx, info);
+    //    }
+    //    if (int lastx = k_nx*(nrc_x/k_nx); lastx < nrc_x) {
+    //        int nx = nrc_x - lastx;
+    //        switch (nx) {
+    //            case 1: mul_mat_Qx_Qy_Mx1<QFT<FloatY, nrc_y>, QFT<FloatX, 1>>(n, cx, bx, lastx, info); break;
+    //            case 2: mul_mat_Qx_Qy_Mx1<QFT<FloatY, nrc_y>, QFT<FloatX, 2>>(n, cx, bx, lastx, info); break;
+    //            case 3: mul_mat_Qx_Qy_Mx1<QFT<FloatY, nrc_y>, QFT<FloatX, 3>>(n, cx, bx, lastx, info); break;
+    //        }
+    //        //mul_mat_Qx_Qy_Mx1<QFT<FloatY, nrc_y>, QFT<FloatX, 1>>(n, cx, bx, lastx, info);
+    //    }
+    //    return;
+    //}
 #ifdef __AVX512F__
     constexpr int k_nx = 5;
 #else
     constexpr int k_nx = nrc_y == 1 ? 4 : 2;
 #endif
-    const char * cx = (const char *)vx;
     for (int ix = 0; ix < nrc_x/k_nx; ++ix) {
         mul_mat_Qx_Qy_MxN<QFT<FloatY, nrc_y>, QFT<FloatX, k_nx>>(n, cx, bx, ix*k_nx, info);
     }

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -12439,12 +12439,32 @@ struct Q6_0_R4_Dequantizer {
     const int8x16_t m32 = vdupq_n_s8(-32);
 };
 
+inline void qx_0_q8_0_dot(const int8x16_t * qx, const int8_t * qy, int32x4_t& sumi1, int32x4_t& sumi2) {
+    auto y = vld1q_s8_x2(qy);
+    sumi1 = sumi2 = vdupq_n_s32(0);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[0], y.val[0], 0);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[1], y.val[0], 0);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[2], y.val[0], 1);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[3], y.val[0], 1);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[4], y.val[0], 2);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[5], y.val[0], 2);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[6], y.val[0], 3);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[7], y.val[0], 3);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[8+0], y.val[1], 0);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[8+1], y.val[1], 0);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[8+2], y.val[1], 1);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[8+3], y.val[1], 1);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[8+4], y.val[1], 2);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[8+5], y.val[1], 2);
+    sumi1 = vdotq_laneq_s32(sumi1, qx[8+6], y.val[1], 3);
+    sumi2 = vdotq_laneq_s32(sumi2, qx[8+7], y.val[1], 3);
+}
+
 template <int nrc_y>
 void mul_mat_q8_0_r4_q8_0(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     GGML_ASSERT(nrc_x%8 == 0);
     Q8<nrc_y, block_q8_0_x4> q8(info);
     int nb = n / QK8_0;
-    GGML_ASSERT(nb%4 == 0);
     float32x4_t acc[2*nrc_y] = {};
     int8x16_t qx[16];
     float d8[4*nrc_y];
@@ -12459,30 +12479,27 @@ void mul_mat_q8_0_r4_q8_0(int n, const void * vx, size_t bx, const DataInfo& inf
                 auto scales1 = vcvt_f32_f16(vget_low_f16 (scales16));
                 auto scales2 = vcvt_f32_f16(vget_high_f16(scales16));
                 for (int j = 0; j < 16; ++j) qx[j] = vld1q_s8(iq8[4*ib4+k].qs + 16*j);
+                int32x4_t sumi1, sumi2;
                 for (int iy = 0; iy < nrc_y; ++iy) {
-                    auto y = vld1q_s8_x2(q8.y[iy][ib4].qs+32*k);
-                    auto sumi1 = vdupq_n_s32(0);
-                    auto sumi2 = vdupq_n_s32(0);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[0], y.val[0], 0);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[1], y.val[0], 0);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[2], y.val[0], 1);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[3], y.val[0], 1);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[4], y.val[0], 2);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[5], y.val[0], 2);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[6], y.val[0], 3);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[7], y.val[0], 3);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[8+0], y.val[1], 0);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[8+1], y.val[1], 0);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[8+2], y.val[1], 1);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[8+3], y.val[1], 1);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[8+4], y.val[1], 2);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[8+5], y.val[1], 2);
-                    sumi1 = vdotq_laneq_s32(sumi1, qx[8+6], y.val[1], 3);
-                    sumi2 = vdotq_laneq_s32(sumi2, qx[8+7], y.val[1], 3);
+                    qx_0_q8_0_dot(qx, q8.y[iy][ib4].qs+32*k, sumi1, sumi2);
                     auto dy = vdupq_n_f32(d8[4*iy+k]);
                     acc[2*iy+0] = vfmaq_f32(acc[2*iy+0], vmulq_f32(scales1, dy), vcvtq_f32_s32(sumi1));
                     acc[2*iy+1] = vfmaq_f32(acc[2*iy+1], vmulq_f32(scales2, dy), vcvtq_f32_s32(sumi2));
                 }
+            }
+        }
+        for (int ib = 4*(nb/4); ib < nb; ++ib) {
+            auto scales16 = vld1q_f16((const float16_t *)iq8[ib].d);
+            auto scales1 = vcvt_f32_f16(vget_low_f16 (scales16));
+            auto scales2 = vcvt_f32_f16(vget_high_f16(scales16));
+            for (int j = 0; j < 16; ++j) qx[j] = vld1q_s8(iq8[ib].qs + 16*j);
+            int32x4_t sumi1, sumi2;
+            for (int iy = 0; iy < nrc_y; ++iy) {
+                auto qy = (const block_q8_0 *)q8.y[iy];
+                qx_0_q8_0_dot(qx, qy[ib].qs, sumi1, sumi2);
+                auto dy = vdupq_n_f32(GGML_FP16_TO_FP32(qy[ib].d));
+                acc[2*iy+0] = vfmaq_f32(acc[2*iy+0], vmulq_f32(scales1, dy), vcvtq_f32_s32(sumi1));
+                acc[2*iy+1] = vfmaq_f32(acc[2*iy+1], vmulq_f32(scales2, dy), vcvtq_f32_s32(sumi2));
             }
         }
         for (int iy = 0; iy < nrc_y; ++iy) {


### PR DESCRIPTION

PR started by me adding the `-gp` option to `llama-bench` as per https://github.com/ggerganov/llama.cpp/pull/11126 because I wanted to test TG performance after a long prompt to be able to compare to the MLA attention implementation in  https://github.com/ggerganov/llama.cpp/pull/11446.

But then I noticed that the repacked `Q8_0` and `Q4_0` quants do not work for row tensor sizes that are not a multiple of 128 (4 x block size of 32), which is the case for some of the tensors in Deepseek2-Lite that I used for testing, so I fixed that.

And than I was comparing performance after the fix on `Llama-3.2-1B`, and noticed that FA with `Q8_0` K-cache does not work.  `Llama-3.2-1B` has a head size of 64 and there was a comment in the code that `Q8_0` does not work for a head sizes less than 128, so I fixed that as well.  
