### PR TITLE
Fix KLD precision

### DIFF
--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -133,7 +133,7 @@ static double log_softmax(int n_vocab, const float * logits, uint16_t * log_prob
         max_logit = std::max(max_logit, logits[i]);
         min_logit = std::min(min_logit, logits[i]);
     }
-    min_logit = std::max(min_logit, max_logit - 16);
+    min_logit = std::max(min_logit, max_logit - 24);
     double sum_exp = 0.0;
     for (int i = 0; i < n_vocab; ++i) {
         sum_exp += expf(logits[i] - max_logit);


### PR DESCRIPTION

Some people insist that perplexity tells us nothing, and that [Kullback-Leibler Divergence](https://en.wikipedia.org/wiki/Kullback–Leibler_divergence) (KLD), along with the other statistics computed by `llama-perplexity` with the `--kl-divergence` option, are the one and only one true measure of quantization accuracy. Computing KLD requires 1st running the `llama-perplexity` tool with `--kl-divergence-base` to compute the logits of the base model, which are then used to compute KLD and other token probability statistics in a subsequent run with a quantized (or otherwise approximate) model. The base model logits file is quite large as it stores the log-probabilities for each evaluated token for all tokens in the vocabulary. Hence, when I added KLD capabilities to `llama.cpp` with [this](https://github.com/ggml-org/llama.cpp/pull/5076) and [this](https://github.com/ggml-org/llama.cpp/pull/5081) PRs, I used 16-bit precision to store the logits of the base model, setting the minimum logit to `std::max(min_logit, max_logit - 16). That was adequate for the models available at the time. 

As I'm notoriously short on disk space, I don't keep the large base logits file around. Hence, I find it a hassle to use KLD to evaluate quantization accuracy of some new technique, so I basically never use the `--kl-divergence` option in the `llama-perplexity` tool. But the other day I saw [this post](https://huggingface.co/blog/bartowski/llama4-scout-off) using the statistics produced by `llama-perplexity --kl-divergence` to compare several quantizations of LlaMA-4-Scout, and as I was experimenting with quantization of that model, I decided to run some KLD calculations myself. Hahaha! In all of this time, nobody noticed that my 16-bit approximation for the stored base model logits is not adequate. More specifically,  with much increased vocabulary size, the `std::max(min_logit, max_logit - 16)` lower bound of the log-probabilities stored in the file is too high. The effect is that the perplexity of the base model computed from the stored logits is different from the perplexity computed directly from the float probabilities. I was concerned that other statistics will be influenced as well, but it looks like it is only PPL that becomes wrong.

A lot of talk for this one-liner PR, which fixes the problem.
