### PR TITLE
Trellis quants: faster CPU prompt processing

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1618,8 +1618,8 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float_ref           = (ggml_from_float_t)quantize_row_iq4_kt_ref,
         .vec_dot                  = vec_dot_iq4_kt_q8_k,
 #ifdef __ARM_NEON
-        //.vec_dot_type             = GGML_TYPE_F16,
-        .vec_dot_type             = GGML_TYPE_F32,
+        .vec_dot_type             = GGML_TYPE_F16,
+        //.vec_dot_type             = GGML_TYPE_F32,
 #else
         .vec_dot_type             = GGML_TYPE_F32,
 #endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1619,7 +1619,6 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .vec_dot                  = vec_dot_iq4_kt_q8_k,
 #ifdef __ARM_NEON
         .vec_dot_type             = GGML_TYPE_F16,
-        //.vec_dot_type             = GGML_TYPE_F32,
 #else
         .vec_dot_type             = GGML_TYPE_F32,
 #endif

--- a/ggml/src/iqk/iqk_gemm_ktquants.cpp
+++ b/ggml/src/iqk/iqk_gemm_ktquants.cpp
@@ -97,7 +97,7 @@ struct Trellis2 {
     }
 };
 
-void iqk_dequantize_iq2_kt(int n, const void * vx, size_t bx, ggml_half * y, size_t stride_y, int nrc_x) {
+void iqk_dequantize_iq2_kt(int n, const void * vx, size_t bx, float * y, size_t stride_y, int nrc_x) {
     GGML_ASSERT(n%QK_K == 0);
     const int nb = n/QK_K;
 

--- a/ggml/src/iqk/iqk_gemm_ktquants.h
+++ b/ggml/src/iqk/iqk_gemm_ktquants.h
@@ -8,6 +8,6 @@
 
 bool iqk_set_kernels_ktquants(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels, mul_mat_t& func16);
 
-bool iqk_dequantize_ktquants(int type, int n, const void * vx, size_t bx, float * y, size_t stride_y, int nrc_x);
+bool iqk_dequantize_ktquants(int type, int n, const void * vx, size_t bx, void * vy, size_t stride_y, int nrc_x);
 
 #endif

--- a/ggml/src/iqk/iqk_gemm_ktquants.h
+++ b/ggml/src/iqk/iqk_gemm_ktquants.h
@@ -8,4 +8,6 @@
 
 bool iqk_set_kernels_ktquants(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels, mul_mat_t& func16);
 
+void iqk_dequantize_iq4_kt(int n, const void * vx, size_t bx, float * y, size_t stride_y, int nrc_x);
+
 #endif

--- a/ggml/src/iqk/iqk_gemm_ktquants.h
+++ b/ggml/src/iqk/iqk_gemm_ktquants.h
@@ -8,6 +8,6 @@
 
 bool iqk_set_kernels_ktquants(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels, mul_mat_t& func16);
 
-void iqk_dequantize_iq4_kt(int n, const void * vx, size_t bx, float * y, size_t stride_y, int nrc_x);
+bool iqk_dequantize_ktquants(int type, int n, const void * vx, size_t bx, float * y, size_t stride_y, int nrc_x);
 
 #endif

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -233,6 +233,15 @@ struct MulMat {
         }
     }
     static bool prepare(int typeA, int typeB, int ne00, MulMat& mm, int Ny);
+    static inline bool is_dequant_better(ggml_type type, int nrc_y) {
+#ifdef __AVX2__
+        switch (type) {
+            case GGML_TYPE_IQ4_KT: return nrc_y >= 32;
+            default: break;
+        }
+#endif
+        return false;
+    }
     static inline int num_rows(ggml_type type) {
 #ifdef HAVE_FANCY_SIMD
         switch (type) {
@@ -312,6 +321,54 @@ extern "C" IQK_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
         float * C, long stride_C, int ith, int nth) {
 
     MulMat mm;
+
+    if (MulMat::is_dequant_better(ggml_type(typeA), Ny)) {
+        if (!MulMat::prepare(GGML_TYPE_F32, typeB, ne00, mm, Ny)) {
+            return false;
+        }
+
+        constexpr int k_x_step = 32;
+
+        auto num_rows = MulMat::num_rows(ggml_type(typeA));
+        GGML_ASSERT(Nx%num_rows == 0);
+        auto nrc_x = (Nx/num_rows + nth - 1)/nth;
+        auto first_x = ith*nrc_x;
+        if (first_x + nrc_x > Nx/num_rows) nrc_x = Nx/num_rows - first_x;
+        first_x *= num_rows;
+        nrc_x   *= num_rows;
+
+        thread_local std::vector<float> f32;
+
+        size_t row_size_qx = ne00*sizeof(float);
+        size_t row_size_qy = strideB;
+
+        DataInfo info{C + first_x, (const char *)B, (size_t)stride_C, row_size_qy, 0, 1, nullptr, 0};
+
+        for (int ix = 0; ix < nrc_x; ix += k_x_step) {
+            auto this_info = info;
+            this_info.s += ix;
+            int this_nrc_x = ix + k_x_step <= nrc_x ? k_x_step : nrc_x - ix;
+            if (f32.size() < std::vector<float>::size_type(ne00*this_nrc_x)) f32.resize(ne00*this_nrc_x);
+            iqk_dequantize_iq4_kt(ne00, (const char *)A + (first_x + ix)*strideA, strideA, f32.data(), ne00, this_nrc_x);
+            mm.mul_mat_NxM(ne00, (const char *)f32.data(), row_size_qx, this_info, this_nrc_x, Ny);
+        }
+
+        //thread_local std::vector<float> f32;
+        //if (f32.size() < std::vector<float>::size_type(ne00*nrc_x)) f32.resize(ne00*nrc_x);
+
+        //iqk_dequantize_iq4_kt(ne00, (const char *)A + first_x*strideA, strideA, f32.data(), ne00, nrc_x);
+
+        //size_t row_size_qx = ne00*sizeof(float);
+        //size_t row_size_qy = strideB;
+
+        //DataInfo info{C + first_x, (const char *)B, (size_t)stride_C, row_size_qy, 0, 1, nullptr, 0};
+
+        //mm.mul_mat_NxM(ne00, (const char *)f32.data(), row_size_qx, info, nrc_x, Ny);
+
+        return true;
+
+    }
+
     if (!MulMat::prepare(typeA, typeB, ne00, mm, Ny)) {
         return false;
     }

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -245,6 +245,7 @@ struct MulMat {
         switch (type) {
             case GGML_TYPE_IQ2_KT: return nrc_y >= 32 ? GGML_TYPE_F16 : type;
             case GGML_TYPE_IQ3_KT: return nrc_y >= 32 ? GGML_TYPE_F16 : type;
+            case GGML_TYPE_IQ4_KT: return nrc_y >= 32 ? GGML_TYPE_F16 : type;
             default: break;
         }
 #endif

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -8243,6 +8243,9 @@ size_t quantize_iq2_kt(const float * src, void * dst, int64_t nrows, int64_t n_p
 
 void dequantize_row_iq2_kt(const block_iq2_kt * x, float * y, int64_t k) {
     assert(k % QuantizerIQ2KT::kSuperBlockSize == 0);
+#ifdef __AVX2__
+    if (iqk_dequantize_ktquants(GGML_TYPE_IQ2_KT, k, x, 0, y, 0, 1)) return;
+#endif
     const int nb = k / QuantizerIQ2KT::kSuperBlockSize;
     const float * dptr = (const float *)x;
     const float d = *dptr * QuantizerIQ2KT::kScale;
@@ -8496,6 +8499,9 @@ size_t quantize_iq3_kt(const float * src, void * dst, int64_t nrows, int64_t n_p
 }
 
 void dequantize_row_iq3_kt(const block_iq3_kt * x, float * y, int64_t k) {
+#ifdef __AVX2__
+    if (iqk_dequantize_ktquants(GGML_TYPE_IQ3_KT, k, x, 0, y, 0, 1)) return;
+#endif
     using Q = QuantizerIQ3KT;
     constexpr int kNumGroups = Q::kSuperBlockSize/Q::kGroupSize;
     assert(k % Q::kSuperBlockSize == 0);
@@ -8753,8 +8759,8 @@ size_t quantize_iq4_kt(const float * src, void * dst, int64_t nrows, int64_t n_p
 
 void dequantize_row_iq4_kt(const block_iq4_kt * x, float * y, int64_t k) {
 #ifdef __AVX2__
-    iqk_dequantize_iq4_kt(k, x, 0, y, 0, 1);
-#else
+    if (iqk_dequantize_ktquants(GGML_TYPE_IQ4_KT, k, x, 0, y, 0, 1)) return;
+#endif
     using Q = QuantizerIQ4KT;
     assert(k % Q::kSuperBlockSize == 0);
     constexpr int kNumGroups = Q::kSuperBlockSize/Q::kGroupSize;
@@ -8782,7 +8788,6 @@ void dequantize_row_iq4_kt(const block_iq4_kt * x, float * y, int64_t k) {
             }
         }
     }
-#endif
 }
 
 void vec_dot_iq4_kt_q8_k(int n, float * s, size_t bs, const void * vx, size_t bx, const void * vy, size_t by, int nrc) {

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -14,6 +14,8 @@
 #include "iqk_quantize.h"
 #include "iqk_config.h"
 
+#include "iqk_gemm_ktquants.h"
+
 #include <vector>
 #include <utility>
 #include <cstdint>
@@ -8750,6 +8752,9 @@ size_t quantize_iq4_kt(const float * src, void * dst, int64_t nrows, int64_t n_p
 }
 
 void dequantize_row_iq4_kt(const block_iq4_kt * x, float * y, int64_t k) {
+#ifdef __AVX2__
+    iqk_dequantize_iq4_kt(k, x, 0, y, 0, 1);
+#else
     using Q = QuantizerIQ4KT;
     assert(k % Q::kSuperBlockSize == 0);
     constexpr int kNumGroups = Q::kSuperBlockSize/Q::kGroupSize;
@@ -8777,6 +8782,7 @@ void dequantize_row_iq4_kt(const block_iq4_kt * x, float * y, int64_t k) {
             }
         }
     }
+#endif
 }
 
 void vec_dot_iq4_kt_q8_k(int n, float * s, size_t bs, const void * vx, size_t bx, const void * vy, size_t by, int nrc) {


### PR DESCRIPTION

The trellis quants `IQ2_KT, IQ3_KT, IQ4_KT` are very slow on the CPU. On the main branch using BLAS results in a better prompt processing performance. But BLAS is slower for basically all other data types, so that's not a good idea.

This PR improves prompt processing speed of the trellis quants by adding "dequantizing GEMM". Basically, blocks of trelis quantized weights are converted to `fp32` (`AVX2` or `fp16` (ARM) on-the-fly, and then the `fp32/fp16` GEMM kernels are used to multiply the bock with the entire right matrix. This amortizes the very high dequantization cost much better than the standard kernel templates that allow up to 8 right matrix columns.

On my `Zen4/AVX2` CPUs this results in a better PP performance than using BLAS (or Intel MKL). On the M2-Max PP performance is about 80% of BLAS (which tells me that my `ARM_NEON` GEMM kernel for `fp16` is not optimal).

TG performance is not affected by the PR and is still very low.

Here is a PP-512 performance comparison between the main branch (without BLAS) and this PR for LlaMA-3.1-8B on a Ryzen-7950X CPU

| quant | PP-512 (main) | PP-512 (PR) | Speedup |
| ---: | ---: | ---: | ---: |
| IQ2_KT | 57.98 |  132.47 |  2.28 |
| IQ3_KT | 47.44 |  127.80 |  2.69 |
| IQ2_KT | 40.09 |  126.31 |  3.15 |