### PR TITLE
Fix termux/android build

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -211,7 +211,8 @@ set(GGML_PUBLIC_HEADERS
     include/ggml-metal.h
     include/ggml-rpc.h
     include/ggml-sycl.h
-    include/ggml-vulkan.h)
+    include/ggml-vulkan.h
+    src/iqk/iqk_mul_mat.h)
 
 set_target_properties(ggml PROPERTIES PUBLIC_HEADER "${GGML_PUBLIC_HEADERS}")
 #if (GGML_METAL)

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -211,8 +211,7 @@ set(GGML_PUBLIC_HEADERS
     include/ggml-metal.h
     include/ggml-rpc.h
     include/ggml-sycl.h
-    include/ggml-vulkan.h
-    src/iqk/iqk_mul_mat.h)
+    include/ggml-vulkan.h)
 
 set_target_properties(ggml PROPERTIES PUBLIC_HEADER "${GGML_PUBLIC_HEADERS}")
 #if (GGML_METAL)

--- a/ggml/src/iqk/iqk_config.h
+++ b/ggml/src/iqk/iqk_config.h
@@ -16,7 +16,6 @@
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 #    define IQK_API __declspec(dllexport)
-#endif
 #else
 #    define IQK_API __attribute__ ((visibility ("default")))
 #endif

--- a/ggml/src/iqk/iqk_config.h
+++ b/ggml/src/iqk/iqk_config.h
@@ -14,10 +14,18 @@
 #define IQK_IMPLEMENT
 #endif
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-#define IQK_API __declspec(dllexport)
+#ifdef GGML_SHARED
+#    if defined(_WIN32) && !defined(__MINGW32__)
+#        ifdef GGML_BUILD
+#            define IQK_API __declspec(dllexport)
+#        else
+#            define IQK_API __declspec(dllimport)
+#        endif
+#    else
+#        define IQK_API __attribute__ ((visibility ("default")))
+#    endif
 #else
-#define IQK_API __attribute__ ((visibility ("default")))
+#    define IQK_API
 #endif
 
 #ifdef _MSC_VER

--- a/ggml/src/iqk/iqk_config.h
+++ b/ggml/src/iqk/iqk_config.h
@@ -14,6 +14,13 @@
 #define IQK_IMPLEMENT
 #endif
 
+#if defined(_WIN32) && !defined(__MINGW32__)
+#    define IQK_API __declspec(dllexport)
+#endif
+#else
+#    define IQK_API __attribute__ ((visibility ("default")))
+#endif
+
 #ifdef _MSC_VER
 #define IQK_NOINLINE __declspec(noinline)
 #define IQK_ALWAYS_INLINE inline

--- a/ggml/src/iqk/iqk_config.h
+++ b/ggml/src/iqk/iqk_config.h
@@ -15,9 +15,9 @@
 #endif
 
 #if defined(_WIN32) && !defined(__MINGW32__)
-#    define IQK_API __declspec(dllexport)
+#define IQK_API __declspec(dllexport)
 #else
-#    define IQK_API __attribute__ ((visibility ("default")))
+#define IQK_API __attribute__ ((visibility ("default")))
 #endif
 
 #ifdef _MSC_VER

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -29,7 +29,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 
 // TODO: get the ggml_type enum here without polution
 //
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+extern "C" IQK_API  bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,
@@ -253,7 +253,7 @@ extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(
 
 #else
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int type_mask, [[maybe_unused]] float max_bias,
+extern "C" IQK_API bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int type_mask, [[maybe_unused]] float max_bias,
                             [[maybe_unused]] int neq3, [[maybe_unused]] int neq2, [[maybe_unused]] long nbq3, [[maybe_unused]] long nbq2,
                             [[maybe_unused]] int nek3, [[maybe_unused]] int nek2, [[maybe_unused]] long nbk3, [[maybe_unused]] long nbk2,
                             [[maybe_unused]] int nev3, [[maybe_unused]] int nev2, [[maybe_unused]] long nbv3, [[maybe_unused]] long nbv2,

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -258,9 +258,10 @@ extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(
                             [[maybe_unused]] int nek3, [[maybe_unused]] int nek2, [[maybe_unused]] long nbk3, [[maybe_unused]] long nbk2,
                             [[maybe_unused]] int nev3, [[maybe_unused]] int nev2, [[maybe_unused]] long nbv3, [[maybe_unused]] long nbv2,
                             [[maybe_unused]] int ne2,  [[maybe_unused]] int ne1,  [[maybe_unused]] long nb1,
-                            [[maybe_unused]] int int_type_k,         // type of k
-                            [[maybe_unused]] int int_type_v,         // type of v
-                            [[maybe_unused]] int D,                  // head size
+                            [[maybe_unused]] int type_k,             // type of k
+                            [[maybe_unused]] int type_v,             // type of v
+                            [[maybe_unused]] int Dk,                 // K head size
+                            [[maybe_unused]] int Dv,                 // V head size
                             [[maybe_unused]] int nq,                 // number of columns in q
                             [[maybe_unused]] int nk,                 // number of rows in k
                             [[maybe_unused]] int stride_q,           // distance between q columns in bytes

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -29,7 +29,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 
 // TODO: get the ggml_type enum here without polution
 //
-GGML_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+__attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -29,7 +29,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 
 // TODO: get the ggml_type enum here without polution
 //
-bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+GGML_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -29,7 +29,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 
 // TODO: get the ggml_type enum here without polution
 //
-__attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -29,7 +29,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 
 // TODO: get the ggml_type enum here without polution
 //
-extern "C" IQK_API  bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,
@@ -253,7 +253,7 @@ extern "C" IQK_API  bool iqk_flash_attn_noalibi(int type_q, int type_mask, float
 
 #else
 
-extern "C" IQK_API bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int type_mask, [[maybe_unused]] float max_bias,
+bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int type_mask, [[maybe_unused]] float max_bias,
                             [[maybe_unused]] int neq3, [[maybe_unused]] int neq2, [[maybe_unused]] long nbq3, [[maybe_unused]] long nbq2,
                             [[maybe_unused]] int nek3, [[maybe_unused]] int nek2, [[maybe_unused]] long nbk3, [[maybe_unused]] long nbk2,
                             [[maybe_unused]] int nev3, [[maybe_unused]] int nev2, [[maybe_unused]] long nbv3, [[maybe_unused]] long nbv2,

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -253,7 +253,7 @@ extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(
 
 #else
 
-bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int type_mask, [[maybe_unused]] float max_bias,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int type_mask, [[maybe_unused]] float max_bias,
                             [[maybe_unused]] int neq3, [[maybe_unused]] int neq2, [[maybe_unused]] long nbq3, [[maybe_unused]] long nbq2,
                             [[maybe_unused]] int nek3, [[maybe_unused]] int nek2, [[maybe_unused]] long nbk3, [[maybe_unused]] long nbk2,
                             [[maybe_unused]] int nev3, [[maybe_unused]] int nev2, [[maybe_unused]] long nbv3, [[maybe_unused]] long nbv2,

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -403,7 +403,7 @@ private:
 
 }
 
-bool iqk_mul_mat(long Nx, long Ny, long ne00,
+GGML_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth) {
@@ -440,7 +440,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 }
 }
 
-bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+GGML_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
@@ -545,7 +545,7 @@ bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
     return true;
 }
 
-bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+GGML_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -571,7 +571,7 @@ bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
     return true;
 }
 
-bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+GGML_API bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -17550,11 +17550,11 @@ bool iqk_flash_attn_impl(int int_type_k,         // type of k
 
 #else  // IQK_IMPLEMENT
 
-bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
+GGML_API bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
     return false;
 }
 
-bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
+GGML_API bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
         long /*ne02*/, long /*ne03*/, long /*ne12*/, long /*ne13*/,
         long /*nb02*/, long /*nb03*/, long /*nb12*/, long /*nb13*/, long /*nb2*/, long /*nb3*/,
         int /*typeA*/, const void * /*A*/, long /*strideA*/,
@@ -17563,12 +17563,12 @@ bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
     return false;
 }
 
-bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
+GGML_API bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
         const void *, int, int) {
     return false;
 }
 
-bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
+GGML_API bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
         int /*typeA*/, const void * /*Aup*/, const void * /*Agate*/, long /*strideA*/,
         int /*typeB*/, const void * /*B*/, long /*strideB*/,
         float * /*C*/, long /*nb1*/, long /*nb2*/, const void * /*vrow_mapping*/, int /*ith*/, int /*nth*/) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -15,7 +15,6 @@
 #include <type_traits>
 #include <vector>
 
-#include "ggml.h"
 #include "ggml-impl.h"
 #include "ggml-quants.h"
 #include "iqk_mul_mat.h"
@@ -404,7 +403,7 @@ private:
 
 }
 
-GGML_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth) {
@@ -441,7 +440,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 }
 }
 
-GGML_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
@@ -546,7 +545,7 @@ GGML_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
     return true;
 }
 
-GGML_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -572,7 +571,7 @@ GGML_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
     return true;
 }
 
-GGML_API bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+__attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -17551,11 +17550,11 @@ bool iqk_flash_attn_impl(int int_type_k,         // type of k
 
 #else  // IQK_IMPLEMENT
 
-GGML_API bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
     return false;
 }
 
-GGML_API bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
         long /*ne02*/, long /*ne03*/, long /*ne12*/, long /*ne13*/,
         long /*nb02*/, long /*nb03*/, long /*nb12*/, long /*nb13*/, long /*nb2*/, long /*nb3*/,
         int /*typeA*/, const void * /*A*/, long /*strideA*/,
@@ -17564,12 +17563,12 @@ GGML_API bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
     return false;
 }
 
-GGML_API bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
         const void *, int, int) {
     return false;
 }
 
-GGML_API bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
+__attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
         int /*typeA*/, const void * /*Aup*/, const void * /*Agate*/, long /*strideA*/,
         int /*typeB*/, const void * /*B*/, long /*strideB*/,
         float * /*C*/, long /*nb1*/, long /*nb2*/, const void * /*vrow_mapping*/, int /*ith*/, int /*nth*/) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "ggml.h"
 #include "ggml-impl.h"
 #include "ggml-quants.h"
 #include "iqk_mul_mat.h"

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -403,7 +403,7 @@ private:
 
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat(long Nx, long Ny, long ne00,
+extern "C" IQK_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth) {
@@ -440,7 +440,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 }
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+extern "C" IQK_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
@@ -545,7 +545,7 @@ extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx,
     return true;
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+extern "C" IQK_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -571,7 +571,7 @@ extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx
     return true;
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+extern "C" IQK_API bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -17550,11 +17550,11 @@ bool iqk_flash_attn_impl(int int_type_k,         // type of k
 
 #else  // IQK_IMPLEMENT
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
+extern "C" IQK_API bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
     return false;
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
+extern "C" IQK_API bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
         long /*ne02*/, long /*ne03*/, long /*ne12*/, long /*ne13*/,
         long /*nb02*/, long /*nb03*/, long /*nb12*/, long /*nb13*/, long /*nb2*/, long /*nb3*/,
         int /*typeA*/, const void * /*A*/, long /*strideA*/,
@@ -17563,12 +17563,12 @@ extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long /*N
     return false;
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
+extern "C" IQK_API bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
         const void *, int, int) {
     return false;
 }
 
-extern "C" __attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
+extern "C" IQK_API bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
         int /*typeA*/, const void * /*Aup*/, const void * /*Agate*/, long /*strideA*/,
         int /*typeB*/, const void * /*B*/, long /*strideB*/,
         float * /*C*/, long /*nb1*/, long /*nb2*/, const void * /*vrow_mapping*/, int /*ith*/, int /*nth*/) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -403,7 +403,7 @@ private:
 
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat(long Nx, long Ny, long ne00,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth) {
@@ -440,7 +440,7 @@ inline uint32_t simple_gcd(uint32_t a, uint32_t b) {
 }
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
@@ -545,7 +545,7 @@ __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, l
     return true;
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -571,7 +571,7 @@ __attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, 
     return true;
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth) {
@@ -17550,11 +17550,11 @@ bool iqk_flash_attn_impl(int int_type_k,         // type of k
 
 #else  // IQK_IMPLEMENT
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
     return false;
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long /*Nx*/, long /*Ny*/, long /*ne00*/,
         long /*ne02*/, long /*ne03*/, long /*ne12*/, long /*ne13*/,
         long /*nb02*/, long /*nb03*/, long /*nb12*/, long /*nb13*/, long /*nb2*/, long /*nb3*/,
         int /*typeA*/, const void * /*A*/, long /*strideA*/,
@@ -17563,12 +17563,12 @@ __attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long /*Nx*/, long /
     return false;
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long, long, long, int, int, const void *, long, int, const void *, long, float *, long, long,
         const void *, int, int) {
     return false;
 }
 
-__attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
+extern "C" __attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
         int /*typeA*/, const void * /*Aup*/, const void * /*Agate*/, long /*strideA*/,
         int /*typeB*/, const void * /*B*/, long /*strideB*/,
         float * /*C*/, long /*nb1*/, long /*nb2*/, const void * /*vrow_mapping*/, int /*ith*/, int /*nth*/) {

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -11,31 +11,31 @@
 extern "C" {
 #endif
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat(long Nx, long Ny, long ne00,
+IQK_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth);
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+IQK_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth);
 
-__attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+IQK_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
-__attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+IQK_API bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
 typedef void (*barrier_t) (void *);
 
-__attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
+#include "ggml.h"
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -11,31 +11,31 @@
 extern "C" {
 #endif
 
-bool iqk_mul_mat(long Nx, long Ny, long ne00,
+GGML_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth);
 
-bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+GGML_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth);
 
-bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+GGML_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
-bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+GGML_API bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
 typedef void (*barrier_t) (void *);
 
-bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+GGML_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -7,36 +7,35 @@
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
-#include "ggml.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-GGML_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat(long Nx, long Ny, long ne00,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth);
 
-GGML_API bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat_4d(long Nx, long Ny, long ne00,
         long ne02, long ne03, long ne12, long ne13,
         long nb02, long nb03, long nb12, long nb13, long nb2, long nb3,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long stride_C, int ith, int nth);
 
-GGML_API bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
+__attribute__ ((visibility ("default"))) bool iqk_mul_mat_moe(long Nx, long Ny, long ne00, int ne11,
         int typeA, const void * A, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
-GGML_API bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
+__attribute__ ((visibility ("default"))) bool iqk_moe_fused_up_gate(long Nx, long Ny, long ne00, int ne11, int unary_op,
         int typeA, const void * Aup, const void * Agate, long strideA,
         int typeB, const void * B, long strideB,
         float * C, long nb1, long nb2, const void * vrow_mapping, int ith, int nth);
 
 typedef void (*barrier_t) (void *);
 
-GGML_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
+__attribute__ ((visibility ("default"))) bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             int neq3, int neq2, long nbq3, long nbq2,
                             int nek3, int nek2, long nbk3, long nbk2,
                             int nev3, int nev2, long nbv3, long nbv2,

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
+#include "iqk_config.h"
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
@ikawrakow

Sorry this is a mess, but this does get it to build now on my android device where I was able to replicate the compile error (my device does not support __ARM_FEATURE_DOTPROD so even though it now builds, it does not use the IQK stuff, but I may be able to confirm it works later on a device that that does support dotprod later).

I did catch the additional issue of the changed iqk_flash_attn_noalibi definition in the case where your building this repo and IQK_IMPLEMENT is not defined because my device doesn't support dotprod.

Fixes #159