### PR TITLE
Add DRY and fix the server to use other new samplers.

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -671,22 +671,35 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
     }
     if (arg == "--dry-base") {
         CHECK_ARG
-        sparams.dry_base = std::stof(argv[i]);
-        return true;
+        float potential_base = std::stof(argv[i]);
+        if (potential_base >= 1.0f) {
+            sparams.dry_base = potential_base;
+        }
     }
     if (arg == "--dry-allowed-length") {
         CHECK_ARG
-        sparams.dry_allowed_length = std::stof(argv[i]);
+        sparams.dry_allowed_length = std::stoi(argv[i]);
         return true;
     }
     if (arg == "--dry-penalty-last-n") {
         CHECK_ARG
-        sparams.dry_penalty_last_n = std::stof(argv[i]);
+        sparams.dry_penalty_last_n = std::stoi(argv[i]);
         return true;
     }
     if (arg == "--dry-sequence-breaker") {
         CHECK_ARG
-        sparams.dry_sequence_breakers = std::stof(argv[i]);
+        static bool defaults_cleared = false;
+
+        if (!defaults_cleared) {
+            sparams.dry_sequence_breakers.clear();
+            defaults_cleared = true;
+        }
+
+        if (std::string(argv[i]) == "none") {
+            sparams.dry_sequence_breakers.clear();
+        } else {
+            sparams.dry_sequence_breakers.emplace_back(argv[i]);
+        }
         return true;
         //add input checking
     }
@@ -1685,18 +1698,12 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
 
 sparams.dry_allowed_length)});
     options.push_back({ "*",           "       --dry-allowed-length N",        "dry_allowed_length: %d (default: 2\n)", 
-(double)sparams.sparams.dry_base});
+(double)sparams.dry_base});
     options.push_back({ "*",           "       --dry-base t",        "dry_base: %.2f (default: 1.75\n)", 
-(double)sparams.sparams.dry_multiplier);
+(double)sparams.dry_multiplier);
     options.push_back({ "*",           "       ---dry-multiplier t",        "dry_multiplier: %.1f (default: 0.0\n)", 
-sparams.sparams.dry_penalty_last_n});
+sparams.dry_penalty_last_n});
     options.push_back({ "*",           "       --dry-penalty-last-n N",        "dry_penalty_last_n: %d default: -1 (0 = disable, -1 = context size)\n", 
-
-//sparams.xtc_threshold});
-//    options.push_back({ "*",           "       --top-n-sigma t",        "top-n-sigma parmeter (default: %.1f, 0.0 = disabled)", 
-
-
-
     options.push_back({ "main",        "       --cfg-negative-prompt PROMPT",
                                                                         "negative prompt to use for guidance (default: '%s')", sparams.cfg_negative_prompt.c_str() });
     options.push_back({ "main",        "       --cfg-negative-prompt-file FNAME",
@@ -3459,7 +3466,7 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "xtc_threshold: %f # default: 0.0\n", sparams.xtc_threshold);
     fprintf(stream, "top_n_sigma: %f # default: 0.0\n", sparams.top_n_sigma);
     fprintf(stream, "dry_allowed_length: %d # default: 2\n", sparams.dry_allowed_length);
-    fprintf(stream, "dry_base: %.2f # default: 1.75\n", sparams.dry_base);Add commentMore actions
+    fprintf(stream, "dry_base: %.2f # default: 1.75\n", sparams.dry_base);
     fprintf(stream, "dry_multiplier: %.1f # default: 0.0\n", sparams.dry_multiplier);
     fprintf(stream, "dry_penalty_last_n: %d # default: -1 (0 = disable, -1 = context size)\n", sparams.dry_penalty_last_n);
     fprintf(stream, "mlock: %s # default: false\n", params.use_mlock ? "true" : "false");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -664,6 +664,32 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         sparams.top_n_sigma = std::stof(argv[i]);
         return true;
     }
+    if (arg == "--dry-multiplier") {
+        CHECK_ARG
+        sparams.dry_multiplier = std::stof(argv[i]);
+        return true;
+    }
+    if (arg == "--dry-base") {
+        CHECK_ARG
+        sparams.dry_base = std::stof(argv[i]);
+        return true;
+    }
+    if (arg == "--dry-allowed-length") {
+        CHECK_ARG
+        sparams.dry_allowed_length = std::stof(argv[i]);
+        return true;
+    }
+    if (arg == "--dry-penalty-last-n") {
+        CHECK_ARG
+        sparams.dry_penalty_last_n = std::stof(argv[i]);
+        return true;
+    }
+    if (arg == "--dry-sequence-breaker") {
+        CHECK_ARG
+        sparams.dry_sequence_breakers = std::stof(argv[i]);
+        return true;
+        //add input checking
+    }
     if (arg == "--cfg-negative-prompt") {
         CHECK_ARG
         sparams.cfg_negative_prompt = argv[i];
@@ -1656,6 +1682,21 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "       -l TOKEN_ID(+/-)BIAS",   "modifies the likelihood of token appearing in the completion,\n"
                                                                         "i.e. `--logit-bias 15043+1` to increase likelihood of token ' Hello',\n"
                                                                         "or `--logit-bias 15043-1` to decrease likelihood of token ' Hello'" });
+
+sparams.dry_allowed_length)});
+    options.push_back({ "*",           "       --dry-allowed-length N",        "dry_allowed_length: %d (default: 2\n)", 
+(double)sparams.sparams.dry_base});
+    options.push_back({ "*",           "       --dry-base t",        "dry_base: %.2f (default: 1.75\n)", 
+(double)sparams.sparams.dry_multiplier);
+    options.push_back({ "*",           "       ---dry-multiplier t",        "dry_multiplier: %.1f (default: 0.0\n)", 
+sparams.sparams.dry_penalty_last_n});
+    options.push_back({ "*",           "       --dry-penalty-last-n N",        "dry_penalty_last_n: %d default: -1 (0 = disable, -1 = context size)\n", 
+
+//sparams.xtc_threshold});
+//    options.push_back({ "*",           "       --top-n-sigma t",        "top-n-sigma parmeter (default: %.1f, 0.0 = disabled)", 
+
+
+
     options.push_back({ "main",        "       --cfg-negative-prompt PROMPT",
                                                                         "negative prompt to use for guidance (default: '%s')", sparams.cfg_negative_prompt.c_str() });
     options.push_back({ "main",        "       --cfg-negative-prompt-file FNAME",
@@ -3417,6 +3458,10 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "xtc_probability: %f # default: 0.0\n", sparams.xtc_probability);
     fprintf(stream, "xtc_threshold: %f # default: 0.0\n", sparams.xtc_threshold);
     fprintf(stream, "top_n_sigma: %f # default: 0.0\n", sparams.top_n_sigma);
+    fprintf(stream, "dry_allowed_length: %d # default: 2\n", sparams.dry_allowed_length);
+    fprintf(stream, "dry_base: %.2f # default: 1.75\n", sparams.dry_base);Add commentMore actions
+    fprintf(stream, "dry_multiplier: %.1f # default: 0.0\n", sparams.dry_multiplier);
+    fprintf(stream, "dry_penalty_last_n: %d # default: -1 (0 = disable, -1 = context size)\n", sparams.dry_penalty_last_n);
     fprintf(stream, "mlock: %s # default: false\n", params.use_mlock ? "true" : "false");
     fprintf(stream, "model: %s # default: %s\n", params.model.c_str(), DEFAULT_MODEL_PATH);
     fprintf(stream, "model_draft: %s # default:\n", params.model_draft.c_str());

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1690,21 +1690,22 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "       --mirostat-lr N",        "Mirostat learning rate, parameter eta (default: %.1f)", (double)sparams.mirostat_eta });
     options.push_back({ "*",           "       --mirostat-ent N",       "Mirostat target entropy, parameter tau (default: %.1f)", (double)sparams.mirostat_tau });
     options.push_back({ "*",           "       --xtc-probability p",    "xtc probability (default: %.1f, 0.0 = disabled)", (double)sparams.xtc_probability });
-    options.push_back({ "*",           "       --xtc-threshold t",      "xtc threshold (default: %.1f, >0.5 = disabled)", (double)sparams.xtc_threshold});
-    options.push_back({ "*",           "       --top-n-sigma t",        "top-n-sigma parmeter (default: %.1f, 0.0 = disabled)", (double)sparams.top_n_sigma});
+    options.push_back({ "*",           "       --xtc-threshold t",      "xtc threshold (default: %.1f, >0.5 = disabled)", (double)sparams.xtc_threshold });
+    options.push_back({ "*",           "       --top-n-sigma t",        "top-n-sigma parmeter (default: %.1f, 0.0 = disabled)", (double)sparams.top_n_sigma });
     options.push_back({ "*",           "       -l TOKEN_ID(+/-)BIAS",   "modifies the likelihood of token appearing in the completion,\n"
                                                                         "i.e. `--logit-bias 15043+1` to increase likelihood of token ' Hello',\n"
-                                                                        "or `--logit-bias 15043-1` to decrease likelihood of token ' Hello'" });
+                                                                        "or `--logit-bias 15043-1` to decrease likelihood of token ' Hello'",
 
-sparams.dry_allowed_length)});
+sparams.dry_allowed_length });
     options.push_back({ "*",           "       --dry-allowed-length N",        "dry_allowed_length: %d (default: 2\n)", 
-(double)sparams.dry_base});
+(double)sparams.dry_base });
     options.push_back({ "*",           "       --dry-base t",        "dry_base: %.2f (default: 1.75\n)", 
-(double)sparams.dry_multiplier);
+(double)sparams.dry_multiplier });
     options.push_back({ "*",           "       ---dry-multiplier t",        "dry_multiplier: %.1f (default: 0.0\n)", 
-sparams.dry_penalty_last_n});
-    options.push_back({ "*",           "       --dry-penalty-last-n N",        "dry_penalty_last_n: %d default: -1 (0 = disable, -1 = context size)\n", 
-    options.push_back({ "main",        "       --cfg-negative-prompt PROMPT",
+sparams.dry_penalty_last_n });
+    options.push_back({ "*",           "       --dry-penalty-last-n N",        "dry_penalty_last_n: %d default: -1 (0 = disable, -1 = context size)\n"}); 
+ 
+   options.push_back({ "main",         "       --cfg-negative-prompt PROMPT",
                                                                         "negative prompt to use for guidance (default: '%s')", sparams.cfg_negative_prompt.c_str() });
     options.push_back({ "main",        "       --cfg-negative-prompt-file FNAME",
                                                                         "negative prompt file to use for guidance" });

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1697,13 +1697,13 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
                                                                         "or `--logit-bias 15043-1` to decrease likelihood of token ' Hello'",
 
 sparams.dry_allowed_length });
-    options.push_back({ "*",           "       --dry-allowed-length N",        "dry_allowed_length: %d (default: 2\n)", 
+    options.push_back({ "*",           "       --dry-allowed-length N",        "dry_allowed_length: (default: 2)", 
 (double)sparams.dry_base });
-    options.push_back({ "*",           "       --dry-base t",        "dry_base: %.2f (default: 1.75\n)", 
+    options.push_back({ "*",           "       --dry-base t",        "dry_base: (default: 1.75)", 
 (double)sparams.dry_multiplier });
-    options.push_back({ "*",           "       ---dry-multiplier t",        "dry_multiplier: %.1f (default: 0.0\n)", 
+    options.push_back({ "*",           "       ---dry-multiplier t",        "dry_multiplier: (default: 0.0)", 
 sparams.dry_penalty_last_n });
-    options.push_back({ "*",           "       --dry-penalty-last-n N",        "dry_penalty_last_n: %d default: -1 (0 = disable, -1 = context size)\n"}); 
+    options.push_back({ "*",           "       --dry-penalty-last-n N",        "dry_penalty_last_n: default: -1 (0 = disable, -1 = context size)"}); 
  
    options.push_back({ "main",         "       --cfg-negative-prompt PROMPT",
                                                                         "negative prompt to use for guidance (default: '%s')", sparams.cfg_negative_prompt.c_str() });

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -122,11 +122,12 @@ std::string llama_sampling_print(const llama_sampling_params & params) {
             "\trepeat_last_n = %d, repeat_penalty = %.3f, frequency_penalty = %.3f, presence_penalty = %.3f\n"
             "\ttop_k = %d, tfs_z = %.3f, top_p = %.3f, min_p = %.3f, typical_p = %.3f, temp = %.3f\n"
             "\tmirostat = %d, mirostat_lr = %.3f, mirostat_ent = %.3f\n"
-            "\txtc_probability = %.3f, xtc_threshold = %.3f, top_n_sigma = %.3f",
+            "\txtc_probability = %.3f, xtc_threshold = %.3f, top_n_sigma = %.3f, 
+            "\tdry_multiplier = %.3f, dry_base = %.3f, dry_allowed_length = %d, dry_penalty_last_n = %d\n"",
             params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present,
             params.top_k, params.tfs_z, params.top_p, params.min_p, params.typical_p, params.temp,
             params.mirostat, params.mirostat_eta, params.mirostat_tau,
-            params.xtc_probability, params.xtc_threshold, params.top_n_sigma);
+            params.xtc_probability, params.xtc_threshold, params.top_n_sigma, params.dry_multiplier, params.dry_base, params.dry_allowed_length, params.dry_penalty_last_n);
 
     return std::string(result);
 }
@@ -157,6 +158,7 @@ std::string llama_sampling_type_to_str(llama_sampler_type sampler_type) {
         case llama_sampler_type::TEMPERATURE: return "temperature";
         case llama_sampler_type::XTC        : return "xtc";
         case llama_sampler_type::TOP_N_SIGMA: return "top_n_sigma";
+        case llama_sampler_type::DRY        : return "dry";
         default : return "";
     }
 }
@@ -170,6 +172,7 @@ std::vector<llama_sampler_type> llama_sampling_types_from_names(const std::vecto
         {"tfs_z",       llama_sampler_type::TFS_Z},
         {"xtc",         llama_sampler_type::XTC},
         {"top_n_sigma", llama_sampler_type::TOP_N_SIGMA},
+        {"dry",         llama_sampler_type::DRY},
         {"temperature", llama_sampler_type::TEMPERATURE}
     };
 
@@ -186,6 +189,7 @@ std::vector<llama_sampler_type> llama_sampling_types_from_names(const std::vecto
         {"tfs",         llama_sampler_type::TFS_Z},
         {"xtc",         llama_sampler_type::XTC},
         {"top-n-sigma", llama_sampler_type::TOP_N_SIGMA},
+        {"dry",         llama_sampler_type::DRY},
         {"temp",        llama_sampler_type::TEMPERATURE}
     };
 
@@ -222,6 +226,7 @@ std::vector<llama_sampler_type> llama_sampling_types_from_chars(const std::strin
         {'f', llama_sampler_type::TFS_Z},
         {'x', llama_sampler_type::XTC},
         {'n', llama_sampler_type::TOP_N_SIGMA},
+        {'d', llama_sampler_type::DRY},
         {'t', llama_sampler_type::TEMPERATURE}
     };
 
@@ -242,17 +247,22 @@ static void sampler_queue(
             const llama_sampling_params & params,
                  llama_token_data_array & cur_p,
                                  size_t   min_keep) {
-    const float         temp              = params.temp;
-    const float         dynatemp_range    = params.dynatemp_range;
-    const float         dynatemp_exponent = params.dynatemp_exponent;
-    const int32_t       top_k             = params.top_k;
-    const float         top_p             = params.top_p;
-    const float         min_p             = params.min_p;
-    const float         tfs_z             = params.tfs_z;
-    const float         typical_p         = params.typical_p;
-    const float         xtc_probability   = params.xtc_probability;
-    const float         xtc_threshold     = params.xtc_threshold;
-    const float         top_n_sigma       = params.top_n_sigma;
+    const float         temp               = params.temp;
+    const float         dynatemp_range     = params.dynatemp_range;
+    const float         dynatemp_exponent  = params.dynatemp_exponent;
+    const int32_t       top_k              = params.top_k;
+    const float         top_p              = params.top_p;
+    const float         min_p              = params.min_p;
+    const float         tfs_z              = params.tfs_z;
+    const float         typical_p          = params.typical_p;
+    const float         xtc_probability    = params.xtc_probability;
+    const float         xtc_threshold      = params.xtc_threshold;
+    const float         top_n_sigma        = params.top_n_sigma;
+    const float         dry_multiplier     = params. dry_multiplier;
+    const float         dry_base           = params.dry_base; 
+    const int32_t       dry_allowed_length = params.dry_allowed_length;
+    const int32_t       dry_penalty_last_n = params.dry_penalty_last_n;
+
     const std::vector<llama_sampler_type> & samplers_sequence = params.samplers_sequence;
 
     for (auto sampler_type : samplers_sequence) {
@@ -263,6 +273,7 @@ static void sampler_queue(
             case llama_sampler_type::TOP_P      : llama_sample_top_p    (ctx_main, &cur_p, top_p,     min_keep); break;
             case llama_sampler_type::MIN_P      : llama_sample_min_p    (ctx_main, &cur_p, min_p,     min_keep); break;
             case llama_sampler_type::XTC        : llama_sample_xtc      (ctx_main, &cur_p, xtc_probability, xtc_threshold, min_keep); break;
+            case llama_sampler_type::DRY        : llama_sample_dry      (ctx_main, &cur_p, dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n, min_keep); break;
             case llama_sampler_type::TOP_N_SIGMA: llama_sample_top_n_sigma(ctx_main, &cur_p, top_n_sigma); break;
             case llama_sampler_type::TEMPERATURE:
                 if (dynatemp_range > 0) {

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -17,6 +17,7 @@ enum class llama_sampler_type : char {
     TFS_Z       = 'f',
     XTC         = 'x',
     TOP_N_SIGMA = 'n',
+    DRY = 'd',
     TYPICAL_P   = 'y',
     TEMPERATURE = 't'
 };
@@ -44,6 +45,10 @@ typedef struct llama_sampling_params {
     float       xtc_probability       = 0.0f;               // xtc probability
     float       xtc_threshold         = 1.0f;               // xtc threshold, disabled if > 0.5
     float       top_n_sigma           = 0.0f;               // top-n-sigma
+    float   dry_multiplier     = 0.0f;  // 0.0 = disabled;      DRY repetition penalty for tokens extending repetition:
+    float   dry_base           = 1.75f; // 0.0 = disabled;      multiplier * base ^ (length of sequence before token - allowed length)
+    int32_t dry_allowed_length = 2;     // tokens extending repetitions beyond this receive penalty
+    int32_t dry_penalty_last_n = -1;    // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
     bool        penalize_nl           = false;              // consider newlines as a repeatable token
     uint32_t    seed                  = LLAMA_DEFAULT_SEED; // the seed used to initialize llama_sampling_context
 
@@ -55,6 +60,8 @@ typedef struct llama_sampling_params {
         llama_sampler_type::MIN_P,
         llama_sampler_type::TEMPERATURE
     };
+
+    std::vector<std::string> dry_sequence_breakers = {"\n", ":", "\"", "*"};     // default sequence breakers for DRY
 
     std::string grammar;  // optional BNF-like grammar to constrain sampling
 

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -17,7 +17,7 @@ enum class llama_sampler_type : char {
     TFS_Z       = 'f',
     XTC         = 'x',
     TOP_N_SIGMA = 'n',
-    DRY = 'd',
+    DRY         = 'd',
     TYPICAL_P   = 'y',
     TEMPERATURE = 't'
 };
@@ -45,10 +45,10 @@ typedef struct llama_sampling_params {
     float       xtc_probability       = 0.0f;               // xtc probability
     float       xtc_threshold         = 1.0f;               // xtc threshold, disabled if > 0.5
     float       top_n_sigma           = 0.0f;               // top-n-sigma
-    float   dry_multiplier     = 0.0f;  // 0.0 = disabled;      DRY repetition penalty for tokens extending repetition:
-    float   dry_base           = 1.75f; // 0.0 = disabled;      multiplier * base ^ (length of sequence before token - allowed length)
-    int32_t dry_allowed_length = 2;     // tokens extending repetitions beyond this receive penalty
-    int32_t dry_penalty_last_n = -1;    // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
+    float       dry_multiplier        = 0.0f;               // 0.0 = disabled;      DRY repetition penalty for tokens extending repetition:
+    float       dry_base              = 1.75f;              // 0.0 = disabled;      multiplier * base ^ (length of sequence before token - allowed length)
+    int32_t     dry_allowed_length    = 2;                  // tokens extending repetitions beyond this receive penalty
+    int32_t     dry_penalty_last_n    = -1;                 // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
     bool        penalize_nl           = false;              // consider newlines as a repeatable token
     uint32_t    seed                  = LLAMA_DEFAULT_SEED; // the seed used to initialize llama_sampling_context
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -904,30 +904,51 @@ struct server_context {
             slot.oaicompat_model = "";
         }
 
-        slot.params.stream             = json_value(data, "stream",            false);
-        slot.params.cache_prompt       = json_value(data, "cache_prompt",      true);
-        slot.params.n_predict          = json_value(data, "n_predict",         json_value(data, "max_tokens", default_params.n_predict));
-        slot.sparams.top_k             = json_value(data, "top_k",             default_sparams.top_k);
-        slot.sparams.top_p             = json_value(data, "top_p",             default_sparams.top_p);
-        slot.sparams.min_p             = json_value(data, "min_p",             default_sparams.min_p);
-        slot.sparams.tfs_z             = json_value(data, "tfs_z",             default_sparams.tfs_z);
-        slot.sparams.typical_p         = json_value(data, "typical_p",         default_sparams.typical_p);
-        slot.sparams.temp              = json_value(data, "temperature",       default_sparams.temp);
-        slot.sparams.dynatemp_range    = json_value(data, "dynatemp_range",    default_sparams.dynatemp_range);
-        slot.sparams.dynatemp_exponent = json_value(data, "dynatemp_exponent", default_sparams.dynatemp_exponent);
-        slot.sparams.penalty_last_n    = json_value(data, "repeat_last_n",     default_sparams.penalty_last_n);
-        slot.sparams.penalty_repeat    = json_value(data, "repeat_penalty",    default_sparams.penalty_repeat);
-        slot.sparams.penalty_freq      = json_value(data, "frequency_penalty", default_sparams.penalty_freq);
-        slot.sparams.penalty_present   = json_value(data, "presence_penalty",  default_sparams.penalty_present);
-        slot.sparams.mirostat          = json_value(data, "mirostat",          default_sparams.mirostat);
-        slot.sparams.mirostat_tau      = json_value(data, "mirostat_tau",      default_sparams.mirostat_tau);
-        slot.sparams.mirostat_eta      = json_value(data, "mirostat_eta",      default_sparams.mirostat_eta);
-        slot.sparams.penalize_nl       = json_value(data, "penalize_nl",       default_sparams.penalize_nl);
-        slot.params.n_keep             = json_value(data, "n_keep",            slot.params.n_keep);
-        slot.params.n_discard          = json_value(data, "n_discard",         default_params.n_discard);
-        slot.sparams.seed              = json_value(data, "seed",              default_sparams.seed);
-        slot.sparams.n_probs           = json_value(data, "n_probs",           default_sparams.n_probs);
-        slot.sparams.min_keep          = json_value(data, "min_keep",          default_sparams.min_keep);
+        slot.params.stream              = json_value(data, "stream",             false);
+        slot.params.cache_prompt        = json_value(data, "cache_prompt",       true);
+        slot.params.n_predict           = json_value(data, "n_predict",          json_value(data, "max_tokens", default_params.n_predict));
+        slot.sparams.top_k              = json_value(data, "top_k",              default_sparams.top_k);
+        slot.sparams.top_p              = json_value(data, "top_p",              default_sparams.top_p);
+        slot.sparams.min_p              = json_value(data, "min_p",              default_sparams.min_p);
+        slot.sparams.tfs_z              = json_value(data, "tfs_z",              default_sparams.tfs_z);
+        slot.sparams.typical_p          = json_value(data, "typical_p",          default_sparams.typical_p);
+        slot.sparams.temp               = json_value(data, "temperature",        default_sparams.temp);
+        slot.sparams.dynatemp_range     = json_value(data, "dynatemp_range",     default_sparams.dynatemp_range);
+        slot.sparams.dynatemp_exponent  = json_value(data, "dynatemp_exponent",  default_sparams.dynatemp_exponent);
+        slot.sparams.penalty_last_n     = json_value(data, "repeat_last_n",      default_sparams.penalty_last_n);
+        slot.sparams.penalty_repeat     = json_value(data, "repeat_penalty",     default_sparams.penalty_repeat);
+        slot.sparams.penalty_freq       = json_value(data, "frequency_penalty",  default_sparams.penalty_freq);
+        slot.sparams.penalty_present    = json_value(data, "presence_penalty",   default_sparams.penalty_present);
+        slot.sparams.mirostat           = json_value(data, "mirostat",           default_sparams.mirostat);
+        slot.sparams.mirostat_tau       = json_value(data, "mirostat_tau",       default_sparams.mirostat_tau);
+        slot.sparams.mirostat_eta       = json_value(data, "mirostat_eta",       default_sparams.mirostat_eta);
+        slot.sparams.xtc_probability    = json_value(data, "xtc_probability",    default_sparams.xtc_probability);
+        slot.sparams.xtc_threshold      = json_value(data, "xtc_threshold",      default_sparams.xtc_threshold);
+        slot.sparams.top_n_sigma        = json_value(data, "top_n_sigma",        default_sparams.top_n_sigma);
+        slot.sparams.dry_multiplier     = json_value(data, "dry_multiplier",     default_sparams.dry_multiplier);
+        slot.sparams.dry_base           = json_value(data, "dry_base",           default_sparams.dry_base);
+        slot.sparams.dry_allowed_length = json_value(data, "dry_allowed_length", default_sparams.dry_allowed_length);
+        slot.sparams.dry_penalty_last_n = json_value(data, "dry_penalty_last_n", default_sparams.dry_penalty_last_n);
+        slot.sparams.penalize_nl        = json_value(data, "penalize_nl",        default_sparams.penalize_nl);
+        slot.params.n_keep              = json_value(data, "n_keep",             slot.params.n_keep);
+        slot.params.n_discard           = json_value(data, "n_discard",          default_params.n_discard);
+        slot.sparams.seed               = json_value(data, "seed",               default_sparams.seed);
+        slot.sparams.n_probs            = json_value(data, "n_probs",            default_sparams.n_probs);
+        slot.sparams.min_keep           = json_value(data, "min_keep",           default_sparams.min_keep);
+
+        // Parse dry_sequence_breakers array
+        if (data.contains("dry_sequence_breakers") && data["dry_sequence_breakers"].is_array()) {
+            slot.sparams.dry_sequence_breakers.clear();
+            for (const auto& breaker : data["dry_sequence_breakers"]) {
+                if (breaker.is_string()) {
+                    slot.sparams.dry_sequence_breakers.push_back(breaker.get<std::string>());
+                }
+            }
+        } else {
+            // Use defaults if not provided
+            slot.sparams.dry_sequence_breakers = default_sparams.dry_sequence_breakers;
+        }
+
 
         // process "json_schema" and "grammar"
         if (data.contains("json_schema") && !data.at("json_schema").is_null() && data.contains("grammar") && !data.at("grammar").is_null()) {
@@ -1350,6 +1371,13 @@ struct server_context {
             {"mirostat",                  slot.sparams.mirostat},
             {"mirostat_tau",              slot.sparams.mirostat_tau},
             {"mirostat_eta",              slot.sparams.mirostat_eta},
+            {"xtc_probability",           slot.sparams.xtc_probability},
+            {"xtc_threshold",             slot.sparams.xtc_threshold},
+            {"top_n_sigma",               slot.sparams.top_n_sigma},
+            {"dry_multiplier",            slot.sparams.dry_multiplier},
+            {"dry_base",                  slot.sparams.dry_base},
+            {"dry_allowed_length",        slot.sparams.dry_allowed_length},
+            {"dry_penalty_last_n",        slot.sparams.dry_penalty_last_n},
             {"penalize_nl",               slot.sparams.penalize_nl},
             {"stop",                      slot.params.antiprompt},
             {"n_predict",                 slot.params.n_predict}, // TODO: fix duplicate key n_predict

--- a/include/llama.h
+++ b/include/llama.h
@@ -16,6 +16,9 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+#include <vector>
+#include <string>
+
 #ifdef LLAMA_SHARED
 #    if defined(_WIN32) && !defined(__MINGW32__)
 #        ifdef LLAMA_BUILD
@@ -1223,14 +1226,16 @@ extern "C" {
                            float   top_n_sigma);
 
     ///  @details DRY sampler, designed by p-e-w, as described in: https://github.com/oobabooga/text-generation-webui/pull/5677, porting Koboldcpp implementation authored by pi6am: https://github.com/LostRuins/koboldcpp/pull/982Add
-    LLAMA_API struct llama_sampler *    llama_sampler_init_dry(
-            const struct llama_model *  model,
-                               float    dry_multiplier,
-                               float    dry_base,
-                             int32_t    dry_allowed_length,
-                             int32_t    dry_penalty_last_n,
-                          const char ** seq_breakers,
-                              size_t    num_breakers);
+LLAMA_API void llama_sample_dry(
+        struct llama_context * ctx,
+      llama_token_data_array * candidates_p,
+                       float   dry_multiplier,
+                       float   dry_base,
+                     int32_t   dry_allowed_length,
+                     int32_t   dry_penalty_last_n,
+const std::vector<std::string> & dry_sequence_breakers);
+
+LLAMA_API void llama_sample_dry_accept_token(struct llama_context * ctx, llama_token token);
 
     /// @details Mirostat 1.0 algorithm described in the paper https://arxiv.org/abs/2007.14966. Uses tokens instead of words.
     /// @param candidates A vector of `llama_token_data` containing the candidate tokens, their probabilities (p), and log-odds (logit) for the current position in the generated text.

--- a/include/llama.h
+++ b/include/llama.h
@@ -1222,6 +1222,15 @@ extern "C" {
           llama_token_data_array * candidates_p,
                            float   top_n_sigma);
 
+    ///  @details DRY sampler, designed by p-e-w, as described in: https://github.com/oobabooga/text-generation-webui/pull/5677, porting Koboldcpp implementation authored by pi6am: https://github.com/LostRuins/koboldcpp/pull/982Add
+    LLAMA_API struct llama_sampler *    llama_sampler_init_dry(
+            const struct llama_model *  model,
+                               float    dry_multiplier,
+                               float    dry_base,
+                             int32_t    dry_allowed_length,
+                             int32_t    dry_penalty_last_n,
+                          const char ** seq_breakers,
+                              size_t    num_breakers);
 
     /// @details Mirostat 1.0 algorithm described in the paper https://arxiv.org/abs/2007.14966. Uses tokens instead of words.
     /// @param candidates A vector of `llama_token_data` containing the candidate tokens, their probabilities (p), and log-odds (logit) for the current position in the generated text.

--- a/include/llama.h
+++ b/include/llama.h
@@ -15,9 +15,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdbool.h>
-
+#ifdef __cplusplus
 #include <vector>
 #include <string>
+#endif
 
 #ifdef LLAMA_SHARED
 #    if defined(_WIN32) && !defined(__MINGW32__)
@@ -1224,7 +1225,7 @@ extern "C" {
             struct llama_context * ctx,
           llama_token_data_array * candidates_p,
                            float   top_n_sigma);
-
+#ifdef __cplusplus
     ///  @details DRY sampler, designed by p-e-w, as described in: https://github.com/oobabooga/text-generation-webui/pull/5677, porting Koboldcpp implementation authored by pi6am: https://github.com/LostRuins/koboldcpp/pull/982Add
 LLAMA_API void llama_sample_dry(
         struct llama_context * ctx,
@@ -1234,7 +1235,7 @@ LLAMA_API void llama_sample_dry(
                      int32_t   dry_allowed_length,
                      int32_t   dry_penalty_last_n,
 const std::vector<std::string> & dry_sequence_breakers);
-
+#endif
 LLAMA_API void llama_sample_dry_accept_token(struct llama_context * ctx, llama_token token);
 
     /// @details Mirostat 1.0 algorithm described in the paper https://arxiv.org/abs/2007.14966. Uses tokens instead of words.

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -7,6 +7,10 @@
 #include <numeric>
 #include <unordered_map>
 
+#include "llama-vocab.h"
+#include <unordered_map>
+#include <cmath>
+
 static void llama_log_softmax(float * array, size_t size) {
     float max_l = *std::max_element(array, array + size);
     float sum = 0.f;
@@ -533,7 +537,7 @@ struct llama_sampler * llama_sampler_init_dry_impl(
                            float    dry_multiplier,
                            float    dry_base,
                          int32_t    dry_allowed_length,
-                         int32_t    dry_penalty_last_n,Add commentMore actions
+                         int32_t    dry_penalty_last_n,
                       const char ** seq_breakers,
                           size_t    num_breakers);
 
@@ -555,9 +559,14 @@ struct llama_sampler_dry {
 };
 
 // Ported from Koboldcpp, original PR: https://github.com/LostRuins/koboldcpp/pull/982 (Original author: pi6am)
-static void get_overlapping_token_sequences(const llama_vocab & vocab, const std::string& str, std::unordered_multimap<llama_token, std::vector<llama_token>>& token_sequences, int max_tail_len = -1) {
+static void get_overlapping_token_sequences(llama_context * ctx, const std::string& str, std::unordered_multimap<llama_token, std::vector<llama_token>>& token_sequences, int max_tail_len = -1) {
+
+    const llama_vocab & vocab = llama_get_model(ctx)->vocab;  // GET VOCAB FROM CTX
     for (llama_token token_id = 0; token_id < (llama_token)vocab.n_vocab; token_id++) {
-        std::string word = llama_detokenize(vocab, {token_id}, true);
+        std::string word = llama_detokenize(ctx, {token_id}, true);
+
+ //   for (llama_token token_id = 0; token_id < (llama_token)vocab.n_vocab; token_id++) {
+ //       std::string word = llama_detokenize(vocab, {token_id}, true);
         if (word.find(str) != std::string::npos) {
             token_sequences.emplace(token_id, std::vector<llama_token>());
         } else {

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -572,6 +572,14 @@ void llama_sample_top_n_sigma_impl(struct llama_sampling * smpl, llama_token_dat
 void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array * candidates,
                           float dry_multiplier, float dry_base, int32_t dry_allowed_length,
                           int32_t dry_penalty_last_n, const std::vector<std::string> & dry_sequence_breakers) {
+   
+    // DEBUG: Print when DRY is called
+    static int call_count = 0;
+    if (++call_count <= 5) {
+        fprintf(stderr, "DRY CALL %d: mult=%.2f base=%.2f allowed=%d last_n=%d history_size=%zu\n",
+                call_count, dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n,
+                smpl ? smpl->dry_last_tokens.size() : 0);
+    }
 
     if (dry_multiplier == 0.0f || dry_base < 1.0f || dry_penalty_last_n == 0 || !smpl) {
         return;
@@ -708,6 +716,10 @@ void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array 
         }
     }
 
+    // DEBUG: Show penalties applied
+    if (!smpl->dry_max_token_repeat.empty()) {
+        fprintf(stderr, "DRY: Applied penalties to %zu tokens\n", smpl->dry_max_token_repeat.size());
+    }
     candidates->sorted = false;
 }
 

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -526,6 +526,412 @@ void llama_sample_top_n_sigma_impl(struct llama_sampling * smpl, llama_token_dat
 }
 
 
+
+struct llama_sampler * llama_sampler_init_dry_impl(
+        const struct llama_vocab &  vocab,
+                         int32_t    context_size,
+                           float    dry_multiplier,
+                           float    dry_base,
+                         int32_t    dry_allowed_length,
+                         int32_t    dry_penalty_last_n,Add commentMore actions
+                      const char ** seq_breakers,
+                          size_t    num_breakers);
+
+
+// DRY
+
+struct llama_sampler_dry {
+    int32_t total_context_size;
+
+    const float   dry_multiplier;
+    const float   dry_base;
+    const int32_t dry_allowed_length;
+    const int32_t dry_penalty_last_n;
+
+    std::unordered_multimap<llama_token, std::vector<llama_token>> dry_processed_breakers;
+    std::vector<int> dry_repeat_count;
+    std::unordered_map<llama_token, int> dry_max_token_repeat;
+    ring_buffer<llama_token> last_tokens;
+};
+
+// Ported from Koboldcpp, original PR: https://github.com/LostRuins/koboldcpp/pull/982 (Original author: pi6am)
+static void get_overlapping_token_sequences(const llama_vocab & vocab, const std::string& str, std::unordered_multimap<llama_token, std::vector<llama_token>>& token_sequences, int max_tail_len = -1) {
+    for (llama_token token_id = 0; token_id < (llama_token)vocab.n_vocab; token_id++) {
+        std::string word = llama_detokenize(vocab, {token_id}, true);
+        if (word.find(str) != std::string::npos) {
+            token_sequences.emplace(token_id, std::vector<llama_token>());
+        } else {
+            size_t word_len = word.size(), str_len = str.size();
+            size_t pos = -1;
+            while ((pos = word.find(str[0], pos + 1)) != std::string::npos) {
+                bool match = true;
+                size_t i;
+                for (i = 1; i < str_len && i + pos < word_len; ++i) {
+                    if (word[pos + i] != str[i]) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) {
+                    std::vector<llama_token> tokenization = llama_tokenize_internal(vocab, str.substr(i), false, false);
+                    if (max_tail_len >= 0 && tokenization.size() > (size_t)max_tail_len) {
+                        tokenization.resize(max_tail_len);
+                    }
+
+                    // Ensure we don't already have a duplicate matching tokenization
+                    auto its = token_sequences.equal_range(token_id);
+                    bool found = false;
+                    for (auto it = its.first; it != its.second; ++it) {
+                        if (tokenization == it->second) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        token_sequences.emplace(token_id, tokenization);
+                    }
+                }
+            }
+        }
+    }
+}
+
+static const char * llama_sampler_dry_name(const struct llama_sampler * /*smpl*/) {
+    return "dry";
+}
+
+static void llama_sampler_dry_accept(struct llama_sampler * smpl, llama_token token) {
+    auto * ctx = (llama_sampler_dry *) smpl->ctx;
+    if (ctx->dry_multiplier == 0.0f || ctx->dry_base < 1.0f || ctx->dry_penalty_last_n == 0) {
+        return;
+    }
+
+    ctx->last_tokens.push_back(token);
+}
+
+// Ported from Koboldcpp, original PR: https://github.com/LostRuins/koboldcpp/pull/982 (Original author: pi6am)
+static void llama_sampler_dry_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
+    auto * ctx = (llama_sampler_dry *) smpl->ctx;
+
+    if (ctx->dry_multiplier == 0.0f || ctx->dry_base < 1.0f || ctx->dry_penalty_last_n == 0) {
+        return;
+    }
+
+    int32_t effective_dry_penalty_last_n = (ctx->dry_penalty_last_n == -1) ? ctx->total_context_size : std::max(ctx->dry_penalty_last_n, 0);
+    int last_n_repeat = std::min(std::min((int)ctx->last_tokens.size(), effective_dry_penalty_last_n), ctx->total_context_size);
+
+    if (last_n_repeat <= ctx->dry_allowed_length) {
+        return;
+    }
+
+    ctx->dry_repeat_count.assign(last_n_repeat, 0);
+    ctx->dry_max_token_repeat.clear();
+
+    // Step 1: Look for restart sequences to limit the maximum repetition length.
+    // Work backwards through the context looking for any token that begins a restart sequence.
+    //
+    // The collection `restart_sequences` is a mapping from a "head" token to all "tail"
+    // sequences that together comprise a restart sequence. This allows us to quickly check
+    // whether each token is the head of a complete sequence. Most restart sequences are actually
+    // a single token, and for these the "tail" is an empty vector.
+    //
+    // If the token is a "head", test all restart sequences that begin with this token
+    // (there will often only be one sequence for each token, but if sequences like 'aaaq1' and
+    // 'aaa1' are used as restart strings, both could start with 'aaa' when tokenized). The
+    // longest matching sequence (if any) is used to limit the maximum repetition length.
+    //
+    // Note that in the case case of a short sequence contained in a longer one, this might fail to
+    // find the smallest value for `rep_limit`. For example, if 'amniotic' and 'ni' are both used as
+    // restart sequences, 'ni' will be found first, and since it's shorter it will fail to suppress
+    // 'otic'. This is a minor issue since fully contained restart sequences are likely to be rare.
+    //
+    // This is theoretically worst-case O(N^2) for arbitrary restart sequences, which is why we
+    // have already clamped the maximum tail sequence length when generating `restart_sequences`.
+    // With clamping, this scan is O(N) in the context length.
+
+    int rep_limit = last_n_repeat;
+    for (int i = 0; i < last_n_repeat; ++i) {
+        llama_token token = ctx->last_tokens.rat(i);
+        auto its = ctx->dry_processed_breakers.equal_range(token);
+        if (its.first == ctx->dry_processed_breakers.end()) {
+            continue;
+        }
+        int longest_match = -1;
+        for (auto it = its.first; it != its.second; ++it) {
+            // Note that (*it) does not contain the head character, so seq_len will be
+            // the restart sequence length minus 1.
+            // In the common case of a single-token restart sequence, (*it) will be empty
+            // and we will trivially match.
+            int seq_len = (int)it->second.size();
+            if (seq_len > longest_match && seq_len <= (int)i) {
+                bool match = true;
+                for (int offset = 0; offset < seq_len; ++offset) {
+                    // The -1 when indexing `last_tokens` is because we already matched the head.
+                    if (it->second[offset] != ctx->last_tokens.rat(i - offset - 1)) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) {
+                    longest_match = seq_len;
+                }
+            }
+        }
+        if (longest_match >= 0) {
+            // We found a restart sequence starting `i` tokens from the end and continuing for
+            // `longest_match` tokens.
+            rep_limit = i - longest_match;
+            break;
+        }
+    }
+    if (rep_limit < ctx->dry_allowed_length) {
+        return;
+    }
+
+    // Step 2: Iterate in reverse over the last N tokens of the context, using the "Z-algorithm" (in
+    // the reverse direction) to efficiently compute the positions and lengths of suffixes appearing
+    // elsewhere in the context. We limit the suffix length to `rep_limit` to respect restart sequences.
+    //
+    // This algorithm is not currently documented on Wikipedia, but there is a clear description here:
+    // https://ivanyu.me/blog/2014/10/15/z-algorithm/
+    //
+    // The code below is adapted from the public domain implementation by the same author here:
+    // https://github.com/ivanyu/string-algorithms/blob/master/z_algorithm.py
+    //
+    // Example:
+    // Last N tokens: a b c c b c y a b c
+    // Repeat counts: 0 0 3 1 0 2 0 0 0 0
+    //                    ^
+    //   This `3` means that the last three tokens of the context (a b c) also appear here.
+    //
+    // This step is worst case O(N) since the Z-algorithm is linear, despite the appearance of nested
+    // for/while loops. This can be seen by observing that the `lt` and `rt` bounds are set after each
+    // repeated suffix is detected (i.e. after each while loop when n > 0). These bound variables
+    // ensure that the inner while loops only examine each token in the context once as the outer
+    // for loop iterates over the context.
+
+    {
+        const int last = last_n_repeat - 1;
+        int rt = 0, lt = 0;
+
+        for (int k = 1; k < last_n_repeat; ++k) {
+            if (k > rt) {
+                // If k is outside the current Z-box, do naive computation.
+                int n = 0;
+                while (n + k < last_n_repeat && ctx->last_tokens.rat(n) == ctx->last_tokens.rat(n+k)) {
+                    ++n;
+                }
+                ctx->dry_repeat_count[last - k] = std::min(n, rep_limit);
+                if (n > 0) {
+                    lt = k;
+                    rt = k+n-1;
+                }
+            } else {
+                // If k is inside the current Z-box, consider two cases.
+
+                int p = k - lt; // Pair index.
+                int right_part_len = rt - k + 1;
+
+                if (ctx->dry_repeat_count[last - p] < right_part_len) {
+                    int n = std::min(ctx->dry_repeat_count[last - p], rep_limit);
+                    ctx->dry_repeat_count[last - k] = n;
+                } else {
+                    int i = rt + 1;
+                    while (i < last_n_repeat && ctx->last_tokens.rat(i) == ctx->last_tokens.rat(i - k)) {
+                        i += 1;
+                    }
+
+                    int n = std::min(i - k, rep_limit);
+                    ctx->dry_repeat_count[last - k] = n;
+                    lt = k;
+                    rt = i - 1;
+                }
+            }
+        }
+    }
+
+    // Step 3: Iterate over dry_repeat_count and last_tokens, examining the maximum repeat length
+    // that would be generated by emitting each new token that would extend a sequence.
+    //
+    // Following the same example as above:
+    // Last N tokens: a b c c b c y a b c
+    // Repeat counts: 0 0 3 1 0 2 0 0 0 0
+    //
+    // For each non-zero, look ahead one token. This token, if emitted, would extend the repetition.
+    // c: 3 -> 4 (from `a b c` to `a b c c`)
+    // b: 1 -> 2 (from `c` to `c b`)
+    // y: 2 -> 3 (from `b c` to `b c y`)
+
+    for (int i = 0; i < last_n_repeat - 1; ++i) {
+        int repeat_len = ctx->dry_repeat_count[i];
+        if (repeat_len >= ctx->dry_allowed_length) {
+            // This token ends a repeat, so the next token would continue one.
+            // By convention, the value of `repeat_len` only includes the tokens currently
+            // in the context, not the new token that would be added.
+            llama_token token = ctx->last_tokens.rat(last_n_repeat - 2 - i);
+            // Track the maximum sequence ending in this token.
+            const auto& it = ctx->dry_max_token_repeat.find(token);
+            if (it == ctx->dry_max_token_repeat.end() || it->second < repeat_len) {
+                ctx->dry_max_token_repeat[token] = repeat_len;
+            }
+        }
+    }
+
+    // Step 4: Apply logit penalties based on the maximum repeat length for relevant tokens.
+
+    // Prevent floating point overflow in `pow(penalty_base, exponent)` by clamping to `max_exponent`.
+    // Compute it from `penalty_base` and the approximate log of `std::numeric_limits<float>::max()`
+    const float FLOAT_MAX_LOG = 88.7228391f;
+    int max_exponent = 0;
+    if (ctx->dry_base > 1.000001f) {
+        max_exponent = FLOAT_MAX_LOG / std::log(ctx->dry_base);
+    }
+
+    for (size_t i = 0; i < cur_p->size; ++i) {
+        const auto& af_kvp = ctx->dry_max_token_repeat.find(cur_p->data[i].id);
+        if (af_kvp != ctx->dry_max_token_repeat.end()) {
+            // Check all sequence breakers starting with this token
+            auto range = ctx->dry_processed_breakers.equal_range(cur_p->data[i].id);
+            bool is_single_token_breaker = false;
+
+            for (auto it = range.first; it != range.second; ++it) {
+                if (it->second.empty()) {
+                    is_single_token_breaker = true;
+                    break;
+                }
+            }
+
+            // Apply penalty only if it's not a single-token sequence breaker
+            if (!is_single_token_breaker) {
+                int repeat_exp = af_kvp->second - ctx->dry_allowed_length;
+                if (max_exponent > 0 && repeat_exp > max_exponent) {
+                    repeat_exp = max_exponent;
+                }
+                float penalty = ctx->dry_multiplier * std::pow(ctx->dry_base, repeat_exp);
+                cur_p->data[i].logit -= penalty;
+            }
+        }
+    }
+
+    cur_p->sorted = false;
+}
+
+static void llama_sampler_dry_reset(struct llama_sampler * smpl) {
+    auto * ctx = (llama_sampler_dry *) smpl->ctx;
+    ctx->last_tokens.clear();
+    ctx->dry_repeat_count.clear();
+    ctx->dry_max_token_repeat.clear();
+}
+
+static struct llama_sampler * llama_sampler_dry_clone(const struct llama_sampler * smpl) {
+    const auto * ctx = (llama_sampler_dry *) smpl->ctx;
+
+    // nullptr is passed as vocab because it is only needed for raw sequence breaker processing, which we have already done and will be copying
+    auto * result = llama_sampler_init_dry(nullptr, ctx->dry_multiplier, ctx->dry_base, ctx->dry_allowed_length, ctx->dry_penalty_last_n, NULL, 0);
+    // Copy the state, including the processed breakers
+    {
+        auto * result_ctx = (llama_sampler_dry *) result->ctx;
+        result_ctx->dry_processed_breakers = ctx->dry_processed_breakers;
+        result_ctx->dry_repeat_count = ctx->dry_repeat_count;
+        result_ctx->dry_max_token_repeat = ctx->dry_max_token_repeat;
+        result_ctx->last_tokens = ctx->last_tokens;
+    }
+
+    return result;
+}
+
+static void llama_sampler_dry_free(struct llama_sampler * smpl) {
+    delete (llama_sampler_dry *) smpl->ctx;
+}
+
+static struct llama_sampler_i llama_sampler_dry_i = {
+    /* .name   = */ llama_sampler_dry_name,
+    /* .accept = */ llama_sampler_dry_accept,
+    /* .apply  = */ llama_sampler_dry_apply,
+    /* .reset  = */ llama_sampler_dry_reset,
+    /* .clone  = */ llama_sampler_dry_clone,
+    /* .free   = */ llama_sampler_dry_free,
+};
+
+struct llama_sampler * llama_sampler_init_dry_impl(const struct llama_vocab & vocab, int32_t context_size, float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const char** seq_breakers, size_t num_breakers) {
+    int32_t effective_dry_penalty_last_n = (dry_penalty_last_n == -1) ? context_size : std::max(dry_penalty_last_n, 0);
+    std::unordered_multimap<llama_token, std::vector<llama_token>> processed_breakers;
+    const int MAX_CHAR_LEN = 40;
+    const int MAX_SEQ_LEN = 20;
+
+    const bool dry_enabled = (dry_multiplier != 0.0f && dry_base >= 1.0f && dry_penalty_last_n != 0);
+
+    if (dry_enabled && seq_breakers != nullptr && num_breakers > 0) {
+        // Process sequence breakers
+        for (size_t i = 0; i < num_breakers; ++i) {
+            if (seq_breakers[i] == nullptr || std::strlen(seq_breakers[i]) == 0) {
+                LLAMA_LOG_WARN("skipping null or empty DRY sequence breaker at index %zu\n", i);
+                continue;
+            }
+
+            std::string sequence_break(seq_breakers[i]);
+            if (sequence_break.empty()) {
+                LLAMA_LOG_WARN("skipping empty DRY sequence breaker\n");
+                continue;
+            }
+
+            if (sequence_break.size() > MAX_CHAR_LEN) {
+                LLAMA_LOG_WARN("truncating DRY sequence breaker to %d characters\n", MAX_CHAR_LEN);
+                sequence_break.resize(MAX_CHAR_LEN);
+            }
+
+            get_overlapping_token_sequences(vocab, sequence_break, processed_breakers, MAX_SEQ_LEN);
+        }
+    }
+
+    return new llama_sampler {
+        /* .iface = */ &llama_sampler_dry_i,
+        /* .ctx   = */ new llama_sampler_dry {
+            /* .total_context_size     = */ context_size,
+            /* .dry_multiplier         = */ dry_multiplier,
+            /* .dry_base               = */ dry_base,
+            /* .dry_allowed_length     = */ dry_allowed_length,
+            /* .dry_penalty_last_n     = */ dry_penalty_last_n,
+            /* .dry_processed_breakers = */ std::move(processed_breakers),
+            /* .dry_repeat_count       = */ dry_enabled ? std::vector<int>(effective_dry_penalty_last_n, 0) : std::vector<int>{},
+            /* .dry_max_token_repeat   = */ {},
+            /* .last_tokens            = */ dry_enabled ? ring_buffer<llama_token>(effective_dry_penalty_last_n) : ring_buffer<llama_token>(0),
+        },
+    };
+}
+
+// wrapper for test-sampling.cpp
+struct llama_sampler * llama_sampler_init_dry_testing(int32_t context_size, float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const std::vector<std::vector<llama_token>>& seq_breakers) {
+    llama_vocab dummy_vocab;
+    auto * result = llama_sampler_init_dry_impl(dummy_vocab, context_size, dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n, NULL, 0);
+    auto * ctx = (llama_sampler_dry *) result->ctx;
+
+    // Process the token-based sequence breakers
+    ctx->dry_processed_breakers.clear();
+    if (seq_breakers.empty()) {
+        LLAMA_LOG_WARN("empty DRY sequence breakers list in llama_sampler_init_dry_testing\n");
+    } else {
+        for (const auto& breaker : seq_breakers) {
+            if (breaker.empty()) {
+                LLAMA_LOG_WARN("skipping DRY empty sequence breaker\n");
+                continue;
+            }
+            llama_token head_token = breaker[0];
+            std::vector<llama_token> tail_tokens(breaker.begin() + 1, breaker.end());
+            ctx->dry_processed_breakers.emplace(head_token, std::move(tail_tokens));
+        }
+
+        if (ctx->dry_processed_breakers.empty()) {
+            LLAMA_LOG_WARN("no valid DRY sequence breakers processed in llama_sampler_init_dry_testing\n");
+        }
+    }
+
+    return result;
+}
+
+//DRY end
+ 
+
 void llama_sample_repetition_penalties_impl(
         struct llama_sampling * smpl,
        llama_token_data_array * candidates,

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -573,6 +573,7 @@ void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array 
                           float dry_multiplier, float dry_base, int32_t dry_allowed_length,
                           int32_t dry_penalty_last_n, const std::vector<std::string> & dry_sequence_breakers) {
    
+#ifdef DRY_DEBUG
     // DEBUG: Print when DRY is called
     static int call_count = 0;
     if (++call_count <= 5) {
@@ -580,7 +581,7 @@ void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array 
                 call_count, dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n,
                 smpl ? smpl->dry_last_tokens.size() : 0);
     }
-
+#endif
     if (dry_multiplier == 0.0f || dry_base < 1.0f || dry_penalty_last_n == 0 || !smpl) {
         return;
     }
@@ -715,11 +716,12 @@ void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array 
             }
         }
     }
-
+#ifdef DRY_DEBUG
     // DEBUG: Show penalties applied
     if (!smpl->dry_max_token_repeat.empty()) {
         fprintf(stderr, "DRY: Applied penalties to %zu tokens\n", smpl->dry_max_token_repeat.size());
     }
+#endif
     candidates->sorted = false;
 }
 

--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -10,6 +10,43 @@
 #include "llama-vocab.h"
 #include <unordered_map>
 #include <cmath>
+#include <vector>
+
+
+template<typename T>
+class ring_buffer {
+private:
+    std::vector<T> buffer;
+    size_t head = 0;
+    size_t tail = 0;
+    size_t count = 0;
+    size_t capacity;
+
+public:
+    ring_buffer(size_t cap) : capacity(cap) {
+        if (cap > 0) buffer.resize(cap);
+    }
+
+    void push_back(const T& item) {
+        if (capacity == 0) return;
+        buffer[tail] = item;
+        tail = (tail + 1) % capacity;
+        if (count < capacity) {
+            count++;
+        } else {
+            head = (head + 1) % capacity;
+        }
+    }
+
+    T rat(size_t index) const {  // "reverse at" - indexing from the end
+        if (index >= count) return T{};
+        size_t actual_index = (tail - 1 - index + capacity) % capacity;
+        return buffer[actual_index];
+    }
+
+    size_t size() const { return count; }
+    void clear() { head = tail = count = 0; }
+};
 
 static void llama_log_softmax(float * array, size_t size) {
     float max_l = *std::max_element(array, array + size);
@@ -528,155 +565,46 @@ void llama_sample_top_n_sigma_impl(struct llama_sampling * smpl, llama_token_dat
         smpl->n_sample++;
     }
 }
+//DRY
 
 
 
-struct llama_sampler * llama_sampler_init_dry_impl(
-        const struct llama_vocab &  vocab,
-                         int32_t    context_size,
-                           float    dry_multiplier,
-                           float    dry_base,
-                         int32_t    dry_allowed_length,
-                         int32_t    dry_penalty_last_n,
-                      const char ** seq_breakers,
-                          size_t    num_breakers);
+void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array * candidates,
+                          float dry_multiplier, float dry_base, int32_t dry_allowed_length,
+                          int32_t dry_penalty_last_n, const std::vector<std::string> & dry_sequence_breakers) {
 
-
-// DRY
-
-struct llama_sampler_dry {
-    int32_t total_context_size;
-
-    const float   dry_multiplier;
-    const float   dry_base;
-    const int32_t dry_allowed_length;
-    const int32_t dry_penalty_last_n;
-
-    std::unordered_multimap<llama_token, std::vector<llama_token>> dry_processed_breakers;
-    std::vector<int> dry_repeat_count;
-    std::unordered_map<llama_token, int> dry_max_token_repeat;
-    ring_buffer<llama_token> last_tokens;
-};
-
-// Ported from Koboldcpp, original PR: https://github.com/LostRuins/koboldcpp/pull/982 (Original author: pi6am)
-static void get_overlapping_token_sequences(llama_context * ctx, const std::string& str, std::unordered_multimap<llama_token, std::vector<llama_token>>& token_sequences, int max_tail_len = -1) {
-
-    const llama_vocab & vocab = llama_get_model(ctx)->vocab;  // GET VOCAB FROM CTX
-    for (llama_token token_id = 0; token_id < (llama_token)vocab.n_vocab; token_id++) {
-        std::string word = llama_detokenize(ctx, {token_id}, true);
-
- //   for (llama_token token_id = 0; token_id < (llama_token)vocab.n_vocab; token_id++) {
- //       std::string word = llama_detokenize(vocab, {token_id}, true);
-        if (word.find(str) != std::string::npos) {
-            token_sequences.emplace(token_id, std::vector<llama_token>());
-        } else {
-            size_t word_len = word.size(), str_len = str.size();
-            size_t pos = -1;
-            while ((pos = word.find(str[0], pos + 1)) != std::string::npos) {
-                bool match = true;
-                size_t i;
-                for (i = 1; i < str_len && i + pos < word_len; ++i) {
-                    if (word[pos + i] != str[i]) {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match) {
-                    std::vector<llama_token> tokenization = llama_tokenize_internal(vocab, str.substr(i), false, false);
-                    if (max_tail_len >= 0 && tokenization.size() > (size_t)max_tail_len) {
-                        tokenization.resize(max_tail_len);
-                    }
-
-                    // Ensure we don't already have a duplicate matching tokenization
-                    auto its = token_sequences.equal_range(token_id);
-                    bool found = false;
-                    for (auto it = its.first; it != its.second; ++it) {
-                        if (tokenization == it->second) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        token_sequences.emplace(token_id, tokenization);
-                    }
-                }
-            }
-        }
-    }
-}
-
-static const char * llama_sampler_dry_name(const struct llama_sampler * /*smpl*/) {
-    return "dry";
-}
-
-static void llama_sampler_dry_accept(struct llama_sampler * smpl, llama_token token) {
-    auto * ctx = (llama_sampler_dry *) smpl->ctx;
-    if (ctx->dry_multiplier == 0.0f || ctx->dry_base < 1.0f || ctx->dry_penalty_last_n == 0) {
+    if (dry_multiplier == 0.0f || dry_base < 1.0f || dry_penalty_last_n == 0 || !smpl) {
         return;
     }
 
-    ctx->last_tokens.push_back(token);
-}
+    // Step 1: Get effective context size
+    int32_t effective_dry_penalty_last_n = (dry_penalty_last_n == -1) ?
+        smpl->dry_last_tokens.size() : std::max(dry_penalty_last_n, 0);
+    int last_n_repeat = std::min((int)smpl->dry_last_tokens.size(), effective_dry_penalty_last_n);
 
-// Ported from Koboldcpp, original PR: https://github.com/LostRuins/koboldcpp/pull/982 (Original author: pi6am)
-static void llama_sampler_dry_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
-    auto * ctx = (llama_sampler_dry *) smpl->ctx;
-
-    if (ctx->dry_multiplier == 0.0f || ctx->dry_base < 1.0f || ctx->dry_penalty_last_n == 0) {
+    if (last_n_repeat <= dry_allowed_length) {
         return;
     }
 
-    int32_t effective_dry_penalty_last_n = (ctx->dry_penalty_last_n == -1) ? ctx->total_context_size : std::max(ctx->dry_penalty_last_n, 0);
-    int last_n_repeat = std::min(std::min((int)ctx->last_tokens.size(), effective_dry_penalty_last_n), ctx->total_context_size);
+    // Step 2: Initialize working arrays
+    smpl->dry_repeat_count.assign(last_n_repeat, 0);
+    smpl->dry_max_token_repeat.clear();
 
-    if (last_n_repeat <= ctx->dry_allowed_length) {
-        return;
-    }
-
-    ctx->dry_repeat_count.assign(last_n_repeat, 0);
-    ctx->dry_max_token_repeat.clear();
-
-    // Step 1: Look for restart sequences to limit the maximum repetition length.
-    // Work backwards through the context looking for any token that begins a restart sequence.
-    //
-    // The collection `restart_sequences` is a mapping from a "head" token to all "tail"
-    // sequences that together comprise a restart sequence. This allows us to quickly check
-    // whether each token is the head of a complete sequence. Most restart sequences are actually
-    // a single token, and for these the "tail" is an empty vector.
-    //
-    // If the token is a "head", test all restart sequences that begin with this token
-    // (there will often only be one sequence for each token, but if sequences like 'aaaq1' and
-    // 'aaa1' are used as restart strings, both could start with 'aaa' when tokenized). The
-    // longest matching sequence (if any) is used to limit the maximum repetition length.
-    //
-    // Note that in the case case of a short sequence contained in a longer one, this might fail to
-    // find the smallest value for `rep_limit`. For example, if 'amniotic' and 'ni' are both used as
-    // restart sequences, 'ni' will be found first, and since it's shorter it will fail to suppress
-    // 'otic'. This is a minor issue since fully contained restart sequences are likely to be rare.
-    //
-    // This is theoretically worst-case O(N^2) for arbitrary restart sequences, which is why we
-    // have already clamped the maximum tail sequence length when generating `restart_sequences`.
-    // With clamping, this scan is O(N) in the context length.
-
+    // Step 3: Look for restart sequences (sequence breaker logic)
     int rep_limit = last_n_repeat;
     for (int i = 0; i < last_n_repeat; ++i) {
-        llama_token token = ctx->last_tokens.rat(i);
-        auto its = ctx->dry_processed_breakers.equal_range(token);
-        if (its.first == ctx->dry_processed_breakers.end()) {
+        llama_token token = smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 1 - i];
+        auto range = smpl->dry_processed_breakers.equal_range(token);
+        if (range.first == smpl->dry_processed_breakers.end()) {
             continue;
         }
         int longest_match = -1;
-        for (auto it = its.first; it != its.second; ++it) {
-            // Note that (*it) does not contain the head character, so seq_len will be
-            // the restart sequence length minus 1.
-            // In the common case of a single-token restart sequence, (*it) will be empty
-            // and we will trivially match.
+        for (auto it = range.first; it != range.second; ++it) {
             int seq_len = (int)it->second.size();
             if (seq_len > longest_match && seq_len <= (int)i) {
                 bool match = true;
                 for (int offset = 0; offset < seq_len; ++offset) {
-                    // The -1 when indexing `last_tokens` is because we already matched the head.
-                    if (it->second[offset] != ctx->last_tokens.rat(i - offset - 1)) {
+                    if (it->second[offset] != smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 1 - i + offset + 1]) {
                         match = false;
                         break;
                     }
@@ -687,258 +615,102 @@ static void llama_sampler_dry_apply(struct llama_sampler * smpl, llama_token_dat
             }
         }
         if (longest_match >= 0) {
-            // We found a restart sequence starting `i` tokens from the end and continuing for
-            // `longest_match` tokens.
             rep_limit = i - longest_match;
             break;
         }
     }
-    if (rep_limit < ctx->dry_allowed_length) {
+
+    if (rep_limit < dry_allowed_length) {
         return;
     }
 
-    // Step 2: Iterate in reverse over the last N tokens of the context, using the "Z-algorithm" (in
-    // the reverse direction) to efficiently compute the positions and lengths of suffixes appearing
-    // elsewhere in the context. We limit the suffix length to `rep_limit` to respect restart sequences.
-    //
-    // This algorithm is not currently documented on Wikipedia, but there is a clear description here:
-    // https://ivanyu.me/blog/2014/10/15/z-algorithm/
-    //
-    // The code below is adapted from the public domain implementation by the same author here:
-    // https://github.com/ivanyu/string-algorithms/blob/master/z_algorithm.py
-    //
-    // Example:
-    // Last N tokens: a b c c b c y a b c
-    // Repeat counts: 0 0 3 1 0 2 0 0 0 0
-    //                    ^
-    //   This `3` means that the last three tokens of the context (a b c) also appear here.
-    //
-    // This step is worst case O(N) since the Z-algorithm is linear, despite the appearance of nested
-    // for/while loops. This can be seen by observing that the `lt` and `rt` bounds are set after each
-    // repeated suffix is detected (i.e. after each while loop when n > 0). These bound variables
-    // ensure that the inner while loops only examine each token in the context once as the outer
-    // for loop iterates over the context.
+    // Step 4: Z-algorithm for suffix matching
+    const int last = last_n_repeat - 1;
+    int rt = 0, lt = 0;
 
-    {
-        const int last = last_n_repeat - 1;
-        int rt = 0, lt = 0;
+    for (int k = 1; k < last_n_repeat; ++k) {
+        if (k > rt) {
+            // If k is outside the current Z-box, do naive computation
+            int n = 0;
+            while (n + k < last_n_repeat &&
+                   smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 1 - n] ==
+                   smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 1 - (n + k)]) {
+                ++n;
+            }
+            smpl->dry_repeat_count[last - k] = std::min(n, rep_limit);
+            if (n > 0) {
+                lt = k;
+                rt = k + n - 1;
+            }
+        } else {
+            // If k is inside the current Z-box
+            int p = k - lt;
+            int right_part_len = rt - k + 1;
 
-        for (int k = 1; k < last_n_repeat; ++k) {
-            if (k > rt) {
-                // If k is outside the current Z-box, do naive computation.
-                int n = 0;
-                while (n + k < last_n_repeat && ctx->last_tokens.rat(n) == ctx->last_tokens.rat(n+k)) {
-                    ++n;
-                }
-                ctx->dry_repeat_count[last - k] = std::min(n, rep_limit);
-                if (n > 0) {
-                    lt = k;
-                    rt = k+n-1;
-                }
+            if (smpl->dry_repeat_count[last - p] < right_part_len) {
+                int n = std::min(smpl->dry_repeat_count[last - p], rep_limit);
+                smpl->dry_repeat_count[last - k] = n;
             } else {
-                // If k is inside the current Z-box, consider two cases.
-
-                int p = k - lt; // Pair index.
-                int right_part_len = rt - k + 1;
-
-                if (ctx->dry_repeat_count[last - p] < right_part_len) {
-                    int n = std::min(ctx->dry_repeat_count[last - p], rep_limit);
-                    ctx->dry_repeat_count[last - k] = n;
-                } else {
-                    int i = rt + 1;
-                    while (i < last_n_repeat && ctx->last_tokens.rat(i) == ctx->last_tokens.rat(i - k)) {
-                        i += 1;
-                    }
-
-                    int n = std::min(i - k, rep_limit);
-                    ctx->dry_repeat_count[last - k] = n;
-                    lt = k;
-                    rt = i - 1;
+                int i = rt + 1;
+                while (i < last_n_repeat &&
+                       smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 1 - i] ==
+                       smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 1 - (i - k)]) {
+                    i += 1;
                 }
+                int n = std::min(i - k, rep_limit);
+                smpl->dry_repeat_count[last - k] = n;
+                lt = k;
+                rt = i - 1;
             }
         }
     }
 
-    // Step 3: Iterate over dry_repeat_count and last_tokens, examining the maximum repeat length
-    // that would be generated by emitting each new token that would extend a sequence.
-    //
-    // Following the same example as above:
-    // Last N tokens: a b c c b c y a b c
-    // Repeat counts: 0 0 3 1 0 2 0 0 0 0
-    //
-    // For each non-zero, look ahead one token. This token, if emitted, would extend the repetition.
-    // c: 3 -> 4 (from `a b c` to `a b c c`)
-    // b: 1 -> 2 (from `c` to `c b`)
-    // y: 2 -> 3 (from `b c` to `b c y`)
-
+    // Step 5: Build penalty map
     for (int i = 0; i < last_n_repeat - 1; ++i) {
-        int repeat_len = ctx->dry_repeat_count[i];
-        if (repeat_len >= ctx->dry_allowed_length) {
-            // This token ends a repeat, so the next token would continue one.
-            // By convention, the value of `repeat_len` only includes the tokens currently
-            // in the context, not the new token that would be added.
-            llama_token token = ctx->last_tokens.rat(last_n_repeat - 2 - i);
-            // Track the maximum sequence ending in this token.
-            const auto& it = ctx->dry_max_token_repeat.find(token);
-            if (it == ctx->dry_max_token_repeat.end() || it->second < repeat_len) {
-                ctx->dry_max_token_repeat[token] = repeat_len;
+        int repeat_len = smpl->dry_repeat_count[i];
+        if (repeat_len >= dry_allowed_length) {
+            llama_token token = smpl->dry_last_tokens[smpl->dry_last_tokens.size() - 2 - i];
+            auto it = smpl->dry_max_token_repeat.find(token);
+            if (it == smpl->dry_max_token_repeat.end() || it->second < repeat_len) {
+                smpl->dry_max_token_repeat[token] = repeat_len;
             }
         }
     }
 
-    // Step 4: Apply logit penalties based on the maximum repeat length for relevant tokens.
-
-    // Prevent floating point overflow in `pow(penalty_base, exponent)` by clamping to `max_exponent`.
-    // Compute it from `penalty_base` and the approximate log of `std::numeric_limits<float>::max()`
+    // Step 6: Apply penalties
     const float FLOAT_MAX_LOG = 88.7228391f;
     int max_exponent = 0;
-    if (ctx->dry_base > 1.000001f) {
-        max_exponent = FLOAT_MAX_LOG / std::log(ctx->dry_base);
+    if (dry_base > 1.000001f) {
+        max_exponent = FLOAT_MAX_LOG / std::log(dry_base);
     }
 
-    for (size_t i = 0; i < cur_p->size; ++i) {
-        const auto& af_kvp = ctx->dry_max_token_repeat.find(cur_p->data[i].id);
-        if (af_kvp != ctx->dry_max_token_repeat.end()) {
-            // Check all sequence breakers starting with this token
-            auto range = ctx->dry_processed_breakers.equal_range(cur_p->data[i].id);
+    for (size_t i = 0; i < candidates->size; ++i) {
+        auto it = smpl->dry_max_token_repeat.find(candidates->data[i].id);
+        if (it != smpl->dry_max_token_repeat.end()) {
+            // Check if it's a single-token sequence breaker
+            auto range = smpl->dry_processed_breakers.equal_range(candidates->data[i].id);
             bool is_single_token_breaker = false;
-
-            for (auto it = range.first; it != range.second; ++it) {
-                if (it->second.empty()) {
+            for (auto br_it = range.first; br_it != range.second; ++br_it) {
+                if (br_it->second.empty()) {
                     is_single_token_breaker = true;
                     break;
                 }
             }
 
-            // Apply penalty only if it's not a single-token sequence breaker
             if (!is_single_token_breaker) {
-                int repeat_exp = af_kvp->second - ctx->dry_allowed_length;
+                int repeat_exp = it->second - dry_allowed_length;
                 if (max_exponent > 0 && repeat_exp > max_exponent) {
                     repeat_exp = max_exponent;
                 }
-                float penalty = ctx->dry_multiplier * std::pow(ctx->dry_base, repeat_exp);
-                cur_p->data[i].logit -= penalty;
+                float penalty = dry_multiplier * std::pow(dry_base, repeat_exp);
+                candidates->data[i].logit -= penalty;
             }
         }
     }
 
-    cur_p->sorted = false;
+    candidates->sorted = false;
 }
 
-static void llama_sampler_dry_reset(struct llama_sampler * smpl) {
-    auto * ctx = (llama_sampler_dry *) smpl->ctx;
-    ctx->last_tokens.clear();
-    ctx->dry_repeat_count.clear();
-    ctx->dry_max_token_repeat.clear();
-}
-
-static struct llama_sampler * llama_sampler_dry_clone(const struct llama_sampler * smpl) {
-    const auto * ctx = (llama_sampler_dry *) smpl->ctx;
-
-    // nullptr is passed as vocab because it is only needed for raw sequence breaker processing, which we have already done and will be copying
-    auto * result = llama_sampler_init_dry(nullptr, ctx->dry_multiplier, ctx->dry_base, ctx->dry_allowed_length, ctx->dry_penalty_last_n, NULL, 0);
-    // Copy the state, including the processed breakers
-    {
-        auto * result_ctx = (llama_sampler_dry *) result->ctx;
-        result_ctx->dry_processed_breakers = ctx->dry_processed_breakers;
-        result_ctx->dry_repeat_count = ctx->dry_repeat_count;
-        result_ctx->dry_max_token_repeat = ctx->dry_max_token_repeat;
-        result_ctx->last_tokens = ctx->last_tokens;
-    }
-
-    return result;
-}
-
-static void llama_sampler_dry_free(struct llama_sampler * smpl) {
-    delete (llama_sampler_dry *) smpl->ctx;
-}
-
-static struct llama_sampler_i llama_sampler_dry_i = {
-    /* .name   = */ llama_sampler_dry_name,
-    /* .accept = */ llama_sampler_dry_accept,
-    /* .apply  = */ llama_sampler_dry_apply,
-    /* .reset  = */ llama_sampler_dry_reset,
-    /* .clone  = */ llama_sampler_dry_clone,
-    /* .free   = */ llama_sampler_dry_free,
-};
-
-struct llama_sampler * llama_sampler_init_dry_impl(const struct llama_vocab & vocab, int32_t context_size, float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const char** seq_breakers, size_t num_breakers) {
-    int32_t effective_dry_penalty_last_n = (dry_penalty_last_n == -1) ? context_size : std::max(dry_penalty_last_n, 0);
-    std::unordered_multimap<llama_token, std::vector<llama_token>> processed_breakers;
-    const int MAX_CHAR_LEN = 40;
-    const int MAX_SEQ_LEN = 20;
-
-    const bool dry_enabled = (dry_multiplier != 0.0f && dry_base >= 1.0f && dry_penalty_last_n != 0);
-
-    if (dry_enabled && seq_breakers != nullptr && num_breakers > 0) {
-        // Process sequence breakers
-        for (size_t i = 0; i < num_breakers; ++i) {
-            if (seq_breakers[i] == nullptr || std::strlen(seq_breakers[i]) == 0) {
-                LLAMA_LOG_WARN("skipping null or empty DRY sequence breaker at index %zu\n", i);
-                continue;
-            }
-
-            std::string sequence_break(seq_breakers[i]);
-            if (sequence_break.empty()) {
-                LLAMA_LOG_WARN("skipping empty DRY sequence breaker\n");
-                continue;
-            }
-
-            if (sequence_break.size() > MAX_CHAR_LEN) {
-                LLAMA_LOG_WARN("truncating DRY sequence breaker to %d characters\n", MAX_CHAR_LEN);
-                sequence_break.resize(MAX_CHAR_LEN);
-            }
-
-            get_overlapping_token_sequences(vocab, sequence_break, processed_breakers, MAX_SEQ_LEN);
-        }
-    }
-
-    return new llama_sampler {
-        /* .iface = */ &llama_sampler_dry_i,
-        /* .ctx   = */ new llama_sampler_dry {
-            /* .total_context_size     = */ context_size,
-            /* .dry_multiplier         = */ dry_multiplier,
-            /* .dry_base               = */ dry_base,
-            /* .dry_allowed_length     = */ dry_allowed_length,
-            /* .dry_penalty_last_n     = */ dry_penalty_last_n,
-            /* .dry_processed_breakers = */ std::move(processed_breakers),
-            /* .dry_repeat_count       = */ dry_enabled ? std::vector<int>(effective_dry_penalty_last_n, 0) : std::vector<int>{},
-            /* .dry_max_token_repeat   = */ {},
-            /* .last_tokens            = */ dry_enabled ? ring_buffer<llama_token>(effective_dry_penalty_last_n) : ring_buffer<llama_token>(0),
-        },
-    };
-}
-
-// wrapper for test-sampling.cpp
-struct llama_sampler * llama_sampler_init_dry_testing(int32_t context_size, float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const std::vector<std::vector<llama_token>>& seq_breakers) {
-    llama_vocab dummy_vocab;
-    auto * result = llama_sampler_init_dry_impl(dummy_vocab, context_size, dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n, NULL, 0);
-    auto * ctx = (llama_sampler_dry *) result->ctx;
-
-    // Process the token-based sequence breakers
-    ctx->dry_processed_breakers.clear();
-    if (seq_breakers.empty()) {
-        LLAMA_LOG_WARN("empty DRY sequence breakers list in llama_sampler_init_dry_testing\n");
-    } else {
-        for (const auto& breaker : seq_breakers) {
-            if (breaker.empty()) {
-                LLAMA_LOG_WARN("skipping DRY empty sequence breaker\n");
-                continue;
-            }
-            llama_token head_token = breaker[0];
-            std::vector<llama_token> tail_tokens(breaker.begin() + 1, breaker.end());
-            ctx->dry_processed_breakers.emplace(head_token, std::move(tail_tokens));
-        }
-
-        if (ctx->dry_processed_breakers.empty()) {
-            LLAMA_LOG_WARN("no valid DRY sequence breakers processed in llama_sampler_init_dry_testing\n");
-        }
-    }
-
-    return result;
-}
-
-//DRY end
  
 
 void llama_sample_repetition_penalties_impl(

--- a/src/llama-sampling.h
+++ b/src/llama-sampling.h
@@ -12,6 +12,13 @@ struct llama_sampling {
     mutable int64_t t_sample_us = 0;
     mutable int32_t n_sample = 0;
 
+    // DRY sampler state
+    std::unordered_multimap<llama_token, std::vector<llama_token>> dry_processed_breakers;
+    std::vector<llama_token> dry_last_tokens;
+    std::vector<int> dry_repeat_count;
+    std::unordered_map<llama_token, int> dry_max_token_repeat;
+    bool dry_breakers_initialized = false;
+
     void reset_timings() const {
         t_sample_us = 0;
         n_sample = 0;
@@ -34,6 +41,9 @@ void llama_sample_entropy_impl  (struct llama_sampling * smpl, llama_token_data_
 void llama_sample_temp_impl     (struct llama_sampling * smpl, llama_token_data_array * candidates, float temp);
 void llama_sample_xtc_impl      (struct llama_sampling * smpl, llama_token_data_array * candidates, float probability, float threshold, size_t min_keep);
 void llama_sample_top_n_sigma_impl(struct llama_sampling * smpl, llama_token_data_array * candidates, float top_n_sigma);
+void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array * candidates,
+                          float dry_multiplier, float dry_base, int32_t dry_allowed_length,
+                          int32_t dry_penalty_last_n, const std::vector<std::string> & dry_sequence_breakers);
 
 void llama_sample_repetition_penalties_impl(
         struct llama_sampling * smpl,

--- a/src/llama-sampling.h
+++ b/src/llama-sampling.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "llama-impl.h"
+#include <vector>
+#include <unordered_map>
 
 struct llama_sampling {
     llama_sampling(int32_t n_vocab) : n_vocab(n_vocab) {}
 
     std::mt19937 rng;
-
     int32_t n_vocab = 0;
-
     mutable int64_t t_sample_us = 0;
     mutable int32_t n_sample = 0;
 
@@ -41,9 +41,13 @@ void llama_sample_entropy_impl  (struct llama_sampling * smpl, llama_token_data_
 void llama_sample_temp_impl     (struct llama_sampling * smpl, llama_token_data_array * candidates, float temp);
 void llama_sample_xtc_impl      (struct llama_sampling * smpl, llama_token_data_array * candidates, float probability, float threshold, size_t min_keep);
 void llama_sample_top_n_sigma_impl(struct llama_sampling * smpl, llama_token_data_array * candidates, float top_n_sigma);
+
+
 void llama_sample_dry_impl(struct llama_sampling * smpl, llama_token_data_array * candidates,
                           float dry_multiplier, float dry_base, int32_t dry_allowed_length,
                           int32_t dry_penalty_last_n, const std::vector<std::string> & dry_sequence_breakers);
+
+
 
 void llama_sample_repetition_penalties_impl(
         struct llama_sampling * smpl,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -23373,13 +23373,14 @@ void llama_sample_dry(struct llama_context * ctx, llama_token_data_array * candi
 void llama_sample_dry_accept_token(struct llama_context * ctx, llama_token token) {
     if (!ctx) return;
 
+#ifdef DRY_DEBUG
     //Debug
     static int accept_count = 0;
     if (++accept_count <= 5) {
         fprintf(stderr, "DRY ACCEPT %d: token=%d history_size=%zu\n",
                 accept_count, token, ctx->sampling.dry_last_tokens.size());
     }
-
+#endif
     ctx->sampling.dry_last_tokens.push_back(token);
 
     // Only bound by actual context size to prevent infinite memory growth

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -23372,6 +23372,14 @@ void llama_sample_dry(struct llama_context * ctx, llama_token_data_array * candi
 
 void llama_sample_dry_accept_token(struct llama_context * ctx, llama_token token) {
     if (!ctx) return;
+
+    //Debug
+    static int accept_count = 0;
+    if (++accept_count <= 5) {
+        fprintf(stderr, "DRY ACCEPT %d: token=%d history_size=%zu\n",
+                accept_count, token, ctx->sampling.dry_last_tokens.size());
+    }
+
     ctx->sampling.dry_last_tokens.push_back(token);
 
     // Only bound by actual context size to prevent infinite memory growth


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [X] Medium
  - [ ] High

So with some vibe coding I added what should be a working dry implementation. Nothing has exploded. Also the server was never modified to use the new samplers so they did nothing unless you were using the main llama.cpp executable without a front end.

I didn't update docs as the other PR seems to do that (but not the server, lol). Let me know if this is any good or not. Much lighter than porting the new sampler arch. 

There's also a spot in the header where sampler order array was never updated? Does it have to be?