### PR TITLE
Improve DeepSeek batched processing speed

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -17103,25 +17103,23 @@ template <int Dk, int Dv, int k_step, typename KHelper, typename VHelper>
 inline void iqk_flash_helper(KHelper& kh, VHelper& vh, int nq1, int nk1, int stride_q, int stride_m, int stride_qkv,
                         const float * q, const char * mask, float scale, float softcap, float * qkv, float * M, float * S) {
 
-    // Not sure if this actually helps.
-    // So, let's reduce compilation time by commenting it out for now.
-    //if (nk1 >= 256) { //4096) {
-    //    if (nq1 >= 64) {
-    //        FlashAttn<Dk, Dv, 64, k_step> fa(scale, softcap);
-    //        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
-    //        return;
-    //    }
-    //    if (nq1 >= 32) {
-    //        FlashAttn<Dk, Dv, 32, k_step> fa(scale, softcap);
-    //        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
-    //        return;
-    //    }
-    //    if (nq1 >= 16) {
-    //        FlashAttn<Dk, Dv, 16, k_step> fa(scale, softcap);
-    //        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
-    //        return;
-    //    }
-    //}
+    if (nk1 >= 256) { //4096) {
+        if (nq1 >= 64) {
+            FlashAttn<Dk, Dv, 64, k_step> fa(scale, softcap);
+            fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
+            return;
+        }
+        if (nq1 >= 32) {
+            FlashAttn<Dk, Dv, 32, k_step> fa(scale, softcap);
+            fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
+            return;
+        }
+        if (nq1 >= 16) {
+            FlashAttn<Dk, Dv, 16, k_step> fa(scale, softcap);
+            fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
+            return;
+        }
+    }
     if (nq1 >= 8) {
         FlashAttn<Dk, Dv, 8, k_step> fa(scale, softcap);
         fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -17103,23 +17103,25 @@ template <int Dk, int Dv, int k_step, typename KHelper, typename VHelper>
 inline void iqk_flash_helper(KHelper& kh, VHelper& vh, int nq1, int nk1, int stride_q, int stride_m, int stride_qkv,
                         const float * q, const char * mask, float scale, float softcap, float * qkv, float * M, float * S) {
 
-    if (nk1 >= 256) { //4096) {
-        if (nq1 >= 64) {
-            FlashAttn<Dk, Dv, 64, k_step> fa(scale, softcap);
-            fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
-            return;
-        }
-        if (nq1 >= 32) {
-            FlashAttn<Dk, Dv, 32, k_step> fa(scale, softcap);
-            fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
-            return;
-        }
-        if (nq1 >= 16) {
-            FlashAttn<Dk, Dv, 16, k_step> fa(scale, softcap);
-            fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
-            return;
-        }
-    }
+    // Not sure if this actually helps.
+    // So, let's reduce compilation time by commenting it out for now.
+    //if (nk1 >= 256) { //4096) {
+    //    if (nq1 >= 64) {
+    //        FlashAttn<Dk, Dv, 64, k_step> fa(scale, softcap);
+    //        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
+    //        return;
+    //    }
+    //    if (nq1 >= 32) {
+    //        FlashAttn<Dk, Dv, 32, k_step> fa(scale, softcap);
+    //        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
+    //        return;
+    //    }
+    //    if (nq1 >= 16) {
+    //        FlashAttn<Dk, Dv, 16, k_step> fa(scale, softcap);
+    //        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
+    //        return;
+    //    }
+    //}
     if (nq1 >= 8) {
         FlashAttn<Dk, Dv, 8, k_step> fa(scale, softcap);
         fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, (const char *)mask, qkv, M, S);
@@ -17265,13 +17267,25 @@ template <int step_k, typename KHelper, typename VHelper>
 inline void iqk_deepseek_helper(KHelper& kh, VHelper& vh,
                         int nq1, int nk1, int stride_q, int stride_m, int stride_qkv,
                         const float * q, const char * mask, float scale, float softcap, float * qkv, float * M, float * S) {
-    if (nq1 % 8 == 0) {
+    if (nq1 >= 8) {
         FlashAttn<576, 512, 8, step_k> fa(scale, softcap);
         fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
-    } else {
+    }
+    else if (nq1 >= 4) {
+        FlashAttn<576, 512, 4, step_k> fa(scale, softcap);
+        fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
+    }
+    else {
         FlashAttn<576, 512, 1, step_k> fa(scale, softcap);
         fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
     }
+    //if (nq1 % 8 == 0) {
+    //    FlashAttn<576, 512, 8, step_k> fa(scale, softcap);
+    //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
+    //} else {
+    //    FlashAttn<576, 512, 1, step_k> fa(scale, softcap);
+    //    fa.compute(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
+    //}
 }
 
 template <int step_k>

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13896,7 +13896,7 @@ struct llm_build_context {
 
         // whether to use n_tokens as the matrix dimension during multiplication or n_head
         // n_tokens is higher during prompt processing, this allows to optimize for this case
-        bool pp_opt = n_tokens > n_head;
+        bool pp_opt = n_tokens >= 128; // Is it a fixed constant or is it somehow relared to n_head? original: n_tokens > n_head;
 
         for (int il = 0; il < n_layer; ++il) {
             struct ggml_tensor * inpSA = inpL;


### PR DESCRIPTION

I was looking into the batched processing performance dips observed by @saood06 [here](https://github.com/ikawrakow/ik_llama.cpp/pull/277#issuecomment-2745952185) and I saw this for DeepSeek-Lite:

![batched0](https://github.com/user-attachments/assets/63d465fc-bf18-403c-839b-c68f392ed1f7)

Commandline was
```
./bin/llama-batched-bench -m junk1.bin -npp 512 -ntg 128 -npl 4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120 -pps -fmoe -fa -mla 3 -t 16
```
It took me a while to figure out the reason for the dramatic drop in performance between a batch size of 16 and a batch size of 20. I was suspecting that something goes wrong how the work is being distributed between the threads. But at the end it turned out that it is due to the way the compute graph is built: when `n_token > n_head` we switch to "PP optimized" processing, which means we go from FA with `Dk = 576, Dv = 512` to `Dk = 192, Dv = 128`, which requires two additional matrix multiplications. For DeepSeek-Lite `n_head = 16`, so with steps of 4 for the batch size 20 is exactly where the switch is made. I'm not sure what the rationale was for selecting this specific transition point (the optimization came from the [mainline llama.cpp PR](https://github.com/ggml-org/llama.cpp/pull/11446), but it clearly kills performance. If we look at prompt processing performance using "PP optimized" vs "TG optimized" DeepSeek compute graphs, we see this picture:

 
![pp_opt](https://github.com/user-attachments/assets/8b981565-9eb9-4bf4-b35e-48e6ed5ec028)

I.e., "TG optimized" is better than "PP optimized" for prompt lengths up to 64 tokens, and is not too far behind at 128 tokens. So, we can easily solve the performance drop by using "TG optimized" up to `n_prompt = 128`. By doing that, we get this result:

 
![batched](https://github.com/user-attachments/assets/79859f66-1147-4173-8ada-6916e7f07286)

The calculations take quite some time, so I didn't have the patience to run beyond batch size of 100 to see the exact crossover point. But eyeballing the graph, it looks like 128 is a good choice for DeepSeek-Lite. DeepSeek-V3/R1 have 128 heads, so this PR will not change the behavior for this models. But it isn't clear to me if one shouldn't use a larger threshold for the "TG optimized" -> "PP optimized" transition.

Concerning DeepSeek-R1, there is a small change in this PR that I hope will reduce the performance dips observed by @saood06 