### PR TITLE
Add support for FP8 GGUF creation and re-quantization (WIP)

### DIFF
--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -1317,6 +1317,7 @@ class GGMLQuantizationType(IntEnum):
     IQ4_KS_R4 = 344
     Q8_KV_R8  = 398
     Q8_K_R8   = 399
+    FP8_E4M3  = 999
 
 
 class ExpertGatingFuncType(IntEnum):
@@ -1395,6 +1396,7 @@ class LlamaFileType(IntEnum):
     MOSTLY_IQ4_KS_R4       = 337    #except 1d tensors
     MOSTLY_Q8_KV_R8        = 398    #except 1d tensors
     MOSTLY_Q8_K_R8         = 399    #except 1d tensors
+    MOSTLY_FP8_E4M3        = 999    #except 1d tensors
 
 
     GUESSED              = 1024  # not specified in the model file
@@ -1522,6 +1524,7 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.IQ4_KS_R4   : ( 256,  136),
     GGMLQuantizationType.Q8_KV_R8    : (  32,   32),
     GGMLQuantizationType.Q8_K_R8     : ( 256,  258),
+    GGMLQuantizationType.FP8_E4M3    : (   1,    1),
 }
 
 

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -61,7 +61,6 @@ def quantize(data: np.ndarray, qtype: GGMLQuantizationType) -> np.ndarray:
     elif (q := _type_traits.get(qtype)) is not None:
         return q.quantize(data)
     else:
-        print(_type_traits)
         raise NotImplementedError(f"Quantization for {qtype.name} is not yet implemented")
 
 


### PR DESCRIPTION
The goal of this is to be able to directly handle FP8 (more specifically E4M3) native models by creating an FP8 GGUF, which can then be quantized into a GGUF that can be used for inferencing (inference on FP8 is beyond the scope of this PR similar to #169).

Currently only the FP8 GGUF creation is implemented (which involved including the weight_scale_inv and FP8_E4M3 quant methods). Tested with [this](https://huggingface.co/Qwen/Qwen3-0.6B-FP8/tree/main) tiny model for now which successfully created a GGUF and was able to dump it.

I picked that model as I think it follows the same usage of scale as Deepseek and is tiny. Other models such as [this](https://huggingface.co/RedHatAI/Mistral-Nemo-Instruct-2407-FP8/tree/main) seem like they handle scale differently and so that is definitely something that should be addressed if we want to support all FP8 native models but I'm leaving that for later.

I will attempt to add the quantization support later (handling the scale) but wanted to create this draft PR now in case there is any feedback on this idea or approach. 

(Also the enum value for FP8_E4M3 is set to 999 for now as I don't know where it should slot in)