### PR TITLE
Flash MLA (CPU only)

### DIFF
--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -11,6 +11,7 @@
 #include "ggml-quants.h"
 #include "ggml-impl.h"
 #if GGML_USE_IQK_MULMAT
+#include "iqk/iqk_config.h"
 #include "iqk/iqk_mul_mat.h"
 #include "iqk/iqk_quantize.h"
 #endif
@@ -5449,7 +5450,12 @@ void ggml_vec_dot_q6_0_q8_0(int n, float * restrict s, size_t bs, const void * r
 
 void ggml_vec_dot_q8_0_q8_0(int n, float * restrict s, size_t bs, const void * restrict vx, size_t bx, const void * restrict vy, size_t by, int nrc) {
 #if GGML_USE_IQK_MULMAT
-    if (iqk_mul_mat(nrc, nrc, n, GGML_TYPE_Q8_0, vx, bx, GGML_TYPE_Q8_0, vy, by, s, bs, 0, 1)) {
+#ifdef HAVE_FANCY_SIMD
+    enum ggml_type dot_type = GGML_TYPE_Q8_1_X4;
+#else
+    enum ggml_type dot_type = GGML_TYPE_Q8_0_X4;
+#endif
+    if (iqk_mul_mat(nrc, nrc, n, GGML_TYPE_Q8_0, vx, bx, dot_type, vy, by, s, bs, 0, 1)) {
         return;
     }
 #endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -17870,7 +17870,7 @@ static void ggml_compute_forward_flash_attn_ext_f16(
     }
 
 #if GGML_USE_IQK_MULMAT
-    if (max_bias <= 0.0f && q->type == GGML_TYPE_F32 && mask && mask->type == GGML_TYPE_F16) {
+    if (false && max_bias <= 0.0f && q->type == GGML_TYPE_F32 && mask && mask->type == GGML_TYPE_F16) {
         // I keep changing my mind what is the best strategy to split the threads when processing
         // multiple heads. This is my current thinking, the commented out code below was the previous.
         int ntg = nth/simple_gcd(neq2*neq3, nth);
@@ -17906,8 +17906,8 @@ static void ggml_compute_forward_flash_attn_ext_f16(
         }
         return;
 IQK_Flash_Attn_NotAvailable:;
+        //printf("iqk_flash was rejected\n");
     }
-
 #endif
 
     const uint32_t n_head      = neq2;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -17870,7 +17870,9 @@ static void ggml_compute_forward_flash_attn_ext_f16(
     }
 
 #if GGML_USE_IQK_MULMAT
-    if (false && max_bias <= 0.0f && q->type == GGML_TYPE_F32 && mask && mask->type == GGML_TYPE_F16) {
+    if (max_bias <= 0.0f && q->type == GGML_TYPE_F32 && mask && mask->type == GGML_TYPE_F16) {
+        //if (ith == 0) printf("k: %ld x %ld x %ld, q: %ld x %ld x %ld, v: %ld x %ld x %ld mask: %ld x %ld x %ld\n",
+        //        k->ne[0], k->ne[1], k->ne[2], q->ne[0], q->ne[1], q->ne[2], v->ne[0], v->ne[1], v->ne[2], mask->ne[0], mask->ne[1], mask->ne[2]);
         // I keep changing my mind what is the best strategy to split the threads when processing
         // multiple heads. This is my current thinking, the commented out code below was the previous.
         int ntg = nth/simple_gcd(neq2*neq3, nth);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -10451,7 +10451,7 @@ static void ggml_compute_forward_dup_bytes(
         ne00 == ne0 &&
         nb00 == type_size && nb0 == type_size) {
         // copy by rows
-        const size_t rs = ne00 * type_size;
+        const size_t rs = ggml_row_size(src0->type, ne00); //ne00 * type_size;
         for (int64_t i03 = 0; i03 < ne03; i03++) {
             for (int64_t i02 = 0; i02 < ne02; i02++) {
                 for (int64_t i01 = ir0; i01 < ir1; i01++) {
@@ -17908,7 +17908,7 @@ static void ggml_compute_forward_flash_attn_ext_f16(
         }
         return;
 IQK_Flash_Attn_NotAvailable:;
-        //printf("iqk_flash was rejected\n");
+        printf("iqk_flash was rejected\n");
     }
 #endif
 

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -17242,7 +17242,8 @@ bool iqk_flash_attn_noalibi(int int_type_k,         // type of k
     auto type_k = ggml_type(int_type_k);
     auto type_v = ggml_type(int_type_v);
 
-    if (type_k == GGML_TYPE_Q8_0 && type_v == GGML_TYPE_Q8_0 && Dk == 576 && Dv == 512) {
+    if (Dk == 576 && Dv == 512) {
+    //if (type_k == GGML_TYPE_Q8_0 && type_v == GGML_TYPE_Q8_0 && Dk == 576 && Dv == 512) {
         // This is a DeepSeek model with MLA. In that case we only have one cache (and k and v are different views of the cache),
         // so type_k must be the same as type_v
         GGML_ASSERT(type_k == type_v);
@@ -17250,13 +17251,13 @@ bool iqk_flash_attn_noalibi(int int_type_k,         // type of k
             case GGML_TYPE_Q8_0: {
                 HelperQ80<576, 32> kh((const char *)k, stride_k);
                 HelperQ80<512, 32> vh((const char *)v, stride_v);
-                if (nq1 % 8 == 0) {
-                    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
-                    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                } else {
+                //if (nq1 % 8 == 0) {
+                //    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
+                //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
+                //} else {
                     FlashAttn<576, 512, 1, 32> fa(scale, softcap);
                     fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                }
+                //}
                 return true;
             } break;
             // Something is wrong with Q8_KV in this case.
@@ -17275,26 +17276,26 @@ bool iqk_flash_attn_noalibi(int int_type_k,         // type of k
             case GGML_TYPE_F16: {
                 HelperF16<576, 32> kh((const char *)k, stride_k);
                 HelperF16<512, 32> vh((const char *)v, stride_v);
-                if (nq1 % 8 == 0) {
-                    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
-                    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                } else {
+                //if (nq1 % 8 == 0) {
+                //    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
+                //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
+                //} else {
                     FlashAttn<576, 512, 1, 32> fa(scale, softcap);
                     fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                }
+                //}
                 return true;
             } break;
 #ifdef __AVX512BF16__
             case GGML_TYPE_BF16: {
                 HelperBF16<576, 32> kh((const char *)k, stride_k);
                 HelperBF16<512, 32> vh((const char *)v, stride_v);
-                if (nq1 % 8 == 0) {
-                    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
-                    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                } else {
+                //if (nq1 % 8 == 0) {
+                //    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
+                //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
+                //} else {
                     FlashAttn<576, 512, 1, 32> fa(scale, softcap);
                     fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                }
+                //}
                 return true;
             } break;
 #endif

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -17249,15 +17249,16 @@ bool iqk_flash_attn_noalibi(int int_type_k,         // type of k
         GGML_ASSERT(type_k == type_v);
         switch (type_k) {
             case GGML_TYPE_Q8_0: {
+                //printf("%s: nk1 = %d, nq1 = %d, k = %p, v = %p, stride_k = %d stride_v = %d, stride_m = %d\n", __func__, nk1, nq1, k, v, stride_k, stride_v, stride_m);
                 HelperQ80<576, 32> kh((const char *)k, stride_k);
                 HelperQ80<512, 32> vh((const char *)v, stride_v);
-                //if (nq1 % 8 == 0) {
-                //    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
-                //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                //} else {
+                if (nq1 % 8 == 0) {
+                    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
+                    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
+                } else {
                     FlashAttn<576, 512, 1, 32> fa(scale, softcap);
                     fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                //}
+                }
                 return true;
             } break;
             // Something is wrong with Q8_KV in this case.
@@ -17276,26 +17277,26 @@ bool iqk_flash_attn_noalibi(int int_type_k,         // type of k
             case GGML_TYPE_F16: {
                 HelperF16<576, 32> kh((const char *)k, stride_k);
                 HelperF16<512, 32> vh((const char *)v, stride_v);
-                //if (nq1 % 8 == 0) {
-                //    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
-                //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                //} else {
+                if (nq1 % 8 == 0) {
+                    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
+                    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
+                } else {
                     FlashAttn<576, 512, 1, 32> fa(scale, softcap);
                     fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                //}
+                }
                 return true;
             } break;
 #ifdef __AVX512BF16__
             case GGML_TYPE_BF16: {
                 HelperBF16<576, 32> kh((const char *)k, stride_k);
                 HelperBF16<512, 32> vh((const char *)v, stride_v);
-                //if (nq1 % 8 == 0) {
-                //    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
-                //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                //} else {
+                if (nq1 % 8 == 0) {
+                    FlashAttn<576, 512, 8, 32> fa(scale, softcap);
+                    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
+                } else {
                     FlashAttn<576, 512, 1, 32> fa(scale, softcap);
                     fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv);
-                //}
+                }
                 return true;
             } break;
 #endif

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3168,7 +3168,7 @@ static bool llama_kv_cache_init(
 
     // DeepSeek MLA
     cache.kv_l.reserve(n_layer);
-    if (cparams.mla_attn == 1) {
+    if (cparams.mla_attn == 1 && !cparams.flash_attn) {
         cache.kvt_l.reserve(n_layer);
     }
 
@@ -3201,14 +3201,20 @@ static bool llama_kv_cache_init(
             const uint32_t n_embd_head_qk_rope = hparams.n_rot;
             const uint32_t kv_lora_rank = hparams.n_lora_kv;
             LLAMA_LOG_INFO("%s: layer %d: n_embd_head_qk_rope = %d, kv_lora_rank = %d\n", __func__, i, n_embd_head_qk_rope, kv_lora_rank);
-            auto kv_type = cparams.mla_attn == 1 ? cache.type_k : cache.type_v;
-            ggml_tensor * kv = ggml_new_tensor_2d(ctx, kv_type, kv_lora_rank + n_embd_head_qk_rope, kv_size);
-            ggml_format_name(kv, "cache_kv_l%d", i);
-            cache.kv_l.push_back(kv);
-            if (cparams.mla_attn == 1) {
-                ggml_tensor * kvt = ggml_new_tensor_1d(ctx, cache.type_v, kv_lora_rank*kv_size);
-                ggml_format_name(kvt, "cache_kvt_l%d", i);
-                cache.kvt_l.push_back(kvt);
+            if (cparams.flash_attn) {
+                ggml_tensor * kv = ggml_new_tensor_2d(ctx, cache.type_k, kv_lora_rank + n_embd_head_qk_rope, kv_size);
+                ggml_format_name(kv, "cache_kv_l%d", i);
+                cache.kv_l.push_back(kv);
+            } else {
+                auto kv_type = cparams.mla_attn == 1 ? cache.type_k : cache.type_v;
+                ggml_tensor * kv = ggml_new_tensor_2d(ctx, kv_type, kv_lora_rank + n_embd_head_qk_rope, kv_size);
+                ggml_format_name(kv, "cache_kv_l%d", i);
+                cache.kv_l.push_back(kv);
+                if (cparams.mla_attn == 1) {
+                    ggml_tensor * kvt = ggml_new_tensor_1d(ctx, cache.type_v, kv_lora_rank*kv_size);
+                    ggml_format_name(kvt, "cache_kvt_l%d", i);
+                    cache.kvt_l.push_back(kvt);
+                }
             }
             n_mla++;
         }
@@ -13588,7 +13594,7 @@ struct llm_build_context {
 
                     ggml_tensor * kv_cache_trans;
 
-                    if (lctx.cparams.mla_attn == 1) {
+                    if (lctx.cparams.mla_attn == 1 && !lctx.cparams.flash_attn) {
                         ggml_tensor * kv_cache_trans_view = ggml_view_2d(ctx0, kv_self.kvt_l[il], n_tokens, kv_lora_rank,
                                 ggml_row_size(kv_self.kvt_l[il]->type, kv_self.size), ggml_row_size(kv_self.kvt_l[il]->type, kv_head));
                         cb(kv_cache_trans_view, "kv_cache_trans_view", il);
@@ -13630,70 +13636,85 @@ struct llm_build_context {
                     ggml_tensor * q = ggml_concat(ctx0, q_nope2, ggml_permute(ctx0, q_rope, 0, 2, 1, 3), 0);
                     cb(q, "q", il);
 
-                    if (lctx.cparams.mla_attn > 1) {
+                    ggml_tensor * kqv_compressed;
+
+                    if (lctx.cparams.flash_attn) {
                         ggml_tensor * kv_cache_lora = ggml_view_2d(ctx0, kv_self.kv_l[il],
                                 kv_lora_rank, n_kv,
                                 ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank + n_embd_head_qk_rope), 0);
-                        cb(kv_cache, "kv_cache_lora", il);
+                        cb(kv_cache_lora, "kv_cache_lora", il);
 
-                        kv_cache_trans = ggml_cont(ctx0, ggml_transpose(ctx0, kv_cache_lora));
-                        cb(kv_cache_trans, "kv_cache_trans", il);
+                        kqv_compressed = ggml_flash_attn_ext(ctx0, q, kv_cache, kv_cache_lora, KQ_mask, kq_scale, hparams.f_max_alibi_bias, 0.f);
+                        cb(kqv_compressed, "kqv_compressed", il);
+
+                        kqv_compressed = ggml_permute(ctx0, kqv_compressed, 0, 2, 1, 3);
+                        cb(kqv_compressed, "kqv_compressed_perm", il);
                     }
+                    else {
+                        if (lctx.cparams.mla_attn > 1) {
+                            ggml_tensor * kv_cache_lora = ggml_view_2d(ctx0, kv_self.kv_l[il],
+                                    kv_lora_rank, n_kv,
+                                    ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank + n_embd_head_qk_rope), 0);
+                            cb(kv_cache, "kv_cache_lora", il);
 
-                    ggml_tensor * kqv_compressed;
-                    auto kq_size = kv_cache->ne[1]*q->ne[1]*q->ne[2]*sizeof(float)/(1024*1024); // K*Q in MiB
-                    if (lctx.cparams.attn_max_batch <= 0 || lctx.cparams.attn_max_batch >= kq_size) {
-                        if (!pp_opt) {
-                            q = ggml_permute(ctx0, q, 0, 2, 1, 3);
-                            cb(q, "q_perm", il);
+                            kv_cache_trans = ggml_cont(ctx0, ggml_transpose(ctx0, kv_cache_lora));
+                            cb(kv_cache_trans, "kv_cache_trans", il);
                         }
 
-                        ggml_tensor * kq = ggml_mul_mat(ctx0, kv_cache, q);
-                        cb(kq, "kq", il);
-
-                        if (!pp_opt) {
-                            kq = ggml_cont(ctx0, ggml_permute(ctx0, kq, 0, 2, 1, 3));
-                            cb(kq, "kq_perm", il);
-                        }
-
-                        kq = ggml_soft_max_ext(ctx0, kq, KQ_mask, kq_scale, hparams.f_max_alibi_bias);
-                        cb(kq, "kq_soft_max_ext", il);
-
-                        if (!pp_opt) {
-                            kq = ggml_permute(ctx0, kq, 0, 2, 1, 3);
-                            cb(kq, "kq_soft_max_ext_perm", il);
-                        }
-
-                        kqv_compressed = ggml_mul_mat(ctx0, kv_cache_trans, kq);
-                        cb(kqv_compressed, "kqv_compressed", il);
-
-                        if (!pp_opt) {
-                            kqv_compressed = ggml_permute(ctx0, kqv_compressed, 0, 2, 1, 3);
-                            cb(kqv_compressed, "kqv_compressed_perm", il);
-                        }
-
-                    } else {
-
-                        int n_step = (kq_size + lctx.cparams.attn_max_batch - 1)/lctx.cparams.attn_max_batch;
-                        n_step = std::min(n_step, int(q->ne[2]));
-                        int n_per_step = (q->ne[2] + n_step - 1)/n_step;
-
-                        //printf("kq size would be %ld MiB -> splitting kqv computation into %d steps\n", kq_size, n_step);
-
-                        for (int i_head = 0; i_head < q->ne[2]; i_head += n_per_step) {
-                            int this_ne12 = i_head + n_per_step <= q->ne[2] ? n_per_step : q->ne[2] - i_head;
-                            ggml_tensor * q_i = ggml_view_3d(ctx0, q, q->ne[0], q->ne[1], this_ne12, q->nb[1], q->nb[2], q->nb[2]*i_head);
-                            ggml_tensor * kq_i = ggml_mul_mat(ctx0, kv_cache, q_i);
-                            kq_i = ggml_soft_max_ext(ctx0, kq_i, KQ_mask, kq_scale, hparams.f_max_alibi_bias);
-                            ggml_tensor * kqv_i = ggml_mul_mat(ctx0, kv_cache_trans, kq_i);
-                            if (i_head == 0) {
-                                kqv_compressed = kqv_i;
-                            } else {
-                                kqv_compressed = ggml_concat(ctx0, kqv_compressed, kqv_i, 2);
+                        auto kq_size = kv_cache->ne[1]*q->ne[1]*q->ne[2]*sizeof(float)/(1024*1024); // K*Q in MiB
+                        if (lctx.cparams.attn_max_batch <= 0 || lctx.cparams.attn_max_batch >= kq_size) {
+                            if (!pp_opt) {
+                                q = ggml_permute(ctx0, q, 0, 2, 1, 3);
+                                cb(q, "q_perm", il);
                             }
-                            ggml_build_forward_expand(gf, kqv_compressed);
+
+                            ggml_tensor * kq = ggml_mul_mat(ctx0, kv_cache, q);
+                            cb(kq, "kq", il);
+
+                            if (!pp_opt) {
+                                kq = ggml_cont(ctx0, ggml_permute(ctx0, kq, 0, 2, 1, 3));
+                                cb(kq, "kq_perm", il);
+                            }
+
+                            kq = ggml_soft_max_ext(ctx0, kq, KQ_mask, kq_scale, hparams.f_max_alibi_bias);
+                            cb(kq, "kq_soft_max_ext", il);
+
+                            if (!pp_opt) {
+                                kq = ggml_permute(ctx0, kq, 0, 2, 1, 3);
+                                cb(kq, "kq_soft_max_ext_perm", il);
+                            }
+
+                            kqv_compressed = ggml_mul_mat(ctx0, kv_cache_trans, kq);
+                            cb(kqv_compressed, "kqv_compressed", il);
+
+                            if (!pp_opt) {
+                                kqv_compressed = ggml_permute(ctx0, kqv_compressed, 0, 2, 1, 3);
+                                cb(kqv_compressed, "kqv_compressed_perm", il);
+                            }
+
+                        } else {
+
+                            int n_step = (kq_size + lctx.cparams.attn_max_batch - 1)/lctx.cparams.attn_max_batch;
+                            n_step = std::min(n_step, int(q->ne[2]));
+                            int n_per_step = (q->ne[2] + n_step - 1)/n_step;
+
+                            //printf("kq size would be %ld MiB -> splitting kqv computation into %d steps\n", kq_size, n_step);
+
+                            for (int i_head = 0; i_head < q->ne[2]; i_head += n_per_step) {
+                                int this_ne12 = i_head + n_per_step <= q->ne[2] ? n_per_step : q->ne[2] - i_head;
+                                ggml_tensor * q_i = ggml_view_3d(ctx0, q, q->ne[0], q->ne[1], this_ne12, q->nb[1], q->nb[2], q->nb[2]*i_head);
+                                ggml_tensor * kq_i = ggml_mul_mat(ctx0, kv_cache, q_i);
+                                kq_i = ggml_soft_max_ext(ctx0, kq_i, KQ_mask, kq_scale, hparams.f_max_alibi_bias);
+                                ggml_tensor * kqv_i = ggml_mul_mat(ctx0, kv_cache_trans, kq_i);
+                                if (i_head == 0) {
+                                    kqv_compressed = kqv_i;
+                                } else {
+                                    kqv_compressed = ggml_concat(ctx0, kqv_compressed, kqv_i, 2);
+                                }
+                                ggml_build_forward_expand(gf, kqv_compressed);
+                            }
+                            cb(kqv_compressed, "kqv_compressed", il);
                         }
-                        cb(kqv_compressed, "kqv_compressed", il);
                     }
 
                     struct ggml_tensor * wv_b = ggml_view_3d(ctx0, model.layers[il].wv_b, kv_lora_rank, n_embd_head_v, n_head,
@@ -18226,7 +18247,7 @@ struct llama_context * llama_new_context_with_model(
             }
 
             if (memory_size_kv + memory_size_kvt > 0) {
-                if (cparams.mla_attn == 1) {
+                if (cparams.mla_attn == 1 && !cparams.flash_attn) {
                     LLAMA_LOG_INFO("%s: KV self size  = %7.2f MiB, c^KV (%s): %7.2f MiB, kv^T (%s): %7.2f MiB\n", __func__,
                             (float)(memory_size_kv + memory_size_kvt) / (1024.0f * 1024.0f),
                             ggml_type_name(kv_type), (float)memory_size_kv / (1024.0f * 1024.0f),

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13644,6 +13644,9 @@ struct llm_build_context {
                                 ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank + n_embd_head_qk_rope), 0);
                         cb(kv_cache_lora, "kv_cache_lora", il);
 
+                        //ggml_tensor * v = ggml_cont(ctx0, kv_cache_lora);
+                        //kqv_compressed = ggml_flash_attn_ext(ctx0, q, kv_cache, v, KQ_mask, kq_scale, hparams.f_max_alibi_bias, 0.f);
+
                         kqv_compressed = ggml_flash_attn_ext(ctx0, q, kv_cache, kv_cache_lora, KQ_mask, kq_scale, hparams.f_max_alibi_bias, 0.f);
                         cb(kqv_compressed, "kqv_compressed", il);
 


### PR DESCRIPTION
This PR adds Flash Attention for MLA for the CPU back-end. This should be of interest to people running DeepSeeklV3/R1 on the CPU.

Benefits:
* Reduced KV cache size - only the K-cache is required. Hence, the KV cache can be quantized. One can achieve the same with `-mla 2`, but this comes at a significant performance penalty (the transposed view of the cache needs to be computed on each compute graph evaluation)
* Reduced compute buffer size - the `K*Q` tensor, which is the major contributor to compute buffer size for long contexts, never materializes. One can keep the compute buffer size to a desired maximum size using the `-amb` option, but this comes with the inconvenience of having to think about compute buffer sizes, and a small performance penalty for large contexts
* Same or slightly better prompt processing performance compared to just `-mla 1` (but performance for long contexts is still lower than standard attention with FA)
* The same or nearly the same token generation performance

Here is a what we get for KV cache and compute buffer size for DeepSeek-Lite with just MLA for a context of 65k tokens
```
./bin/llama-cli -m $model ... -c 65536 -ctk q8_KV -mla 1
llama_kv_cache_init:        CPU KV buffer size =  2713,50 MiB
llama_new_context_with_model: KV self size  = 2713,50 MiB, c^KV (q8_KV):  985,50 MiB, kv^T (f16): 1728,00 MiB
llama_new_context_with_model:        CPU  output buffer size =     0,39 MiB
llama_new_context_with_model:        CPU compute buffer size =  2228,01 MiB
llama_new_context_with_model: graph nodes  = 1449
llama_new_context_with_model: graph splits = 1
```

And here the same with FA enabled
```
./bin/llama-cli -m $model ... -c 65536 -ctk q8_KV -mla 1 -fa
llama_kv_cache_init:        CPU KV buffer size =   985,50 MiB
llama_new_context_with_model: KV self size  =  985,50 MiB, c^KV (q8_KV):  985,50 MiB, kv^T: not used
llama_new_context_with_model:        CPU  output buffer size =     0,39 MiB
llama_new_context_with_model:        CPU compute buffer size =   240,01 MiB
llama_new_context_with_model: graph nodes  = 1342
llama_new_context_with_model: graph splits = 1
```
For DeepSeekV3/R1 KV cache will be `61/27 = 2.26X` larger. Without FA, the compute buffer would be 8X larger (8X more heads), with FA it would be only marginally larger (due to the larger embedding size).

Just for fun, here is what we need without MLA:
```
./bin/llama-cli -m $model ... -ctk q8_KV -mla 0 -fa
llama_kv_cache_init:        CPU KV buffer size = 12312,00 MiB
llama_new_context_with_model: KV self size  = 12312,00 MiB, K (q8_KV): 5400,00 MiB, V (f16): 6912,00 MiB
llama_new_context_with_model:        CPU  output buffer size =     0,39 MiB
llama_new_context_with_model:        CPU compute buffer size =   214,01 MiB
llama_new_context_with_model: graph nodes  = 1315
llama_new_context_with_model: graph splits = 1
```
And now without MLA and without FA (i.e., what one has available in mainline `llama.cpp`)
```
./bin/llama-cli -m $model ... -ctk q8_KV 
llama_kv_cache_init:        CPU KV buffer size = 12312,00 MiB
llama_new_context_with_model: KV self size  = 12312,00 MiB, K (q8_KV): 5400,00 MiB, V (f16): 6912,00 MiB
llama_new_context_with_model:        CPU  output buffer size =     0,39 MiB
llama_new_context_with_model:        CPU compute buffer size =  2200,01 MiB
llama_new_context_with_model: graph nodes  = 1422
llama_new_context_with_model: graph splits = 1
```
Hahaha - 14.2 GiB. For DeepSeekV3/R1 scale KV cache size by 2.26 and compute buffer size by 8, so 44 GiB.

 
Anyway, here is a performance comparison between FlashMLA and regular MLA for DeepSeek-Lite on a Ryzen-7950X (Zen4) and a Ryzen-5975WX (AVX2)

| model                | platform   | type_k | mla | rtr | fmoe |      test |  t/s (no FA)     |     t/s (FA)     |
| ---------------------| ---------- | -----: | --: | --: | ---: | --------: | ---------------: | ---------------: |
| deepseek2 16B IQ4_NL | Zen4       |  q8_KV |   1 |   1 |    1 |     pp512 |    603.88 ± 2.13 |    616.65 ± 2.81 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp1024 |    575.34 ± 2.60 |    579.28 ± 0.65 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp2048 |    520.35 ± 3.50 |    518.01 ± 4.12 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp4096 |    425.10 ± 0.83 |    433.62 ± 0.38 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp8192 |    311.88 ± 0.70 |    309.52 ± 0.37 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   pp16384 |    198.67 ± 2.81 |    181.15 ± 1.47 |
| deepseek2 16B IQ4_NL | AVX2       |  q8_KV |   1 |   1 |    1 |     pp512 |    551.07 ± 3.32 |    571.88 ± 2.92 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp1024 |    520.66 ± 3.82 |    551.12 ± 1.85 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp2048 |    473.37 ± 3.58 |    504.35 ± 0.92 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp4096 |    395.86 ± 3.17 |    421.14 ± 0.58 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    pp8192 |    302.35 ± 1.82 |    315.33 ± 0.49 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   pp16384 |    186.79 ± 0.90 |    193.28 ± 2.92 |

I.e., about the same on `Zen4` and slightly better on vanilla `AVX2`. I think the lower performance at 16k tokens can be improved, but I leave this for another PR.

Here the same but for TG as a function of tokens in the KV cache

| model                | platform   | type_k | mla | rtr | fmoe |          test |    t/s (no FA)   |    t/s (FA)      | 
| ---------------------| ---------- | -----: | --: | --: | ---: | ------------: | ---------------: | ---------------: | 
| deepseek2 16B IQ4_NL | Zen4       |  q8_KV |   1 |   1 |    1 |    tg64@pp128 |     32.21 ± 0.01 |     32.32 ± 0.02 | 
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    tg64@pp256 |     32.07 ± 0.02 |     32.11 ± 0.06 | 
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    tg64@pp512 |     31.40 ± 0.03 |     31.82 ± 0.06 | 
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp1024 |     31.18 ± 0.01 |     31.37 ± 0.00 | 
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp2048 |     30.05 ± 0.01 |     30.49 ± 0.07 | 
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp4096 |     28.17 ± 0.06 |     28.83 ± 0.04 | 
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp8192 |     25.16 ± 0.01 |     26.00 ± 0.13 | 
| deepseek2 16B IQ4_NL | AVX2       |  q8_KV |   1 |   1 |    1 |    tg64@pp128 |     31.21 ± 0.01 |     31.30 ± 0.00 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    tg64@pp256 |     31.26 ± 0.02 |     30.63 ± 0.02 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |    tg64@pp512 |     30.79 ± 0.02 |     30.22 ± 0.00 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp1024 |     30.02 ± 0.00 |     29.09 ± 0.00 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp2048 |     28.89 ± 0.00 |     27.38 ± 0.02 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp4096 |     27.01 ± 0.00 |     25.07 ± 0.01 |
| deepseek2 16B IQ4_NL |            |  q8_KV |   1 |   1 |    1 |   tg64@pp8192 |     23.40 ± 0.01 |     21.30 ± 0.00 |

I.e., very slightly better on `Zen4`  and slightly slower on vanilla `AVX2`. 

Supported KV caches are:
* `F16`
* `BF16` (if CPU has native support for `BF16` instructions
* `Q8_0`
* `Q8_KV` - the fastest option
* `Q6_0`

I didn't allow lower quantization than `Q6_0` because a) quality loss becomes significant; b) build time becomes too long as one adds additional quantization types; and c) KV cache is now so much smaller compared to standard attention that it does not make sense to be stingy with KV cache bits. 

  