### PR TITLE
Fix division by zero bug

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -21790,7 +21790,7 @@ struct ggml_cplan ggml_graph_plan(const struct ggml_cgraph * cgraph, int n_threa
                     const struct ggml_tensor * k = node->src[1];
                     if (q->ne[1] == 1 && q->ne[3] == 1 && q->ne[2]/k->ne[2] > 1 && n_tasks > 1 && k->ne[1]/32 > 1) {
                         if (k->ne[2] > 1) {
-                            int nk = 32 * (k->ne[2]*k->ne[1]/(32*n_tasks));
+                            int nk = MAX(1, 32 * (k->ne[2]*k->ne[1]/(32*n_tasks)));
                             int nstep_k = k->ne[2]*k->ne[1]/nk;
                             size_t result_size = (Dv + 16)*q->ne[2]/k->ne[2]*sizeof(float);
                             size_t size = nstep_k*result_size;

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -154,7 +154,7 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
     }
 
     if (neq3 == 1 && rk2 > 1 && rk2 == rv2 && neq1 == 1 && nth >= 1 && nek2*nek1 >= 32*nth) {
-        int nk = 32 * (nek2*nek1/(32*nth));
+        int nk = std::max(1, 32 * (nek2*nek1/(32*nth)));
         int nkk = (nek1 + nk - 1)/nk;
         int nstep_k = nek2*nkk;
         auto result_size = (Dv + 16)*rk2*sizeof(float);


### PR DESCRIPTION

The bug was in the calculation of number of work items to use when computing FA on the CPU. In my case (maximum of 32 threads) it triggered with the GLM-4 model that has an unusually small number of KV heads (just 2). But I guess it can also trigger with a larger number of threads for more common numbers of KV heads.

Fixed by just using `max(1, nk)`. This will result in a far from optimal number of compute chunks, but at least it works.

I'm working on a better strategy for dividing the work between the threads on [this branch](https://github.com/ikawrakow/ik_llama.cpp/tree/ik/fattn_work_buffer),  but not quite ready for a PR yet.