### PR TITLE
Faster MLA prompt processing

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13465,13 +13465,15 @@ struct llm_build_context {
 
                 if (lctx.cparams.mla_attn && model.layers[il].wk_b && model.layers[il].wv_b) {
 
-                    struct ggml_tensor * kv_cache_view = ggml_view_1d(ctx0, kv_self.kv_l[il], n_tokens*kv_lora_rank, ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank)*kv_head);
+                    struct ggml_tensor * kv_cache_view = ggml_view_1d(ctx0, kv_self.kv_l[il], n_tokens*kv_lora_rank,
+                            ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank)*kv_head);
                     cb(kv_cache_view, "kv_cache_view", il);
 
                     // note: storing c^KV in the KV cache
                     ggml_build_forward_expand(gf, ggml_cpy(ctx0, kv_compressed, kv_cache_view));
 
-                    struct ggml_tensor * kv_cache_trans_view = ggml_view_2d(ctx0, kv_self.kvt_l[il], n_tokens, kv_lora_rank, ggml_row_size(kv_self.kv_l[il]->type, kv_self.size), ggml_row_size(kv_self.kv_l[il]->type, kv_head));
+                    struct ggml_tensor * kv_cache_trans_view = ggml_view_2d(ctx0, kv_self.kvt_l[il], n_tokens, kv_lora_rank,
+                            ggml_row_size(kv_self.kv_l[il]->type, kv_self.size), ggml_row_size(kv_self.kv_l[il]->type, kv_head));
                     cb(kv_cache_trans_view, "kv_cache_trans_view", il);
 
                     // note: storing transposed c^KV in the transposed KV cache
@@ -13491,7 +13493,8 @@ struct llm_build_context {
                                 0);
                     cb(kv_cache_trans, "kv_cache_trans", il);
 
-                    struct ggml_tensor * kr_cache_view = ggml_view_1d(ctx0, kv_self.kr_l[il], n_tokens*n_embd_head_qk_rope, ggml_row_size(kv_self.kr_l[il]->type, n_embd_head_qk_rope)*kv_head);
+                    struct ggml_tensor * kr_cache_view = ggml_view_1d(ctx0, kv_self.kr_l[il], n_tokens*n_embd_head_qk_rope,
+                            ggml_row_size(kv_self.kr_l[il]->type, n_embd_head_qk_rope)*kv_head);
                     cb(kr_cache_view, "kr_cache_view", il);
 
                     // note: storing RoPE-ed version of K^R in the KV cache
@@ -13504,16 +13507,13 @@ struct llm_build_context {
                                 0);
                     cb(kr_cache, "kr_cache", il);
 
-                    struct ggml_tensor * wk_b = ggml_view_3d(ctx0, model.layers[il].wk_b, n_embd_head_qk_nope, kv_lora_rank, n_head, ggml_row_size(model.layers[il].wk_b->type, n_embd_head_qk_nope), ggml_row_size(model.layers[il].wk_b->type, kv_lora_rank) * n_embd_head_qk_nope, 0);
+                    struct ggml_tensor * wk_b = ggml_view_3d(ctx0, model.layers[il].wk_b, n_embd_head_qk_nope, kv_lora_rank, n_head,
+                            ggml_row_size(model.layers[il].wk_b->type, n_embd_head_qk_nope),
+                            ggml_row_size(model.layers[il].wk_b->type, kv_lora_rank)*n_embd_head_qk_nope, 0);
                     cb(wk_b, "wk_b", il);
 
                     q_nope = ggml_permute(ctx0, q_nope, 0, 2, 1, 3);
                     cb(q_nope, "q_nope_perm", il);
-
-                    //ggml_tensor * wkv_b = ggml_view_2d(ctx0, model.layers[il].wkv_b, kv_lora_rank, n_embd_head_qk_nope*n_head,
-                    //        ggml_row_size(model.layers[il].wkv_b->type, kv_lora_rank), 0);
-                    //ggml_tensor * ik1 = ggml_mul_mat(ctx0, wkv_b, kv_cache);
-                    //ggml_tensor * ik2 = ggml_view_3d(ctx0, ik1, n_embd_head_qk_nope,
 
                     struct ggml_tensor * q_nope2 = ggml_mul_mat(ctx0, wk_b, q_nope);
                     cb(q_nope2, "q_nope2", il);
@@ -13524,10 +13524,6 @@ struct llm_build_context {
                     }
                     struct ggml_tensor * kq_nope = ggml_mul_mat(ctx0, kv_cache, q_nope2);
                     cb(kq_nope, "kq_nope", il);
-                    //printf("kq_nope = kv_cache(%d x %d x %d x %d) * [wk_b (%d x %d x %d x %d) * q_nope (%d x %d x %d x %d)]\n",
-                    //        (int)kv_cache->ne[0], (int)kv_cache->ne[1], (int)kv_cache->ne[2], (int)kv_cache->ne[3],
-                    //        (int)wk_b->ne[0], (int)wk_b->ne[1], (int)wk_b->ne[2], (int)wk_b->ne[3],
-                    //        (int)q_nope->ne[0], (int)q_nope->ne[1], (int)q_nope->ne[2], (int)q_nope->ne[3]);
 
                     if (!pp_opt) {
                         kq_nope = ggml_permute(ctx0, kq_nope, 0, 2, 1, 3);


### PR DESCRIPTION

This PR speeds up prompt processing (PP) when MLA is enabled. It is still slower than no-MLA, so I'm making this a draft for now to try some more. Still it would be great if somebody else tested to confirm that a) I did not introduce bugs and b) It is indeed faster on their systems.

Speedup is achieved by concatenating the no- and rotational position encoding parts of `K` and `Q` (this also eliminates the `k_r` cache), which allows us to combine the former `kq_nope` and `kq_pe` matrix multiplications into a single matrix multiplication. This also eliminates the fairly expensive addition of  `kq_nope` and `kq_pe`. 

Here is a comparison between PP performance on the main branch and this PR for DeepSeek-Lite quantized with `IQ4_XS` and running on a Ryzen-7950X using `Q8_0` for K-cache

| model                |          test |    t/s (main)    |    t/s (PR)      |  Speedup |
| -------------------- | ------------: | ---------------: | ---------------: | -------: |
| deepseek2 16B IQ4_XS |         pp512 |    478.58 ± 5.14 |    489.40 ± 1.08 |  1.023   |
| deepseek2 16B IQ4_XS |        pp1024 |    438.56 ± 0.75 |    458.37 ± 1.51 |  1.045   |
| deepseek2 16B IQ4_XS |        pp2048 |    378.95 ± 1.40 |    407.83 ± 2.07 |  1.076   |
| deepseek2 16B IQ4_XS |        pp4096 |    294.71 ± 2.86 |    327.88 ± 0.18 |  1.113   |
| deepseek2 16B IQ4_XS |        pp8192 |    204.52 ± 0.27 |    234.17 ± 0.37 |  1.145   |
| deepseek2 16B IQ4_XS |       pp16384 |    126.31 ± 0.13 |    148.35 ± 0.38 |  1.174   |

TG performance (the whole point of MLA) is not sacrificed. Here the results of `llama-bench -gp -Np,64` for different prompt lengths `Np`

| model                 |          test |     t/s (main)   |  t/s (PR)        |   Speedup |
| --------------------- | ------------: | ---------------: | ---------------: | --------: |
| deepseek2 16B IQ4_XS  |    tg64@pp128 |     33.58 ± 0.06 |     33.80 ± 0.00 |  1.007    |
| deepseek2 16B IQ4_XS  |    tg64@pp256 |     32.67 ± 0.00 |     32.76 ± 0.01 |  1.003    |
| deepseek2 16B IQ4_XS  |    tg64@pp512 |     32.38 ± 0.08 |     32.68 ± 0.05 |  1.009    |
| deepseek2 16B IQ4_XS  |   tg64@pp1024 |     31.50 ± 0.02 |     32.02 ± 0.00 |  1.017    |
| deepseek2 16B IQ4_XS  |   tg64@pp2048 |     30.01 ± 0.01 |     30.31 ± 0.03 |  1.010    |
| deepseek2 16B IQ4_XS  |   tg64@pp4096 |     27.08 ± 0.03 |     27.54 ± 0.10 |  1.017    |
| deepseek2 16B IQ4_XS  |   tg64@pp8192 |     22.82 ± 0.00 |     23.12 ± 0.01 |  1.013    |
| deepseek2 16B IQ4_XS  |  tg64@pp16384 |     17.24 ± 0.00 |     18.74 ± 0.09 |  1.087    |

Not sure if the ~9% improvement at 16k tokens is real. It may be just due to less thermal trottling because of the prompt processing part finishing quicker.

