### PR TITLE
IQ1_S: much faster CPU prompt processing

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1205,7 +1205,11 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_iq1_s,
         .from_float_ref           = (ggml_from_float_t)quantize_row_iq1_s_ref,
         .vec_dot                  = ggml_vec_dot_iq1_s_q8_K,
+#ifdef __AVX2__
+        .vec_dot_type             = GGML_TYPE_Q8_2_X4,
+#else
         .vec_dot_type             = GGML_TYPE_Q8_K,
+#endif
         .nrows                    = 1,
         .row_meta_size            = 0,
     },

--- a/ggml/src/iqk/iqk_gemm_1bit.h
+++ b/ggml/src/iqk/iqk_gemm_1bit.h
@@ -8,4 +8,6 @@
 
 bool iqk_set_kernels_1bit(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels, mul_mat_t& func16);
 
+bool iqk_convert_1bit_q80_r8(int type, int n, const void * vx, size_t bx, void * vy, int nrc_x);
+
 #endif

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -236,11 +236,12 @@ struct MulMat {
     static inline ggml_type is_dequant_better(ggml_type type, int nrc_y) {
 #ifdef __AVX2__
         switch (type) {
-            case GGML_TYPE_IQ2_KT: return nrc_y >= 32 ? GGML_TYPE_F32 : type;
-            case GGML_TYPE_IQ3_KT: return nrc_y >= 32 ? GGML_TYPE_F32 : type;
-            case GGML_TYPE_IQ4_KT: return nrc_y >= 32 ? GGML_TYPE_F32 : type;
+            case GGML_TYPE_IQ2_KT : return nrc_y >= 32 ? GGML_TYPE_F32 : type;
+            case GGML_TYPE_IQ3_KT : return nrc_y >= 32 ? GGML_TYPE_F32 : type;
+            case GGML_TYPE_IQ4_KT : return nrc_y >= 32 ? GGML_TYPE_F32 : type;
             case GGML_TYPE_IQ2_XXS: return nrc_y >= 32 ? GGML_TYPE_Q8_0_R8 : type;
             case GGML_TYPE_IQ3_XXS: return nrc_y >= 32 ? GGML_TYPE_Q8_0_R8 : type;
+            case GGML_TYPE_IQ1_S  : return nrc_y >= 32 ? GGML_TYPE_Q8_0_R8 : type;
             default: break;
         }
 #else
@@ -397,13 +398,13 @@ bool iqk_convert_repack(int typeA, int n, const void * vx, size_t bx, void * vy,
         //case GGML_TYPE_Q8_0_R8:
         //case GGML_TYPE_IQ4_NL_R4:
         //    return iqk_set_kernels_legacy_quants(ne00, typeA, typeB, mm.funcs, mm.func16);
-        //case GGML_TYPE_IQ1_S:
+        case GGML_TYPE_IQ1_S:
         //case GGML_TYPE_IQ1_S_R4:
         //case GGML_TYPE_IQ1_M_R4:
         //case GGML_TYPE_IQ1_BN:
         //case GGML_TYPE_IQ2_BN:
         //case GGML_TYPE_IQ2_BN_R4:
-        //    return iqk_set_kernels_1bit(ne00, typeA, typeB, mm.funcs, mm.func16);
+            return iqk_convert_1bit_q80_r8(typeA, n, vx, bx, vy, nrc_x);
 
         default:
             return false;


### PR DESCRIPTION

This PR is a follow up of #515 and #516, and applies the same technique to `IQ1_S`. We see nearly 2X increase in prompt processing speed compared to `IQ1_S` and `IQ1_S_R4.

Sweep-bench for `IQ1_S` quantization of LlaMA-3.1-8B on a Ryzen-7950X CPU:

### IQ1_S, main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|   512 |    128 |      0 |    3.272 |   156.47 |    4.605 |    27.79 |
|   512 |    128 |    512 |    3.351 |   152.77 |    5.092 |    25.14 |
|   512 |    128 |   1024 |    3.402 |   150.52 |    5.084 |    25.18 |
|   512 |    128 |   1536 |    3.677 |   139.25 |    5.201 |    24.61 |
|   512 |    128 |   2048 |    3.586 |   142.79 |    5.515 |    23.21 |

### IQ1_S_R4, main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|   512 |    128 |      0 |    3.101 |   165.10 |    4.543 |    28.18 |
|   512 |    128 |    512 |    3.166 |   161.74 |    4.836 |    26.47 |
|   512 |    128 |   1024 |    3.309 |   154.75 |    5.282 |    24.23 |
|   512 |    128 |   1536 |    3.348 |   152.92 |    5.093 |    25.13 |
|   512 |    128 |   2048 |    3.447 |   148.55 |    5.265 |    24.31 |


### IQ1_S, PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|   512 |    128 |      0 |    1.855 |   275.94 |    4.643 |    27.57 |
|   512 |    128 |    512 |    1.940 |   263.87 |    5.056 |    25.32 |
|   512 |    128 |   1024 |    2.188 |   234.05 |    5.099 |    25.10 |
|   512 |    128 |   1536 |    2.097 |   244.20 |    5.112 |    25.04 |
|   512 |    128 |   2048 |    2.184 |   234.42 |    5.368 |    23.85 |
