### PR TITLE
Specify tensor name regex for tensors to be repacked

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -420,6 +420,7 @@ extern "C" {
         void * imatrix;                      // pointer to importance matrix data
         void * kv_overrides;                 // pointer to vector containing overrides
         void * custom_quants;                // pointer to vector containing custom quantization rules
+        void * repack_pattern;               // pointer to a vector containing regexes to be used for matching tensor names. Can be null
     } llama_model_quantize_params;
 
     // grammar types


### PR DESCRIPTION

This PR follows in the footsteps of #272 and adds the ability to specify one or more regular expressions to use for matching tensor names to be repacked. This is useful for hybrid GPU/CPU inference where one will want to repack only the tensors that stay on the CPU.

Usage
```
./bin/llama-quantize --repack --repack-pattern regex1,regex2,... some_model output_file_name quant_type
```

E.g., if one uses tensor override `-ot exps=CPU` for inference to have the DeepSeek MoE experts stay on the CPU, one would use
```
./bin/llama-quantize --repack --repack-pattern exps some_model output_file_name quant_type
```
to repack an existing model. 