### PR TITLE
CUDA call tracer

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -66,7 +66,7 @@ extern "C" {
     GGML_API GGML_CALL void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
     GGML_API GGML_CALL void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
 
-    GGML_API void ggml_backend_synchronize(ggml_backend_t backend);
+    GGML_API void ggml_backend_synchronize(ggml_backend_t backend, const char * func, const char * file, int line);
 
     GGML_API ggml_backend_graph_plan_t ggml_backend_graph_plan_create(ggml_backend_t backend, struct ggml_cgraph * cgraph);
     GGML_API void                      ggml_backend_graph_plan_free  (ggml_backend_t backend, ggml_backend_graph_plan_t plan);

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -91,7 +91,7 @@ extern "C" {
         bool (*GGML_CALL cpy_tensor_async)(ggml_backend_t backend_src, ggml_backend_t backend_dst, const struct ggml_tensor * src, struct ggml_tensor * dst);
 
         // (optional) complete all pending operations
-        void (*GGML_CALL synchronize)(ggml_backend_t backend);
+        void (*GGML_CALL synchronize)(ggml_backend_t backend, const char * func, const char * file, int line);
 
         // compute graph with a plan (not used currently)
         // create a new plan for a graph

--- a/ggml/src/ggml-backend.c
+++ b/ggml/src/ggml-backend.c
@@ -1809,8 +1809,6 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         // copy the input tensors to the split backend
         for (int j = 0; j < split->n_inputs; j++) {
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[j]);
-            GGML_ASSERT(input_backend);
-            GGML_ASSERT(input_backend->context);
             struct ggml_tensor * input = split->inputs[j];
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
 
@@ -1829,6 +1827,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 } else {
                     ggml_backend_synchronize(split_backend);
                 }
+                GGML_ASSERT(input_backend);
+                GGML_ASSERT(input_backend->context);
                 // try async copy, but if not possible, we can still use a sync copy without synchronizing the dst backend, since we handle the synchronization here with multiple copies and events
                 // TODO: add public function to facilitate this, since applications do not have direct access to the backend interface
                 if (!split_backend->iface.cpy_tensor_async || !split_backend->iface.cpy_tensor_async(input_backend, split_backend, input, input_cpy)) {

--- a/ggml/src/ggml-backend.c
+++ b/ggml/src/ggml-backend.c
@@ -1809,6 +1809,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         // copy the input tensors to the split backend
         for (int j = 0; j < split->n_inputs; j++) {
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[j]);
+            GGML_ASSERT(input_backend);
+            GGML_ASSERT(input_backend->context);
             struct ggml_tensor * input = split->inputs[j];
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
 

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2748,6 +2748,7 @@ static bool ggml_cuda_up_gate_unary(ggml_backend_cuda_context & ctx, ggml_tensor
             dst_row.data  =  dst_up_contiguous.get();
             ggml_cuda_mul_mat(ctx, &src0_1_row, &src1_row, &dst_row);
             CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cudaStreamSynchronize(stream));
 
             dst_row.data  = dst_gate_contiguous.get();
             ggml_cuda_mul_mat(ctx, &src0_2_row, &src1_row, &dst_row);
@@ -2756,6 +2757,7 @@ static bool ggml_cuda_up_gate_unary(ggml_backend_cuda_context & ctx, ggml_tensor
             ggml_fused_mul_unary(ctx, (ggml_unary_op)dst->op_params[0], ggml_nelements(&dst_row),
                         (const float *)dst_gate_contiguous.get(), (const float *)dst_up_contiguous.get(), (float *)dst_gate_contiguous.get());
             CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cudaStreamSynchronize(stream));
 
             if (fuse_down) {
 
@@ -2777,6 +2779,7 @@ static bool ggml_cuda_up_gate_unary(ggml_backend_cuda_context & ctx, ggml_tensor
                 ggml_cuda_mul_mat(ctx, &final_src, &dst_row, &final_dst);
                 //ggml_cuda_mul_mat(ctx, next->src[0], &dst_row, &final_dst);
                 CUDA_CHECK(cudaGetLastError());
+                CUDA_CHECK(cudaStreamSynchronize(stream));
 
                 dim3 block_dims(std::min((unsigned int)next->ne[0], 768u));
                 dim3 grid_dims(num_src1_rows);

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2796,6 +2796,8 @@ static bool ggml_cuda_up_gate_unary(ggml_backend_cuda_context & ctx, ggml_tensor
         }
     }
 
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
     return fuse_down;
 }
 
@@ -3063,10 +3065,10 @@ GGML_CALL static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_
     CUDA_CHECK(cudaGetDevice(&cur_device));
 
     if (backend_src != backend_dst) {
-        if (cuda_ctx_src->device != cur_device) {
-            GGML_CUDA_LOG_WARN("%s: attempt to copy on device %d while current device is %d\n", __func__, cuda_ctx_src->device, cur_device);
-            CUDA_CHECK(cudaSetDevice(cuda_ctx_src->device));
-        }
+        //if (cuda_ctx_src->device != cur_device) {
+        //    GGML_CUDA_LOG_WARN("%s: attempt to copy on device %d while current device is %d\n", __func__, cuda_ctx_src->device, cur_device);
+        //    CUDA_CHECK(cudaSetDevice(cuda_ctx_src->device));
+        //}
         // copy on src stream
         if (cuda_ctx_src->device == cuda_ctx_dst->device) {
             CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, ggml_nbytes(dst), cudaMemcpyDeviceToDevice, cuda_ctx_src->stream()));
@@ -3097,10 +3099,10 @@ GGML_CALL static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_
         CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx_dst->stream(), cuda_ctx_src->copy_event, 0));
     } else {
         // src and dst are on the same backend
-        if (cuda_ctx_src->device != cur_device) {
-            GGML_CUDA_LOG_WARN("%s: attempt to copy on device %d while current device is %d\n", __func__, cuda_ctx_src->device, cur_device);
-            CUDA_CHECK(cudaSetDevice(cuda_ctx_src->device));
-        }
+        //if (cuda_ctx_src->device != cur_device) {
+        //    GGML_CUDA_LOG_WARN("%s: attempt to copy on device %d while current device is %d\n", __func__, cuda_ctx_src->device, cur_device);
+        //    CUDA_CHECK(cudaSetDevice(cuda_ctx_src->device));
+        //}
         CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, ggml_nbytes(dst), cudaMemcpyDeviceToDevice, cuda_ctx_src->stream()));
     }
     return true;
@@ -3112,12 +3114,12 @@ GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend, cons
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
     auto stream = cuda_ctx->stream();
     GGML_ASSERT(stream);
-    int cur_device;
-    (void)cudaGetDevice(&cur_device);
-    if (cur_device != cuda_ctx->device) {
-        GGML_CUDA_LOG_WARN("%s: curent device is %d, context device is %d\n", __func__, cur_device, cuda_ctx->device);
-        CUDA_CHECK(cudaSetDevice(cuda_ctx->device));
-    }
+    //int cur_device;
+    //(void)cudaGetDevice(&cur_device);
+    //if (cur_device != cuda_ctx->device) {
+    //    GGML_CUDA_LOG_WARN("%s: curent device is %d, context device is %d\n", __func__, cur_device, cuda_ctx->device);
+    //    CUDA_CHECK(cudaSetDevice(cuda_ctx->device));
+    //}
 
     auto err = cudaStreamSynchronize(stream);
     if (err != cudaSuccess) {
@@ -3127,10 +3129,10 @@ GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend, cons
     }
     //CUDA_CHECK(cudaStreamSynchronize(stream));
 
-    if (cur_device != cuda_ctx->device) {
-        GGML_CUDA_LOG_WARN("%s: reverting device to %d\n", __func__, cur_device);
-        CUDA_CHECK(cudaSetDevice(cur_device));
-    }
+    //if (cur_device != cuda_ctx->device) {
+    //    GGML_CUDA_LOG_WARN("%s: reverting device to %d\n", __func__, cur_device);
+    //    CUDA_CHECK(cudaSetDevice(cur_device));
+    //}
     GGML_UNUSED(backend);
 }
 
@@ -3812,18 +3814,18 @@ GGML_CALL ggml_backend_t ggml_backend_cuda_init(int device) {
         /* .context   = */ ctx
     };
 
-#ifndef GGML_CUDA_NO_PEER_COPY
-    if (num_devices > 1) {
-        CUDA_CHECK(cudaSetDevice(device));
-        for (int i = 0; i < num_devices; ++i) {
-            if (i == device) continue;
-            cudaError_t err = cudaDeviceEnablePeerAccess(i, 0);
-            if (err != cudaSuccess && err != cudaErrorPeerAccessAlreadyEnabled) {
-                GGML_CUDA_LOG_ERROR("Failed to enable peer access from %d to %d: %s", device, i, cudaGetErrorString(err));
-            }
-        }
-    }
-#endif
+//#ifndef GGML_CUDA_NO_PEER_COPY
+//    if (num_devices > 1) {
+//        CUDA_CHECK(cudaSetDevice(device));
+//        for (int i = 0; i < num_devices; ++i) {
+//            if (i == device) continue;
+//            cudaError_t err = cudaDeviceEnablePeerAccess(i, 0);
+//            if (err != cudaSuccess && err != cudaErrorPeerAccessAlreadyEnabled) {
+//                GGML_CUDA_LOG_ERROR("Failed to enable peer access from %d to %d: %s", device, i, cudaGetErrorString(err));
+//            }
+//        }
+//    }
+//#endif
     return cuda_backend;
 }
 

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2812,9 +2812,12 @@ static bool ggml_cuda_up_gate_unary(ggml_backend_cuda_context & ctx, ggml_tensor
         GGML_CUDA_LOG_ERROR("src0_1: %s, %s, %d x %d x %d\n", src0_1->name, ggml_type_name(src0_1->type), (int)src0_1->ne[0], (int)src0_1->ne[1], (int)src0_1->ne[2]);
         GGML_CUDA_LOG_ERROR("src0_2: %s, %s, %d x %d x %d\n", src0_2->name, ggml_type_name(src0_2->type), (int)src0_2->ne[0], (int)src0_2->ne[1], (int)src0_2->ne[2]);
         GGML_CUDA_LOG_ERROR("src1  : %s, %s, %d x %d x %d\n", src1->name, ggml_type_name(src1->type), (int)src1->ne[0], (int)src1->ne[1], (int)src1->ne[2]);
+        GGML_CUDA_LOG_ERROR("nb0_1 : %zu x %zu x %zu\n", src0_1->nb[0], src0_1->nb[1], src0_1->nb[2]);
+        GGML_CUDA_LOG_ERROR("nb0_2 : %zu x %zu x %zu\n", src0_2->nb[0], src0_2->nb[1], src0_2->nb[2]);
         if (fuse_down) {
             GGML_CUDA_LOG_ERROR("src0_n: %s, %s, %d x %d x %d\n", next->src[0]->name, ggml_type_name(next->src[0]->type), (int)next->src[0]->ne[0], (int)next->src[0]->ne[1], (int)next->src[0]->ne[2]);
             GGML_CUDA_LOG_ERROR("next  : %s, %s, %d x %d x %d\n", next->name, ggml_type_name(next->type), (int)next->ne[0], (int)next->ne[1], (int)next->ne[2]);
+            GGML_CUDA_LOG_ERROR("nxt_nb: %zu x %zu x %zu\n", next->src[0]->nb[0], next->src[0]->nb[1], next->src[0]->nb[2]);
             auto next_ctx = (ggml_backend_cuda_buffer_context *)next->buffer->context;
             auto next_src = (ggml_backend_cuda_buffer_context *)next->src[0]->buffer->context;
             GGML_CUDA_LOG_ERROR("next devices: %d, %d\n", next_ctx->device, next_src->device);

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3080,9 +3080,13 @@ GGML_CALL static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_
 }
 
 GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
+    GGML_ASSERT(backend);
+    GGML_ASSERT(backend->context);
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    auto stream = cuda_ctx->stream();
+    GGML_ASSERT(stream);
 
-    CUDA_CHECK(cudaStreamSynchronize(cuda_ctx->stream()));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     GGML_UNUSED(backend);
 }

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3079,14 +3079,20 @@ GGML_CALL static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_
     return true;
 }
 
-GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
+GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend, const char * func, const char * file, int line) {
     GGML_ASSERT(backend);
     GGML_ASSERT(backend->context);
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
     auto stream = cuda_ctx->stream();
     GGML_ASSERT(stream);
 
-    CUDA_CHECK(cudaStreamSynchronize(stream));
+    auto err = cudaStreamSynchronize(stream);
+    if (err != cudaSuccess) {
+        ggml_cuda_error("cudaStreamSynchronize", func, file, line, cudaGetErrorString(err));
+    } else {
+        Tracer::register_call(func, file, line);
+    }
+    //CUDA_CHECK(cudaStreamSynchronize(stream));
 
     GGML_UNUSED(backend);
 }

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -1658,6 +1658,7 @@ static void ggml_cuda_op_mul_mat(
         char  * src1_ddq_i = dev[id].src1_ddq;
         float *   dst_dd_i =   dev[id].dst_dd;
         cudaStream_t stream = ctx.stream(id, 0);
+        ggml_cuda_set_device(id);
         ggml_cuda_op_mul_mat_vec_q_3D(ctx, src0, src1, dst, src0_dd_i, src1_ddf_i, src1_ddq_i, dst_dd_i,
                 dev[id].row_low, dev[id].row_high, ne11, src1_padded_col_size, stream);
         CUDA_CHECK(cudaGetLastError());

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3520,20 +3520,24 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     if (args.ne01 % mmq_y == 0) {
         constexpr bool need_check = false;
 
-        mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_mmq, block_dims, shmem, stream>>>
-            (args.x, args.y, args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+        (mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_mmq, block_dims, shmem, stream>>>
+            (args.x, args.y, args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0));
+        CUDA_CHECK(cudaGetLastError());
 
         mul_mat_q_stream_k_fixup<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, 0, stream>>>
             (args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.ne11, args.ne0, block_nums_mmq.x);
+        CUDA_CHECK(cudaGetLastError());
 
     } else {
         constexpr bool need_check = true;
 
         mul_mat_q<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_mmq, block_dims, shmem, stream>>>
             (args.x, args.y, args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.stride01, args.ne10, args.ne11, args.stride11, args.ne0);
+        CUDA_CHECK(cudaGetLastError());
 
         mul_mat_q_stream_k_fixup<type, mmq_x, MMQ_NWARPS, need_check><<<block_nums_xy_tiling, block_dims, 0, stream>>>
             (args.dst, tmp_fixup.ptr, args.ne00, args.ne01, args.ne11, args.ne0, block_nums_mmq.x);
+        CUDA_CHECK(cudaGetLastError());
 
     }
 }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -72,10 +72,13 @@ static __device__ void mul_mat_vec_q(
 
     constexpr vec_dot_q_cuda_t vec_dot_q_cuda = get_vec_dot_q_cuda(type);
 
+    //int64_t rows_per_cuda_block = ggml_cuda_info().devices[id].cc < CC_RDNA2 ?
+    //    ncols_y < 4 ? 1 : 2 : 1;
+
 #if defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__) && (defined(RDNA2) || defined(RDNA3))
     constexpr int rows_per_cuda_block = 1;
 #else
-    constexpr int rows_per_cuda_block = ncols_y == 1 ? 1 : 2;
+    constexpr int rows_per_cuda_block = ncols_y < 4 ? 1 : 2;
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__) && !defined(RDNA2) && !defined(RDNA3)
 
     const     int tid = WARP_SIZE*threadIdx.y + threadIdx.x;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -568,6 +568,7 @@ void ggml_cuda_op_mul_mat_vec_q_3D(
         src0_dd_i, src1_ddq_i, dst_dd_i, nullptr,
         row_low, row_high, src1_ncols,
         src1_padded_row_size, stream);
+    CUDA_CHECK(cudaGetLastError());
 
     GGML_UNUSED(src1_ddf_i);
 }
@@ -589,6 +590,7 @@ void ggml_cuda_op_mul_mat_vec_q(
         src0_dd_i, src1_ddq_i, dst_dd_i, nullptr,
         row_low, row_high, src1_ncols,
         src1_padded_row_size, stream);
+    CUDA_CHECK(cudaGetLastError());
 
     GGML_UNUSED(src1_ddf_i);
 }
@@ -615,6 +617,7 @@ void ggml_cuda_op_mul_mat_vec_q_id(
         src0_dd_i, src1_ddq_i, dst_dd_i, (const char *)ids->data,
         row_low, row_high, src1_ncols,
         src1_padded_row_size, stream);
+    CUDA_CHECK(cudaGetLastError());
 
     GGML_UNUSED(src1_ddf_i);
 }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7025,6 +7025,7 @@ static void llm_prepare_mla(llama_model & model, int mla) {
         auto name = std::string{"blk."} + std::to_string(il) + ".attn_kv_b.weight";
 
         l.computed_wkv_b = std::make_unique<ggml_tensor>(*wkv_b);
+        l.computed_wkv_b->view_src = nullptr;
         l.computed_wkv_b->buffer = ggml_backend_buft_alloc_buffer(ggml_backend_buffer_get_type(l.wk_b->buffer), ggml_nbytes(wkv_b));
         l.computed_wkv_b->data   = ggml_backend_buffer_get_base(l.computed_wkv_b->buffer);
         l.computed_wkv_b->op = GGML_OP_NONE; // we absolutely need to do this, else the backend will attempt to find the parents

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -623,11 +623,11 @@ struct test_case {
         }
 
         // run
-        ggml_backend_synchronize(backend);
+        ggml_backend_synchronize(backend, __func__, __FILE__, __LINE__);
 
         int64_t start_time = ggml_time_us();
         ggml_backend_graph_compute(backend, gf);
-        ggml_backend_synchronize(backend);
+        ggml_backend_synchronize(backend, __func__, __FILE__, __LINE__);
         int64_t end_time = ggml_time_us();
         double time_us = end_time - start_time;
 


### PR DESCRIPTION
This PR adds a CUDA call tracer. The main purpose of the tracer is to hopefully help debug the illegal memory access crashes reported in #398 and #425. If there is a crash, the last 32 invocations of `CUDA_CHECK` will be printed to `stderr` before aborting. In my testing the overhead added by the tracer has negligible impact on performance.
