### PR TITLE
IQ1_M_R4: better 1.75 bpw quants

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -30,6 +30,7 @@ static const std::vector<struct quant_option> QUANT_OPTIONS = {
     { "IQ2_M_R4", LLAMA_FTYPE_MOSTLY_IQ2_M_R4, " 2.7  bpw quantization",            },
     { "IQ1_S",    LLAMA_FTYPE_MOSTLY_IQ1_S,    " 1.56 bpw quantization",            },
     { "IQ1_S_R4", LLAMA_FTYPE_MOSTLY_IQ1_S_R4, " 1.5 bpw quantization",             },
+    { "IQ1_M_R4", LLAMA_FTYPE_MOSTLY_IQ1_M_R4, " 1.75 bpw quantization",            },
     { "IQ1_M",    LLAMA_FTYPE_MOSTLY_IQ1_M,    " 1.75 bpw quantization",            },
     { "IQ1_BN",   LLAMA_FTYPE_MOSTLY_IQ1_BN,   " 1.62 bpw quantization (Bitnet)",   },
     { "IQ2_BN",   LLAMA_FTYPE_MOSTLY_IQ2_BN,   " 2.00 bpw quantization (Bitnet)",   },
@@ -512,6 +513,7 @@ int main(int argc, char ** argv) {
          params.ftype == LLAMA_FTYPE_MOSTLY_Q2_K_S || params.ftype == LLAMA_FTYPE_MOSTLY_IQ2_XS_R4 ||
          params.ftype == LLAMA_FTYPE_MOSTLY_IQ1_S  ||
          params.ftype == LLAMA_FTYPE_MOSTLY_IQ1_S_R4 ||
+         params.ftype == LLAMA_FTYPE_MOSTLY_IQ1_M_R4 ||
          params.ftype == LLAMA_FTYPE_MOSTLY_IQ1_M)) {
         fprintf(stderr, "\n==========================================================================================================\n");
         fprintf(stderr, "Please do not use IQ1_S, IQ1_M, IQ2_S, IQ2_XXS, IQ2_XS or Q2_K_S quantization without an importance matrix\n");

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -432,6 +432,7 @@ extern "C" {
         GGML_TYPE_IQ3_S_R4  = 221,
         GGML_TYPE_IQ2_S_R4  = 222,
         GGML_TYPE_IQ4_XS_R4 = 223,
+        GGML_TYPE_IQ1_M_R4  = 229,
         GGML_TYPE_BF16_R16  = 230,
         GGML_TYPE_Q6_0_R4   = 233,
         GGML_TYPE_IQ2_BN_R4 = 335,
@@ -516,6 +517,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_IQ3_S_R4  = 220, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ2_S_R4  = 221, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ4_XS_R4 = 222, // except 1d tensors
+        GGML_FTYPE_MOSTLY_IQ1_M_R4  = 223, // except 1d tensors
         GGML_FTYPE_MOSTLY_BF16_R16  = 224, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q6_0_R4   = 227, // except 1d tensors
         GGML_FTYPE_MOSTLY_IQ2_BN_R4 = 329, // except 1d tensors

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -499,6 +499,14 @@ typedef struct {
 } block_iq1_m;
 static_assert(sizeof(block_iq1_m) == QK_K/8 + QK_K/16 + QK_K/32, "wrong iq1_m block size/padding");
 
+// 1.75 bpw - blocks of 32 with 4 interleaved rows = 128 quants
+typedef struct {
+    uint8_t  qs[16];     // grid index, low 8 bits
+    uint8_t  qh[ 8];     // grid index, high 3 bits + grid shift bits (for two groups of 8)
+    uint8_t  scales[4];  // 4-bit block scales
+} block_iq1_m_r4;
+static_assert(sizeof(block_iq1_m_r4) == 28, "wrong iq1_m_r4 block size/padding");
+
 //
 // Bitnet and TriLM - implemented as 1.625 bpw
 //

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -14145,85 +14145,6 @@ static void quantize_row_iq1_s_impl(const float * restrict x, void * restrict vy
             int best_shift;
             iq1s_process_1block(block_size, xb, weight, L, &scales[ib], index, &best_shift, pairs, sumx, sumw);
 
-//            float max = fabsf(xb[0]);
-//            for (int i = 1; i < block_size; ++i) max = MAX(max, fabsf(xb[i]));
-//            if (max < GROUP_MAX_EPS_IQ1_S) {
-//                scales[ib] = 0;
-//                memset(L, 1, block_size);
-//                continue;
-//            }
-//            // Here we solve exactly the sum of squared difference (SSD) weighted minimization problem.
-//            // With just 3 allowed quant values (-1, 0, 1), we can search exhaustively for the two
-//            // boundaries that split the weights xb[i] into 3 groups. To do so, we sort the weights
-//            // in ascending order, compute Si = sum[weight[j] xb[j], j = 0...i] and
-//            // Wi = sum[weight[j], j = 0...i], and use these to quckly get get the optimum scale
-//            // for each possible and score for each split.
-//            for (int j = 0; j < block_size; ++j) {
-//                pairs[2*j] = xb[j];
-//                idx[2*j] = j;
-//            }
-//            qsort(pairs, block_size, 2*sizeof(float), iq1_sort_helper);
-//            {
-//                sumx[0] = sumw[0] = 0;
-//                for (int j = 0; j < block_size; ++j) {
-//                    int i = idx[2*j];
-//                    sumx[j+1] = sumx[j] + weight[i]*xb[i];
-//                    sumw[j+1] = sumw[j] + weight[i];
-//                }
-//            }
-//            float best_score = -FLT_MIN, scale = max;
-//            int besti1 = -1, besti2 = -1, best_shift = 0;
-//            for (int i1 = 0; i1 <= block_size; ++i1) {
-//                for (int i2 = i1; i2 <= block_size; ++i2) {
-//                    float sumqx = (sumx[i1] - sumx[0])*x_p[0] + (sumx[i2] - sumx[i1])*x_p[1] + (sumx[block_size] - sumx[i2])*x_p[2];
-//                    float sumq2 = (sumw[i1] - sumw[0])*x_p[0]*x_p[0] + (sumw[i2] - sumw[i1])*x_p[1]*x_p[1] + (sumw[block_size] - sumw[i2])*x_p[2]*x_p[2];
-//                    if (sumq2 > 0 && sumqx*sumqx > best_score*sumq2) {
-//                        scale = sumqx/sumq2; best_score = scale*sumqx;
-//                        besti1 = i1; besti2 = i2; best_shift = 1;
-//                    }
-//                    sumqx = (sumx[i1] - sumx[0])*x_m[0] + (sumx[i2] - sumx[i1])*x_m[1] + (sumx[block_size] - sumx[i2])*x_m[2];
-//                    sumq2 = (sumw[i1] - sumw[0])*x_m[0]*x_m[0] + (sumw[i2] - sumw[i1])*x_m[1]*x_m[1] + (sumw[block_size] - sumw[i2])*x_m[2]*x_m[2];
-//                    if (sumq2 > 0 && sumqx*sumqx > best_score*sumq2) {
-//                        scale = sumqx/sumq2; best_score = scale*sumqx;
-//                        besti1 = i1; besti2 = i2; best_shift = -1;
-//                    }
-//                }
-//            }
-//            GGML_ASSERT(besti1 >= 0 && besti2 >= 0 && best_shift != 0);
-//            for (int j =      0; j < besti1; ++j) L[idx[2*j]] = 0;
-//            for (int j = besti1; j < besti2; ++j) L[idx[2*j]] = 1;
-//            for (int j = besti2; j < block_size; ++j) L[idx[2*j]] = 2;
-//            if (scale < 0) {
-//                for (int j = 0; j < block_size; ++j) L[j] = 2 - L[j];
-//                scale = -scale; best_shift = -best_shift;
-//            }
-//            bool all_on_grid = true;
-//            const float * xx = best_shift == 1 ? x_p : x_m;
-//            for (int k = 0; k < block_size/8; ++k) {
-//                uint16_t u = 0;
-//                for (int j = 0; j < 8; ++j) u |= (L[8*k+j] << 2*j);
-//                int grid_index = kmap_q2xs[u];
-//                if (grid_index < 0) {
-//                    all_on_grid = false;
-//                    const uint16_t * neighbours = kneighbors_q2xs - kmap_q2xs[u] - 1;
-//                    grid_index = iq1_find_best_neighbour2(neighbours, kgrid_q2xs, xb + 8*k, weight + 8*k, scale, xx, L + 8*k, NGRID_IQ1S);
-//                    GGML_ASSERT(grid_index >= 0);
-//                }
-//                index[k] = grid_index;
-//            }
-//            if (!all_on_grid) {
-//                float sumqx = 0, sumq2 = 0;
-//                for (int k = 0; k < block_size/8; ++k) {
-//                    const int8_t * pg = (const int8_t *)(kgrid_q2xs + index[k]);
-//                    for (int j = 0; j < 8; ++j) {
-//                        float w = weight[8*k + j];
-//                        float q = xx[(pg[j] - 1)/2];
-//                        sumqx += w*q*xb[8*k+j];
-//                        sumq2 += w*q*q;
-//                    }
-//                }
-//                if (sumqx > 0 && sumq2 > 0) scale = sumqx/sumq2;
-//            }
             uint16_t h = 0;
             for (int k = 0; k < block_size/8; ++k) {
                 y[ibl].qs[(block_size/8)*ib + k] = index[k] & 255;
@@ -14232,10 +14153,7 @@ static void quantize_row_iq1_s_impl(const float * restrict x, void * restrict vy
             y[ibl].qh[ib] = h;
             GGML_ASSERT(scales[ib] >= 0);
             max_scale = MAX(max_scale, scales[ib]);
-            //GGML_ASSERT(scale >= 0);
-            //scales[ib] = scale;
             shifts[ib] = best_shift;
-            //max_scale = MAX(max_scale, scale);
         }
 
         if (!max_scale) {
@@ -14287,6 +14205,166 @@ void quantize_row_iq1_s  (const float * GGML_RESTRICT x, void * GGML_RESTRICT y,
     quantize_row_iq1_s_ref(x, (block_iq1_s *)y, k);
 }
 
+void iq1m_process_1block(const float * xb, const float * weight, int8_t * L, float * the_scale, uint16_t * the_index, int * the_shift,
+        float * pairs) {
+
+    const int block_size = IQ1M_BLOCK_SIZE;
+
+    const float x_p[3] = {-1 + IQ1M_DELTA,  IQ1M_DELTA, 1 + IQ1M_DELTA};
+    const float x_m[3] = {-1 - IQ1M_DELTA, -IQ1M_DELTA, 1 - IQ1M_DELTA};
+
+    float sumqx[4], sumq2[4];
+
+    const int gindex = iq2_data_index(GGML_TYPE_IQ1_M);
+
+    const uint64_t * kgrid_q2xs      = iq2_data[gindex].grid;
+    const int      * kmap_q2xs       = iq2_data[gindex].map;
+    const uint16_t * kneighbors_q2xs = iq2_data[gindex].neighbours;
+
+    GGML_ASSERT(kgrid_q2xs      && "forgot to call ggml_quantize_init()?");
+    GGML_ASSERT(kmap_q2xs       && "forgot to call ggml_quantize_init()?");
+    GGML_ASSERT(kneighbors_q2xs && "forgot to call ggml_quantize_init()?");
+
+    // Here we solve exactly the sum of squared difference (SSD) weighted minimization problem.
+    // With just 3 allowed quant values (-1, 0, 1), we can search exhaustively for the two
+    // boundaries that split the weights xb[i] into 3 groups. To do so, we sort the weights
+    // in ascending order, compute Si = sum[weight[j] xb[j], j = 0...i] and
+    // Wi = sum[weight[j], j = 0...i], and use these to quckly get get the optimum scale
+    // for each possible and score for each split.
+    int * idx = (int *)(pairs + 1);
+    for (int j = 0; j < block_size; ++j) {
+        pairs[2*j] = xb[j];
+        idx[2*j] = j;
+    }
+    qsort(pairs, block_size, 2*sizeof(float), iq1_sort_helper);
+    float best_score = -FLT_MIN, scale = 0.f;
+    int besti1 = -1, besti2 = -1, best_k = -1;
+    // 0: +, +
+    // 1: +, -
+    // 2: -, +
+    // 3: -, -
+    for (int i1 = 0; i1 <= block_size; ++i1) {
+        for (int i2 = i1; i2 <= block_size; ++i2) {
+            memset(sumqx, 0, 4*sizeof(float));
+            memset(sumq2, 0, 4*sizeof(float));
+            for (int j = 0; j < i1; ++j) {
+                int i = idx[2*j];
+                if (i < block_size/2) {
+                    sumqx[0] += weight[i]*x_p[0]*xb[i];
+                    sumqx[1] += weight[i]*x_p[0]*xb[i];
+                    sumqx[2] += weight[i]*x_m[0]*xb[i];
+                    sumqx[3] += weight[i]*x_m[0]*xb[i];
+                    sumq2[0] += weight[i]*x_p[0]*x_p[0];
+                    sumq2[1] += weight[i]*x_p[0]*x_p[0];
+                    sumq2[2] += weight[i]*x_m[0]*x_m[0];
+                    sumq2[3] += weight[i]*x_m[0]*x_m[0];
+                } else {
+                    sumqx[0] += weight[i]*x_p[0]*xb[i];
+                    sumqx[2] += weight[i]*x_p[0]*xb[i];
+                    sumqx[1] += weight[i]*x_m[0]*xb[i];
+                    sumqx[3] += weight[i]*x_m[0]*xb[i];
+                    sumq2[0] += weight[i]*x_p[0]*x_p[0];
+                    sumq2[2] += weight[i]*x_p[0]*x_p[0];
+                    sumq2[1] += weight[i]*x_m[0]*x_m[0];
+                    sumq2[3] += weight[i]*x_m[0]*x_m[0];
+                }
+            }
+            for (int j = i1; j < i2; ++j) {
+                int i = idx[2*j];
+                if (i < block_size/2) {
+                    sumqx[0] += weight[i]*x_p[1]*xb[i];
+                    sumqx[1] += weight[i]*x_p[1]*xb[i];
+                    sumqx[2] += weight[i]*x_m[1]*xb[i];
+                    sumqx[3] += weight[i]*x_m[1]*xb[i];
+                    sumq2[0] += weight[i]*x_p[1]*x_p[1];
+                    sumq2[1] += weight[i]*x_p[1]*x_p[1];
+                    sumq2[2] += weight[i]*x_m[1]*x_m[1];
+                    sumq2[3] += weight[i]*x_m[1]*x_m[1];
+                } else {
+                    sumqx[0] += weight[i]*x_p[1]*xb[i];
+                    sumqx[2] += weight[i]*x_p[1]*xb[i];
+                    sumqx[1] += weight[i]*x_m[1]*xb[i];
+                    sumqx[3] += weight[i]*x_m[1]*xb[i];
+                    sumq2[0] += weight[i]*x_p[1]*x_p[1];
+                    sumq2[2] += weight[i]*x_p[1]*x_p[1];
+                    sumq2[1] += weight[i]*x_m[1]*x_m[1];
+                    sumq2[3] += weight[i]*x_m[1]*x_m[1];
+                }
+            }
+            for (int j = i2; j < block_size; ++j) {
+                int i = idx[2*j];
+                if (i < block_size/2) {
+                    sumqx[0] += weight[i]*x_p[2]*xb[i];
+                    sumqx[1] += weight[i]*x_p[2]*xb[i];
+                    sumqx[2] += weight[i]*x_m[2]*xb[i];
+                    sumqx[3] += weight[i]*x_m[2]*xb[i];
+                    sumq2[0] += weight[i]*x_p[2]*x_p[2];
+                    sumq2[1] += weight[i]*x_p[2]*x_p[2];
+                    sumq2[2] += weight[i]*x_m[2]*x_m[2];
+                    sumq2[3] += weight[i]*x_m[2]*x_m[2];
+                } else {
+                    sumqx[0] += weight[i]*x_p[2]*xb[i];
+                    sumqx[2] += weight[i]*x_p[2]*xb[i];
+                    sumqx[1] += weight[i]*x_m[2]*xb[i];
+                    sumqx[3] += weight[i]*x_m[2]*xb[i];
+                    sumq2[0] += weight[i]*x_p[2]*x_p[2];
+                    sumq2[2] += weight[i]*x_p[2]*x_p[2];
+                    sumq2[1] += weight[i]*x_m[2]*x_m[2];
+                    sumq2[3] += weight[i]*x_m[2]*x_m[2];
+                }
+            }
+            for (int k = 0; k < 4; ++k) {
+                if (sumq2[k] > 0 && sumqx[k]*sumqx[k] > best_score*sumq2[k]) {
+                    scale = sumqx[k]/sumq2[k]; best_score = scale*sumqx[k];
+                    besti1 = i1; besti2 = i2; best_k = k;
+                }
+            }
+        }
+    }
+    GGML_ASSERT(besti1 >= 0 && besti2 >= 0 && best_k >= 0);
+    for (int j =      0; j < besti1; ++j) L[idx[2*j]] = 0;
+    for (int j = besti1; j < besti2; ++j) L[idx[2*j]] = 1;
+    for (int j = besti2; j < block_size; ++j) L[idx[2*j]] = 2;
+    if (scale < 0) {
+        for (int j = 0; j < block_size; ++j) L[j] = 2 - L[j];
+        scale = -scale;
+        best_k = 3 - best_k;
+    }
+    bool all_on_grid = true;
+    const float * xx;
+    for (int k = 0; k < block_size/8; ++k) {
+        if (k == 0) xx = best_k < 2 ? x_p : x_m;
+        else xx = best_k%2 == 0 ? x_p : x_m;
+        uint16_t u = 0;
+        for (int j = 0; j < 8; ++j) u |= (L[8*k+j] << 2*j);
+        int grid_index = kmap_q2xs[u];
+        if (grid_index < 0) {
+            all_on_grid = false;
+            const uint16_t * neighbours = kneighbors_q2xs - kmap_q2xs[u] - 1;
+            grid_index = iq1_find_best_neighbour2(neighbours, kgrid_q2xs, xb + 8*k, weight + 8*k, scale, xx, L + 8*k, NGRID_IQ1S);
+            GGML_ASSERT(grid_index >= 0);
+        }
+        the_index[k] = grid_index;
+    }
+    if (!all_on_grid) {
+        float sumqx_f = 0, sumq2_f = 0;
+        for (int k = 0; k < block_size/8; ++k) {
+            if (k == 0) xx = best_k < 2 ? x_p : x_m;
+            else xx = best_k%2 == 0 ? x_p : x_m;
+            const int8_t * pg = (const int8_t *)(kgrid_q2xs + the_index[k]);
+            for (int j = 0; j < 8; ++j) {
+                float w = weight[8*k + j];
+                float q = xx[(pg[j] - 1)/2];
+                sumqx_f += w*q*xb[8*k+j];
+                sumq2_f += w*q*q;
+            }
+        }
+        if (sumqx_f > 0 && sumq2_f > 0) scale = sumqx_f/sumq2_f;
+    }
+    *the_scale = scale;
+    *the_shift = best_k;
+}
+
 static void quantize_row_iq1_m_impl(const float * restrict x, void * restrict vy, int64_t n, const float * restrict quant_weights,
         float    * scales,
         float    * weight,
@@ -14301,7 +14379,6 @@ static void quantize_row_iq1_m_impl(const float * restrict x, void * restrict vy
     const int      * kmap_q2xs       = iq2_data[gindex].map;
     const uint16_t * kneighbors_q2xs = iq2_data[gindex].neighbours;
 
-    //GGML_ASSERT(quant_weights   && "missing quantization weights");
     GGML_ASSERT(kgrid_q2xs      && "forgot to call ggml_quantize_init()?");
     GGML_ASSERT(kmap_q2xs       && "forgot to call ggml_quantize_init()?");
     GGML_ASSERT(kneighbors_q2xs && "forgot to call ggml_quantize_init()?");
@@ -14316,10 +14393,6 @@ static void quantize_row_iq1_m_impl(const float * restrict x, void * restrict vy
     const float x_p[3] = {-1 + IQ1M_DELTA,  IQ1M_DELTA, 1 + IQ1M_DELTA};
     const float x_m[3] = {-1 - IQ1M_DELTA, -IQ1M_DELTA, 1 - IQ1M_DELTA};
     const uint8_t masks[4] = {0x00, 0x80, 0x08, 0x88};
-
-    int * idx = (int *)(pairs + 1);
-
-    float sumqx[4], sumq2[4];
 
     iq1m_scale_t s;
     const float * xx;
@@ -14351,147 +14424,15 @@ static void quantize_row_iq1_m_impl(const float * restrict x, void * restrict vy
                 memset(L, 1, block_size);
                 continue;
             }
-            // Here we solve exactly the sum of squared difference (SSD) weighted minimization problem.
-            // With just 3 allowed quant values (-1, 0, 1), we can search exhaustively for the two
-            // boundaries that split the weights xb[i] into 3 groups. To do so, we sort the weights
-            // in ascending order, compute Si = sum[weight[j] xb[j], j = 0...i] and
-            // Wi = sum[weight[j], j = 0...i], and use these to quckly get get the optimum scale
-            // for each possible and score for each split.
-            for (int j = 0; j < block_size; ++j) {
-                pairs[2*j] = xb[j];
-                idx[2*j] = j;
-            }
-            qsort(pairs, block_size, 2*sizeof(float), iq1_sort_helper);
-            float best_score = -FLT_MIN, scale = max;
-            int besti1 = -1, besti2 = -1, best_k = -1;
-            // 0: +, +
-            // 1: +, -
-            // 2: -, +
-            // 3: -, -
-            for (int i1 = 0; i1 <= block_size; ++i1) {
-                for (int i2 = i1; i2 <= block_size; ++i2) {
-                    memset(sumqx, 0, 4*sizeof(float));
-                    memset(sumq2, 0, 4*sizeof(float));
-                    for (int j = 0; j < i1; ++j) {
-                        int i = idx[2*j];
-                        if (i < block_size/2) {
-                            sumqx[0] += weight[i]*x_p[0]*xb[i];
-                            sumqx[1] += weight[i]*x_p[0]*xb[i];
-                            sumqx[2] += weight[i]*x_m[0]*xb[i];
-                            sumqx[3] += weight[i]*x_m[0]*xb[i];
-                            sumq2[0] += weight[i]*x_p[0]*x_p[0];
-                            sumq2[1] += weight[i]*x_p[0]*x_p[0];
-                            sumq2[2] += weight[i]*x_m[0]*x_m[0];
-                            sumq2[3] += weight[i]*x_m[0]*x_m[0];
-                        } else {
-                            sumqx[0] += weight[i]*x_p[0]*xb[i];
-                            sumqx[2] += weight[i]*x_p[0]*xb[i];
-                            sumqx[1] += weight[i]*x_m[0]*xb[i];
-                            sumqx[3] += weight[i]*x_m[0]*xb[i];
-                            sumq2[0] += weight[i]*x_p[0]*x_p[0];
-                            sumq2[2] += weight[i]*x_p[0]*x_p[0];
-                            sumq2[1] += weight[i]*x_m[0]*x_m[0];
-                            sumq2[3] += weight[i]*x_m[0]*x_m[0];
-                        }
-                    }
-                    for (int j = i1; j < i2; ++j) {
-                        int i = idx[2*j];
-                        if (i < block_size/2) {
-                            sumqx[0] += weight[i]*x_p[1]*xb[i];
-                            sumqx[1] += weight[i]*x_p[1]*xb[i];
-                            sumqx[2] += weight[i]*x_m[1]*xb[i];
-                            sumqx[3] += weight[i]*x_m[1]*xb[i];
-                            sumq2[0] += weight[i]*x_p[1]*x_p[1];
-                            sumq2[1] += weight[i]*x_p[1]*x_p[1];
-                            sumq2[2] += weight[i]*x_m[1]*x_m[1];
-                            sumq2[3] += weight[i]*x_m[1]*x_m[1];
-                        } else {
-                            sumqx[0] += weight[i]*x_p[1]*xb[i];
-                            sumqx[2] += weight[i]*x_p[1]*xb[i];
-                            sumqx[1] += weight[i]*x_m[1]*xb[i];
-                            sumqx[3] += weight[i]*x_m[1]*xb[i];
-                            sumq2[0] += weight[i]*x_p[1]*x_p[1];
-                            sumq2[2] += weight[i]*x_p[1]*x_p[1];
-                            sumq2[1] += weight[i]*x_m[1]*x_m[1];
-                            sumq2[3] += weight[i]*x_m[1]*x_m[1];
-                        }
-                    }
-                    for (int j = i2; j < block_size; ++j) {
-                        int i = idx[2*j];
-                        if (i < block_size/2) {
-                            sumqx[0] += weight[i]*x_p[2]*xb[i];
-                            sumqx[1] += weight[i]*x_p[2]*xb[i];
-                            sumqx[2] += weight[i]*x_m[2]*xb[i];
-                            sumqx[3] += weight[i]*x_m[2]*xb[i];
-                            sumq2[0] += weight[i]*x_p[2]*x_p[2];
-                            sumq2[1] += weight[i]*x_p[2]*x_p[2];
-                            sumq2[2] += weight[i]*x_m[2]*x_m[2];
-                            sumq2[3] += weight[i]*x_m[2]*x_m[2];
-                        } else {
-                            sumqx[0] += weight[i]*x_p[2]*xb[i];
-                            sumqx[2] += weight[i]*x_p[2]*xb[i];
-                            sumqx[1] += weight[i]*x_m[2]*xb[i];
-                            sumqx[3] += weight[i]*x_m[2]*xb[i];
-                            sumq2[0] += weight[i]*x_p[2]*x_p[2];
-                            sumq2[2] += weight[i]*x_p[2]*x_p[2];
-                            sumq2[1] += weight[i]*x_m[2]*x_m[2];
-                            sumq2[3] += weight[i]*x_m[2]*x_m[2];
-                        }
-                    }
-                    for (int k = 0; k < 4; ++k) {
-                        if (sumq2[k] > 0 && sumqx[k]*sumqx[k] > best_score*sumq2[k]) {
-                            scale = sumqx[k]/sumq2[k]; best_score = scale*sumqx[k];
-                            besti1 = i1; besti2 = i2; best_k = k;
-                        }
-                    }
-                }
-            }
-            GGML_ASSERT(besti1 >= 0 && besti2 >= 0 && best_k >= 0);
-            for (int j =      0; j < besti1; ++j) L[idx[2*j]] = 0;
-            for (int j = besti1; j < besti2; ++j) L[idx[2*j]] = 1;
-            for (int j = besti2; j < block_size; ++j) L[idx[2*j]] = 2;
-            if (scale < 0) {
-                for (int j = 0; j < block_size; ++j) L[j] = 2 - L[j];
-                scale = -scale;
-                best_k = best_k == 0 ? 3 : best_k == 1 ? 2 : best_k == 2 ? 1 : 0;
-            }
-            bool all_on_grid = true;
-            for (int k = 0; k < block_size/8; ++k) {
-                if (k == 0) xx = best_k < 2 ? x_p : x_m;
-                else xx = best_k%2 == 0 ? x_p : x_m;
-                uint16_t u = 0;
-                for (int j = 0; j < 8; ++j) u |= (L[8*k+j] << 2*j);
-                int grid_index = kmap_q2xs[u];
-                if (grid_index < 0) {
-                    all_on_grid = false;
-                    const uint16_t * neighbours = kneighbors_q2xs - kmap_q2xs[u] - 1;
-                    grid_index = iq1_find_best_neighbour2(neighbours, kgrid_q2xs, xb + 8*k, weight + 8*k, scale, xx, L + 8*k, NGRID_IQ1S);
-                    GGML_ASSERT(grid_index >= 0);
-                }
-                index[k] = grid_index;
-            }
-            if (!all_on_grid) {
-                float sumqx_f = 0, sumq2_f = 0;
-                for (int k = 0; k < block_size/8; ++k) {
-                    if (k == 0) xx = best_k < 2 ? x_p : x_m;
-                    else xx = best_k%2 == 0 ? x_p : x_m;
-                    const int8_t * pg = (const int8_t *)(kgrid_q2xs + index[k]);
-                    for (int j = 0; j < 8; ++j) {
-                        float w = weight[8*k + j];
-                        float q = xx[(pg[j] - 1)/2];
-                        sumqx_f += w*q*xb[8*k+j];
-                        sumq2_f += w*q*q;
-                    }
-                }
-                if (sumqx_f > 0 && sumq2_f > 0) scale = sumqx_f/sumq2_f;
-            }
+
+            int best_k = -1;
+            iq1m_process_1block(xb, weight, L, &scales[ib], index, &best_k, pairs);
+
             y[ibl].qs[2*ib + 0] = index[0] & 255;
             y[ibl].qs[2*ib + 1] = index[1] & 255;
             y[ibl].qh[ib] = (index[0] >> 8) | ((index[1] >> 8) << 4);
-            GGML_ASSERT(scale >= 0);
-            scales[ib] = scale;
             shifts[ib] = best_k;
-            max_scale = MAX(max_scale, scale);
+            max_scale = MAX(max_scale, scales[ib]);
         }
 
         if (!max_scale) {
@@ -14551,6 +14492,19 @@ size_t quantize_iq1_m(const float * restrict src, void * restrict dst, int64_t n
         qrow += nblock*sizeof(block_iq1_m);
     }
     return nrow * nblock * sizeof(block_iq1_m);
+}
+
+void quantize_row_iq1_m_ref  (const float * GGML_RESTRICT x, block_iq1_m   * GGML_RESTRICT y, int64_t k) {
+    int nblock = k/QK_K;
+    float qw[QK_K];
+    for (int j = 0; j < QK_K; ++j) qw[j] = 1;
+    for (int ibl = 0; ibl < nblock; ++ibl) {
+        quantize_iq1_m(x + ibl*QK_K, &y[ibl], 1, QK_K, qw);
+    }
+}
+
+void quantize_row_iq1_m  (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+    quantize_row_iq1_m_ref(x, (block_iq1_m *)y, k);
 }
 
 // ============================ 4-bit non-linear quants
@@ -15246,6 +15200,7 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_IQ3_S_R4: break;
         case GGML_TYPE_IQ2_S_R4: break;
         case GGML_TYPE_IQ1_S_R4: break;
+        case GGML_TYPE_IQ1_M_R4: break;
         case GGML_TYPE_Q4_0_R4: break;
         case GGML_TYPE_Q5_0_R4: break;
         case GGML_TYPE_Q6_0_R4: break;

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -43,6 +43,7 @@ void quantize_row_iq3_s_ref  (const float * GGML_RESTRICT x, block_iq3_s   * GGM
 void quantize_row_iq2_s_ref  (const float * GGML_RESTRICT x, block_iq2_s   * GGML_RESTRICT y, int64_t k);
 void quantize_row_iq1_bn_ref (const float * GGML_RESTRICT x, block_iq1_bn  * GGML_RESTRICT y, int64_t k);
 void quantize_row_iq1_s_ref  (const float * GGML_RESTRICT x, block_iq1_s   * GGML_RESTRICT y, int64_t k);
+void quantize_row_iq1_m_ref  (const float * GGML_RESTRICT x, block_iq1_m   * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_q4_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_q4_1(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
@@ -68,6 +69,7 @@ void quantize_row_iq3_s  (const float * GGML_RESTRICT x, void * GGML_RESTRICT y,
 void quantize_row_iq2_s  (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_iq1_bn (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_iq1_s  (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void quantize_row_iq1_m  (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 // Dequantization
 void dequantize_row_q4_0(const block_q4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -152,6 +154,8 @@ void iq3xs_free_impl(int grid_size);
 
 void iq1s_process_1block(int block_size, const float * xb, const float * weight, int8_t * L,
         float * the_scale, uint16_t * the_index, int * the_shift, float * pairs, float * sumx, float * sumw);
+void iq1m_process_1block(const float * xb, const float * weight, int8_t * L,
+        float * the_scale, uint16_t * the_index, int * the_shift, float * pairs);
 
 #if defined(__ARM_FEATURE_SVE)
 extern int ggml_sve_cnt_b;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1218,7 +1218,7 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_iq1_m_r4,
         .from_float_ref           = (ggml_from_float_t)quantize_row_iq1_m_r4_ref,
         .vec_dot                  = vec_dot_iq1_m_r4_q8_k,
-        .vec_dot_type             = GGML_TYPE_Q8_1_X4,
+        .vec_dot_type             = GGML_TYPE_Q8_0_X4,
         .nrows                    = 1,
         .row_meta_size            = 2,
     },

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1202,12 +1202,25 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .type_size                = sizeof(block_iq1_m),
         .is_quantized             = true,
         .to_float                 = (ggml_to_float_t) dequantize_row_iq1_m,
-        .from_float               = NULL,
-        .from_float_ref           = NULL,
+        .from_float               = quantize_row_iq1_m,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_iq1_m_ref,
         .vec_dot                  = ggml_vec_dot_iq1_m_q8_K,
         .vec_dot_type             = GGML_TYPE_Q8_K,
         .nrows                    = 1,
         .row_meta_size            = 0,
+    },
+    [GGML_TYPE_IQ1_M_R4] = {
+        .type_name                = "iq1_m_r4",
+        .blck_size                = 32,
+        .type_size                = sizeof(block_iq1_m_r4)/4,
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_iq1_m_r4,
+        .from_float               = quantize_row_iq1_m_r4,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_iq1_m_r4_ref,
+        .vec_dot                  = vec_dot_iq1_m_r4_q8_k,
+        .vec_dot_type             = GGML_TYPE_Q8_1_X4,
+        .nrows                    = 1,
+        .row_meta_size            = 2,
     },
     [GGML_TYPE_IQ1_BN] = {
         .type_name                = "iq1_bn",
@@ -4401,6 +4414,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_IQ2_S:         wtype = GGML_TYPE_IQ2_S;    break;
         case GGML_FTYPE_MOSTLY_IQ2_S_R4:      wtype = GGML_TYPE_IQ2_S_R4; break;
         case GGML_FTYPE_MOSTLY_IQ1_S_R4:      wtype = GGML_TYPE_IQ1_S_R4; break;
+        case GGML_FTYPE_MOSTLY_IQ1_M_R4:      wtype = GGML_TYPE_IQ1_M_R4; break;
         case GGML_FTYPE_MOSTLY_Q4_0_4_4:      wtype = GGML_TYPE_Q4_0_4_4; break;
         case GGML_FTYPE_MOSTLY_Q4_0_4_8:      wtype = GGML_TYPE_Q4_0_4_8; break;
         case GGML_FTYPE_MOSTLY_Q4_0_8_8:      wtype = GGML_TYPE_Q4_0_8_8; break;
@@ -10949,6 +10963,7 @@ static void ggml_compute_forward_add(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
         case GGML_TYPE_Q4_0_8_8:
@@ -11418,6 +11433,7 @@ static void ggml_compute_forward_add1(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
         case GGML_TYPE_Q4_0_8_8:
@@ -11584,6 +11600,7 @@ static void ggml_compute_forward_acc(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
         case GGML_TYPE_Q4_0_8_8:
@@ -14823,6 +14840,7 @@ static void ggml_compute_forward_out_prod(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
         case GGML_TYPE_Q4_0_8_8:
@@ -15229,6 +15247,7 @@ static void ggml_compute_forward_set(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
         case GGML_TYPE_Q4_0_8_8:
@@ -15529,6 +15548,7 @@ static void ggml_compute_forward_get_rows(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q4_0_4_4:
         case GGML_TYPE_Q4_0_4_8:
         case GGML_TYPE_Q4_0_8_8:
@@ -16158,6 +16178,7 @@ static void ggml_compute_forward_clamp(
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ2_S_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
         case GGML_TYPE_Q8_K:
         case GGML_TYPE_Q8_K64:
         case GGML_TYPE_Q8_K16:
@@ -22914,6 +22935,7 @@ void ggml_quantize_init(enum ggml_type type) {
         case GGML_TYPE_IQ2_S:
         case GGML_TYPE_IQ1_S:
         case GGML_TYPE_IQ1_M:   iq2xs_init_impl(type); break;
+        case GGML_TYPE_IQ1_M_R4:iq2xs_init_impl(GGML_TYPE_IQ1_M); break;
         case GGML_TYPE_IQ1_S_R4:iq2xs_init_impl(GGML_TYPE_IQ1_S); break;
         case GGML_TYPE_IQ3_XXS_R4:
         case GGML_TYPE_IQ3_XXS: iq3xs_init_impl(256); break;
@@ -22998,6 +23020,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_IQ2_S:   result = quantize_iq2_s  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ2_S_R4:result = quantize_iq2_s_r4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ1_S_R4:result = quantize_iq1_s_r4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_IQ1_M_R4:result = quantize_iq1_m_r4(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ1_S:   result = quantize_iq1_s  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ1_M:   result = quantize_iq1_m  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_IQ1_BN:  result = quantize_iq1_bn (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3612,7 +3612,7 @@ static void mul_mat_iq1_s_r4_q8_1(int n, const void * vx, size_t bx, const DataI
 }
 
 template <int nrc_y>
-static void mul_mat_iq1_m_r4_q8_1(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
+static void mul_mat_iq1_m_r4_q8_0(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     GGML_ASSERT(nrc_x%4 == 0);
     Q8<nrc_y, block_q8_0_x4> q8(info);
     int nb = n / 32;
@@ -9181,16 +9181,16 @@ bool MulMat::prepare(int typeA, int typeB, int ne00, MulMat& mm, int Ny) {
             break;
         case GGML_TYPE_IQ1_M_R4:
             assert (ne00 % QK4_NL == 0);
-            mm.funcs[0] = mul_mat_iq1_m_r4_q8_1<1>;
-            mm.funcs[1] = mul_mat_iq1_m_r4_q8_1<2>;
-            mm.funcs[2] = mul_mat_iq1_m_r4_q8_1<3>;
-            mm.funcs[3] = mul_mat_iq1_m_r4_q8_1<4>;
-            mm.funcs[4] = mul_mat_iq1_m_r4_q8_1<5>;
-            mm.funcs[5] = mul_mat_iq1_m_r4_q8_1<6>;
-            mm.funcs[6] = mul_mat_iq1_m_r4_q8_1<7>;
-            mm.funcs[7] = mul_mat_iq1_m_r4_q8_1<8>;
+            mm.funcs[0] = mul_mat_iq1_m_r4_q8_0<1>;
+            mm.funcs[1] = mul_mat_iq1_m_r4_q8_0<2>;
+            mm.funcs[2] = mul_mat_iq1_m_r4_q8_0<3>;
+            mm.funcs[3] = mul_mat_iq1_m_r4_q8_0<4>;
+            mm.funcs[4] = mul_mat_iq1_m_r4_q8_0<5>;
+            mm.funcs[5] = mul_mat_iq1_m_r4_q8_0<6>;
+            mm.funcs[6] = mul_mat_iq1_m_r4_q8_0<7>;
+            mm.funcs[7] = mul_mat_iq1_m_r4_q8_0<8>;
 #ifdef HAVE_FANCY_SIMD
-            mm.func16 = mul_mat_iq1_m_r4_q8_1<16>;
+            mm.func16 = mul_mat_iq1_m_r4_q8_0<16>;
 #endif
             expected_typeB = GGML_TYPE_Q8_0_X4;
             break;

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -205,6 +205,12 @@ size_t quantize_iq1_s_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT d
 void   dequantize_row_iq1_s_r4(const block_iq1_s_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 void   vec_dot_iq1_s_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
+void   quantize_row_iq1_m_r4_ref(const float * GGML_RESTRICT x, block_iq1_m_r4  * GGML_RESTRICT y, int64_t k);
+void   quantize_row_iq1_m_r4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+size_t quantize_iq1_m_r4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+void   dequantize_row_iq1_m_r4(const block_iq1_m_r4  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void   vec_dot_iq1_m_r4_q8_k(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 void   quantize_row_q8_k_r8_ref(const float * GGML_RESTRICT x, block_q8_k_r8  * GGML_RESTRICT y, int64_t k);
 void   quantize_row_q8_k_r8(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 size_t quantize_q8_k_r8(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);

--- a/include/llama.h
+++ b/include/llama.h
@@ -197,6 +197,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_IQ3_S_R4      = 226, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ2_M_R4      = 229, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ4_XS_R4     = 230, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_IQ1_M_R4      = 231, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q6_0_R4       = 335, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_BF16_R16      = 232, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ2_BN_R4     = 337, // except 1d tensors


### PR DESCRIPTION

Following in the foot steps of #185, this PR adds `IQ1_M_R4`, a 4-row interleaved version of `IQ1_M`. 

* I have removed the `f16` super-block scale (replaced with a `f16` per row scale) and have changed the 3-bit `IQ1_M` block scales with 4 bit. Hence, we end up using the same 1.75 bpw as `IQ1_M`.
* The above change allows to implement `IQ1_M_R4` with a block size of 32. I wanted to have this because DeepSeek-Lite, the model I'm testing with, has a lot of tensors with row sizes not divisible by 256, so a significant fraction of tensors gets quantized to `IQ4_NL` when using `IQ1_M`
*  Quantization mixes for MoE models are adjusted. Today's mainline `llama.cpp` arrives at a context-512 perplexity (`PPL(512)` in what follows) of 20.75 for DeepSeek-Lite using 2.74 bpw with `IQ1_M`. The `IQ1_M_R4` quantization in this PR gets `PPL-512 = 8.85` with 1.966 bpw for the repeating layers.
* `IQ1_M_R4` is **much faster** on the CPU compared to `IQ1_M` (see tables below). I never implemented iqk-style GEMM for `IQ1_S/IQ1_M`, so these quantization types run at the snail speed of mainline `llama.cpp`.
* Caveat: it is CPU only for now.

The following table compares prompt processing (pp512) and token generation (tg128) speed for LLaMA-3.1-8B on `AVX2` (Ryzen-5975WX), `Zen4` (Ryzen-7950X) and `ARM_NEON` (M2-Max CPU). I didn't use DeepSeek-Lite for this comparison to avoid the difference in quantization types one ends up with due to not all tensors having row sizes that are multiple of 256.

| platform   | threads |          test |     t/s (IQ1_M)  |   t/s (IQ1_M_R4) |  Speedup |
| ---------- | ------: | ------------: | ---------------: | ---------------: | -------: |
| AVX2       |      32 |         pp512 |     43.98 ± 0.09 |    187.94 ± 0.21 |  4.273   |
| Zen4       |      16 |         pp512 |     26.70 ± 0.03 |    149.57 ± 0.31 |  5.602   |
| NEON       |       8 |         pp512 |     17.61 ± 0.03 |     95.04 ± 0.16 |  5.397   |
| AVX2       |       2 |         tg128 |      2.66 ± 0.00 |      3.96 ± 0.00 |  1.489   |
|            |       4 |         tg128 |      5.25 ± 0.00 |      7.76 ± 0.00 |  1.478   |
|            |       8 |         tg128 |      9.93 ± 0.16 |     13.71 ± 0.01 |  1.381   |
|            |      16 |         tg128 |     17.14 ± 0.00 |     22.60 ± 0.01 |  1.319   |
|            |      32 |         tg128 |     23.91 ± 0.01 |     25.39 ± 0.02 |  1.062   |
| Zen4       |       2 |         tg128 |      3.39 ± 0.00 |      5.29 ± 0.00 |  1.560   |
|            |       4 |         tg128 |      6.50 ± 0.00 |     10.19 ± 0.00 |  1.568   |
|            |       8 |         tg128 |     11.68 ± 0.01 |     17.54 ± 0.01 |  1.502   |
|            |      16 |         tg128 |     19.13 ± 0.05 |     25.91 ± 0.43 |  1.354   |
| NEON       |       2 |         tg128 |      4.16 ± 0.00 |      5.27 ± 0.01 |  1.267   |
|            |       4 |         tg128 |      7.88 ± 0.00 |      9.99 ± 0.01 |  1.268   |
|            |       8 |         tg128 |     14.74 ± 0.26 |     19.19 ± 0.01 |  1.302   |
