### PR TITLE
Is this better for DeepSeek-R1?

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -15021,7 +15021,10 @@ static void ggml_compute_forward_mul_mat_id_up_gate(
     if (ids->ne[1] == 1 && dst->type == GGML_TYPE_F32) {
         int gcd = simple_gcd(n_ids, nth);
         if (gcd > 1) {
-            ggml_barrier(params->shared);
+            if (src1->type != vec_dot_type) {
+                // make sure quantization has finished
+                ggml_barrier(params->shared);
+            }
             const void * wdata    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
             const size_t row_size = ggml_row_size(vec_dot_type, ne10);
             int counter = 0;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -532,7 +532,9 @@ bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
 
     const mmid_row_mapping * row_mapping = (const mmid_row_mapping *)vrow_mapping;
-    assert(row_mapping != nullptr);
+    // Removing this assert to accomodate usage without row id mapping (e.g., for Ny = 1,
+    // or if B has been prepared to be contiguous.
+    //assert(row_mapping != nullptr);
 
     MulMat mm;
     if (!MulMat::prepare(typeA, typeB, ne00, mm, Ny)) {


### PR DESCRIPTION

This PR implements MoE matrix multiplications on the CPU with a different strategy for distributing the work among the threads. I observe a very slight performance improvement for DeepSeek-Lite (~1%). I'm wondering if this could have more impact for DeepSeek-R1.

What is the difference?

In the implementation on the main branch all threads participate in each matrix multiplication for the involved experts, and the multiplications are performed one after the other.

In this PR we have MoE matrix multiplications be performed in parallel, with each multiplication being done by fewer threads. My thinking is that in this way we may better utilize the available memory bandwidth, as threads are accessing different tensors, which may be stored in different memory banks/be accessed via different memory controllers. On my Ryzen-7950X test system I'm maxing out the available memory bandwidth, so there cannot be much impact from this change. But on an EPYC or Xeon with 400+ GB/s available, the benchmark results we are getting for DeepSeek-R1 are far from saturating the memory bandwidth, so perhaps this PR could have a positive impact on TG performance.

To be most effective, the number of threads used should be a multiple of the number of activated experts (8 for DeepSeek-R1), so 8, 16, 24, 32, etc.  