### PR TITLE
Fix q4_1 and q5_1 on Arm

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -741,7 +741,11 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float_ref           = (ggml_from_float_t) quantize_row_q4_1_ref,
         .vec_dot                  = ggml_vec_dot_q4_1_q8_1,
 #if GGML_USE_IQK_MULMAT
+#if defined __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_1_X4,
+#endif
 #else
         .vec_dot_type             = GGML_TYPE_Q8_1,
 #endif
@@ -809,7 +813,11 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float_ref           = (ggml_from_float_t) quantize_row_q5_1_ref,
         .vec_dot                  = ggml_vec_dot_q5_1_q8_1,
 #if GGML_USE_IQK_MULMAT
+#ifdef __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_1_X4,
+#endif
 #else
         .vec_dot_type             = GGML_TYPE_Q8_1,
 #endif


### PR DESCRIPTION

When I changed the `vet_dot_type` for `q8_1_x4` to `q8_2_x4` for the quants using `q8_1_x4` I forgot to also make the change for the `ARM_NEON` implementation. As a result `q4_1` and `q5_1` are currently broken. But because `q4_0/q5_0` will use `q4_1/q5_1` for a few `ffn_down` layers, `q4_0` and `q5_0` are broken as well.

Looking at the implementation, changing to use `q8_2_x4` would be too a major change. Hence, just go back to using `q8_1_x4` on Arm. If this results in some models not working correctly, then simply don't use legacy quants for those models.  