### PR TITLE
Better gemm/gemv on AVX2 fr q4_0_r8

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -3620,8 +3620,7 @@ inline __m256i accum_q4_0_quants(const __m256i * v, const int8_t * qs) {
                                   _mm256_maddubs_epi16(v[5], _mm256_shuffle_epi32(yh, 0x55)));
     auto sumi4 = _mm256_add_epi16(_mm256_maddubs_epi16(v[6], _mm256_shuffle_epi32(yh, 0xaa)),
                                   _mm256_maddubs_epi16(v[7], _mm256_shuffle_epi32(yh, 0xff)));
-    auto sumi = _mm256_add_epi32(_mm256_madd_epi16(_mm256_set1_epi16(1), _mm256_add_epi16(sumi1, sumi2)),
-                                 _mm256_madd_epi16(_mm256_set1_epi16(1), _mm256_add_epi16(sumi3, sumi4)));
+    auto sumi = _mm256_madd_epi16(_mm256_set1_epi16(1), _mm256_add_epi16(_mm256_add_epi16(sumi1, sumi2), _mm256_add_epi16(sumi3, sumi4)));
 #endif
     return sumi;
 }


### PR DESCRIPTION

I constantly get confused how many `int16_t` dot products (`_mm256_maddubs_epi16()` results) I can sum up as `int16_t` before overflowing. In the case of `Q4_0` I was adding too few, and was having one unnecessary `_mm256_madd_epi16` because of that.  This PR fixes this. The result is a ~10% gain in performance when tested with Geema-3-12B-Instruct.