### PR TITLE
Correct L4 rms_norm

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -9913,8 +9913,8 @@ struct llm_build_context {
 
                 if (model.arch == LLM_ARCH_LLAMA4 && use_rope && hparams.use_kq_norm) {
                     // Llama4TextL2Norm
-                    Qcur = ggml_rms_norm(ctx0, Qcur, 1e-6);
-                    Kcur = ggml_rms_norm(ctx0, Kcur, 1e-6);
+                    Qcur = ggml_rms_norm(ctx0, Qcur, hparams.f_norm_rms_eps);
+                    Kcur = ggml_rms_norm(ctx0, Kcur, hparams.f_norm_rms_eps);
                     cb(Qcur, "Qcur_normed", il);
                     cb(Kcur, "Kcur_normed", il);
                 }


### PR DESCRIPTION

I was wondering about the hard-coded `1e-6` when porting the mainline PR, but left it the way it is. Mainline has now [corrected it](https://github.com/ggml-org/llama.cpp/pull/12882), so let's do that here as well.