### PR TITLE
Faster FlashMLA prompt processing

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3216,22 +3216,20 @@ static bool llama_kv_cache_init(
                             //(n_embd_head_qk_nope + hparams.n_embd_head_v)*n_head, kv_size);
                     ggml_format_name(cache.kv_aux_f32, "kv_aux_f32%d", 0);
 
-                    cache.k_aux = ggml_new_tensor_2d(ctx, cache.type_k,
-                            hparams.n_embd_head_k*n_head, kv_size);
+                    cache.k_aux = ggml_new_tensor_3d(ctx, cache.type_k, hparams.n_embd_head_k, n_head, kv_size);
                     ggml_format_name(cache.k_aux, "k_aux%d", 0);
 
-                    cache.v_aux = ggml_new_tensor_2d(ctx, cache.type_k,
-                            hparams.n_embd_head_v*n_head, kv_size);
+                    cache.v_aux = ggml_new_tensor_3d(ctx, cache.type_k, hparams.n_embd_head_v, n_head, kv_size);
                     ggml_format_name(cache.v_aux, "v_aux%d", 0);
 
                     //cache.kv_aux_2   = ggml_new_tensor_2d(ctx, GGML_TYPE_F32,
                     //        (hparams.n_embd_head_k + hparams.n_embd_head_v)*n_head, kv_size);
                     //ggml_format_name(cache.kv_aux, "kv_aux%d", 0);
                     //ggml_format_name(cache.kv_aux_2, "kv_aux%d", 2);
-                    LLAMA_LOG_INFO("%s: allocated kv auxilary tensors as %ld x %ld, %ld x %ld, %ld x %ld\n", __func__,
+                    LLAMA_LOG_INFO("%s: allocated kv auxilary tensors as %ld x %ld, %ld x %ld x %ld, %ld x %ld x %ld\n", __func__,
                             cache.kv_aux_f32->ne[0], cache.kv_aux_f32->ne[1],
-                            cache.k_aux->ne[0], cache.k_aux->ne[1],
-                            cache.v_aux->ne[0], cache.v_aux->ne[1]);
+                            cache.k_aux->ne[0], cache.k_aux->ne[1], cache.k_aux->ne[2],
+                            cache.v_aux->ne[0], cache.v_aux->ne[1], cache.v_aux->ne[2]);
                 }
             } else {
                 auto kv_type = cparams.mla_attn == 1 ? cache.type_k : cache.type_v;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -2691,6 +2691,9 @@ struct llama_kv_cache {
     // DeepSeek MLA
     std::vector<struct ggml_tensor *> kv_l;
     std::vector<struct ggml_tensor *> kvt_l;
+    ggml_tensor * kv_aux_f32 = nullptr;
+    ggml_tensor * k_aux = nullptr;
+    ggml_tensor * v_aux = nullptr;
 
     std::vector<struct ggml_context *> ctxs;
     std::vector<ggml_backend_buffer_t> bufs;
@@ -3199,12 +3202,37 @@ static bool llama_kv_cache_init(
         if (cparams.mla_attn && model.layers[i].wk_b && model.layers[i].wv_b) {
             // DeepSeek MLA
             const uint32_t n_embd_head_qk_rope = hparams.n_rot;
+            const uint32_t n_embd_head_qk_nope = hparams.n_embd_head_k - hparams.n_rot;
             const uint32_t kv_lora_rank = hparams.n_lora_kv;
             LLAMA_LOG_INFO("%s: layer %d: n_embd_head_qk_rope = %d, kv_lora_rank = %d\n", __func__, i, n_embd_head_qk_rope, kv_lora_rank);
             if (cparams.flash_attn) {
                 ggml_tensor * kv = ggml_new_tensor_2d(ctx, cache.type_k, kv_lora_rank + n_embd_head_qk_rope, kv_size);
                 ggml_format_name(kv, "cache_kv_l%d", i);
                 cache.kv_l.push_back(kv);
+                if (cparams.mla_attn > 1 && cache.kv_aux_f32 == nullptr) {
+
+                    cache.kv_aux_f32 = ggml_new_tensor_2d(ctx, GGML_TYPE_F32,
+                            kv_lora_rank + n_embd_head_qk_rope, kv_size);
+                            //(n_embd_head_qk_nope + hparams.n_embd_head_v)*n_head, kv_size);
+                    ggml_format_name(cache.kv_aux_f32, "kv_aux_f32%d", 0);
+
+                    cache.k_aux = ggml_new_tensor_2d(ctx, cache.type_k,
+                            hparams.n_embd_head_k*n_head, kv_size);
+                    ggml_format_name(cache.k_aux, "k_aux%d", 0);
+
+                    cache.v_aux = ggml_new_tensor_2d(ctx, cache.type_k,
+                            hparams.n_embd_head_v*n_head, kv_size);
+                    ggml_format_name(cache.v_aux, "v_aux%d", 0);
+
+                    //cache.kv_aux_2   = ggml_new_tensor_2d(ctx, GGML_TYPE_F32,
+                    //        (hparams.n_embd_head_k + hparams.n_embd_head_v)*n_head, kv_size);
+                    //ggml_format_name(cache.kv_aux, "kv_aux%d", 0);
+                    //ggml_format_name(cache.kv_aux_2, "kv_aux%d", 2);
+                    LLAMA_LOG_INFO("%s: allocated kv auxilary tensors as %ld x %ld, %ld x %ld, %ld x %ld\n", __func__,
+                            cache.kv_aux_f32->ne[0], cache.kv_aux_f32->ne[1],
+                            cache.k_aux->ne[0], cache.k_aux->ne[1],
+                            cache.v_aux->ne[0], cache.v_aux->ne[1]);
+                }
             } else {
                 auto kv_type = cparams.mla_attn == 1 ? cache.type_k : cache.type_v;
                 ggml_tensor * kv = ggml_new_tensor_2d(ctx, kv_type, kv_lora_rank + n_embd_head_qk_rope, kv_size);
@@ -13625,6 +13653,111 @@ struct llm_build_context {
                             ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank + n_embd_head_qk_rope), 0);
                     cb(kv_cache, "kv_cache", il);
 
+                    ggml_tensor * kqv;
+
+                    if (lctx.cparams.mla_attn > 1 && lctx.cparams.flash_attn && (pp_opt || lctx.cparams.mla_attn > 2)) {
+
+                        // Hahaha, we need to convert the KV cache for this layer to f32 because the general purpose ML library ggml does not
+                        // provide ops on (almost) anything other than f32. In this case, the cache will be the second operand to a matrix
+                        // multiplication, which *must* be f32.
+                        auto kv_cache_view = ggml_view_2d(ctx0, kv_self.kv_l[il], kv_self.kv_l[il]->ne[0], n_kv, kv_self.kv_l[il]->nb[1], 0);
+                        auto kv_cache_view_f32 = ggml_view_2d(ctx0, kv_self.kv_aux_f32, kv_self.kv_aux_f32->ne[0], n_kv, kv_self.kv_aux_f32->nb[1], 0);
+                        kv_cache_view_f32 = ggml_cpy(ctx0, kv_cache_view, kv_cache_view_f32);
+
+                        // The no- and rorational position encoding portions of the KV cache
+                        auto kv_cache_nope = ggml_view_2d(ctx0, kv_cache_view_f32, kv_lora_rank, n_kv, kv_cache_view_f32->nb[1], 0);
+                        auto kv_cache_rope = ggml_view_3d(ctx0, kv_cache_view_f32, n_embd_head_qk_rope, 1, n_kv,
+                                kv_cache_view_f32->nb[1], kv_cache_view_f32->nb[1], ggml_row_size(kv_cache_view_f32->type, kv_lora_rank));
+
+                        auto kv_f32 = ggml_mul_mat(ctx0, model.layers[il].wkv_b, kv_cache_nope);
+
+                    //// split into {n_head * n_embd_head_qk_nope, n_tokens}
+                    //struct ggml_tensor * k_nope = ggml_view_3d(ctx0, kv, n_embd_head_qk_nope, n_head, n_tokens,
+                    //        ggml_row_size(kv->type, n_embd_head_qk_nope + hparams.n_embd_head_v),
+                    //        ggml_row_size(kv->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                    //        0);
+                    //cb(k_nope, "k_nope", il);
+
+                    //// and {n_head * n_embd_head_v, n_tokens}
+                    //struct ggml_tensor * v_states = ggml_view_3d(ctx0, kv, hparams.n_embd_head_v, n_head, n_tokens,
+                    //        ggml_row_size(kv->type, (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                    //        ggml_row_size(kv->type, (n_embd_head_qk_nope + hparams.n_embd_head_v)*n_head),
+                    //        ggml_row_size(kv->type, (n_embd_head_qk_nope)));
+                    //cb(v_states, "v_states", il);
+
+                        auto k_nope_f32 = ggml_view_3d(ctx0, kv_f32, n_embd_head_qk_nope, n_kv, n_head,
+                                ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                                ggml_row_size(kv_f32->type, n_embd_head_qk_nope + hparams.n_embd_head_v), 0);
+
+                        ggml_tensor repeater;
+                        repeater.ne[0] = n_embd_head_qk_rope; repeater.ne[1] = n_head; repeater.ne[2] = n_kv; repeater.ne[3] = 1;
+                        auto k_rope_f32 = ggml_permute(ctx0, ggml_repeat(ctx0, kv_cache_rope, &repeater), 0, 2, 1, 3);
+
+                        auto k_f32 = ggml_concat(ctx0, k_nope_f32, k_rope_f32, 0);
+
+                        auto k_row_size = ggml_row_size(kv_self.k_aux->type, k_f32->ne[0]);
+                        auto k = ggml_view_3d(ctx0, kv_self.k_aux, k_f32->ne[0], k_f32->ne[1], k_f32->ne[2],
+                                k_row_size, k_row_size*k_f32->ne[1], 0);
+                                //kv_self.k_aux->nb[1], k_row_size, 0);
+                                //k_row_size, kv_self.k_aux->nb[1], 0);
+                        k = ggml_cpy(ctx0, k_f32, k);
+
+                        auto v_f32 = ggml_view_3d(ctx0, kv_f32, hparams.n_embd_head_v, n_kv, n_head,
+                                ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                                ggml_row_size(kv_f32->type, n_embd_head_qk_nope + hparams.n_embd_head_v),
+                                ggml_row_size(kv_f32->type, n_embd_head_qk_nope));
+
+                        auto v_row_size = ggml_row_size(kv_self.v_aux->type, v_f32->ne[0]);
+                        auto v = ggml_view_3d(ctx0, kv_self.v_aux, v_f32->ne[0], v_f32->ne[1], v_f32->ne[2],
+                                v_row_size, v_row_size*v_f32->ne[1], 0);
+                                //kv_self.v_aux->nb[1], v_row_size, 0);
+                                //v_row_size, kv_self.v_aux->nb[1], 0);
+                        v = ggml_cpy(ctx0, v_f32, v);
+
+                        //auto kv_cache_nope = ggml_view_2d(ctx0, kv_self.kv_l[il], kv_lora_rank, n_kv, kv_cache->nb[1], 0);
+                        //auto kv_cache_rope = ggml_view_2d(ctx0, kv_self.kv_l[il], n_embd_head_qk_rope, n_kv, kv_cache->nb[1],
+                        //        ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank));
+                        ////kv_cache_rope = ggml_permute(ctx0, kv_cache_rope, 0, 2, 1, 3);
+
+                        //auto kv_cache_nope_f32 = ggml_view_2d(ctx0, kv_self.kv_aux_f32, kv_lora_rank, n_kv, kv_self.kv_aux_f32->nb[1], 0);
+                        //kv_cache_nope_f32 = ggml_cpy(ctx0, kv_cache_nope, kv_cache_nope_f32);
+                        //auto kv_f32 = ggml_mul_mat(ctx0, model.layers[il].wkv_b, kv_cache_nope_f32);
+
+                        ////auto kv = ggml_new_tensor_2d(ctx0, kv_self.kv_l[il]->type, model.layers[il].wkv_b->ne[1], n_kv);
+                        ////auto kv = ggml_new_tensor_2d(ctx0, kv_self.kv_l[il]->type, kv_f32->ne[0], kv_f32->ne[1]);
+                        //auto kv = ggml_view_2d(ctx0, kv_self.kv_aux, kv_self.kv_aux->ne[0], n_kv, kv_self.kv_aux->nb[1], 0);
+                        //kv = ggml_cpy(ctx0, kv_f32, kv);
+
+                        //auto k_nope = ggml_view_3d(ctx0, kv, n_embd_head_qk_nope, n_kv, n_head,
+                        //        ggml_row_size(kv->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                        //        ggml_row_size(kv->type, n_embd_head_qk_nope + hparams.n_embd_head_v), 0);
+
+                        //ggml_tensor repeater;
+                        //repeater.ne[0] = n_embd_head_qk_rope; repeater.ne[1] = n_kv; repeater.ne[2] = n_head; repeater.ne[3] = 1;
+                        //auto k = ggml_concat(ctx0, k_nope, ggml_repeat(ctx0, kv_cache_rope, &repeater), 0);
+
+                        //auto v = ggml_view_3d(ctx0, kv, hparams.n_embd_head_v, n_kv, n_head,
+                        //             ggml_row_size(kv->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                        //             ggml_row_size(kv->type, n_embd_head_qk_nope + hparams.n_embd_head_v),
+                        //             ggml_row_size(kv->type, n_embd_head_qk_nope));
+
+                        auto q = ggml_concat(ctx0, q_nope, q_rope, 0);
+                        q = ggml_permute(ctx0, q, 0, 2, 1, 3);
+
+                        kqv = ggml_flash_attn_ext(ctx0, q, k, v, KQ_mask, kq_scale, hparams.f_max_alibi_bias, 0.f);
+                        cb(kqv, "kqv", il);
+
+                        cur = ggml_reshape_2d(ctx0, kqv, n_embd_head_v*n_head, n_tokens);
+
+                        //kqv_compressed = ggml_permute(ctx0, kqv_compressed, 0, 2, 1, 3);
+                        //cb(kqv_compressed, "kqv_compressed_perm", il);
+                    }
+                    else {
+
+                    ggml_tensor * kqv_compressed;
+
+                    //printf("wkv_b: %ld x %ld x %ld kv_cache: %ld x %ld x %ld\n", model.layers[il].wkv_b->ne[0], model.layers[il].wkv_b->ne[1], model.layers[il].wkv_b->ne[2], kv_cache->ne[0], kv_cache->ne[1], kv_cache->ne[2]);
+
                     struct ggml_tensor * wk_b = ggml_view_3d(ctx0, model.layers[il].wk_b, n_embd_head_qk_nope, kv_lora_rank, n_head,
                             ggml_row_size(model.layers[il].wk_b->type, n_embd_head_qk_nope),
                             ggml_row_size(model.layers[il].wk_b->type, kv_lora_rank)*n_embd_head_qk_nope, 0);
@@ -13636,11 +13769,11 @@ struct llm_build_context {
 
                     struct ggml_tensor * q_nope2 = ggml_mul_mat(ctx0, wk_b, q_nope);
                     cb(q_nope2, "q_nope2", il);
+                    //printf("q_nope2 (%ld x %ld x %ld) = wk_b (%ld x %ld x %ld) * q_nope (%ld x %ld x %ld)\n", q_nope2->ne[0], q_nope2->ne[1], q_nope2->ne[2],
+                    //        wk_b->ne[0], wk_b->ne[1], wk_b->ne[2], q_nope->ne[0], q_nope->ne[1], q_nope->ne[2]);
 
                     ggml_tensor * q = ggml_concat(ctx0, q_nope2, ggml_permute(ctx0, q_rope, 0, 2, 1, 3), 0);
                     cb(q, "q", il);
-
-                    ggml_tensor * kqv_compressed;
 
                     if (lctx.cparams.flash_attn) {
                         ggml_tensor * kv_cache_lora = ggml_view_2d(ctx0, kv_self.kv_l[il],
@@ -13729,7 +13862,7 @@ struct llm_build_context {
                             ggml_row_size(model.layers[il].wv_b->type, kv_lora_rank)*n_embd_head_v, 0);
                     cb(wv_b, "wv_b", il);
 
-                    struct ggml_tensor * kqv = ggml_mul_mat(ctx0, wv_b, kqv_compressed);
+                    kqv = ggml_mul_mat(ctx0, wv_b, kqv_compressed);
                     cb(kqv, "kqv", il);
 
                     kqv = ggml_cont(ctx0, ggml_permute(ctx0, kqv, 0, 2, 1, 3));
@@ -13737,6 +13870,7 @@ struct llm_build_context {
 
                     cur = ggml_view_2d(ctx0, kqv, n_embd_head_v*n_head, n_tokens, ggml_row_size(kqv->type, n_embd_head_v*n_head), 0);
                     cb(cur, "kqv_2d", il);
+                    }
 
                     ggml_build_forward_expand(gf, cur);
 


### PR DESCRIPTION

MLA as used in the DeepSeek models is great for token generation (TG), but prompt processing (PP) speed is much lower compared to standard attention even with FA enabled.

This PR improves FlashMLA speed by a large margin. FlashMLA is CPU only, but the PR paves the way to perhaps also get it on CUDA (but this is left for a future PR).

The following table compares FlashMLA PP speed for DeepSeek-Lite quantized as `IQ4_NL` between the main branch and this PR. CPU is Ryzen-7950X, the cache is quantized with `Q8_0`, `fmoe` is on.

| model                |          test |     t/s (main)   |   t/s (PR)       |  Speedup |
| ---------------------| ------------: | ---------------: | ---------------: | -------: |
| deepseek2 16B IQ4_NL |         pp512 |    605.29 ± 4.92 |    681.72 ± 1.12 |  1.126   |
| deepseek2 16B IQ4_NL |        pp1024 |    568.79 ± 0.75 |    648.71 ± 1.48 |  1.141   |
| deepseek2 16B IQ4_NL |        pp2048 |    509.15 ± 4.38 |    598.99 ± 0.83 |  1.176   |
| deepseek2 16B IQ4_NL |        pp4096 |    420.10 ± 0.82 |    514.62 ± 2.68 |  1.225   |
| deepseek2 16B IQ4_NL |        pp8192 |    293.24 ± 2.09 |    399.14 ± 5.89 |  1.361   |
| deepseek2 16B IQ4_NL |       pp16384 |    170.66 ± 0.76 |    269.01 ± 4.64 |  1.576   |

For reference, here is a comparison between standard attention with FA enabled and FlashMLA with this PR

| model                |          test | t/s (standard FA)|   t/s (PR)       |  Speedup |
| ---------------------| ------------: | ---------------: | ---------------: | -------: |
| deepseek2 16B IQ4_NL |         pp512 |    675.89 ± 7.49 |    681.72 ± 1.12 |  1.009   |   
| deepseek2 16B IQ4_NL |        pp1024 |    658.84 ± 1.08 |    648.71 ± 1.48 |  0.985   |   
| deepseek2 16B IQ4_NL |        pp2048 |    635.75 ± 1.70 |    598.99 ± 0.83 |  0.942   |   
| deepseek2 16B IQ4_NL |        pp4096 |    591.13 ± 0.06 |    514.62 ± 2.68 |  0.871   |   
| deepseek2 16B IQ4_NL |        pp8192 |    515.03 ± 2.53 |    399.14 ± 5.89 |  0.775   |   
| deepseek2 16B IQ4_NL |       pp16384 |    400.24 ± 0.74 |    269.01 ± 4.64 |  0.672   |   

I.e., still quite a bit slower than standard attention with FA enabled for long contexts, but much better than the original implementation.

The new functionality is enabled via `-mla 2 -fa` as command line arguments. I know, it is getting confusing, so here is a summary of what happens with the different `mla` and `fa` combinations:

* `mla = 0, fa = 0`: standard attention without FA. Works on the CPU and on CUDA. Large K- and V-cache required. The V cache cannot be quantized
* `mla = 0, fa = 1`: standard attention with FA. Works on the CPU and on CUDA. Large K- and V-cache required. The V cache can be quantized. Best PP performance, TG performance is slightly lower than standard attention without FA
* `mla = 1, fa = 0`: MLA attention. Works on the CPU and on CUDA. Smaller K- and smaller transposed V cache required.  The V cache cannot be quantized. Great TG performance, pathetic TG performance. 
* `mla = 1, fa = 1`: FlashMLA. Works only on the CPU. Only small K cache required. Great TG performance, slightly less pathetic PP performance
* `mla = 2, fa = 0`: FlashMLA . Works only on the CPU and on CUDA. Only small K cache required (the transposed V cache is computed on the fly). Great TG performance (but slightly lower than `mla = 1` for long contexts), pathetic PP performance.
* `mla = 2, fa = 1`: FlashMLA from this PR. Works only on CPU. Only small K cache required. Great TG performance, more acceptable PP performance. 

### Background

Let $X$ and $Q$ be the activations and the query after projection with their corresponding MQA tensors and after applying rotational position encoding (RoPE). In standard attention one computes (apart from scaling factors and masks that I'll omit for simplicity)

$$K = W_k X, \quad\quad V = W_v X,\quad\quad R = V_{\rm cache} {\rm softmax}(K_{\rm cache} Q)$$

In practice the $W_k$ and $W_v$ tensors are combined into $W_{kv}$ (the tensor `wkv_b` in `llama.cpp`), one computes $Y = W_{kv} X$, and the tensors $K$ and $V$ are views into $Y$. The matrix multiplication with $W_{kv}$ is performed only for the tokens in the batch being processed, the results are stored in the cache, and the tensors $V_{\rm cache}$ and $K_{\rm cache}$ are views into the KV cache.

With MLA one computes

$$Q' = W_k^T Q,\quad\quad R = W_v \left[ V_{\rm cache}  {\rm softmax}(K_{\rm cache} Q' \right]$$

where one stores $X$ directly into the K-cache, and $K_{\rm cache}$ is an appropriate view into the cache. $V_{\rm cache}$ is a transposed version of $K_{\rm cache}$ with FA is not used, or a slightly different view into the K-cache with FA or `mla=2`. The benefit of doing this reordering of the operations is that the cache becomes much smaller. But as these are not square matrices, the amount of multiply-adds (madds in the following) does depend on the order of the matrix multiplications. If we denote the number of madds in the standard attention implementation wit $N$, for the DeepSeek models the number of madds with MLA is $(576 + 512)/(192 + 128) \times N = 3.4 \times N$. Why is TG with MLA faster than with standard attention if one needs to do more computation? The difference comes from the shapes of the various matrices involved. TG with standard attention results in the tensor $Q$ being of shape $M \times 1 \times L$, so all multiplications are matrix-vector (a.k.a. GEMV), which are memory bound on basically any modern system (CPU or GPU). With MLA the shape of $Q'$ is $M' \times L$, so the calculation involves matrix-matrix multiplications (a.k.a. GEMM), which are much faster per madd, so one ends up with a better performance despite having computed more madds. But for PP in both cases we are dealing with GEMMs, so the `3.4X` more madds makes MLA PP processing slower. As an example, for 8k tokens with standard attention and FA, about 25% of the time is spent in the flash attention computation. We can estimate the expected MLA PP performance to be `0.75 + 0.25 x 3.4 = 1.6` times slower. From the above tables we see that in practice it is `515 t/s / 293 t/s = 1.75` times slower. As there are some other differences in the performed matrix multiplications, our back-of-the-envelope estimate comes quite close to the observed behavior.

So, how can we improve? We can rearrange the computation back to standard attention. The only difference: as we are storing $X$ into the cache, we need to multiply $W_{kv}$ with the **entire** content of the cache. This seems pretty  stupid at first glance (and I had had the idea to rearrange the multiplications quite a while ago but discarded it because of that), but if one sits down and counts the actual madds that are required, one finds that for DeepSeek this results in $(192 + 3 \times 128)/(192 + 128) = 1.8 \times N$ more madds than standard attention. I.e., we still need more madds, but significantly less madds than the existing MLA implementation. What about TG? We save the day by applying the rearranged matrix multiplications only if the number of tokens in the batch is greater than 1 (or some suitably chosen threshold). In this way we keep the good TG performance, keep the reduced cache size, and get improved prompt processing speed.

