### PR TITLE
Convert models to row-interleaved quants using the quantize tool

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -145,6 +145,7 @@ static void usage(const char * executable) {
     printf("  --output-tensor-type ggml_type: use this ggml_type for the output.weight tensor.\n");
     printf("  --token-embedding-type ggml_type: use this ggml_type for the token_embd.weight tensor.\n\n");
     printf("  --custom-q regex1=type1,regex2=type2...: use this to specify custom quantization type rules.\n\n");
+    printf("  --repack Repack all tensors to the corresponding _r4/8 variant if available.\n\n");
     printf("Additional specific tensor quantization types used in the custom quant scheme 'CQS (default is Q2_K):\n");
     printf("      --attn-q-type ggml_type: use this ggml_type for the attn_q.weight tensor.\n");
     printf("      --attn-k-type ggml_type: use this ggml_type for the attn_k.weight tensor.\n");
@@ -331,6 +332,8 @@ int main(int argc, char ** argv) {
             params.quantize_output_tensor = false;
         } else if (strcmp(argv[arg_idx], "--ignore-imatrix-rules") == 0) {
             params.ignore_imatrix_rules = true;
+        } else if (strcmp(argv[arg_idx], "--repack") == 0) {
+            params.only_repack = true;
         } else if (strcmp(argv[arg_idx], "--output-tensor-type") == 0) {
             if (arg_idx < argc-1) {
                 params.output_tensor_type = parse_ggml_type(argv[++arg_idx]);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -10626,6 +10626,10 @@ static void ggml_compute_forward_dup_q(
         return;
     }
 
+    if (dst->type != GGML_TYPE_F32) {
+        printf("%s: %s -> %s is of type %s\n", __func__, dst->src[0]->name, dst->name, ggml_type_name(dst->type));
+        GGML_ABORT("fatal error");
+    }
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
     struct ggml_tensor * src0 = dst->src[0];
     GGML_ASSERT(src0->ne[0] == dst->ne[0] && src0->nb[0] == ggml_type_size(src0->type));

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -10590,6 +10590,7 @@ static void ggml_compute_forward_dup_q(
     int nth = params->nth;
 
     if (dst->src[0]->type == dst->type &&
+        dst->src[0]->nb[0] == ggml_type_size(dst->type) &&
         dst->nb[0] == ggml_type_size(dst->type)) {
         ggml_compute_forward_dup_bytes(params, dst);
         return;

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -6781,7 +6781,8 @@ const Modify * get_modify_info(ggml_type type) {
     return it != k_mod_map.end() ? &it->second : nullptr;
 }
 bool is_forbidden_tensor(const std::string& name) {
-    if (name == "token_embd.weight") return true;
+    static const std::string kTokenEmbd{"token_embd.weight"};
+    if (name == kTokenEmbd) return true;
     //if (auto pos = name.find("attn_kv_b.weight"); pos != std::string::npos) return true;
     return false;
 }
@@ -6789,9 +6790,9 @@ bool is_forbidden_tensor(const std::string& name) {
 
 bool iqk_should_modify_tensor(const struct ggml_tensor * tensor) {
     return false;
-    if (is_forbidden_tensor(tensor->name)) return false;
-    auto mptr = get_modify_info(tensor->type);
-    return mptr ? true : false;
+    //if (is_forbidden_tensor(tensor->name)) return false;
+    //auto mptr = get_modify_info(tensor->type);
+    //return mptr ? true : false;
 }
 
 bool iqk_modify_tensor(struct ggml_tensor * tensor) {

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -25,6 +25,7 @@
 #include <thread>
 #include <atomic>
 #include <unordered_map>
+#include <string>
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -6782,18 +6782,20 @@ const Modify * get_modify_info(ggml_type type) {
 }
 bool is_forbidden_tensor(const std::string& name) {
     if (name == "token_embd.weight") return true;
-    if (auto pos = name.find("attn_kv_b.weight"); pos != std::string::npos) return true;
+    //if (auto pos = name.find("attn_kv_b.weight"); pos != std::string::npos) return true;
     return false;
 }
 }
 
 bool iqk_should_modify_tensor(const struct ggml_tensor * tensor) {
+    return false;
     if (is_forbidden_tensor(tensor->name)) return false;
     auto mptr = get_modify_info(tensor->type);
     return mptr ? true : false;
 }
 
 bool iqk_modify_tensor(struct ggml_tensor * tensor) {
+    return false;
     auto mptr = get_modify_info(tensor->type);
     if (!mptr) return false;
     if (is_forbidden_tensor(tensor->name)) return false;
@@ -6901,7 +6903,8 @@ void iqk_repack_tensor(struct ggml_tensor * tensor) {
             int last_row = std::min(first_row + chunkSize*r.num_rows, nrows);
             for (int row = first_row; row < last_row; row += r.num_rows) {
                 std::memcpy(qtmp.data(), data + row*row_size, r.num_rows*row_size);
-                r.repack(r.num_rows, n_per_row, qtmp.data(), data + row*row_size, true);
+                //r.repack(r.num_rows, n_per_row, qtmp.data(), data + row*row_size, true);
+                r.repack(r.num_rows, n_per_row, qtmp.data(), data + row*row_size, false);
             }
         }
     };

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -6788,7 +6788,7 @@ bool is_forbidden_tensor(const std::string& name) {
 }
 }
 
-bool iqk_should_modify_tensor(const struct ggml_tensor * tensor) {
+bool iqk_should_modify_tensor([[maybe_unused]] const struct ggml_tensor * tensor) {
     return false;
     //if (is_forbidden_tensor(tensor->name)) return false;
     //auto mptr = get_modify_info(tensor->type);
@@ -6799,7 +6799,7 @@ bool iqk_modify_tensor(struct ggml_tensor * tensor) {
     return false;
     auto mptr = get_modify_info(tensor->type);
     if (!mptr) return false;
-    if (is_forbidden_tensor(tensor->name)) return false;
+    if (is_forbidden_tensor(std::string{tensor->name})) return false;
 
     auto& m = *mptr;
     int nrows = ggml_nrows(tensor);

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -245,6 +245,9 @@ void repack_bf16_bf16_r16(const void * GGML_RESTRICT src, void * GGML_RESTRICT d
 void iqk_repack_tensor(struct ggml_tensor * tensor);
 bool iqk_modify_tensor(struct ggml_tensor * tensor);
 
+int iqk_repacked_type(const struct ggml_tensor * tensor); // int instead of ggml_type so we don't need to include ggml.h
+bool iqk_should_modify_tensor(const struct ggml_tensor * tensor);
+
 // So we can re-pack Microsoft's BitNet I2_S quants
 void dequantize_row_ms_i2s(const void * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -416,6 +416,7 @@ extern "C" {
         bool pure;                           // quantize all tensors to the default type
         bool keep_split;                     // quantize to the same number of shards
         bool ignore_imatrix_rules;           // If set to true, the built-in rules for refusing to quantize into certain quants without imatrix are ignored
+        bool only_repack;                    // Only repack tensors
         void * imatrix;                      // pointer to importance matrix data
         void * kv_overrides;                 // pointer to vector containing overrides
         void * custom_quants;                // pointer to vector containing custom quantization rules

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8194,7 +8194,8 @@ static bool llm_load_tensors(
                 auto wk_b_f32_t = ggml_cont(ctx, wk_b_f32_tview);
                 wk_b_f32_t->data = (char *)wk_b_f32->data + ggml_nbytes(wk_b_f32);
 
-                auto new_type = ggml_is_quantized(wkv_b.type) ? GGML_TYPE_Q8_0 : wkv_b.type;
+                auto new_type = ggml_is_quantized(wkv_b.type) ?
+                    wkv_b.type >= GGML_TYPE_Q4_0_R8 && wkv_b.type <= GGML_TYPE_Q8_K_R8 ? GGML_TYPE_Q8_0_R8 : GGML_TYPE_Q8_0 : wkv_b.type;
                 auto wk_b = ggml_cast(ctx, wk_b_f32_t, new_type);
                 wk_b->data = (char *)wk_b_f32_t->data + ggml_nbytes(wk_b_f32_t);
 


### PR DESCRIPTION
The main purpose of this PR is to remove the need for run-time-repacking (command line argument `-rtr`) by having a tool to convert models to row-interleaved quantization types. The main motivation for providing this tool is to allow using `mmap` when loading a model and still having row-interleaved quants, so that one can combine the claimed performance gains from using 1 GiB huge pages (see #267) with the performance gains due to row-interleaved quants.

**Note:** this is only useful for **CPU-only** inference. The converted (repacked) model **will not work on a GPU** (or rather it will work but will be slow as all matrix multiplications with the repacked tensors will be done on the CPU).

To use it, simply
```
./bin/llama-quantize --repack some_model repacked_model some_quant
```
The `some_quant` argument is not actually used, but I didn't want to make modifications to the `llama-quantize` command line argument parsing, so the argument must be provided, but it is ignored.

Oh, `bf16` and `f16` models can be repacked too, one gets a `GGML_TYPE_BF16_R16` model as a result. On CPU's with native `bf16` support, `GGML_TYPE_BF16_R16 ` is about 15% faster than `GGML_TYPE_BF16`, and nearly 2X faster than `GGML_TYPE_F16` (for prompt processing, TG is memory bound, so not much difference there).

**Caveat:** Some of the quantization types had a relatively minor, platform-specific, optimization applied when run-time-repacking. But as there is no way to tell if the repacking was done online, or if we are dealing with an offline-repacked model, I had to remove this optimization. This affects `Q8_0_R8, Q8_K_R8, Q8_KV_R8` on Zen4 (127 was added to these quants during run-time-repacking to avoid doing this during inference), and `Q4_0_R8` on ARM (a mask of `0x88` was applied to the packed bits, which converts the otherwise unsigned `Q4_0` values to signed values multiplied with 16).  

Closes #228 