### PR TITLE
CUDA implementation for IQ2_K_R4, IQ3_K_R4, IQ4_K_R4, IQ5_K_R4

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3470,6 +3470,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                     case GGML_TYPE_IQ6_K:
                     case GGML_TYPE_IQ1_BN:
                     case GGML_TYPE_IQ2_BN:
+                    case GGML_TYPE_IQ3_K_R4:
                     case GGML_TYPE_IQ4_K_R4:
                     case GGML_TYPE_IQ5_K_R4:
                         return true;

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3471,6 +3471,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                     case GGML_TYPE_IQ1_BN:
                     case GGML_TYPE_IQ2_BN:
                     case GGML_TYPE_IQ4_K_R4:
+                    case GGML_TYPE_IQ5_K_R4:
                         return true;
                     default:
                         return false;

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3470,6 +3470,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                     case GGML_TYPE_IQ6_K:
                     case GGML_TYPE_IQ1_BN:
                     case GGML_TYPE_IQ2_BN:
+                    case GGML_TYPE_IQ2_K_R4:
                     case GGML_TYPE_IQ3_K_R4:
                     case GGML_TYPE_IQ4_K_R4:
                     case GGML_TYPE_IQ5_K_R4:

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3470,6 +3470,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                     case GGML_TYPE_IQ6_K:
                     case GGML_TYPE_IQ1_BN:
                     case GGML_TYPE_IQ2_BN:
+                    case GGML_TYPE_IQ4_K_R4:
                         return true;
                     default:
                         return false;

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -886,6 +886,54 @@ static __global__ void dequantize_block_iq5_k_r4(const void * __restrict__ vx, d
     }
 }
 
+template<typename dst_t>
+static __global__ void dequantize_block_iq3_k_r4(const void * __restrict__ vx, dst_t * __restrict__ yy, int64_t n_per_row, int64_t row_size) {
+
+    int64_t ii = blockIdx.x;
+
+    int64_t nblock = n_per_row/256;
+    int64_t row  = ii/nblock;
+    int64_t row4 = row/4;
+    int64_t ir   = row%4;
+    int64_t ibl  = row4*nblock + ii%nblock;
+
+    const int tid = threadIdx.x;
+    const int  il = tid/8; // 0...3
+    const int  ib = tid%8; // 0...7
+
+    const block_iq3_k_r4 * x = (const block_iq3_k_r4 *)vx;
+    dst_t * y = yy + 256*ii + 32*ib;
+
+    const float d = __half2float(x[ibl].d[ir]);
+    int is = 8*ib + ir;
+    float dl1 = d * (2*((x[ibl].scales_l[is%32] >> 4*(is/32)) & 0xf) + 1) * ((x[ibl].scales_h[is%8] >> (is/8)) & 1 ? -1 : 1);
+    is += 4;
+    float dl2 = d * (2*((x[ibl].scales_l[is%32] >> 4*(is/32)) & 0xf) + 1) * ((x[ibl].scales_h[is%8] >> (is/8)) & 1 ? -1 : 1);
+    auto values1 = iq3nl_values + (((x[ibl].extra[ir+0] >> ib) & 1) << 3);
+    auto values2 = iq3nl_values + (((x[ibl].extra[ir+4] >> ib) & 1) << 3);
+    auto ql = x[ibl].qs + 32*ib + 4*ir;
+    auto qh = x[ibl].qh + 16*ib + 4*ir;
+    if constexpr (std::is_same_v<dst_t, nv_bfloat16>) {
+        y[il+ 0] = __float2bfloat16(dl1 * values1[((ql[il+ 0] >> 0) & 3) | ((qh[il] << 2) & 4)]);
+        y[il+ 4] = __float2bfloat16(dl1 * values1[((ql[il+ 0] >> 2) & 3) | ((qh[il] << 1) & 4)]);
+        y[il+ 8] = __float2bfloat16(dl1 * values1[((ql[il+ 0] >> 4) & 3) | ((qh[il] << 0) & 4)]);
+        y[il+12] = __float2bfloat16(dl1 * values1[((ql[il+ 0] >> 6) & 3) | ((qh[il] >> 1) & 4)]);
+        y[il+16] = __float2bfloat16(dl2 * values2[((ql[il+16] >> 0) & 3) | ((qh[il] >> 2) & 4)]);
+        y[il+20] = __float2bfloat16(dl2 * values2[((ql[il+16] >> 2) & 3) | ((qh[il] >> 3) & 4)]);
+        y[il+24] = __float2bfloat16(dl2 * values2[((ql[il+16] >> 4) & 3) | ((qh[il] >> 4) & 4)]);
+        y[il+28] = __float2bfloat16(dl2 * values2[((ql[il+16] >> 6) & 3) | ((qh[il] >> 5) & 4)]);
+    } else {
+        y[il+ 0] = dl1 * values1[((ql[il+ 0] >> 0) & 3) | ((qh[il] << 2) & 4)];
+        y[il+ 4] = dl1 * values1[((ql[il+ 0] >> 2) & 3) | ((qh[il] << 1) & 4)];
+        y[il+ 8] = dl1 * values1[((ql[il+ 0] >> 4) & 3) | ((qh[il] << 0) & 4)];
+        y[il+12] = dl1 * values1[((ql[il+ 0] >> 6) & 3) | ((qh[il] >> 1) & 4)];
+        y[il+16] = dl2 * values2[((ql[il+16] >> 0) & 3) | ((qh[il] >> 2) & 4)];
+        y[il+20] = dl2 * values2[((ql[il+16] >> 2) & 3) | ((qh[il] >> 3) & 4)];
+        y[il+24] = dl2 * values2[((ql[il+16] >> 4) & 3) | ((qh[il] >> 4) & 4)];
+        y[il+28] = dl2 * values2[((ql[il+16] >> 6) & 3) | ((qh[il] >> 5) & 4)];
+    }
+}
+
 
 template<typename dst_t>
 static __global__ void dequantize_block_iq5_ks(const void * __restrict__ vx, dst_t * __restrict__ yy, int64_t n_per_row, int64_t row_size) {
@@ -1298,6 +1346,14 @@ static void dequantize_row_iq3_k_cuda(const void * vx, dst_t * y, const int64_t 
 }
 
 template<typename dst_t>
+static void dequantize_row_iq3_k_r4_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
+    const int64_t k = nrows * n_per_row;
+    const int64_t row_size = ggml_row_size(GGML_TYPE_IQ4_K, n_per_row);
+    const int nb = (k + QK_K - 1) / QK_K;
+    dequantize_block_iq3_k_r4<<<nb, 32, 0, stream>>>(vx, y, n_per_row, row_size);
+}
+
+template<typename dst_t>
 static void dequantize_row_iq4_k_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
     const int64_t k = nrows * n_per_row;
     const int nb = (k + QK_K - 1) / QK_K;
@@ -1423,6 +1479,8 @@ to_bf16_cuda_t ggml_get_to_bf16_cuda(ggml_type type) {
             return dequantize_row_iq5_k_cuda<nv_bfloat16>;
         case GGML_TYPE_IQ6_K:
             return dequantize_row_iq6_k_cuda<nv_bfloat16>;
+        case GGML_TYPE_IQ3_K_R4:
+            return dequantize_row_iq3_k_r4_cuda<nv_bfloat16>;
         case GGML_TYPE_IQ4_K_R4:
             return dequantize_row_iq4_k_r4_cuda<nv_bfloat16>;
         case GGML_TYPE_IQ5_K_R4:
@@ -1509,6 +1567,8 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
             return convert_unary_cuda<float>;
         case GGML_TYPE_BF16:
             return convert_from_bf16_cuda;
+        case GGML_TYPE_IQ3_K_R4:
+            return dequantize_row_iq3_k_r4_cuda;
         case GGML_TYPE_IQ4_K_R4:
             return dequantize_row_iq4_k_r4_cuda;
         case GGML_TYPE_IQ5_K_R4:
@@ -1592,6 +1652,8 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
             return convert_unary_cuda<half>;
         case GGML_TYPE_BF16:
             return convert_from_bf16_cuda;
+        case GGML_TYPE_IQ3_K_R4:
+            return dequantize_row_iq3_k_r4_cuda;
         case GGML_TYPE_IQ4_K_R4:
             return dequantize_row_iq4_k_r4_cuda;
         case GGML_TYPE_IQ5_K_R4:

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -759,52 +759,19 @@ static __global__ void dequantize_block_iq4_k_r4(const void * __restrict__ vx, d
 
     int64_t ii = blockIdx.x;
 
-    //int64_t nblock = n_per_row/256;
-    //int64_t row = ii/nblock;
-    //int64_t ibl = ii - row*nblock;
-    //int64_t row4 = row/4;
-    //int64_t ir = row4%4;
-
-    //const block_iq4_k_r4 * x = (const block_iq4_k_r4 *)vx + row4*nblock;
-
-    //int64_t row4 = (256*ii)/(4*n_per_row); // rows of 4 index
-    //int64_t ibl = ii - row4*n_per_row/64;  // block index within the rows of 4
-    //int64_t ir = row4%4;                   // row
-
-    //int64_t ibl = ii/4;
-    //int     ir  = ii%4;
     int64_t nblock = n_per_row/256;
     int64_t row  = ii/nblock;
     int64_t row4 = row/4;
     int64_t ir   = row%4;
     int64_t ibl  = row4*nblock + ii%nblock;
-    // ii = 0 -> row = 0, row4 = 0, ir = 0, ibl should be 0
-    // ii = 1 -> row = 0, row4 = 0, ir = 0, ibl should be 1
-    // ii = 2 -> row = 0, row4 = 0, ir = 0, ibl should be 2
-    // ...
-    // ii = 16 -> row = 1, row4 = 0, ir = 1, ibl should be 0
-    // ..
-    // ii = 64 -> row = 4, row4 = 1, ir = 0, ibl should be 16
 
-
-    const block_iq4_k_r4 * x = (const block_iq4_k_r4 *)vx;
-    ////const block_iq4_k_r4 * x = (const block_iq4_k_r4 *)((const char *)vx + 4*row4*row_size);
-
-    // Say, we have rows of 4096, and we have 8 rows -> 4096*8/256 = 128 blocks of 256, 16 blocks per row
-    // ii = 0 -> ibl = 0, ir = 0 -> warp processes 0...255 in row 0
-    // ii = 1 -> ibl = 0, ir = 1 -> warp processes 0...255 in row 1
-    // ii = 2 -> ibl = 0, ir = 2 -> warp processes 0...255 in row 2
-    // ii = 3 -> ibl = 0, ir = 3 -> warp processes 0...255 in row 3
-    // ii = 4 -> ibl = 1, ir = 0 -> warp processes 256...511 in row 0
-    // ii = 5 -> ibl = 1, ir = 1 -> warp processes 256...511 in row 1
-    // ii = 6 -> ibl = 1, ir = 2 -> warp processes 256...511 in row 2
-    // ii = 7 -> ibl = 1, ir = 3 -> warp processes 256...511 in row 3
-    // ...
-    // ii = 63 -> ibl = 15, ir = 3 -> warp processes 3840...4096 in row 3
-    // ii = 64 -> ibl = 16, ir = 0 -> warp processes 0...255 in row 4, so offset is 4*4096 = 4*16*256
     const int tid = threadIdx.x;
     const int  il = tid/8; // 0...3
     const int  ib = tid%8; // 0...7
+
+    const block_iq4_k_r4 * x = (const block_iq4_k_r4 *)vx;
+    dst_t * y = yy + 256*ii + 32*ib;
+
     const float d = __half2float(x[ibl].d[ir]);
     int is = 8*ib + ir;
     float dl1 = d * ((((x[ibl].scales_l[is%32] >> 4*(is/32)) & 0xf) | (((x[ibl].scales_h[is%16] >> 2*(is/16)) & 3) << 4)) - 32);
@@ -812,9 +779,6 @@ static __global__ void dequantize_block_iq4_k_r4(const void * __restrict__ vx, d
     float dl2 = d * ((((x[ibl].scales_l[is%32] >> 4*(is/32)) & 0xf) | (((x[ibl].scales_h[is%16] >> 2*(is/16)) & 3) << 4)) - 32);
     auto values1 = iq4k_values + (((x[ibl].extra[ir+0] >> ib) & 1) << 4);
     auto values2 = iq4k_values + (((x[ibl].extra[ir+4] >> ib) & 1) << 4);
-    dst_t * y = yy + 256*ii + 32*ib;
-    //dst_t * y = yy + (4*row4 + ir)*n_per_row + ibl*QK_K + 32*ib;
-    //dst_t * y = yy + ir*n_per_row + 4*ibl*QK_K + 32*ib;
     auto qs = x[ibl].qs + 64*ib + 4*ir;
     if constexpr (std::is_same_v<dst_t, nv_bfloat16>) {
         y[il+ 0] = __float2bfloat16(dl1 * values1[qs[il+ 0] & 0xf]);

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -281,40 +281,7 @@ __device__ __forceinline__ void vec_dot_iq4_k_r4_q8_1(
     const uint32_t * scales_h = (const uint32_t *)bq4->scales_h;
     scales = __vsub4(((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) | (((scales_h[2*(ib32%2)+is] >> 2*(ib32/2)) & 0x03030303) << 4), 0x20202020);
     const int8_t * s8 = (const int8_t *)&scales;
-    int2 val1, val2;
-    const int * q4 = (const int *)bq4->qs + 16*ib32;
-    for (int i = 0; i < 4; ++i) {
-        auto values1 = iq4k_values + (((bq4->extra[i+4*is] >> ib32) & 1) << 4);
-        int sumi1 = 0;
-        val1  = get_int_from_table_16(q4[i+4*is+0], values1);
-        sumi1 = ggml_cuda_dp4a(val1.x, q8[0], ggml_cuda_dp4a(val1.y, q8[2], sumi1));
-        val1  = get_int_from_table_16(q4[i+4*is+8], values1);
-        sumi1 = ggml_cuda_dp4a(val1.x, q8[1], ggml_cuda_dp4a(val1.y, q8[3], sumi1));
-        const float d = __half2float(bq4->d[i]) * d8;
-        result[i] += d * sumi1 * s8[i];
-    }
-}
-
-__device__ __forceinline__ void vec_dot_iq5_k_r4_q8_1(
-    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
-
-    return;
-
-    const block_iq4_k_r4 * bq4 = (const block_iq4_k_r4 *)vbq + kbx;
-
-    // iqs is 0...28 in steps of 2
-    const int ib16 = iqs/2;
-    const float d8 = __low2float(bq8_1[ib16/2].ds);
-    const int32_t  * q8 = (const int *)bq8_1[ib16/2].qs + 4*(ib16%2);
-
-    int ib32 = ib16/2;
-    int is   = ib16%2;
-    int scales;
-    const uint32_t * scales_l = (const uint32_t *)bq4->scales_l;
-    const uint32_t * scales_h = (const uint32_t *)bq4->scales_h;
-    scales = __vsub4(((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) | (((scales_h[2*(ib32%2)+is] >> 2*(ib32/2)) & 0x03030303) << 4), 0x20202020);
-    const int8_t * s8 = (const int8_t *)&scales;
-    int2 val1, val2;
+    int2 val1;
     const int * q4 = (const int *)bq4->qs + 16*ib32;
     for (int i = 0; i < 4; ++i) {
         auto values1 = iq4k_values + (((bq4->extra[i+4*is] >> ib32) & 1) << 4);
@@ -424,6 +391,46 @@ __device__ __forceinline__ void vec_dot_iq5_k_q8_1(
     const int ls1 = (((bq5->scales_l[2*(i4/2)+0] >> 4*(i4%2)) & 0xf) | ((sh << 4) & 0x30)) - 32;
     const int ls2 = (((bq5->scales_l[2*(i4/2)+1] >> 4*(i4%2)) & 0xf) | ((sh << 0) & 0x30)) - 32;
     *result += d5 * (__low2float(bq8_1[2*(i4/2)+0].ds) * sumi1 * ls1 + __low2float(bq8_1[2*(i4/2)+1].ds) * sumi2 * ls2);
+}
+
+__device__ __forceinline__ void vec_dot_iq5_k_r4_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
+
+    const block_iq5_k_r4 * bq5 = (const block_iq5_k_r4 *)vbq + kbx;
+
+    // iqs is 0...28 in steps of 2
+    const int ib16 = iqs/2;
+    const float d8 = __low2float(bq8_1[ib16/2].ds);
+    const int32_t  * q8 = (const int *)bq8_1[ib16/2].qs + 4*(ib16%2);
+
+    int ib32 = ib16/2;
+    int is   = ib16%2;
+    int scales;
+    const uint32_t * scales_l = (const uint32_t *)bq5->scales_l;
+    const uint32_t * scales_h = (const uint32_t *)bq5->scales_h;
+    scales = __vsub4(((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) | (((scales_h[2*(ib32%2)+is] >> 2*(ib32/2)) & 0x03030303) << 4), 0x20202020);
+    const int8_t * s8 = (const int8_t *)&scales;
+    int2 val1;
+    const int * q4 = (const int *)bq5->qs + 16*ib32;
+    const int * qh = (const int *)bq5->qh +  4*ib32;
+    int aux32[2];
+    const uint8_t * aux8 = (const uint8_t *)aux32;
+    for (int i = 0; i < 4; ++i) {
+        auto values1 = iq5nl_values + (((bq5->extra[i+4*is] >> ib32) & 1) << 5);
+        int sumi1 = 0;
+        aux32[0] = ((q4[i+4*is+0] >> 0) & 0x0f0f0f0f) | (((qh[i] >> (2*is+0)) & 0x01010101) << 4);
+        aux32[1] = ((q4[i+4*is+0] >> 4) & 0x0f0f0f0f) | (((qh[i] >> (2*is+1)) & 0x01010101) << 4);
+        val1.x  = int_from_table(aux8+0, (const uint8_t *)values1);
+        val1.y  = int_from_table(aux8+4, (const uint8_t *)values1);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[0], ggml_cuda_dp4a(val1.y, q8[2], sumi1));
+        aux32[0] = ((q4[i+4*is+8] >> 0) & 0x0f0f0f0f) | (((qh[i] >> (2*is+4)) & 0x01010101) << 4);
+        aux32[1] = ((q4[i+4*is+8] >> 4) & 0x0f0f0f0f) | (((qh[i] >> (2*is+5)) & 0x01010101) << 4);
+        val1.x  = int_from_table(aux8+0, (const uint8_t *)values1);
+        val1.y  = int_from_table(aux8+4, (const uint8_t *)values1);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[1], ggml_cuda_dp4a(val1.y, q8[3], sumi1));
+        const float d = __half2float(bq5->d[i]) * d8;
+        result[i] += d * sumi1 * s8[i];
+    }
 }
 
 __device__ __forceinline__ void vec_dot_iq5_ks_q8_1(

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -9,6 +9,13 @@
 typedef void (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float *);
 
 template<>
+struct ggml_cuda_type_traits<GGML_TYPE_IQ3_K_R4> {
+    static constexpr int qk = QK_K;
+    static constexpr int qr = QR4_XS;
+    static constexpr int qi = QI4_XS;
+};
+
+template<>
 struct ggml_cuda_type_traits<GGML_TYPE_IQ4_K_R4> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR4_XS;
@@ -466,6 +473,48 @@ __device__ __forceinline__ void vec_dot_iq5_ks_q8_1(
     *result += scale * (__low2float(bq8_1[2*(i4/2)+0].ds) * sumi1 * ls1 + __low2float(bq8_1[2*(i4/2)+1].ds) * sumi2 * ls2);
 }
 
+__device__ __forceinline__ void vec_dot_iq3_k_r4_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
+
+    return;
+
+    const block_iq5_k_r4 * bq5 = (const block_iq5_k_r4 *)vbq + kbx;
+
+    // iqs is 0...28 in steps of 2
+    const int ib16 = iqs/2;
+    const float d8 = __low2float(bq8_1[ib16/2].ds);
+    const int32_t  * q8 = (const int *)bq8_1[ib16/2].qs + 4*(ib16%2);
+
+    int ib32 = ib16/2;
+    int is   = ib16%2;
+    int scales;
+    const uint32_t * scales_l = (const uint32_t *)bq5->scales_l;
+    const uint32_t * scales_h = (const uint32_t *)bq5->scales_h;
+    scales = __vsub4(((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) | (((scales_h[2*(ib32%2)+is] >> 2*(ib32/2)) & 0x03030303) << 4), 0x20202020);
+    const int8_t * s8 = (const int8_t *)&scales;
+    int2 val1;
+    const int * q4 = (const int *)bq5->qs + 16*ib32;
+    const int * qh = (const int *)bq5->qh +  4*ib32;
+    int aux32[2];
+    const uint8_t * aux8 = (const uint8_t *)aux32;
+    for (int i = 0; i < 4; ++i) {
+        auto values1 = iq5nl_values + (((bq5->extra[i+4*is] >> ib32) & 1) << 5);
+        int sumi1 = 0;
+        aux32[0] = ((q4[i+4*is+0] >> 0) & 0x0f0f0f0f) | (((qh[i] >> (2*is+0)) & 0x01010101) << 4);
+        aux32[1] = ((q4[i+4*is+0] >> 4) & 0x0f0f0f0f) | (((qh[i] >> (2*is+1)) & 0x01010101) << 4);
+        val1.x  = int_from_table(aux8+0, (const uint8_t *)values1);
+        val1.y  = int_from_table(aux8+4, (const uint8_t *)values1);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[0], ggml_cuda_dp4a(val1.y, q8[2], sumi1));
+        aux32[0] = ((q4[i+4*is+8] >> 0) & 0x0f0f0f0f) | (((qh[i] >> (2*is+4)) & 0x01010101) << 4);
+        aux32[1] = ((q4[i+4*is+8] >> 4) & 0x0f0f0f0f) | (((qh[i] >> (2*is+5)) & 0x01010101) << 4);
+        val1.x  = int_from_table(aux8+0, (const uint8_t *)values1);
+        val1.y  = int_from_table(aux8+4, (const uint8_t *)values1);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[1], ggml_cuda_dp4a(val1.y, q8[3], sumi1));
+        const float d = __half2float(bq5->d[i]) * d8;
+        result[i] += d * sumi1 * s8[i];
+    }
+}
+
 #define VDR_IQ6_K_Q8_1_MMVQ 4
 #define VDR_IQ6_K_Q8_1_MMQ  4
 
@@ -917,6 +966,14 @@ void mul_mat_vec_iq5_k_r4_q8_1_cuda(
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
 
     iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ5_K_R4, 2, vec_dot_iq5_k_r4_q8_1, 4>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
+}
+
+void mul_mat_vec_iq3_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
+
+    iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ3_K_R4, 2, vec_dot_iq3_k_r4_q8_1, 4>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
 }
 
 void mul_mat_vec_iq4_ks_q8_1_cuda(

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -229,6 +229,36 @@ __device__ __forceinline__ float vec_dot_iq4_k_q8_1(
     return d * (sumi1 * ls1 + sumi2 * ls2);
 }
 
+// TODO
+__device__ __forceinline__ float vec_dot_iq4_k_r4_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
+
+    return 0.f;
+
+    const block_iq4_k * bq4 = (const block_iq4_k *) vbq + kbx;
+    const uint8_t * all_values = (const uint8_t *)iq4k_values;
+
+    // iqs is 0...28
+    const int ib32 = iqs/4;
+    // Why iqs/4 ?
+    const int32_t  * q8 = (const int *)bq8_1[ib32].qs;
+    const uint16_t * q4 = (const uint16_t *)bq4->qs + 8*ib32;
+    const uint16_t extra = bq4->extra >> 2*ib32;
+    int v1, v2;
+    int sumi1 = 0, sumi2 = 0;
+    for (int j = 0; j < 4; ++j) {
+        const uint32_t aux32 = q4[2*j+0] | (q4[2*j+1] << 16);
+        get_int_from_table_16_shift(aux32, extra, all_values, v1, v2);
+        sumi1 = ggml_cuda_dp4a(v1, q8[j+0], sumi1);
+        sumi2 = ggml_cuda_dp4a(v2, q8[j+4], sumi2);
+    }
+    const float d = __half2float(bq4->d) * __low2float(bq8_1[ib32].ds);
+    const uint8_t sh = bq4->scales_h[ib32/2] >> 4*(ib32%2);
+    const int ls1 = ((bq4->scales_l[ib32] & 0xf) | ((sh << 4) & 0x30)) - 32;
+    const int ls2 = ((bq4->scales_l[ib32] >>  4) | ((sh << 2) & 0x30)) - 32;
+    return d * (sumi1 * ls1 + sumi2 * ls2);
+}
+
 #define VDR_IQ4_KS_Q8_1_MMVQ 4
 #define VDR_IQ4_KS_Q8_1_MMQ  4
 
@@ -798,6 +828,14 @@ void mul_mat_vec_iq4_k_q8_1_cuda(
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
 
     iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ4_K, VDR_IQ4_K_Q8_1_MMVQ, vec_dot_iq4_k_q8_1>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
+}
+
+void mul_mat_vec_iq4_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
+
+    iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ4_K, VDR_IQ4_K_Q8_1_MMVQ, vec_dot_iq4_k_r4_q8_1>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
 }
 
 void mul_mat_vec_iq4_ks_q8_1_cuda(

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -476,42 +476,43 @@ __device__ __forceinline__ void vec_dot_iq5_ks_q8_1(
 __device__ __forceinline__ void vec_dot_iq3_k_r4_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
 
-    return;
-
-    const block_iq5_k_r4 * bq5 = (const block_iq5_k_r4 *)vbq + kbx;
+    const block_iq3_k_r4 * bq3 = (const block_iq3_k_r4 *)vbq + kbx;
 
     // iqs is 0...28 in steps of 2
     const int ib16 = iqs/2;
     const float d8 = __low2float(bq8_1[ib16/2].ds);
     const int32_t  * q8 = (const int *)bq8_1[ib16/2].qs + 4*(ib16%2);
 
+    // (8*ib32 + i)%32
+    // (8*ib32 + i)%8: ib32=0->i, ib32=i
     int ib32 = ib16/2;
     int is   = ib16%2;
-    int scales;
-    const uint32_t * scales_l = (const uint32_t *)bq5->scales_l;
-    const uint32_t * scales_h = (const uint32_t *)bq5->scales_h;
-    scales = __vsub4(((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) | (((scales_h[2*(ib32%2)+is] >> 2*(ib32/2)) & 0x03030303) << 4), 0x20202020);
+    int scales[2];
+    const uint32_t * scales_l = (const uint32_t *)bq3->scales_l;
+    const uint32_t * scales_h = (const uint32_t *)bq3->scales_h;
+    scales[0] = (((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) << 1) | 0x01010101;
+    scales[1] = (scales_h[is] >> ib32) & 0x01010101;
     const int8_t * s8 = (const int8_t *)&scales;
     int2 val1;
-    const int * q4 = (const int *)bq5->qs + 16*ib32;
-    const int * qh = (const int *)bq5->qh +  4*ib32;
+    const int * q2 = (const int *)bq3->qs + 8*ib32;
+    const int * qh = (const int *)bq3->qh + 4*ib32;
     int aux32[2];
     const uint8_t * aux8 = (const uint8_t *)aux32;
     for (int i = 0; i < 4; ++i) {
-        auto values1 = iq5nl_values + (((bq5->extra[i+4*is] >> ib32) & 1) << 5);
+        auto values1 = iq3nl_values + (((bq3->extra[i+4*is] >> ib32) & 1) << 3);
         int sumi1 = 0;
-        aux32[0] = ((q4[i+4*is+0] >> 0) & 0x0f0f0f0f) | (((qh[i] >> (2*is+0)) & 0x01010101) << 4);
-        aux32[1] = ((q4[i+4*is+0] >> 4) & 0x0f0f0f0f) | (((qh[i] >> (2*is+1)) & 0x01010101) << 4);
+        aux32[0] = ((q2[i+4*is] >> 0) & 0x03030303) | (((qh[i] >> (4*is+0)) & 0x01010101) << 2);
+        aux32[1] = ((q2[i+4*is] >> 2) & 0x03030303) | (((qh[i] >> (4*is+1)) & 0x01010101) << 2);
         val1.x  = int_from_table(aux8+0, (const uint8_t *)values1);
         val1.y  = int_from_table(aux8+4, (const uint8_t *)values1);
-        sumi1 = ggml_cuda_dp4a(val1.x, q8[0], ggml_cuda_dp4a(val1.y, q8[2], sumi1));
-        aux32[0] = ((q4[i+4*is+8] >> 0) & 0x0f0f0f0f) | (((qh[i] >> (2*is+4)) & 0x01010101) << 4);
-        aux32[1] = ((q4[i+4*is+8] >> 4) & 0x0f0f0f0f) | (((qh[i] >> (2*is+5)) & 0x01010101) << 4);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[0], ggml_cuda_dp4a(val1.y, q8[1], sumi1));
+        aux32[0] = ((q2[i+4*is] >> 4) & 0x03030303) | (((qh[i] >> (4*is+2)) & 0x01010101) << 2);
+        aux32[1] = ((q2[i+4*is] >> 6) & 0x03030303) | (((qh[i] >> (4*is+3)) & 0x01010101) << 2);
         val1.x  = int_from_table(aux8+0, (const uint8_t *)values1);
         val1.y  = int_from_table(aux8+4, (const uint8_t *)values1);
-        sumi1 = ggml_cuda_dp4a(val1.x, q8[1], ggml_cuda_dp4a(val1.y, q8[3], sumi1));
-        const float d = __half2float(bq5->d[i]) * d8;
-        result[i] += d * sumi1 * s8[i];
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[2], ggml_cuda_dp4a(val1.y, q8[3], sumi1));
+        const float d = __half2float(bq3->d[i]) * d8;
+        result[i] += d * sumi1 * s8[i] * (s8[i+4] ? -1 : 1);
     }
 }
 

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -15,6 +15,13 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ4_K_R4> {
     static constexpr int qi = QI4_XS;
 };
 
+template<>
+struct ggml_cuda_type_traits<GGML_TYPE_IQ5_K_R4> {
+    static constexpr int qk = QK_K;
+    static constexpr int qr = QR5_XS;
+    static constexpr int qi = QI5_XS;
+};
+
 
 //  Reminder:
 //    constexpr int qk  = ggml_cuda_type_traits<type>::qk;
@@ -259,6 +266,39 @@ static __device__ __forceinline__ int2 get_int_from_table_16(const int & q4, con
 
 __device__ __forceinline__ void vec_dot_iq4_k_r4_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
+
+    const block_iq4_k_r4 * bq4 = (const block_iq4_k_r4 *)vbq + kbx;
+
+    // iqs is 0...28 in steps of 2
+    const int ib16 = iqs/2;
+    const float d8 = __low2float(bq8_1[ib16/2].ds);
+    const int32_t  * q8 = (const int *)bq8_1[ib16/2].qs + 4*(ib16%2);
+
+    int ib32 = ib16/2;
+    int is   = ib16%2;
+    int scales;
+    const uint32_t * scales_l = (const uint32_t *)bq4->scales_l;
+    const uint32_t * scales_h = (const uint32_t *)bq4->scales_h;
+    scales = __vsub4(((scales_l[2*(ib32%4)+is] >> 4*(ib32/4)) & 0x0f0f0f0f) | (((scales_h[2*(ib32%2)+is] >> 2*(ib32/2)) & 0x03030303) << 4), 0x20202020);
+    const int8_t * s8 = (const int8_t *)&scales;
+    int2 val1, val2;
+    const int * q4 = (const int *)bq4->qs + 16*ib32;
+    for (int i = 0; i < 4; ++i) {
+        auto values1 = iq4k_values + (((bq4->extra[i+4*is] >> ib32) & 1) << 4);
+        int sumi1 = 0;
+        val1  = get_int_from_table_16(q4[i+4*is+0], values1);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[0], ggml_cuda_dp4a(val1.y, q8[2], sumi1));
+        val1  = get_int_from_table_16(q4[i+4*is+8], values1);
+        sumi1 = ggml_cuda_dp4a(val1.x, q8[1], ggml_cuda_dp4a(val1.y, q8[3], sumi1));
+        const float d = __half2float(bq4->d[i]) * d8;
+        result[i] += d * sumi1 * s8[i];
+    }
+}
+
+__device__ __forceinline__ void vec_dot_iq5_k_r4_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
+
+    return;
 
     const block_iq4_k_r4 * bq4 = (const block_iq4_k_r4 *)vbq + kbx;
 
@@ -862,6 +902,14 @@ void mul_mat_vec_iq4_k_r4_q8_1_cuda(
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
 
     iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ4_K_R4, 2, vec_dot_iq4_k_r4_q8_1, 4>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
+}
+
+void mul_mat_vec_iq5_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
+
+    iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ5_K_R4, 2, vec_dot_iq5_k_r4_q8_1, 4>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
 }
 
 void mul_mat_vec_iq4_ks_q8_1_cuda(

--- a/ggml/src/ggml-cuda/iqk_mmvq.cuh
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cuh
@@ -65,3 +65,8 @@ void mul_mat_vec_iq4_k_r4_q8_1_cuda(
     const void * vx, const void * vy, float * dst, const char * ids_data,
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
+
+void mul_mat_vec_iq5_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/iqk_mmvq.cuh
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cuh
@@ -60,3 +60,8 @@ void mul_mat_vec_iq2_bn_q8_1_cuda(
     const void * vx, const void * vy, float * dst, const char * ids_data,
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
+
+void mul_mat_vec_iq4_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/iqk_mmvq.cuh
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cuh
@@ -61,6 +61,11 @@ void mul_mat_vec_iq2_bn_q8_1_cuda(
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
 
+void mul_mat_vec_iq2_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
+
 void mul_mat_vec_iq3_k_r4_q8_1_cuda(
     const void * vx, const void * vy, float * dst, const char * ids_data,
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,

--- a/ggml/src/ggml-cuda/iqk_mmvq.cuh
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cuh
@@ -61,6 +61,11 @@ void mul_mat_vec_iq2_bn_q8_1_cuda(
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
 
+void mul_mat_vec_iq3_k_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
+
 void mul_mat_vec_iq4_k_r4_q8_1_cuda(
     const void * vx, const void * vy, float * dst, const char * ids_data,
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -542,6 +542,9 @@ static void ggml_cuda_op_mul_mat_vec_q_impl(ggml_backend_cuda_context & ctx, ggm
         case GGML_TYPE_IQ3_S:
             mul_mat_vec_iq3_s_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
+        case GGML_TYPE_IQ3_K_R4:
+            mul_mat_vec_iq3_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
+            break;
         case GGML_TYPE_IQ4_K_R4:
             mul_mat_vec_iq4_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
@@ -661,6 +664,7 @@ bool ggml_cuda_mmvq_type_supported(ggml_type src0_type) {
         case GGML_TYPE_IQ5_KS:
         case GGML_TYPE_IQ6_K:
         case GGML_TYPE_IQ3_S:
+        case GGML_TYPE_IQ3_K_R4:
         case GGML_TYPE_IQ4_K_R4:
         case GGML_TYPE_IQ5_K_R4:
             return true;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -542,6 +542,9 @@ static void ggml_cuda_op_mul_mat_vec_q_impl(ggml_backend_cuda_context & ctx, ggm
         case GGML_TYPE_IQ3_S:
             mul_mat_vec_iq3_s_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
+        case GGML_TYPE_IQ4_K_R4:
+            mul_mat_vec_iq4_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
+            break;
         default:
             GGML_ABORT("fatal error");
             break;
@@ -655,6 +658,7 @@ bool ggml_cuda_mmvq_type_supported(ggml_type src0_type) {
         case GGML_TYPE_IQ5_KS:
         case GGML_TYPE_IQ6_K:
         case GGML_TYPE_IQ3_S:
+        case GGML_TYPE_IQ4_K_R4:
             return true;
         default:
             return false;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -545,6 +545,9 @@ static void ggml_cuda_op_mul_mat_vec_q_impl(ggml_backend_cuda_context & ctx, ggm
         case GGML_TYPE_IQ4_K_R4:
             mul_mat_vec_iq4_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
+        case GGML_TYPE_IQ5_K_R4:
+            mul_mat_vec_iq5_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
+            break;
         default:
             GGML_ABORT("fatal error");
             break;
@@ -659,6 +662,7 @@ bool ggml_cuda_mmvq_type_supported(ggml_type src0_type) {
         case GGML_TYPE_IQ6_K:
         case GGML_TYPE_IQ3_S:
         case GGML_TYPE_IQ4_K_R4:
+        case GGML_TYPE_IQ5_K_R4:
             return true;
         default:
             return false;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -542,6 +542,9 @@ static void ggml_cuda_op_mul_mat_vec_q_impl(ggml_backend_cuda_context & ctx, ggm
         case GGML_TYPE_IQ3_S:
             mul_mat_vec_iq3_s_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
+        case GGML_TYPE_IQ2_K_R4:
+            mul_mat_vec_iq2_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
+            break;
         case GGML_TYPE_IQ3_K_R4:
             mul_mat_vec_iq3_k_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
@@ -664,6 +667,7 @@ bool ggml_cuda_mmvq_type_supported(ggml_type src0_type) {
         case GGML_TYPE_IQ5_KS:
         case GGML_TYPE_IQ6_K:
         case GGML_TYPE_IQ3_S:
+        case GGML_TYPE_IQ2_K_R4:
         case GGML_TYPE_IQ3_K_R4:
         case GGML_TYPE_IQ4_K_R4:
         case GGML_TYPE_IQ5_K_R4:


### PR DESCRIPTION
The `IQX_K` quants and their row-interleaved siblings `IQX_K_R4` offer better quantization quality than corresponding i-, k-, or legacy quants at the same bpw. `IQX_K_R4` quants have better CPU performance but cannot be used on CUDA as there is no GEMM/GEMV implementation. Hence, "quant cookers" need to release `IQX_K` quantized model, so users can use them on their GPUs, but that requires users doing CPU-ony inference to repack the model to take advantage of the better CPU performance. In addition, @ubergarm has released various `IQK_X_R4` quantized models (see [here](https://huggingface.co/ubergarm), and those cannot be used for GPU inference. 

To remove such inconvenience, this PR adds CUDA implementation for the row-interleaved quants `IQ2_K_R4, IQ3_K_R4, IQ4_K_R4, IQ5_K_R4`. I'll follow up with a separate PR for `IQ2_KS_R4, IQ4_KS_R4` and `IQ5_KS_R4`.

For now GEMM is implemented via dequantize + cuBLAS. I may add quantized GEMM (a.k.a. MMQ) later.

**Note**: because of the above, if you want to use a `IQX_K_R4` DeepSeek-V3/R1 model on the GPU, you may need to build with `-DGGML_CUDA_IQK_FORCE_BF16=1` to force `bf16` arithmetic with cuBLAS as `fp16` has been noted to lead to numerical instabilities and garbled output. I did not enable `GGML_CUDA_IQK_FORCE_BF16` by default as it reduces prompt processing performance while, as far as I can tell, `bf16` is only required for DeepSeek.