### PR TITLE
FlashMLA-2 (CPU): faster and smaller compute buffer size

### DIFF
--- a/ggml/src/ggml-backend.c
+++ b/ggml/src/ggml-backend.c
@@ -843,7 +843,8 @@ GGML_CALL static bool ggml_backend_cpu_supports_op(ggml_backend_t backend, const
                 op->type != GGML_TYPE_IQ1_S   &&
                 op->type != GGML_TYPE_IQ1_M; // missing type_traits.from_float
         case GGML_OP_MUL_MAT:
-            return op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == ggml_internal_get_type_traits(op->src[0]->type).vec_dot_type;
+            return true;
+            //return op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == ggml_internal_get_type_traits(op->src[0]->type).vec_dot_type;
         default:
             return true;
     }

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -248,6 +248,14 @@ bool iqk_modify_tensor(struct ggml_tensor * tensor);
 // So we can re-pack Microsoft's BitNet I2_S quants
 void dequantize_row_ms_i2s(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
+typedef void (*to_float_t)  (const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+typedef void (*from_float_t)(const float * GGML_RESTRICT x, void  * GGML_RESTRICT y, int64_t k);
+void iqk_quantize_any(int from_type, int to_type,
+                      int64_t ne0, int64_t ne1, int64_t ne2, int64_t ne3,
+                      uint64_t nb0, uint64_t nb1, uint64_t nb2, uint64_t nb3,
+                      const void * GGML_RESTRICT x, void * GGML_RESTRICT y, void * work_buffer,
+                      to_float_t to_float, from_float_t from_float, int ith, int nth);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13661,6 +13661,9 @@ struct llm_build_context {
                             auto k_nope = ggml_cast(ctx0, k_nope_f32, kv_self.kv_l[il]->type);
                             cb(k_nope, "k_nope", il);
 
+                            ggml_build_forward_expand(gf, k_nope);
+                            ggml_build_forward_expand(gf, v);
+
                             auto kv_cache_rope = ggml_view_3d(ctx0, kv_self.kv_l[il], n_embd_head_qk_rope, n_kv, 1,
                                     kv_self.kv_l[il]->nb[1], kv_self.kv_l[il]->nb[2], ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank));
 
@@ -13673,7 +13676,6 @@ struct llm_build_context {
                             cb(k, "k", il);
 
                             ggml_build_forward_expand(gf, k);
-                            ggml_build_forward_expand(gf, v);
                         }
                         else {
                             // Hahaha, we need to convert the KV cache for this layer to f32 because the general purpose ML library ggml does not

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13630,36 +13630,11 @@ struct llm_build_context {
 
                     if (lctx.cparams.mla_attn > 1 && lctx.cparams.flash_attn && (pp_opt || lctx.cparams.mla_attn > 2)) {
 
-                        // Hahaha, we need to convert the KV cache for this layer to f32 because the general purpose ML library ggml does not
-                        // provide ops on (almost) anything other than f32. In this case, the cache will be the second operand to a matrix
-                        // multiplication, which *must* be f32.
-                        auto kv_cache_view = ggml_view_2d(ctx0, kv_self.kv_l[il], kv_self.kv_l[il]->ne[0], n_kv, kv_self.kv_l[il]->nb[1], 0);
-                        auto kv_cache_view_f32 = ggml_cast(ctx0, kv_cache_view, GGML_TYPE_F32);
-                        cb(kv_cache_view_f32, "kv_cache_view_f32", il);
+                        GGML_ASSERT(hparams.n_embd_head_v == n_embd_head_qk_nope);
 
-                        // The no- and rotational position encoding portions of the KV cache
-                        auto kv_cache_nope = ggml_view_2d(ctx0, kv_cache_view_f32, kv_lora_rank, n_kv, kv_cache_view_f32->nb[1], 0);
-                        auto kv_cache_rope = ggml_view_3d(ctx0, kv_cache_view_f32, n_embd_head_qk_rope, 1, n_kv,
-                                kv_cache_view_f32->nb[1], kv_cache_view_f32->nb[1], ggml_row_size(kv_cache_view_f32->type, kv_lora_rank));
-
+                        auto kv_cache_nope = ggml_view_2d(ctx0, kv_self.kv_l[il], kv_lora_rank, n_kv, kv_self.kv_l[il]->nb[1], 0);
                         auto kv_f32 = ggml_mul_mat(ctx0, model.layers[il].wkv_b, kv_cache_nope);
                         cb(kv_f32, "kv_f32", il);
-
-                        auto k_nope_f32 = ggml_view_3d(ctx0, kv_f32, n_embd_head_qk_nope, n_kv, n_head,
-                                ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
-                                ggml_row_size(kv_f32->type, n_embd_head_qk_nope + hparams.n_embd_head_v), 0);
-                        cb(k_nope_f32, "k_nope_f32", il);
-
-                        ggml_tensor repeater;
-                        repeater.ne[0] = n_embd_head_qk_rope; repeater.ne[1] = n_head; repeater.ne[2] = n_kv; repeater.ne[3] = 1;
-                        auto k_rope_f32 = ggml_permute(ctx0, ggml_repeat(ctx0, kv_cache_rope, &repeater), 0, 2, 1, 3);
-                        cb(k_rope_f32, "k_rope_f32", il);
-
-                        auto k_f32 = ggml_concat(ctx0, k_nope_f32, k_rope_f32, 0);
-                        cb(k_f32, "k_f32", il);
-
-                        auto k = ggml_cast(ctx0, k_f32, kv_self.kv_l[il]->type);
-                        cb(k, "k", il);
 
                         auto v_f32 = ggml_view_3d(ctx0, kv_f32, hparams.n_embd_head_v, n_kv, n_head,
                                 ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
@@ -13669,6 +13644,64 @@ struct llm_build_context {
 
                         auto v = ggml_cast(ctx0, v_f32, kv_self.kv_l[il]->type);
                         cb(v, "v", il);
+
+                        auto k_nope_f32 = ggml_view_3d(ctx0, kv_f32, n_embd_head_qk_nope, n_kv, n_head,
+                                ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                                ggml_row_size(kv_f32->type, n_embd_head_qk_nope + hparams.n_embd_head_v), 0);
+                        cb(k_nope_f32, "k_nope_f32", il);
+
+                        auto k_nope = ggml_cast(ctx0, k_nope_f32, kv_self.kv_l[il]->type);
+                        cb(k_nope, "k_nope", il);
+
+                        auto kv_cache_rope = ggml_view_3d(ctx0, kv_self.kv_l[il], n_embd_head_qk_rope, n_kv, 1,
+                                kv_self.kv_l[il]->nb[1], kv_self.kv_l[il]->nb[2], ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank));
+                        ggml_tensor repeater;
+                        repeater.ne[0] = n_embd_head_qk_rope; repeater.ne[1] = n_kv; repeater.ne[2] = n_head; repeater.ne[3] = 1;
+                        auto k_rope = ggml_repeat(ctx0, kv_cache_rope, &repeater);
+                        cb(k_rope, "k_rope", il);
+
+                        auto k = ggml_concat(ctx0, k_nope, k_rope, 0);
+                        cb(k, "k", il);
+
+                        //// Hahaha, we need to convert the KV cache for this layer to f32 because the general purpose ML library ggml does not
+                        //// provide ops on (almost) anything other than f32. In this case, the cache will be the second operand to a matrix
+                        //// multiplication, which *must* be f32.
+                        //auto kv_cache_view = ggml_view_2d(ctx0, kv_self.kv_l[il], kv_self.kv_l[il]->ne[0], n_kv, kv_self.kv_l[il]->nb[1], 0);
+                        //auto kv_cache_view_f32 = ggml_cast(ctx0, kv_cache_view, GGML_TYPE_F32);
+                        //cb(kv_cache_view_f32, "kv_cache_view_f32", il);
+
+                        //// The no- and rotational position encoding portions of the KV cache
+                        //auto kv_cache_nope = ggml_view_2d(ctx0, kv_cache_view_f32, kv_lora_rank, n_kv, kv_cache_view_f32->nb[1], 0);
+                        //auto kv_cache_rope = ggml_view_3d(ctx0, kv_cache_view_f32, n_embd_head_qk_rope, 1, n_kv,
+                        //        kv_cache_view_f32->nb[1], kv_cache_view_f32->nb[1], ggml_row_size(kv_cache_view_f32->type, kv_lora_rank));
+
+                        //auto kv_f32 = ggml_mul_mat(ctx0, model.layers[il].wkv_b, kv_cache_nope);
+                        //cb(kv_f32, "kv_f32", il);
+
+                        //auto k_nope_f32 = ggml_view_3d(ctx0, kv_f32, n_embd_head_qk_nope, n_kv, n_head,
+                        //        ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                        //        ggml_row_size(kv_f32->type, n_embd_head_qk_nope + hparams.n_embd_head_v), 0);
+                        //cb(k_nope_f32, "k_nope_f32", il);
+
+                        //ggml_tensor repeater;
+                        //repeater.ne[0] = n_embd_head_qk_rope; repeater.ne[1] = n_head; repeater.ne[2] = n_kv; repeater.ne[3] = 1;
+                        //auto k_rope_f32 = ggml_permute(ctx0, ggml_repeat(ctx0, kv_cache_rope, &repeater), 0, 2, 1, 3);
+                        //cb(k_rope_f32, "k_rope_f32", il);
+
+                        //auto k_f32 = ggml_concat(ctx0, k_nope_f32, k_rope_f32, 0);
+                        //cb(k_f32, "k_f32", il);
+
+                        //auto k = ggml_cast(ctx0, k_f32, kv_self.kv_l[il]->type);
+                        //cb(k, "k", il);
+
+                        //auto v_f32 = ggml_view_3d(ctx0, kv_f32, hparams.n_embd_head_v, n_kv, n_head,
+                        //        ggml_row_size(kv_f32->type, n_head * (n_embd_head_qk_nope + hparams.n_embd_head_v)),
+                        //        ggml_row_size(kv_f32->type, n_embd_head_qk_nope + hparams.n_embd_head_v),
+                        //        ggml_row_size(kv_f32->type, n_embd_head_qk_nope));
+                        //cb(v_f32, "v_f32", il);
+
+                        //auto v = ggml_cast(ctx0, v_f32, kv_self.kv_l[il]->type);
+                        //cb(v, "v", il);
 
                         auto q = ggml_concat(ctx0, q_nope, q_rope, 0);
                         q = ggml_permute(ctx0, q, 0, 2, 1, 3);


### PR DESCRIPTION

This PR improves the CPU implementation of FlashMLA in 3 ways:
* Faster prompt processing - about 13% improvement for a context of 16k tokens
* Smaller compute buffer size - about  60% reduction for a context of 128k tokens

To recall, FlashMLA-2 is enabled via `-mla 2 -fa`, and is the variant that works on the CPU and on CUDA.

The improvement is achieved by adding implementations for
* `ggml_mul_mat` where the second operand is not `fp32`
* `ggml_concat` where the operands are quantized
* `ggml_repeat` where the operand is not `fp32`

This allows us to avoid conversions to `fp32` that can become quite costly when operating on a very large context.

Here is a PP performance comparison for DeepSeek-Lite running on a Ryzen-7950X CPU between the main branch and this PR

| model                |          test |    t/s (main)    |   t/s (PR)       |  Speedup |
| ---------------------| ------------: | ---------------: | ---------------: | -------: |
| deepseek2 16B IQ4_NL |         pp512 |    668.46 ± 1.74 |   680.74 ± 21.47 |  1.018   |
| deepseek2 16B IQ4_NL |        pp1024 |    646.86 ± 0.94 |    668.65 ± 0.44 |  1.034   |
| deepseek2 16B IQ4_NL |        pp2048 |    596.56 ± 1.70 |    628.99 ± 1.72 |  1.054   |
| deepseek2 16B IQ4_NL |        pp4096 |    513.16 ± 1.42 |    552.36 ± 4.61 |  1.076   |
| deepseek2 16B IQ4_NL |        pp8192 |    398.45 ± 3.51 |    442.89 ± 3.96 |  1.112   |
| deepseek2 16B IQ4_NL |       pp16384 |    272.58 ± 7.06 |    308.21 ± 5.91 |  1.131   |

And here is a comparison between compute buffer sizes along with KV cache size for `fp16` cache

| context |  KV cache size (MiB)  | compute buffer (MiB, PR)  | compute buffer (MiB, main) |
| ----: | ---: | ---: | ---: |
|   2048 |  60.75 | 204.00 |  204.00 |
|  4096  | 121.50 | 204.00 | 204.00 |
| 8192 | 243.00 | 220.01 | 358.01 |
| 16384 | 486.00 | 452.01 | 712.01 |
|  32768 | 972.00 | 884.01 | 1404.02 |
| 65536 | 1944.00 | 1748.01 | 2788.02 |
| 131072 | 3888.00 | 3476.02 | 5556.02 |

I did a quick attempt to also implement on CUDA, but something wasn't working, so left it for a future PR. This also implies that the new way of preparing the compute graph will only be used if the code was built without support for additional back-ends (even if zero layers are uploaded to them, to avoid fighting with the back-end scheduler). 