### PR TITLE
IQ1_M_R4 CUDA implementation

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3477,6 +3477,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                     case GGML_TYPE_IQ5_K_R4:
                     case GGML_TYPE_IQ5_KS_R4:
                     case GGML_TYPE_IQ1_S_R4:
+                    case GGML_TYPE_IQ1_M_R4:
                         return true;
                     default:
                         return false;

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -542,7 +542,7 @@ static __global__ void dequantize_block_iq1_s_r4(const void * __restrict__ vx, d
     const int  ib = tid%8; // 0...7
 
     const half * dptr = (const half *)((const char *)vx + 4*row4*row_size);
-    const float d = (float)dptr[ir];
+    const float d = __half2float(dptr[ir]);
     const block_iq1_s_r4 * x = (const block_iq1_s_r4 *)(dptr + 4) + ibl;
     dst_t * y = yy + 256*ii + 32*ib + 8*il;
 
@@ -551,6 +551,42 @@ static __global__ void dequantize_block_iq1_s_r4(const void * __restrict__ vx, d
 
     uint32_t grid32[2]; const int8_t * q = (const int8_t *)grid32;
     grid32[0] = iq1s_grid_gpu[x[ib].qs[4*il+ir] | (((x[ib].qh[ir] >> 3*il) & 7) << 8)];
+    grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
+    grid32[0] &= 0x0f0f0f0f;
+
+    if constexpr (std::is_same_v<dst_t, nv_bfloat16>) {
+        for (int j = 0; j < 8; ++j) y[j] = __float2bfloat16(dl*q[j] + delta);
+    } else {
+        for (int j = 0; j < 8; ++j) y[j] = dl*q[j] + delta;
+    }
+}
+
+template<typename dst_t>
+static __global__ void dequantize_block_iq1_m_r4(const void * __restrict__ vx, dst_t * __restrict__ yy, int64_t n_per_row, int64_t row_size) {
+
+    int64_t ii = blockIdx.x;
+
+    int64_t nblock = n_per_row/32;
+    int64_t row  = (8*ii)/nblock;
+    int64_t row4 = row/4;
+    int64_t ir   = row%4;
+    int64_t ibl  = (8*ii)%nblock;
+
+    const int tid = threadIdx.x;
+    const int  il = tid/8; // 0...3
+    const int  ib = tid%8; // 0...7
+
+    const half * dptr = (const half *)((const char *)vx + 4*row4*row_size);
+    const float d = __half2float(dptr[ir]);
+    const block_iq1_m_r4 * x = (const block_iq1_m_r4 *)(dptr + 4) + ibl;
+    dst_t * y = yy + 256*ii + 32*ib + 8*il;
+
+    uint8_t qh = x[ib].qh[4*(il/2)+ir] >> 4*(il%2);
+    float dl = d*((x[ib].scales[ir] >> 4*(il/2)) & 0xf);
+    float delta = dl * (qh & 0x8 ? -1-IQ1M_DELTA : -1+IQ1M_DELTA);
+
+    uint32_t grid32[2]; const int8_t * q = (const int8_t *)grid32;
+    grid32[0] = iq1s_grid_gpu[x[ib].qs[4*il+ir] | ((qh & 7) << 8)];
     grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
     grid32[0] &= 0x0f0f0f0f;
 
@@ -1442,6 +1478,14 @@ static void dequantize_row_iq1_s_r4_cuda(const void * vx, dst_t * y, const int64
 }
 
 template<typename dst_t>
+static void dequantize_row_iq1_m_r4_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
+    const int64_t k = nrows * n_per_row;
+    const int64_t row_size = ggml_row_size(GGML_TYPE_IQ1_M_R4, n_per_row);
+    const int nb = (k + QK_K - 1) / QK_K;
+    dequantize_block_iq1_m_r4<<<nb, 32, 0, stream>>>(vx, y, n_per_row, row_size);
+}
+
+template<typename dst_t>
 static void dequantize_row_iq4_nl_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
     const int64_t k = nrows * n_per_row;
     const int nb = (k + QK_K - 1) / QK_K;
@@ -1696,6 +1740,8 @@ to_bf16_cuda_t ggml_get_to_bf16_cuda(ggml_type type) {
             return dequantize_row_iq5_ks_r4_cuda<nv_bfloat16>;
         case GGML_TYPE_IQ1_S_R4:
             return dequantize_row_iq1_s_r4_cuda<nv_bfloat16>;
+        case GGML_TYPE_IQ1_M_R4:
+            return dequantize_row_iq1_m_r4_cuda<nv_bfloat16>;
         default:
             return nullptr;
     }
@@ -1746,6 +1792,8 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
             return dequantize_row_iq1_s_cuda;
         case GGML_TYPE_IQ1_S_R4:
             return dequantize_row_iq1_s_r4_cuda;
+        case GGML_TYPE_IQ1_M_R4:
+            return dequantize_row_iq1_m_r4_cuda;
         case GGML_TYPE_IQ1_M:
             return dequantize_row_iq1_m_cuda;
         case GGML_TYPE_IQ1_BN:
@@ -1839,6 +1887,8 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
             return dequantize_row_iq1_s_cuda;
         case GGML_TYPE_IQ1_S_R4:
             return dequantize_row_iq1_s_r4_cuda;
+        case GGML_TYPE_IQ1_M_R4:
+            return dequantize_row_iq1_m_r4_cuda;
         case GGML_TYPE_IQ1_M:
             return dequantize_row_iq1_m_cuda;
         case GGML_TYPE_IQ1_BN:

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -362,7 +362,7 @@ __device__ __forceinline__ void vec_dot_iq1_s_r4_q8_1(
     for (int k = 0; k < 4; ++k) minus = ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+k], minus);
 
     for (int i = 0; i < 4; ++i) {
-        float dl = (float)dptr[i]*(2*((bq1->qh[i] >> 12) & 7) + 1) * d8;
+        float dl = __half2float(dptr[i])*(2*((bq1->qh[i] >> 12) & 7) + 1) * d8;
         float ml = dl * (bq1->qh[i] & 0x8000 ? -1-IQ1S_DELTA : -1+IQ1S_DELTA);
         grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i] | (((bq1->qh[i] >> 3*iqs) & 7) << 8)];
         grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
@@ -376,14 +376,11 @@ __device__ __forceinline__ void vec_dot_iq1_s_r4_q8_1(
     }
 }
 
-// TODO
 __device__ __forceinline__ void vec_dot_iq1_m_r4_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
 
-    return;
-
     const half * dptr = (const half *)vbq;
-    const block_iq1_s_r4 * bq1 = (const block_iq1_s_r4 *)(dptr + 4) + kbx;
+    const block_iq1_m_r4 * bq1 = (const block_iq1_m_r4 *)(dptr + 4) + kbx;
 
     // iqs is 0 or 2
     const float d8 = __low2float(bq8_1->ds);
@@ -392,21 +389,22 @@ __device__ __forceinline__ void vec_dot_iq1_m_r4_q8_1(
     int32_t grid32[2];
     const int * igrid = (const int *)grid32;
 
-    int minus = 0;
-    for (int k = 0; k < 4; ++k) minus = ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+k], minus);
+    int minus1 = ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+0], ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+1], 0));
+    int minus2 = ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+2], ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+3], 0));
 
     for (int i = 0; i < 4; ++i) {
-        float dl = (float)dptr[i]*(2*((bq1->qh[i] >> 12) & 7) + 1) * d8;
-        float ml = dl * (bq1->qh[i] & 0x8000 ? -1-IQ1S_DELTA : -1+IQ1S_DELTA);
-        grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i] | (((bq1->qh[i] >> 3*iqs) & 7) << 8)];
+        float dl = __half2float(dptr[i])*((bq1->scales[i] >> 4*(iqs/2)) & 0xf) * d8;
+        float ml1 = dl * (bq1->qh[4*(iqs/2)+i] & 0x08 ? -1-IQ1M_DELTA : -1+IQ1M_DELTA);
+        float ml2 = dl * (bq1->qh[4*(iqs/2)+i] & 0x80 ? -1-IQ1M_DELTA : -1+IQ1M_DELTA);
+        grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i] | ((bq1->qh[4*(iqs/2)+i] & 0x07) << 8)];
         grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
         grid32[0] &= 0x0f0f0f0f;
         int sumi = ggml_cuda_dp4a(igrid[0], q8[4*(iqs/2)+0], ggml_cuda_dp4a(igrid[1], q8[4*(iqs/2)+1], 0));
-        grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i+4] | (((bq1->qh[i] >> (3*iqs+3)) & 7) << 8)];
+        grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i+4] | ((bq1->qh[4*(iqs/2)+i] & 0x70) << 4)];
         grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
         grid32[0] &= 0x0f0f0f0f;
         sumi = ggml_cuda_dp4a(igrid[0], q8[4*(iqs/2)+2], ggml_cuda_dp4a(igrid[1], q8[4*(iqs/2)+3], sumi));
-        result[i] += dl * sumi + ml * minus;
+        result[i] += dl * sumi + ml1 * minus1 + ml2*minus2;
     }
 }
 

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -36,6 +36,13 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ5_K_R4> {
     static constexpr int qi = QI5_XS;
 };
 
+template<>
+struct ggml_cuda_type_traits<GGML_TYPE_IQ1_M_R4> {
+    static constexpr int qk = 32;
+    static constexpr int qr = 2;
+    static constexpr int qi = 4;
+};
+
 //  Reminder:
 //    constexpr int qk  = ggml_cuda_type_traits<type>::qk;
 //    constexpr int qi  = ggml_cuda_type_traits<type>::qi;
@@ -338,9 +345,42 @@ __device__ __forceinline__ void vec_dot_iq4_ks_r4_q8_1(
     }
 }
 
-// TODO
 __device__ __forceinline__ void vec_dot_iq1_s_r4_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
+
+    const half * dptr = (const half *)vbq;
+    const block_iq1_s_r4 * bq1 = (const block_iq1_s_r4 *)(dptr + 4) + kbx;
+
+    // iqs is 0 or 2
+    const float d8 = __low2float(bq8_1->ds);
+    const int32_t  * q8 = (const int *)bq8_1->qs;
+
+    int32_t grid32[2];
+    const int * igrid = (const int *)grid32;
+
+    int minus = 0;
+    for (int k = 0; k < 4; ++k) minus = ggml_cuda_dp4a(0x01010101, q8[4*(iqs/2)+k], minus);
+
+    for (int i = 0; i < 4; ++i) {
+        float dl = (float)dptr[i]*(2*((bq1->qh[i] >> 12) & 7) + 1) * d8;
+        float ml = dl * (bq1->qh[i] & 0x8000 ? -1-IQ1S_DELTA : -1+IQ1S_DELTA);
+        grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i] | (((bq1->qh[i] >> 3*iqs) & 7) << 8)];
+        grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
+        grid32[0] &= 0x0f0f0f0f;
+        int sumi = ggml_cuda_dp4a(igrid[0], q8[4*(iqs/2)+0], ggml_cuda_dp4a(igrid[1], q8[4*(iqs/2)+1], 0));
+        grid32[0] = iq1s_grid_gpu[bq1->qs[4*iqs+i+4] | (((bq1->qh[i] >> (3*iqs+3)) & 7) << 8)];
+        grid32[1] = (grid32[0] >> 4) & 0x0f0f0f0f;
+        grid32[0] &= 0x0f0f0f0f;
+        sumi = ggml_cuda_dp4a(igrid[0], q8[4*(iqs/2)+2], ggml_cuda_dp4a(igrid[1], q8[4*(iqs/2)+3], sumi));
+        result[i] += dl * sumi + ml * minus;
+    }
+}
+
+// TODO
+__device__ __forceinline__ void vec_dot_iq1_m_r4_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs, float * result) {
+
+    return;
 
     const half * dptr = (const half *)vbq;
     const block_iq1_s_r4 * bq1 = (const block_iq1_s_r4 *)(dptr + 4) + kbx;
@@ -1129,6 +1169,14 @@ void mul_mat_vec_iq1_s_r4_q8_1_cuda(
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
 
     iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ1_S_R4, 2, vec_dot_iq1_s_r4_q8_1, 4>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
+}
+
+void mul_mat_vec_iq1_m_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, int64_t ids_nb0, cudaStream_t stream) {
+
+    iqk_mul_mat_vec_q_cuda<GGML_TYPE_IQ1_M_R4, 2, vec_dot_iq1_m_r4_q8_1, 4>(vx, vy, dst, ids_data, ncols_x, nrows_x, nrows_y, ncols_y, nrows_dst, ne2, nb02, nb12, nb2, ids_nb0, stream);
 }
 
 void mul_mat_vec_iq5_k_r4_q8_1_cuda(

--- a/ggml/src/ggml-cuda/iqk_mmvq.cuh
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cuh
@@ -95,3 +95,8 @@ void mul_mat_vec_iq1_s_r4_q8_1_cuda(
     const void * vx, const void * vy, float * dst, const char * ids_data,
     const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
     const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);
+
+void mul_mat_vec_iq1_m_r4_q8_1_cuda(
+    const void * vx, const void * vy, float * dst, const char * ids_data,
+    const int ncols_x, const int nrows_x, const int nrows_y, const int ncols_y, const int nrows_dst,
+    const int ne2, const uint64_t nb02, const uint64_t nb12, const uint64_t nb2, const int64_t ids_nb0, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -563,6 +563,9 @@ static void ggml_cuda_op_mul_mat_vec_q_impl(ggml_backend_cuda_context & ctx, ggm
         case GGML_TYPE_IQ1_S_R4:
             mul_mat_vec_iq1_s_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
             break;
+        case GGML_TYPE_IQ1_M_R4:
+            mul_mat_vec_iq1_m_r4_q8_1_cuda(src0_dd_i, src1_ddq_i, dst_dd_i, ids_data, ne00, row_diff, src1_padded_row_size, src1_ncols, nrows_dst,   ne2, nb02, nb12, nb2, ids_nb0, stream);
+            break;
         default:
             GGML_ABORT("fatal error");
             break;
@@ -683,6 +686,7 @@ bool ggml_cuda_mmvq_type_supported(ggml_type src0_type) {
         case GGML_TYPE_IQ5_K_R4:
         case GGML_TYPE_IQ5_KS_R4:
         case GGML_TYPE_IQ1_S_R4:
+        case GGML_TYPE_IQ1_M_R4:
             return true;
         default:
             return false;


### PR DESCRIPTION

To help the quest for the world's smallest DeepSeek model, this PR adds CUDA implementation for `IQ1_M_R4`.

GEMM is done via dequantize+cuBLAS, so may require `cmake -DGGML_CUDA_IQK_FORCE_BF16=ON`.

Performance is on par or even tiny bit better than `IQ1_M`.

Here sweep bench for LlaMA-3-8B on RTX-4080

### IQ1_M

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    512 |      0 |    0.347 |  5909.51 |    2.466 |   207.66 |
|  2048 |    512 |   2048 |    0.329 |  6216.59 |    2.657 |   192.69 |
|  2048 |    512 |   4096 |    0.356 |  5745.00 |    2.928 |   174.88 |
|  2048 |    512 |   6144 |    0.384 |  5332.11 |    3.162 |   161.91 |
|  2048 |    512 |   8192 |    0.411 |  4983.68 |    3.380 |   151.50 |
|  2048 |    512 |  10240 |    0.438 |  4678.79 |    3.634 |   140.88 |
|  2048 |    512 |  12288 |    0.466 |  4398.46 |    3.830 |   133.68 |
|  2048 |    512 |  14336 |    0.494 |  4149.40 |    4.095 |   125.03 |

### IQ1_M_R4 (PR)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    512 |      0 |    0.338 |  6058.78 |    2.440 |   209.81 |
|  2048 |    512 |   2048 |    0.323 |  6337.42 |    2.639 |   193.99 |
|  2048 |    512 |   4096 |    0.350 |  5859.50 |    2.914 |   175.71 |
|  2048 |    512 |   6144 |    0.379 |  5409.73 |    3.151 |   162.47 |
|  2048 |    512 |   8192 |    0.405 |  5054.63 |    3.371 |   151.90 |
|  2048 |    512 |  10240 |    0.432 |  4742.62 |    3.618 |   141.52 |
|  2048 |    512 |  12288 |    0.458 |  4471.08 |    3.804 |   134.59 |
|  2048 |    512 |  14336 |    0.486 |  4210.13 |    4.067 |   125.90 |

