### PR TITLE
Fix DeepSeek q8_0 cache

### DIFF
--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -81,7 +81,7 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
 
     int int_type_k = int_type_k_in;
     auto work_buffer = work_buffer_in;
-    if (neq1 >= 8 || rk2 >= 8) {
+    if (neq1 >= 8 || (rk2 >= 8 && nek2 > 1)) {
         uint64_t row_size = 0;
         work_buffer = iqk_repack_k(int_type_k, Dk, nek1, nek2, nek3, stride_k, nbk2, nbk3, k, work_buffer_in, ith, nth, int_type_k, row_size);
         if (int_type_k != int_type_k_in) {

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -18033,7 +18033,7 @@ bool iqk_flash_attn_impl(int int_type_k,         // type of k
     auto type_v = ggml_type(int_type_v);
 
     if (Dk == 576 && Dv == 512) {
-        GGML_ASSERT(type_k == type_v);
+        GGML_ASSERT(type_k == type_v || (type_k == GGML_TYPE_Q8_0_R8 && type_v == GGML_TYPE_Q8_0));
         stride_q /= sizeof(float); // q stride as float
         return iqk_deepseek_helper<32>(type_k, nq1, nk1, stride_q, stride_k, stride_v, stride_m, stride_qkv,
                         q, (const char *)k, (const char *)v, (const char *)mask, scale, softcap, qkv, M, S);


### PR DESCRIPTION

Nobody has used `ik_llama.cpp` with a DeepSeek model and `Q8_0` KV cache since PR #351?

This PR fixes the assert one gets when one tries to use a DeepSeek model on the CPU using `Q8_0` KV cache.

Also, it seems the optimization I added in #351 to repack the `K` cache to `Q8_0_R8` seems to lower TG performance for DeepSeek models, so disabling it.  