### PR TITLE
Fix bug: missing parentheses in logical expression

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13869,7 +13869,7 @@ struct llm_build_context {
                         ggml_tensor * q = ggml_concat(ctx0, q_nope2, ggml_permute(ctx0, q_rope, 0, 2, 1, 3), 0);
                         cb(q, "q", il);
 
-                        if (lctx.cparams.flash_attn && lctx.cparams.mla_attn == 1 || lctx.cparams.mla_attn == 3) {
+                        if (lctx.cparams.flash_attn && (lctx.cparams.mla_attn == 1 || lctx.cparams.mla_attn == 3)) {
                             ggml_tensor * kv_cache_lora = ggml_view_2d(ctx0, kv_self.kv_l[il],
                                     kv_lora_rank, n_kv,
                                     ggml_row_size(kv_self.kv_l[il]->type, kv_lora_rank + n_embd_head_qk_rope), 0);


### PR DESCRIPTION

This results in GGGGGGGGGGGGG when generating with mla = 3, fa = 0.

Likely also affects @saood06's benchmarking [here](https://github.com/ikawrakow/ik_llama.cpp/pull/273#issuecomment-2743023599)