### PR TITLE
Try not repacking q8_0 for FA computations

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -16659,7 +16659,7 @@ struct FlashAttn {
                     kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, fms, fqkv, q, mask, qkv, M, S);
         }
         else if constexpr (std::is_same_v<KHelper, HelperQ80<Dk, k_step>>) {
-            if (nq1 >= 8) {
+            if (nq1 >= 9999999) { //8) {
 #if FA_TIMING
                 auto t1 = Perf::cur_time();
                 HelperQ80R8<Dk, k_step> khr4(nk1, kh);


### PR DESCRIPTION

On the master branch if the K-cache is `Q8_0` it is repacked to `Q8_0_R8` before performing the Flash Attention computation. This is only done for PP (number of tokens in the batch $\ge$ 8), and tends to improve PP performance when the K-cache size is not too large. But for large K-cache, performance may suffer due to the additional allocation of a fairly significant amount of memory.

This PR disables K-cache repacking to `Q8_0_R8` in the Flash Attention CPU implementation.
I'm throwing it out for testing with `Q8_0` KV cache and large context lengths.
    
I cannot test DeepSeek-V3/R1, but for DeepSeek-Lite I get inconclusive results:
* On my Ryzen-5975WX, PP performance remains about the same, while we get ~15% better TG performance with a context of 32k tokens
* On my Ryzen-7950X, TG performance remains about the same, but we get ~15% **lower** PP performance with a context of 32k tokens.  

Worth noting that the repacking is not done for TG. The effects on TG performance are merely due to the additional largish memory allocation that occurs during PP. Hence, it is hard to predict what happens with a very large model such as DeepSeek-V3/R1.

Another interesting observation is that there is no difference between offline and run-time repacking of the model weights on the Ryzen-7950X. But on the Ryzen-5975WX the offline repacked model results in ~10% better TG and PP performance with a context of 32k tokens. 