### PR TITLE
Option to use MLA without a transposed cache

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -851,7 +851,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "-mla" || arg == "--mla-use") {
-        params.mla_attn = true;
+        CHECK_ARG
+        params.mla_attn = std::stoi(argv[i]);
         return true;
     }
     if (arg == "-fmoe" || arg == "--fused-moe") {
@@ -1514,7 +1515,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "       --keep N",               "number of tokens to keep from the initial prompt (default: %d, -1 = all)", params.n_keep });
     options.push_back({ "*",           "       --chunks N",             "max number of chunks to process (default: %d, -1 = all)", params.n_chunks });
     options.push_back({ "*",           "-fa,   --flash-attn",           "enable Flash Attention (default: %s)", params.flash_attn ? "enabled" : "disabled" });
-    options.push_back({ "*",           "-mla,  --mla-use",              "enable MLA (default: %s)", params.mla_attn ? "enabled" : "disabled" });
+    options.push_back({ "*",           "-mla,  --mla-use",              "enable MLA (default: %d)", params.mla_attn });
     options.push_back({ "*",           "-fmoe, --fused-moe",            "enable fused MoE (default: %s)", params.fused_moe_up_gate ? "enabled" : "disabled" });
     options.push_back({ "*",           "-p,    --prompt PROMPT",        "prompt to start generation with\n"
                                                                         "in conversation mode, this will be used as system prompt\n"
@@ -3357,7 +3358,7 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "simple_io: %s # default: false\n", params.simple_io ? "true" : "false");
     fprintf(stream, "cont_batching: %s # default: false\n", params.cont_batching ? "true" : "false");
     fprintf(stream, "flash_attn: %s # default: false\n", params.flash_attn ? "true" : "false");
-    fprintf(stream, "mla_attn: %s # default: false\n", params.mla_attn ? "true" : "false");
+    fprintf(stream, "mla_attn: %d # default: 0\n", params.mla_attn);
     fprintf(stream, "fused_moe: %s # default: false\n", params.fused_moe_up_gate ? "true" : "false");
     fprintf(stream, "temp: %f # default: 0.8\n", sparams.temp);
 

--- a/common/common.h
+++ b/common/common.h
@@ -175,7 +175,7 @@ struct gpt_params {
     bool simple_io         = false; // improves compatibility with subprocesses and limited consoles
     bool cont_batching     = true;  // insert new sequences for decoding on-the-fly
     bool flash_attn        = false; // flash attention
-    bool mla_attn          = false; // MLA
+    int  mla_attn          = false; // MLA 0: standard attention, 1: MLA with K and transposed V cache, 2: MLA with just K cache
     bool fused_moe_up_gate = false; // fused up*unary(gate) op for MoE models
 
     bool input_prefix_bos  = false; // prefix BOS to user inputs, preceding input_prefix

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -232,7 +232,7 @@ struct cmd_params {
     std::vector<int> main_gpu;
     std::vector<bool> no_kv_offload;
     std::vector<bool> flash_attn;
-    std::vector<bool> mla_attn;
+    std::vector<int> mla_attn;
     std::vector<std::vector<float>> tensor_split;
     std::vector<bool> use_mmap;
     std::vector<bool> embeddings;
@@ -264,7 +264,7 @@ static const cmd_params cmd_params_defaults = {
     /* main_gpu             */ {0},
     /* no_kv_offload        */ {false},
     /* flash_attn           */ {false},
-    /* mla_attn             */ {false},
+    /* mla_attn             */ {0},
     /* tensor_split         */ {std::vector<float>(llama_max_devices(), 0.0f)},
     /* use_mmap             */ {true},
     /* embeddings           */ {false},
@@ -300,7 +300,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -mg, --main-gpu <i>                 (default: %s)\n", join(cmd_params_defaults.main_gpu, ",").c_str());
     printf("  -nkvo, --no-kv-offload <0|1>        (default: %s)\n", join(cmd_params_defaults.no_kv_offload, ",").c_str());
     printf("  -fa, --flash-attn <0|1>             (default: %s)\n", join(cmd_params_defaults.flash_attn, ",").c_str());
-    printf("  -mla, --mla-attn <0|1>              (default: %s)\n", join(cmd_params_defaults.mla_attn, ",").c_str());
+    printf("  -mla, --mla-attn <0|1|2>            (default: %s)\n", join(cmd_params_defaults.mla_attn, ",").c_str());
     printf("  -mmp, --mmap <0|1>                  (default: %s)\n", join(cmd_params_defaults.use_mmap, ",").c_str());
     printf("  --numa <distribute|isolate|numactl> (default: disabled)\n");
     printf("  -embd, --embeddings <0|1>           (default: %s)\n", join(cmd_params_defaults.embeddings, ",").c_str());
@@ -576,7 +576,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 invalid_param = true;
                 break;
             }
-            auto p = string_split<bool>(argv[i], split_delim);
+            auto p = string_split<int>(argv[i], split_delim);
             params.mla_attn.insert(params.mla_attn.end(), p.begin(), p.end());
         } else if (arg == "-mmp" || arg == "--mmap") {
             if (++i >= argc) {
@@ -726,7 +726,7 @@ struct cmd_params_instance {
     int main_gpu;
     bool no_kv_offload;
     bool flash_attn;
-    bool mla_attn;
+    int  mla_attn;
     std::vector<float> tensor_split;
     bool use_mmap;
     bool embeddings;
@@ -955,7 +955,7 @@ struct test {
     int main_gpu;
     bool no_kv_offload;
     bool flash_attn;
-    bool mla_attn;
+    int  mla_attn;
     std::vector<float> tensor_split;
     bool use_mmap;
     bool embeddings;
@@ -1097,13 +1097,13 @@ struct test {
             field == "n_threads" ||
             field == "model_size" || field == "model_n_params" ||
             field == "n_gpu_layers" || field == "main_gpu" ||
-            field == "n_prompt" || field == "n_gen" ||
+            field == "n_prompt" || field == "n_gen" || field == "mla_attn" ||
             field == "avg_ns" || field == "stddev_ns") {
             return INT;
         }
         if (field == "cuda" || field == "vulkan" || field == "kompute" || field == "metal" ||
             field == "gpu_blas" || field == "blas" || field == "sycl" ||field == "f16_kv" || field == "no_kv_offload" ||
-            field == "flash_attn" || field == "mla_attn" || field == "use_mmap" || field == "embeddings" || field == "repack" ||
+            field == "flash_attn" || field == "use_mmap" || field == "embeddings" || field == "repack" ||
             field == "fused_moe") {
             return BOOL;
         }

--- a/include/llama.h
+++ b/include/llama.h
@@ -383,7 +383,7 @@ extern "C" {
         bool embeddings;  // if true, extract embeddings (together with logits)
         bool offload_kqv; // whether to offload the KQV ops (including the KV cache) to GPU
         bool flash_attn;  // whether to use flash attention [EXPERIMENTAL]
-        bool mla_attn;    // whether to use MLA attention [EXPERIMENTAL]
+        int  mla_attn;    // whether to use MLA attention [EXPERIMENTAL]
         bool fused_moe_up_gate; // whether to use fused MoE up/down op [EXPERIMENTAL]
 
         // Abort callback


### PR DESCRIPTION
The `-mla` (or `--mla-use`) command line option turns from previously a boolean value to an integer:
* `mla = 0`: use standard attention
* `mla = 1`: use MLA with transposed cache - this is the existing MLA implementation
* `mla = 2`: use MLA without transposed cache - this is the option added by this PR

Why do we need this? Apparently many people are interested in using the maximum context length of long context models. For DeepSeekV3/R1, the rage of the day, it is 163k tokens. This requires a lot of RAM/VRAM. Let's take a look:
  
* **Standard attention (mla = 0):** memory required per token is `n_layer * (3072 * sizeof(K cache element) + 2048 * sizeof(V cache element))`. For DeepSeekV3/R1 this works out to **610 kB** per token when using `fp16` cache. For `Q8_0` K and V cache it is **324 kB** per token, but this requires FA, so CPU-only inference (CUDA does not support FA with different K and V head sizes as found in the DeepSeek models). So, for GPU or mixed CPU/GPU inference the best one can do is `Q8_0` for K cache and `f16` for V cache, so  **438.4 kB** per token.
* **MLA (mla = 1):** memory required per token is `n_layer * (576 * sizeof(K cache element) + 512 * sizeof(V cache element))`. For DeepSeekV3/R1 this works out to **129.6 kB** per token for `fp16` cache. When using MLA the V cache is transposed, so quantization is not possible at all, so the best one can do is `Q8_0` for K cache and `fp16` for V cache. This results in **97.5 kB** per token
* **MLA(mla = 2):** memory required per token is `n_layer * 576 * sizeof(K cache element)`, so **68.6 kB** per token with `fp16` cache and **36.5 kB** per token with `Q8_0` cache.

I.e., for GPU-only or hybrid GPU/CPU inference, where VRAM is the limiting factor (unless one keeps the cache on the host and copies it to the GPU as needed, but this would make performance much lower), the new option added by the PR uses **12X** less KV cache memory than standards attention and **2.7X** less than the existing MLA implementation. For a context of 163k tokens the memory required will be **5.67 GiB**.

The down side of this is that one has to transpose the K cache during inference (`ggml`, despite representing itself as a general purpose ML library, lacks the ability to perform transposed matrix multiplications, and I haven't come around to add this ability to my fork). This adds an additional computation and requires an extra compute buffer (to hold the contiguous transposed copy of the entire K cache for one layer). The size of this extra buffer can be computed as `n_token * 512 * sizeof(float) = 318 MiB` for 163k tokens, so this should not be a serious limitation.  But the additional operation that copies the transposed K cache into contiguous memory may result in a significant performance penalty, so let's look at that. As I don't have the ability to run DeepSeekV3/R1, I'm using  for the performance comparisons below.  DeepSeek-Lite  has the same architecture as DeepSeekV3/R1 with fewer parameters (16B, MoE, 64 experts, 6 used experts, exat same attention tensor sizes as DeepSeekV3/R1).  


**Note**: at this point `ggml` does not support transposing quantized data, so for `mla = 2` the K cache must be `fp16` or `bf16`. Hence, the above analysis for quantized cache with `mla = 2` will only apply when I have come around to implement transposing a quantized cache. 

### Hybrid GPU/CPU inference

The GPU is RTX-4080, the CPU is Ryzen-7950X. Experts are kept on the CPU, all other tensors are offloaded to the GPU.

| model                 | rtr | fmoe |      test |   t/s (mla = 0)  |    t/s (mla = 1) |   t/s (mla = 2)  |
| --------------------- | --: | ---: | --------: | ---------------: | ---------------: | ---------------: |
| deepseek2 16B IQ4_NL  |   1 |    1 |     pp512 |  1161.48 ± 43.70 |  1121.07 ± 39.10 |  1116.03 ± 43.37 |
| deepseek2 16B IQ4_NL  |   1 |    1 |    pp1024 |   1170.21 ± 4.98 |  1113.50 ± 20.14 |   1124.49 ± 4.31 |
| deepseek2 16B IQ4_NL  |   1 |    1 |    pp2048 |   1149.21 ± 2.62 |   1104.81 ± 7.31 |  1099.57 ± 27.33 |
| deepseek2 16B IQ4_NL  |   1 |    1 |    pp4096 |  1117.39 ± 11.04 |   1081.31 ± 2.93 |   1087.32 ± 2.91 |
| deepseek2 16B IQ4_NL  |   1 |    1 |    pp8192 |  1064.98 ± 12.98 |   1026.89 ± 7.58 |  1022.51 ± 20.84 |
| deepseek2 16B IQ4_NL  |   1 |    1 |   pp16384 |   965.42 ± 11.44 |   924.85 ± 10.69 |    921.28 ± 4.84 |

 I.e., for prompt processing (a.k.a. "prefill") MLA is very slightly slower than standard attention, but there is not real difference between `mla = 1` and `mla = 2` added by this PR.

For token generation (TG) I use the `-gp` option in `llama-bench` to evaluate TG performance as a function of the number of tokens in the KV cache. Here are the results:
 
| model          | rtr | fmoe |          test |   t/s (mla = 1)  |   t/s (mla = 1)  |   t/s (mla = 2)  |
| -------------- | --: | ---: | ------------: | ---------------: | ---------------: | ---------------: |
| deepseek2 16B  |   1 |    1 |    tg64@pp128 |     52.37 ± 0.11 |     52.32 ± 0.04 |     52.63 ± 0.07 |
| deepseek2 16B  |   1 |    1 |    tg64@pp256 |     51.65 ± 1.38 |     52.25 ± 0.10 |     52.60 ± 0.04 |
| deepseek2 16B  |   1 |    1 |    tg64@pp512 |     51.47 ± 0.39 |     51.70 ± 0.34 |     52.20 ± 0.06 |
| deepseek2 16B  |   1 |    1 |   tg64@pp1024 |     48.61 ± 0.67 |     51.45 ± 0.41 |     51.58 ± 0.11 |
| deepseek2 16B  |   1 |    1 |   tg64@pp2048 |     50.10 ± 0.26 |     50.89 ± 0.52 |     50.10 ± 0.98 |
| deepseek2 16B  |   1 |    1 |   tg64@pp4096 |     47.75 ± 0.13 |     49.98 ± 0.44 |     48.78 ± 0.05 |
| deepseek2 16B  |   1 |    1 |   tg64@pp8192 |     43.22 ± 0.47 |     48.07 ± 0.14 |     45.42 ± 0.40 |

I.e., for short contexts `mla = 2` is about on par with `mla = 1`. As the context grows it becomes slower due to the added cost of transposing the K cache, but it is still better than standard attention (`mla = 0`) at 8k tokens. 

### CPU only inference

| model                | rtr | fmoe |      test |    t/s (mla = 0) |    t/s (mla = 1) |   t/s (mla = 2)  |
| -------------------- | --: | ---: | --------: | ---------------: | ---------------: | ---------------: |
| deepseek2 16B IQ4_NL |   1 |    1 |     pp512 |    638.34 ± 2.78 |    581.79 ± 0.82 |    588.73 ± 1.93 |
| deepseek2 16B IQ4_NL |   1 |    1 |    pp1024 |    613.98 ± 1.95 |    539.69 ± 2.67 |    541.44 ± 9.46 |
| deepseek2 16B IQ4_NL |   1 |    1 |    pp2048 |    571.96 ± 0.87 |    471.74 ± 4.37 |    477.14 ± 2.42 |
| deepseek2 16B IQ4_NL |   1 |    1 |    pp4096 |    495.86 ± 1.11 |    368.75 ± 2.62 |    372.69 ± 1.31 |
| deepseek2 16B IQ4_NL |   1 |    1 |    pp8192 |    390.40 ± 4.78 |    254.44 ± 0.06 |    255.92 ± 1.49 |
| deepseek2 16B IQ4_NL |   1 |    1 |   pp16384 |    272.56 ± 1.29 |    156.00 ± 0.75 |    154.40 ± 0.12 |

I.e., when running only on the CPU MLA is significantly slower than standard attention for prompt processing, but there is no real difference between `mla = 1` and `mla = 2`.

| model                | rtr | fmoe |          test |   t/s (mla = 0)  |   t/s (mla = 1)  |   t/s (mla = 2)  |
| ---------------------| --: | ---: | ------------: | ---------------: | ---------------: | ---------------: |
| deepseek2 16B IQ4_NL |   1 |    1 |    tg64@pp128 |     32.55 ± 0.01 |     33.30 ± 0.02 |     32.41 ± 0.05 |
| deepseek2 16B IQ4_NL |   1 |    1 |    tg64@pp256 |     31.74 ± 0.07 |     32.67 ± 0.01 |     31.22 ± 0.02 |
| deepseek2 16B IQ4_NL |   1 |    1 |    tg64@pp512 |     29.98 ± 0.01 |     32.06 ± 0.03 |     30.16 ± 0.01 |
| deepseek2 16B IQ4_NL |   1 |    1 |   tg64@pp1024 |     28.37 ± 0.02 |     31.68 ± 0.01 |     28.48 ± 0.09 |
| deepseek2 16B IQ4_NL |   1 |    1 |   tg64@pp2048 |     25.15 ± 0.02 |     29.98 ± 0.03 |     25.18 ± 0.04 |
| deepseek2 16B IQ4_NL |   1 |    1 |   tg64@pp4096 |     20.22 ± 0.02 |     27.22 ± 0.13 |     20.36 ± 0.01 |
| deepseek2 16B IQ4_NL |   1 |    1 |   tg64@pp8192 |     14.56 ± 0.01 |     22.98 ± 0.11 |     14.18 ± 0.01 |

Here `mla = 2` is much slower than `mla = 1` for long contexts, and about on par with standard attention (`mla = 0`). Looking at the code in `ggml_compute_forward_dup_bytes`, which gets invoked to copy the transposed K cache data to contiguous memory, it is pretty much as inefficient as it gets. But I leave this for a follow up PR.   