### PR TITLE
Honor mmap setting when using tensor overrides

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8015,7 +8015,7 @@ static bool llm_load_tensors(
         // only the mmap region containing the tensors in the model is mapped to the backend buffer
         // this is important for metal with apple silicon: if the entire model could be mapped to a metal buffer, then we could just use metal for all layers
         // this allows using partial offloading when the model size exceeds the metal buffer size, but not the RAM size
-        if (ml.use_mmap && use_mmap_buffer && buft == llama_default_buffer_type_cpu(true)) {
+        if (ml.use_mmap && use_mmap_buffer && (buft == llama_default_buffer_type_cpu(true) || buft == ggml_backend_cpu_buffer_type())) {
             for (uint32_t idx = 0; idx < ml.files.size(); idx++) {
                 void * addr = nullptr;
                 size_t first, last;


### PR DESCRIPTION

The reason why `mmap` was disabled when using tensor overrides is this:
* When the command line argument is parsed (and the override buffer is set to `CPU`), we get  the buffer type returned by `ggml_backend_cpu_buffer_type()`
* The tensor loading logic uses `llama_default_buffer_type_cpu(true)` instead to see if a buffer is a CPU buffer and hence can be memory mapped.
* When CUDA (or some other backend) is enabled, `llama_default_buffer_type_cpu(true)` returns a different buffer type (`CUDA_Host` in the case of the CUDA backend).
* As a result, the tensors set to be stored in the CPU memory buffer are not memory mapped

This PR fixes that by asking the buffer type to be either `llama_default_buffer_type_cpu(true)` or `ggml_backend_cpu_buffer_type()` to be eligible for using `mmap`.

Note, however, that `-rtr` still disables `mmap` because otherwise the model would be overwritten with the repacked tensors.
