### PR TITLE
Better CPU FA performance for DeepSeek-Lite

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -17930,10 +17930,10 @@ inline void iqk_deepseek_helper(KHelper& kh, VHelper& vh,
         return false;
     };
     if (nq1 >= 16) {
-        int n_step = nq1/8;
-        FlashAttn<576, 512, 8, step_k> fa(scale, softcap);
-        fa.compute(kh, vh, 8*n_step, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
-        if (update(8*n_step)) return;
+        int n_step = nq1/16;
+        FlashAttn<576, 512, 16, step_k> fa(scale, softcap);
+        fa.compute(kh, vh, 16*n_step, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
+        if (update(16*n_step)) return;
     }
     if (nq1 >= 8) {
         int n_step = nq1/8;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -17242,7 +17242,7 @@ struct FlashAttn {
             q_size = GGML_PAD(q_size, 64);
             if (q_size > kMaxOnStackSize) {
                 auto qptr = get_q_storage(q_size);
-                if (nq1 >= 8) {
+                if (false && nq1 >= 8) {
                     if constexpr (std::is_same_v<KHelper, HelperQ80<Dk, k_step>>) {
 #if FA_TIMING
                         auto t1 = Perf::cur_time();
@@ -17929,6 +17929,12 @@ inline void iqk_deepseek_helper(KHelper& kh, VHelper& vh,
         if (M && S) { M += n; S += n; }
         return false;
     };
+    if (nq1 >= 16) {
+        int n_step = nq1/8;
+        FlashAttn<576, 512, 8, step_k> fa(scale, softcap);
+        fa.compute(kh, vh, 8*n_step, nk1, stride_q, stride_m, stride_qkv, q, mask, qkv, M, S);
+        if (update(8*n_step)) return;
+    }
     if (nq1 >= 8) {
         int n_step = nq1/8;
         FlashAttn<576, 512, 8, step_k> fa(scale, softcap);


### PR DESCRIPTION

This FA tweak improves DeepSeek-Lite CPU TG performance with `Q8_0` KV cache.

Not sure if it will have a positive impact for the large DeepSeek models. To optimize the FA strategy for those I need to be able to test, which I cannot atm.

The graph shows a comparison between the main branch and this PR for a `Q4_0` quantized DeepSeek-Lite model. The CPU is Ryzen-7950X. The x-axis is `N_KV/1000`, where `N__KV` is the number of tokens in the K cache, which is quantized with `Q8_0`. The `sweep-bench` command was
```
./bin/llama-sweep-bench -m $model -c 16384 -ub 1024 -t 16 -mla 3 -fmoe -fa -rtr
```
  
![z12](https://github.com/user-attachments/assets/fcdcf29d-2802-4562-84ab-f535d09a4c73)

<details>
<summary>Main branch</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.488 |   688.02 |    7.112 |    35.99 |
|  1024 |    256 |   1024 |    1.674 |   611.73 |    7.361 |    34.78 |
|  1024 |    256 |   2048 |    1.788 |   572.75 |    7.524 |    34.02 |
|  1024 |    256 |   3072 |    1.951 |   524.97 |    7.728 |    33.13 |
|  1024 |    256 |   4096 |    2.104 |   486.65 |    7.927 |    32.29 |
|  1024 |    256 |   5120 |    2.276 |   449.93 |    8.152 |    31.40 |
|  1024 |    256 |   6144 |    2.483 |   412.40 |    8.441 |    30.33 |
|  1024 |    256 |   7168 |    2.841 |   360.45 |    8.795 |    29.11 |
|  1024 |    256 |   8192 |    2.794 |   366.55 |    9.294 |    27.54 |
|  1024 |    256 |   9216 |    2.974 |   344.36 |    9.142 |    28.00 |
|  1024 |    256 |  10240 |    3.130 |   327.15 |    9.404 |    27.22 |
|  1024 |    256 |  11264 |    3.328 |   307.69 |    9.654 |    26.52 |
|  1024 |    256 |  12288 |    3.499 |   292.67 |   10.078 |    25.40 |
|  1024 |    256 |  13312 |    3.840 |   266.70 |   10.536 |    24.30 |
|  1024 |    256 |  14336 |    3.886 |   263.53 |   10.969 |    23.34 |
|  1024 |    256 |  15360 |    4.055 |   252.52 |   11.430 |    22.40 |

</details>

<details>
<summary>PR</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.469 |   696.86 |    7.126 |    35.93 |
|  1024 |    256 |   1024 |    1.601 |   639.65 |    7.322 |    34.96 |
|  1024 |    256 |   2048 |    1.759 |   582.03 |    7.446 |    34.38 |
|  1024 |    256 |   3072 |    1.920 |   533.47 |    7.673 |    33.36 |
|  1024 |    256 |   4096 |    2.081 |   491.98 |    7.728 |    33.13 |
|  1024 |    256 |   5120 |    2.282 |   448.64 |    7.852 |    32.60 |
|  1024 |    256 |   6144 |    2.413 |   424.33 |    7.991 |    32.04 |
|  1024 |    256 |   7168 |    2.626 |   389.95 |    8.122 |    31.52 |
|  1024 |    256 |   8192 |    2.753 |   372.02 |    8.238 |    31.08 |
|  1024 |    256 |   9216 |    2.934 |   348.97 |    8.394 |    30.50 |
|  1024 |    256 |  10240 |    3.159 |   324.17 |    8.538 |    29.98 |
|  1024 |    256 |  11264 |    3.299 |   310.44 |    8.668 |    29.53 |
|  1024 |    256 |  12288 |    3.501 |   292.47 |    8.818 |    29.03 |
|  1024 |    256 |  13312 |    3.684 |   277.98 |    8.969 |    28.54 |
|  1024 |    256 |  14336 |    4.074 |   251.37 |    9.089 |    28.16 |
|  1024 |    256 |  15360 |    4.086 |   250.63 |    9.167 |    27.93 |

</details>