### PR TITLE
Much faster CPU prompt processing (part 2)

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1699,7 +1699,11 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_iq5_k,
         .from_float_ref           = (ggml_from_float_t)quantize_row_iq5_k_ref,
         .vec_dot                  = vec_dot_iq5_k_q8_k,
+//#ifdef __AVX2__
+//        .vec_dot_type             = GGML_TYPE_Q8_2_X4,
+//#else
         .vec_dot_type             = GGML_TYPE_Q8_K,
+//#endif
         .nrows                    = 1,
         .row_meta_size            = 0,
     },

--- a/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
@@ -2053,7 +2053,119 @@ template <typename Dequantizer> void set_functions(std::array<mul_mat_t, IQK_MAX
 #endif
 }
 
+inline float convert_to_q8_k_r8(int k, float d0, const __m256i * qx, const int16_t * scales, uint32_t * block, int8_t * q8_k) {
+    auto max_i16 = _mm256_setzero_si256();
+    __m256i qs[16];
+    for (int ib32 = 0; ib32 < 8; ++ib32) {
+        qs[2*ib32+0] = _mm256_cvtepi8_epi16(_mm256_castsi256_si128(qx[ib32]));
+        qs[2*ib32+1] = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(qx[ib32], 1));
+        qs[2*ib32+0] = _mm256_mullo_epi16(qs[2*ib32+0], _mm256_set1_epi16(scales[2*ib32+0]));
+        qs[2*ib32+1] = _mm256_mullo_epi16(qs[2*ib32+1], _mm256_set1_epi16(scales[2*ib32+1]));
+        max_i16 = _mm256_max_epi16(max_i16, _mm256_sign_epi16(qs[2*ib32+0], qs[2*ib32+0]));
+        max_i16 = _mm256_max_epi16(max_i16, _mm256_sign_epi16(qs[2*ib32+1], qs[2*ib32+1]));
+    }
+    auto max_q32 = _mm256_cvtepi16_epi32(_mm_max_epi16(_mm256_castsi256_si128(max_i16), _mm256_extracti128_si256(max_i16, 1)));
+    auto imax4 = _mm_max_epi32(_mm256_castsi256_si128(max_q32), _mm256_extracti128_si256(max_q32, 1));
+    auto max4  = _mm_cvtepi32_ps(imax4);
+    max4 = _mm_max_ps(max4, _mm_movehl_ps(max4, max4));
+    max4 = _mm_max_ss(max4, _mm_movehdup_ps(max4));
+    bool needs_scaling = true;
+    float dnew = _mm_cvtss_f32(max4) * d0;
+    if (dnew < 1.f) {
+        dnew = 1.f; needs_scaling = false;
+    }
+    auto scale = _mm256_set1_ps(std::abs(dnew) > 1e-9f ? 1/dnew : 0.f);
+    for (int ib32 = 0; ib32 < 8; ++ib32) {
+        if (needs_scaling) {
+            auto i0 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(qs[2*ib32+0]));
+            auto i1 = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(qs[2*ib32+0], 1));
+            auto i2 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(qs[2*ib32+1]));
+            auto i3 = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(qs[2*ib32+1], 1));
+            i0 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i0)), _MM_ROUND_NEAREST));
+            i1 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i1)), _MM_ROUND_NEAREST));
+            i2 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i2)), _MM_ROUND_NEAREST));
+            i3 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i3)), _MM_ROUND_NEAREST));
+            i0 = _mm256_packs_epi32(i0, i1);
+            i2 = _mm256_packs_epi32(i2, i3);
+            i0 = _mm256_packs_epi16(i0, i2);
+            i0 = _mm256_permutevar8x32_epi32(i0, _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7));
+            _mm256_storeu_si256((__m256i *)block, i0);
+        } else {
+            // 0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 17, 18, 19, 20, 21, 22, 23, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31
+            auto i0 = _mm256_packs_epi16(qs[2*ib32+0], qs[2*ib32+1]);
+            auto i0_l = _mm256_castsi256_si128(i0);
+            auto i0_h = _mm256_extracti128_si256(i0, 1);
+            _mm_storeu_si128((__m128i *)block+0, _mm_unpacklo_epi64(i0_l, i0_h));
+            _mm_storeu_si128((__m128i *)block+1, _mm_unpackhi_epi64(i0_l, i0_h));
+        }
+        auto qs = (uint32_t *)q8_k + 64*ib32;
+        for (int l = 0; l < 8; ++l) {
+            qs[8*l + k] = block[l];
+        }
+    }
+    return dnew;
+}
+
+void iqk_convert_iq4_ks_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
+    GGML_ASSERT(n%QK_K == 0);
+    GGML_ASSERT(nrc_x%8 == 0);
+
+    int nb = n/QK_K;
+
+    const block_iq4_ks * x8[8];
+
+    block_q8_k_r8 * y = (block_q8_k_r8 *)vy;
+
+    __m256i values[2];
+    {
+        auto v1 = _mm_loadu_si128((const __m128i *)iq4k_values+0);
+        auto v2 = _mm_loadu_si128((const __m128i *)iq4k_values+1);
+        values[0] = MM256_SET_M128I(v1, v1);
+        values[1] = MM256_SET_M128I(v2, v2);
+    }
+
+    float drow[8];
+    float dnew[8];
+    int16_t ls[16];
+
+    __m256i xv[8];
+    uint32_t block[8];
+
+    for (int ix = 0; ix < nrc_x; ix += 8) {
+        for (int k = 0; k < 8; ++k) {
+            const float * dptr = (const float *)((const char *)vx + (ix + k)*bx);
+            drow[k] = dptr[0];
+            x8[k] = (const block_iq4_ks *)(dptr + 1);
+        }
+        auto vd = _mm256_loadu_ps(drow);
+        for (int i = 0; i < nb; ++i) {
+            for (int k = 0; k < 8; ++k) {
+                for (int ib32 = 0; ib32 < 8; ++ib32) {
+                    ls[2*ib32+0] = (x8[k][i].scales[ib32] & 254) - 127;
+                    ls[2*ib32+1] = ls[2*ib32+0];
+                    auto aux128 = _mm_loadu_si128((const __m128i *)x8[k][i].qs+ib32);
+                    xv[ib32] = _mm256_and_si256(MM256_SET_M128I(_mm_srli_epi16(aux128, 4), aux128), _mm256_set1_epi8(0xf));
+                    xv[ib32] = _mm256_shuffle_epi8(values[x8[k][i].scales[ib32] & 1], xv[ib32]);
+                }
+                dnew[k] = convert_to_q8_k_r8(k, 1.f/127, xv, ls, block, y[i].qs);
+            }
+            _mm_storeu_si128((__m128i *)y[i].d, _mm256_cvtps_ph(_mm256_mul_ps(vd, _mm256_loadu_ps(dnew)), _MM_ROUND_NEAREST));
+        }
+        y += nb;
+    }
+}
+
+
 } // namespace
+
+bool iqk_convert_iqk_quants_q80_r8(int type, int n, const void * vx, size_t bx, void * vy, int nrc_x) {
+    if (n%QK_K != 0 || nrc_x%8 != 0) return false;
+    switch (ggml_type(type)) {
+        case GGML_TYPE_IQ4_KS : iqk_convert_iq4_ks_q8_k_r8(n, vx, bx, vy, nrc_x); break;
+        default: return false;
+    }
+    return true;
+}
 
 bool iqk_set_kernels_iqk_quants(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels, mul_mat_t& func16) {
 

--- a/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
@@ -2106,50 +2106,100 @@ inline float convert_to_q8_k_r8(int k, float d0, const __m256i * qx, const int16
     return dnew;
 }
 
-//struct DequantizerIQ3K final : public BaseDequantizer<block_iq3_k> {
-//    DequantizerIQ3K(const void * vx, size_t bx) : BaseDequantizer(vx, bx), iqxk(4, -64), values(load_values()) {}
+//struct DequantizerIQ2K final : public BaseDequantizer<block_iq2_k> {
+//    DequantizerIQ2K(const void * vx, size_t bx) : BaseDequantizer(vx, bx), iqxk(5, -32), values(load_values()) {}
 //    template <typename Q8>
 //    inline void new_block(int i, const Q8& q8, __m256 * accm, __m256i * scales) {
 //        d = GGML_FP16_TO_FP32(x[i].d);
-//        iqxk.process(i, d, x[i].extra, make_scales(x[i].scales_h, x[i].scales_l), q8, accm, scales);
-//        hbits = _mm256_loadu_si256((const __m256i *)x[i].qh);
+//        iqxk.process(i, d, x[i].extra, make_scales(x[i].scales), q8, accm, scales);
 //    }
 //    inline void prepare(int i, int j) {
 //        bits.prepare(x[i].qs, j);
-//        auto h256 = j == 0 ? hbits : _mm256_srli_epi16(hbits, 4);
-//        bits.values[0] = _mm256_or_si256(bits.values[0], _mm256_and_si256(_mm256_slli_epi16(h256, 2), hmask));
-//        bits.values[1] = _mm256_or_si256(bits.values[1], _mm256_and_si256(_mm256_slli_epi16(h256, 1), hmask));
-//        bits.values[2] = _mm256_or_si256(bits.values[2], _mm256_and_si256(h256, hmask));
-//        bits.values[3] = _mm256_or_si256(bits.values[3], _mm256_and_si256(_mm256_srli_epi16(h256, 1), hmask));
 //        bits.values[0] = _mm256_shuffle_epi8(values, bits.values[0]);
 //        bits.values[1] = _mm256_shuffle_epi8(values, bits.values[1]);
 //        bits.values[2] = _mm256_shuffle_epi8(values, bits.values[2]);
 //        bits.values[3] = _mm256_shuffle_epi8(values, bits.values[3]);
 //    }
 //    static inline __m256i load_values() {
-//        static const uint8_t kvalues_iq3nl[16] = {1, 24, 41, 54, 65, 77, 92, 111, 5, 28, 45, 58, 69, 81, 96, 115};
-//        auto val128 = _mm_loadu_si128((const __m128i *)kvalues_iq3nl);
+//        static const uint8_t kvalues_iq2nl[16] = {1, 19, 33, 49, 0, 0, 0, 0,  6, 24, 38, 54, 0, 0, 0, 0};
+//        auto val128 = _mm_loadu_si128((const __m128i *)kvalues_iq2nl);
 //        return MM256_SET_M128I(val128, val128);
 //    }
-//    inline __m128i make_scales(uint16_t signs, const uint8_t * scales_l) const {
+//    inline __m128i make_scales(const uint8_t * scales_l) const {
 //        uint64_t aux64; std::memcpy(&aux64, scales_l, 8);
-//        auto scl = _mm_and_si128(_mm_set_epi64x(aux64 >> 4, aux64), _mm_set1_epi8(0xf));
-//        scl = _mm_add_epi8(_mm_slli_epi16(scl, 1), m1);
-//        const __m128i sc_signs = _mm_cmpeq_epi8(_mm_and_si128(_mm_set1_epi16(signs), sign_mask), sign_mask);
-//        const __m128i sch = _mm_shuffle_epi8(_mm_or_si128(sc_signs, _mm_set1_epi8(1)), hshuff);
-//        return _mm_sign_epi8(scl, sch);
+//        auto scl = _mm_and_si128(_mm_set_epi64x(aux64 >> 4, aux64), maskl);
+//        return _mm_add_epi8(scl, m8);
 //    }
 //
 //    Q2Bits bits;
 //    const IQXKScales iqxk;
 //    const __m256i values;
-//    __m256i hbits;
-//    const __m256i hmask  = _mm256_set1_epi8(4);
-//    const __m128i m1 = _mm_set1_epi8(1);
-//    const __m128i sign_mask = _mm_set_epi64x(0x8080404020201010, 0x0808040402020101);
-//    const __m128i hshuff = _mm_loadu_si128((const __m128i*)k_shuff);
-//    constexpr static uint8_t k_shuff[16] = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
+//    const __m128i m8       = _mm_set1_epi8(-8);
+//    const __m128i maskl    = _mm_set1_epi8(0xf);
 //};
+
+void iqk_convert_iq2_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
+    GGML_ASSERT(n%QK_K == 0);
+    GGML_ASSERT(nrc_x%8 == 0);
+
+    int nb = n/QK_K;
+
+    const block_iq2_k * x8[8];
+
+    block_q8_k_r8 * y = (block_q8_k_r8 *)vy;
+
+    __m256i values;
+    {
+        auto v = _mm_loadl_epi64((const __m128i *)iq2nl_values);
+        values = MM256_SET_M128I(v, v);
+    }
+
+    __m256i  xv[8];
+    uint32_t block[8];
+
+    const __m128i scale_shuffle = _mm_set_epi32(0x0f070e06, 0x0d050c04, 0x0b030a02, 0x09010800);
+
+    union { __m256i vec; int16_t val[16]; } helper;
+
+    auto ml = _mm256_set1_epi8(0x03);
+
+    for (int ix = 0; ix < nrc_x; ix += 8) {
+        for (int k = 0; k < 8; ++k) x8[k] = (const block_iq2_k *)((const char *)vx + (ix+k)*bx);
+        for (int i = 0; i < nb; ++i) {
+            for (int k = 0; k < 8; ++k) {
+                float d = GGML_FP16_TO_FP32(x8[k][i].d);
+                uint64_t aux64; std::memcpy(&aux64, x8[k][i].scales, 8);
+                auto scl = _mm_and_si128(_mm_set_epi64x(aux64 >> 4, aux64), _mm_set1_epi8(0xf));
+                scl = _mm_add_epi8(scl, _mm_set1_epi8(-8));
+                helper.vec = _mm256_cvtepi8_epi16(_mm_shuffle_epi8(scl, scale_shuffle));
+                auto extra = x8[k][i].extra;
+                for (int i128 = 0; i128 < 2; ++i128) {
+                    auto bits = _mm256_loadu_si256((const __m256i *)x8[k][i].qs+i128);
+                    xv[4*i128+0] = _mm256_and_si256(bits, ml);
+                    xv[4*i128+1] = _mm256_and_si256(_mm256_srli_epi16(bits, 2), ml);
+                    xv[4*i128+2] = _mm256_and_si256(_mm256_srli_epi16(bits, 4), ml);
+                    xv[4*i128+3] = _mm256_and_si256(_mm256_srli_epi16(bits, 6), ml);
+                    auto shift1 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x02) << 1), _mm_set1_epi8((extra & 0x01) << 2));
+                    auto shift2 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x08) >> 1), _mm_set1_epi8((extra & 0x04) >> 0));
+                    auto shift3 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x20) >> 3), _mm_set1_epi8((extra & 0x10) >> 2));
+                    auto shift4 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x80) >> 5), _mm_set1_epi8((extra & 0x40) >> 4));
+                    xv[4*i128+0] = _mm256_add_epi8(xv[4*i128+0], shift1);
+                    xv[4*i128+1] = _mm256_add_epi8(xv[4*i128+1], shift2);
+                    xv[4*i128+2] = _mm256_add_epi8(xv[4*i128+2], shift3);
+                    xv[4*i128+3] = _mm256_add_epi8(xv[4*i128+3], shift4);
+                    xv[4*i128+0] = _mm256_shuffle_epi8(values, xv[4*i128+0]);
+                    xv[4*i128+1] = _mm256_shuffle_epi8(values, xv[4*i128+1]);
+                    xv[4*i128+2] = _mm256_shuffle_epi8(values, xv[4*i128+2]);
+                    xv[4*i128+3] = _mm256_shuffle_epi8(values, xv[4*i128+3]);
+                    extra >>= 8;
+                }
+                float dnew = convert_to_q8_k_r8(k, 1.f/120, xv, helper.val, block, y[i].qs);
+                y[i].d[k] = GGML_FP32_TO_FP16(d*dnew);
+            }
+        }
+        y += nb;
+    }
+}
 
 void iqk_convert_iq3_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
     GGML_ASSERT(n%QK_K == 0);
@@ -2647,6 +2697,7 @@ void iqk_convert_iq6_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int
 bool iqk_convert_iqk_quants_q80_r8(int type, int n, const void * vx, size_t bx, void * vy, int nrc_x) {
     if (n%QK_K != 0 || nrc_x%8 != 0) return false;
     switch (ggml_type(type)) {
+        case GGML_TYPE_IQ2_K  : iqk_convert_iq2_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ3_K  : iqk_convert_iq3_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ4_KS : iqk_convert_iq4_ks_q8_k_r8(n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ4_K  : iqk_convert_iq4_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;

--- a/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
@@ -2106,6 +2106,126 @@ inline float convert_to_q8_k_r8(int k, float d0, const __m256i * qx, const int16
     return dnew;
 }
 
+//struct DequantizerIQ3K final : public BaseDequantizer<block_iq3_k> {
+//    DequantizerIQ3K(const void * vx, size_t bx) : BaseDequantizer(vx, bx), iqxk(4, -64), values(load_values()) {}
+//    template <typename Q8>
+//    inline void new_block(int i, const Q8& q8, __m256 * accm, __m256i * scales) {
+//        d = GGML_FP16_TO_FP32(x[i].d);
+//        iqxk.process(i, d, x[i].extra, make_scales(x[i].scales_h, x[i].scales_l), q8, accm, scales);
+//        hbits = _mm256_loadu_si256((const __m256i *)x[i].qh);
+//    }
+//    inline void prepare(int i, int j) {
+//        bits.prepare(x[i].qs, j);
+//        auto h256 = j == 0 ? hbits : _mm256_srli_epi16(hbits, 4);
+//        bits.values[0] = _mm256_or_si256(bits.values[0], _mm256_and_si256(_mm256_slli_epi16(h256, 2), hmask));
+//        bits.values[1] = _mm256_or_si256(bits.values[1], _mm256_and_si256(_mm256_slli_epi16(h256, 1), hmask));
+//        bits.values[2] = _mm256_or_si256(bits.values[2], _mm256_and_si256(h256, hmask));
+//        bits.values[3] = _mm256_or_si256(bits.values[3], _mm256_and_si256(_mm256_srli_epi16(h256, 1), hmask));
+//        bits.values[0] = _mm256_shuffle_epi8(values, bits.values[0]);
+//        bits.values[1] = _mm256_shuffle_epi8(values, bits.values[1]);
+//        bits.values[2] = _mm256_shuffle_epi8(values, bits.values[2]);
+//        bits.values[3] = _mm256_shuffle_epi8(values, bits.values[3]);
+//    }
+//    static inline __m256i load_values() {
+//        static const uint8_t kvalues_iq3nl[16] = {1, 24, 41, 54, 65, 77, 92, 111, 5, 28, 45, 58, 69, 81, 96, 115};
+//        auto val128 = _mm_loadu_si128((const __m128i *)kvalues_iq3nl);
+//        return MM256_SET_M128I(val128, val128);
+//    }
+//    inline __m128i make_scales(uint16_t signs, const uint8_t * scales_l) const {
+//        uint64_t aux64; std::memcpy(&aux64, scales_l, 8);
+//        auto scl = _mm_and_si128(_mm_set_epi64x(aux64 >> 4, aux64), _mm_set1_epi8(0xf));
+//        scl = _mm_add_epi8(_mm_slli_epi16(scl, 1), m1);
+//        const __m128i sc_signs = _mm_cmpeq_epi8(_mm_and_si128(_mm_set1_epi16(signs), sign_mask), sign_mask);
+//        const __m128i sch = _mm_shuffle_epi8(_mm_or_si128(sc_signs, _mm_set1_epi8(1)), hshuff);
+//        return _mm_sign_epi8(scl, sch);
+//    }
+//
+//    Q2Bits bits;
+//    const IQXKScales iqxk;
+//    const __m256i values;
+//    __m256i hbits;
+//    const __m256i hmask  = _mm256_set1_epi8(4);
+//    const __m128i m1 = _mm_set1_epi8(1);
+//    const __m128i sign_mask = _mm_set_epi64x(0x8080404020201010, 0x0808040402020101);
+//    const __m128i hshuff = _mm_loadu_si128((const __m128i*)k_shuff);
+//    constexpr static uint8_t k_shuff[16] = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
+//};
+
+void iqk_convert_iq3_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
+    GGML_ASSERT(n%QK_K == 0);
+    GGML_ASSERT(nrc_x%8 == 0);
+
+    int nb = n/QK_K;
+
+    const block_iq3_k * x8[8];
+
+    block_q8_k_r8 * y = (block_q8_k_r8 *)vy;
+
+    __m256i values;
+    {
+        auto v = _mm_loadu_si128((const __m128i *)iq3nl_values);
+        values = MM256_SET_M128I(v, v);
+    }
+
+    __m256i  xv[8];
+    uint32_t block[8];
+
+    constexpr static uint8_t k_shuff[16] = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
+    const __m128i sign_mask = _mm_set_epi64x(0x8080404020201010, 0x0808040402020101);
+    const __m128i hshuff = _mm_loadu_si128((const __m128i*)k_shuff);
+    const __m128i scale_shuffle = _mm_set_epi32(0x0f070e06, 0x0d050c04, 0x0b030a02, 0x09010800);
+
+    union { __m256i vec; int16_t val[16]; } helper;
+
+    auto ml = _mm256_set1_epi8(0x03);
+    auto hmask  = _mm256_set1_epi8(4);
+
+    for (int ix = 0; ix < nrc_x; ix += 8) {
+        for (int k = 0; k < 8; ++k) x8[k] = (const block_iq3_k *)((const char *)vx + (ix+k)*bx);
+        for (int i = 0; i < nb; ++i) {
+            for (int k = 0; k < 8; ++k) {
+                float d = GGML_FP16_TO_FP32(x8[k][i].d);
+                uint64_t aux64; std::memcpy(&aux64, x8[k][i].scales_l, 8);
+                auto scl = _mm_and_si128(_mm_set_epi64x(aux64 >> 4, aux64), _mm_set1_epi8(0xf));
+                scl = _mm_add_epi8(_mm_slli_epi16(scl, 1), _mm_set1_epi8(1));
+                auto sc_signs = _mm_cmpeq_epi8(_mm_and_si128(_mm_set1_epi16(x8[k][i].scales_h), sign_mask), sign_mask);
+                auto sch   = _mm_shuffle_epi8(_mm_or_si128(sc_signs, _mm_set1_epi8(1)), hshuff);
+                helper.vec = _mm256_cvtepi8_epi16(_mm_shuffle_epi8(_mm_sign_epi8(scl, sch), scale_shuffle));
+                auto extra = x8[k][i].extra;
+                auto hbits = _mm256_loadu_si256((const __m256i *)x8[k][i].qh);
+                for (int i128 = 0; i128 < 2; ++i128) {
+                    auto bits = _mm256_loadu_si256((const __m256i *)x8[k][i].qs+i128);
+                    xv[4*i128+0] = _mm256_and_si256(bits, ml);
+                    xv[4*i128+1] = _mm256_and_si256(_mm256_srli_epi16(bits, 2), ml);
+                    xv[4*i128+2] = _mm256_and_si256(_mm256_srli_epi16(bits, 4), ml);
+                    xv[4*i128+3] = _mm256_and_si256(_mm256_srli_epi16(bits, 6), ml);
+                    xv[4*i128+0] = _mm256_or_si256(xv[4*i128+0], _mm256_and_si256(_mm256_slli_epi16(hbits, 2), hmask));
+                    xv[4*i128+1] = _mm256_or_si256(xv[4*i128+1], _mm256_and_si256(_mm256_slli_epi16(hbits, 1), hmask));
+                    xv[4*i128+2] = _mm256_or_si256(xv[4*i128+2], _mm256_and_si256(hbits, hmask));
+                    xv[4*i128+3] = _mm256_or_si256(xv[4*i128+3], _mm256_and_si256(_mm256_srli_epi16(hbits, 1), hmask));
+                    auto shift1 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x02) << 2), _mm_set1_epi8((extra & 0x01) << 3));
+                    auto shift2 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x08) << 0), _mm_set1_epi8((extra & 0x04) << 1));
+                    auto shift3 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x20) >> 2), _mm_set1_epi8((extra & 0x10) >> 1));
+                    auto shift4 = MM256_SET_M128I(_mm_set1_epi8((extra & 0x80) >> 4), _mm_set1_epi8((extra & 0x40) >> 3));
+                    xv[4*i128+0] = _mm256_add_epi8(xv[4*i128+0], shift1);
+                    xv[4*i128+1] = _mm256_add_epi8(xv[4*i128+1], shift2);
+                    xv[4*i128+2] = _mm256_add_epi8(xv[4*i128+2], shift3);
+                    xv[4*i128+3] = _mm256_add_epi8(xv[4*i128+3], shift4);
+                    xv[4*i128+0] = _mm256_shuffle_epi8(values, xv[4*i128+0]);
+                    xv[4*i128+1] = _mm256_shuffle_epi8(values, xv[4*i128+1]);
+                    xv[4*i128+2] = _mm256_shuffle_epi8(values, xv[4*i128+2]);
+                    xv[4*i128+3] = _mm256_shuffle_epi8(values, xv[4*i128+3]);
+                    hbits = _mm256_srli_epi16(hbits, 4);
+                    extra >>= 8;
+                }
+                float dnew = convert_to_q8_k_r8(k, 1.f/127, xv, helper.val, block, y[i].qs);
+                y[i].d[k] = GGML_FP32_TO_FP16(d*dnew);
+            }
+        }
+        y += nb;
+    }
+}
+
 void iqk_convert_iq4_ks_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
     GGML_ASSERT(n%QK_K == 0);
     GGML_ASSERT(nrc_x%8 == 0);
@@ -2527,6 +2647,7 @@ void iqk_convert_iq6_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int
 bool iqk_convert_iqk_quants_q80_r8(int type, int n, const void * vx, size_t bx, void * vy, int nrc_x) {
     if (n%QK_K != 0 || nrc_x%8 != 0) return false;
     switch (ggml_type(type)) {
+        case GGML_TYPE_IQ3_K  : iqk_convert_iq3_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ4_KS : iqk_convert_iq4_ks_q8_k_r8(n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ4_K  : iqk_convert_iq4_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ5_KS : iqk_convert_iq5_ks_q8_k_r8(n, vx, bx, vy, nrc_x); break;

--- a/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
@@ -2214,53 +2214,6 @@ void iqk_convert_iq4_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int
     }
 }
 
-//struct DequantizerIQ5KS final : public BaseDequantizer<block_iq5_ks, true> {
-//    DequantizerIQ5KS(const void * vx, size_t bx) : BaseDequantizer(vx, bx) { load_values(values); }
-//    template <typename Q8>
-//    inline __m256i new_block(int i, const Q8& q8, __m256 * accd) {
-//        hbits = _mm256_loadu_si256((const __m256i *)x[i].qh);
-//        auto scales128 = _mm_cvtepu8_epi16(_mm_loadl_epi64((const __m128i *)x[i].scales));
-//        auto shifts = _mm_and_si128(_mm_cmpeq_epi16(_mm_and_si128(scales128, m1), m1), m2);
-//        scales128 = _mm_add_epi16(_mm_and_si128(scales128, mask), m127);
-//        auto scales_s = _mm_mullo_epi16(scales128, _mm_add_epi16(m128, shifts));
-//        s8k.accum_mins(scales_s, q8, i, d, accd);
-//        return MM256_SET_M128I(scales128, scales128);
-//    }
-//    inline void prepare(int i, int j) {
-//        bits.prepare(x[i].qs, j);
-//        auto h = j == 0 ? hbits : _mm256_srli_epi16(hbits, 4);
-//        for (int k = 0; k < 4; ++k) {
-//            auto qh = _mm256_and_si256(_mm256_slli_epi16(h, 7-k), mh);
-//            auto q5vl = _mm256_or_si256(bits.values[k], qh);
-//            auto q5vh = _mm256_or_si256(bits.values[k], _mm256_xor_si256(qh, mh));
-//            bits.values[k] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
-//        }
-//    }
-//    static void load_values(__m256i * values) {
-//        static const uint8_t kvalues_iq5nl[32] = {
-//            2,  14,  25,  36,  45,  54,  63,  71,  78,  85,  92,  98, 104, 110, 116, 122, 127,
-//            133, 139, 145, 151, 157, 164, 171, 179, 187, 196, 205, 215, 225, 237, 249,
-//        };
-//        auto values128_1 = _mm_loadu_si128((const __m128i *)kvalues_iq5nl + 0);
-//        auto values128_2 = _mm_loadu_si128((const __m128i *)kvalues_iq5nl + 1);
-//        values[0] = MM256_SET_M128I(values128_1, values128_1);
-//        values[1] = MM256_SET_M128I(values128_2, values128_2);
-//    }
-//
-//    Q4Bits bits;
-//    Scales8KBase s8k;
-//    __m256i hbits;
-//    __m256i values[2];
-//    const __m128i maskl    = _mm_set1_epi8(0xf);
-//    const __m128i maskh    = _mm_set1_epi8(0x30);
-//    const __m256i mh       = _mm256_set1_epi8(-128); // to avoid stupid warning about 0x80 overflowing
-//    const __m128i mask     = _mm_set1_epi16(254);
-//    const __m128i m127     = _mm_set1_epi16(-127);
-//    const __m128i m128     = _mm_set1_epi16(-128);
-//    const __m128i m1       = _mm_set1_epi16(1);
-//    const __m128i m2       = _mm_set1_epi16(2);
-//};
-
 void iqk_convert_iq5_ks_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
     GGML_ASSERT(n%QK_K == 0);
     GGML_ASSERT(nrc_x%8 == 0);
@@ -2328,6 +2281,112 @@ void iqk_convert_iq5_ks_q8_k_r8(int n, const void * vx, size_t bx, void * vy, in
     }
 }
 
+//struct DequantizerIQ5K final : public BaseDequantizer<block_iq5_k> {
+//    DequantizerIQ5K(const void * vx, size_t bx) : BaseDequantizer(vx, bx), iqxk(2, 0) { load_values(values); }
+//    template <typename Q8>
+//    inline void new_block(int i, const Q8& q8, __m256 * accm, __m256i * scales) {
+//        d = GGML_FP16_TO_FP32(x[i].d);
+//        iqxk.process(i, d, x[i].extra, make_scales(x[i].scales_l, (const uint16_t *)x[i].scales_h), q8, accm, scales);
+//        hbits = _mm256_loadu_si256((const __m256i *)x[i].qh);
+//    }
+//    inline void prepare(int i, int j) {
+//        bits.prepare(x[i].qs, j);
+//        auto h = j == 0 ? hbits : _mm256_srli_epi16(hbits, 4);
+//        for (int k = 0; k < 4; ++k) {
+//            auto qh = _mm256_and_si256(_mm256_slli_epi16(h, 7-k), mh);
+//            auto q5vl = _mm256_or_si256(bits.values[k], qh);
+//            auto q5vh = _mm256_or_si256(bits.values[k], _mm256_xor_si256(qh, mh));
+//            bits.values[k] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+//        }
+//    }
+//    __m128i make_scales(const uint8_t * scales_l, const uint16_t * scales_h) const {
+//        uint64_t aux64;
+//        memcpy(&aux64, scales_l, 8);
+//        auto scl = _mm_and_si128(_mm_set_epi64x(aux64 >> 4, aux64), maskl);
+//        const uint32_t aux32 = scales_h[0] | (scales_h[1] << 16);
+//        auto aux = _mm_and_si128(_mm_set_epi32(aux32 >> 2, aux32, aux32 << 2, aux32 << 4), maskh);
+//        auto sch = _mm_shuffle_epi8(aux, iqxk.hshuff);
+//        return _mm_add_epi8(_mm_or_si128(scl, sch), m32);
+//    }
+//    static void load_values(__m256i * values) {
+//        auto values128_1 = _mm_loadu_si128((const __m128i *)iq5nl_values + 0);
+//        auto values128_2 = _mm_loadu_si128((const __m128i *)iq5nl_values + 1);
+//        values[0] = MM256_SET_M128I(values128_1, values128_1);
+//        values[1] = MM256_SET_M128I(values128_2, values128_2);
+//    }
+//
+//    Q4Bits bits;
+//    const IQXKScales iqxk;
+//    __m256i hbits;
+//    __m256i values[2];
+//    const __m128i maskl    = _mm_set1_epi8(0xf);
+//    const __m128i maskh    = _mm_set1_epi8(0x30);
+//    const __m128i m32      = _mm_set1_epi8(-32);
+//    const __m256i mh       = _mm256_set1_epi8(-128); // to avoid stupid warning about 0x80 overflowing
+//};
+
+void iqk_convert_iq5_k_q8_k_r8(int n, const void * vx, size_t bx, void * vy, int nrc_x) {
+    GGML_ASSERT(n%QK_K == 0);
+    GGML_ASSERT(nrc_x%8 == 0);
+
+    int nb = n/QK_K;
+
+    const block_iq5_k * x8[8];
+
+    block_q8_k_r8 * y = (block_q8_k_r8 *)vy;
+
+    __m256i values[2];
+    {
+        auto v1 = _mm_loadu_si128((const __m128i *)iq5nl_values+0);
+        auto v2 = _mm_loadu_si128((const __m128i *)iq5nl_values+1);
+        values[0] = MM256_SET_M128I(v1, v1);
+        values[1] = MM256_SET_M128I(v2, v2);
+    }
+
+    __m256i  xv[8];
+    uint32_t block[8];
+    int16_t  ls[16];
+
+    auto mh = _mm256_set1_epi8(-128); // to avoid stupid warning about 0x80 overflowing
+
+    for (int ix = 0; ix < nrc_x; ix += 8) {
+        for (int k = 0; k < 8; ++k) x8[k] = (const block_iq5_k *)((const char *)vx + (ix+k)*bx);
+        for (int i = 0; i < nb; ++i) {
+            for (int k = 0; k < 8; ++k) {
+                float d = GGML_FP16_TO_FP32(x8[k][i].d);
+                auto extra = x8[k][i].extra;
+                auto hbits = _mm256_loadu_si256((const __m256i *)x8[k][i].qh);
+                for (int ib64 = 0; ib64 < 4; ++ib64) {
+                    ls[4*ib64+0] = ((x8[k][i].scales_l[2*ib64+0] & 0xf) | ((x8[k][i].scales_h[ib64] << 4) & 0x30)) - 32;
+                    ls[4*ib64+1] = ((x8[k][i].scales_l[2*ib64+0] >>  4) | ((x8[k][i].scales_h[ib64] << 2) & 0x30)) - 32;
+                    ls[4*ib64+2] = ((x8[k][i].scales_l[2*ib64+1] & 0xf) | ((x8[k][i].scales_h[ib64] >> 0) & 0x30)) - 32;
+                    ls[4*ib64+3] = ((x8[k][i].scales_l[2*ib64+1] >>  4) | ((x8[k][i].scales_h[ib64] >> 2) & 0x30)) - 32;
+                    auto bits = _mm256_loadu_si256((const __m256i *)x8[k][i].qs+ib64);
+                    xv[2*ib64+0] = _mm256_and_si256(bits, _mm256_set1_epi8(0xf));
+                    xv[2*ib64+1] = _mm256_and_si256(_mm256_srli_epi16(bits, 4), _mm256_set1_epi8(0xf));
+                    auto qh = _mm256_and_si256(_mm256_slli_epi16(hbits, 7), mh);
+                    auto q5vl = _mm256_or_si256(xv[2*ib64+0], qh);
+                    auto q5vh = _mm256_or_si256(xv[2*ib64+0], _mm256_xor_si256(qh, mh));
+                    xv[2*ib64+0] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+                    qh = _mm256_and_si256(_mm256_slli_epi16(hbits, 6), mh);
+                    q5vl = _mm256_or_si256(xv[2*ib64+1], qh);
+                    q5vh = _mm256_or_si256(xv[2*ib64+1], _mm256_xor_si256(qh, mh));
+                    xv[2*ib64+1] = _mm256_or_si256(_mm256_shuffle_epi8(values[0], q5vl), _mm256_shuffle_epi8(values[1], q5vh));
+                    auto shift1 = _mm256_set1_epi8((extra & 1) << 1);
+                    auto shift2 = _mm256_set1_epi8((extra & 2) << 0);
+                    xv[2*ib64+0] = _mm256_add_epi8(xv[2*ib64+0], shift1);
+                    xv[2*ib64+1] = _mm256_add_epi8(xv[2*ib64+1], shift2);
+                    hbits = _mm256_srli_epi16(hbits, 2);
+                    extra >>= 2;
+                }
+                float dnew = convert_to_q8_k_r8(k, 1.f/127, xv, ls, block, y[i].qs);
+                y[i].d[k] = GGML_FP32_TO_FP16(d*dnew);
+            }
+        }
+        y += nb;
+    }
+}
+
 } // namespace
 
 bool iqk_convert_iqk_quants_q80_r8(int type, int n, const void * vx, size_t bx, void * vy, int nrc_x) {
@@ -2336,6 +2395,7 @@ bool iqk_convert_iqk_quants_q80_r8(int type, int n, const void * vx, size_t bx, 
         case GGML_TYPE_IQ4_KS : iqk_convert_iq4_ks_q8_k_r8(n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ4_K  : iqk_convert_iq4_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;
         case GGML_TYPE_IQ5_KS : iqk_convert_iq5_ks_q8_k_r8(n, vx, bx, vy, nrc_x); break;
+        case GGML_TYPE_IQ5_K  : iqk_convert_iq5_k_q8_k_r8 (n, vx, bx, vy, nrc_x); break;
         default: return false;
     }
     return true;

--- a/ggml/src/iqk/iqk_gemm_iqk_quants.h
+++ b/ggml/src/iqk/iqk_gemm_iqk_quants.h
@@ -8,4 +8,6 @@
 
 bool iqk_set_kernels_iqk_quants(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels, mul_mat_t& func16);
 
+bool iqk_convert_iqk_quants_q80_r8(int type, int n, const void * vx, size_t bx, void * vy, int nrc_x);
+
 #endif

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -253,6 +253,7 @@ struct MulMat {
             case GGML_TYPE_IQ4_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ5_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
+            case GGML_TYPE_IQ5_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             default: break;
         }
 #else
@@ -378,13 +379,13 @@ bool iqk_convert_repack(int typeA, int n, const void * vx, size_t bx, void * vy,
         case GGML_TYPE_IQ3_XXS_R4:
         case GGML_TYPE_IQ3_S_R4:
             return iqk_convert_iquants_q80_r8(typeA, n, vx, bx, vy, nrc_x);
-        case GGML_TYPE_IQ4_KS:
-        case GGML_TYPE_IQ5_KS:
-        case GGML_TYPE_IQ4_KSS:
-        case GGML_TYPE_IQ2_K:
         case GGML_TYPE_IQ2_KS:
+        case GGML_TYPE_IQ2_K:
         case GGML_TYPE_IQ3_K:
+        case GGML_TYPE_IQ4_KSS:
+        case GGML_TYPE_IQ4_KS:
         case GGML_TYPE_IQ4_K:
+        case GGML_TYPE_IQ5_KS:
         case GGML_TYPE_IQ5_K:
         case GGML_TYPE_IQ6_K:
         //case GGML_TYPE_IQ2_K_R4:

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -250,6 +250,7 @@ struct MulMat {
             case GGML_TYPE_Q4_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q5_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q6_K   : return nrc_y >= 64 ? GGML_TYPE_Q8_0_R8 : type;
+            case GGML_TYPE_IQ2_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ3_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -250,6 +250,7 @@ struct MulMat {
             case GGML_TYPE_Q4_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q5_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q6_K   : return nrc_y >= 64 ? GGML_TYPE_Q8_0_R8 : type;
+            case GGML_TYPE_IQ4_KS : return nrc_y >= 64 ? GGML_TYPE_Q8_K_R8 : type;
             default: break;
         }
 #else
@@ -375,7 +376,7 @@ bool iqk_convert_repack(int typeA, int n, const void * vx, size_t bx, void * vy,
         case GGML_TYPE_IQ3_XXS_R4:
         case GGML_TYPE_IQ3_S_R4:
             return iqk_convert_iquants_q80_r8(typeA, n, vx, bx, vy, nrc_x);
-        //case GGML_TYPE_IQ4_KS:
+        case GGML_TYPE_IQ4_KS:
         //case GGML_TYPE_IQ5_KS:
         //case GGML_TYPE_IQ4_KSS:
         //case GGML_TYPE_IQ2_K:
@@ -390,7 +391,7 @@ bool iqk_convert_repack(int typeA, int n, const void * vx, size_t bx, void * vy,
         //case GGML_TYPE_IQ5_K_R4:
         //case GGML_TYPE_IQ4_KS_R4:
         //case GGML_TYPE_IQ5_KS_R4:
-        //    return iqk_set_kernels_iqk_quants(ne00, typeA, typeB, mm.funcs, mm.func16);
+            return iqk_convert_iqk_quants_q80_r8(typeA, n, vx, bx, vy, nrc_x);
         case GGML_TYPE_IQ2_KT:
         case GGML_TYPE_IQ3_KT:
         case GGML_TYPE_IQ4_KT:

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -250,6 +250,7 @@ struct MulMat {
             case GGML_TYPE_Q4_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q5_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q6_K   : return nrc_y >= 64 ? GGML_TYPE_Q8_0_R8 : type;
+            case GGML_TYPE_IQ2_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ2_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ3_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -250,6 +250,7 @@ struct MulMat {
             case GGML_TYPE_Q4_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q5_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q6_K   : return nrc_y >= 64 ? GGML_TYPE_Q8_0_R8 : type;
+            case GGML_TYPE_IQ3_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ5_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -250,7 +250,8 @@ struct MulMat {
             case GGML_TYPE_Q4_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q5_K   : return nrc_y >= 32 ? GGML_TYPE_Q8_1    : type;
             case GGML_TYPE_Q6_K   : return nrc_y >= 64 ? GGML_TYPE_Q8_0_R8 : type;
-            case GGML_TYPE_IQ4_KS : return nrc_y >= 64 ? GGML_TYPE_Q8_K_R8 : type;
+            case GGML_TYPE_IQ4_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
+            case GGML_TYPE_IQ4_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             default: break;
         }
 #else
@@ -377,14 +378,14 @@ bool iqk_convert_repack(int typeA, int n, const void * vx, size_t bx, void * vy,
         case GGML_TYPE_IQ3_S_R4:
             return iqk_convert_iquants_q80_r8(typeA, n, vx, bx, vy, nrc_x);
         case GGML_TYPE_IQ4_KS:
-        //case GGML_TYPE_IQ5_KS:
-        //case GGML_TYPE_IQ4_KSS:
-        //case GGML_TYPE_IQ2_K:
-        //case GGML_TYPE_IQ2_KS:
-        //case GGML_TYPE_IQ3_K:
-        //case GGML_TYPE_IQ4_K:
-        //case GGML_TYPE_IQ5_K:
-        //case GGML_TYPE_IQ6_K:
+        case GGML_TYPE_IQ5_KS:
+        case GGML_TYPE_IQ4_KSS:
+        case GGML_TYPE_IQ2_K:
+        case GGML_TYPE_IQ2_KS:
+        case GGML_TYPE_IQ3_K:
+        case GGML_TYPE_IQ4_K:
+        case GGML_TYPE_IQ5_K:
+        case GGML_TYPE_IQ6_K:
         //case GGML_TYPE_IQ2_K_R4:
         //case GGML_TYPE_IQ3_K_R4:
         //case GGML_TYPE_IQ4_K_R4:

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -254,6 +254,7 @@ struct MulMat {
             case GGML_TYPE_IQ4_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ5_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ5_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
+            case GGML_TYPE_IQ6_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             default: break;
         }
 #else

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -252,6 +252,7 @@ struct MulMat {
             case GGML_TYPE_Q6_K   : return nrc_y >= 64 ? GGML_TYPE_Q8_0_R8 : type;
             case GGML_TYPE_IQ4_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             case GGML_TYPE_IQ4_K  : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
+            case GGML_TYPE_IQ5_KS : return nrc_y >= 32 ? GGML_TYPE_Q8_K_R8 : type;
             default: break;
         }
 #else


### PR DESCRIPTION

This PR is a follow up of #531 and applies the technique to `IQK` quants.

Here is a PP-512 performance comparison for LlaMA-3.1-8B-Instruct on a Ryzen-7950X CPU between the main branch and this PR:

| model            |       size |          test |     t/s (main)   |    t/s (PR)      |   Speedup |
| ---------------- | ---------: | ------------: | ---------------: | ---------------: | --------: |
| llama 8B IQ2_KS  |   2.05 GiB |         pp512 |    203.08 ± 0.39 |    372.48 ± 3.69 |  1.834    |    
| llama 8B IQ2_K   |   2.22 GiB |         pp512 |    195.04 ± 2.44 |    365.58 ± 4.25 |  1.874    |    
| llama 8B IQ3_K   |   3.21 GiB |         pp512 |    167.65 ± 0.53 |    354.90 ± 3.44 |  2.117    |    
| llama 8B IQ4_KS  |   3.98 GiB |         pp512 |    198.28 ± 0.57 |    362.81 ± 1.74 |  1.830    |    
| llama 8B IQ4_K   |   4.21 GiB |         pp512 |    177.08 ± 1.71 |    360.58 ± 1.96 |  2.036    |    
| llama 8B IQ5_KS  |   4.91 GiB |         pp512 |    182.40 ± 1.62 |    358.66 ± 3.39 |  1.966    |    
| llama 8B IQ5_K   |   5.14 GiB |         pp512 |    158.74 ± 0.87 |    354.68 ± 0.75 |  2.234    |    
| llama 8B IQ6_K   |   6.19 GiB |         pp512 |    147.07 ± 0.80 |    353.20 ± 3.48 |  2.402    | 

To put things into perspective, the fastest mainline `llama.cpp` quant on this CPU is `Q4_0`, and I get **170 t/s** with today's build (`build: 860a9e4ee (5688)`).

For a bit of history, when [PR 6414](https://github.com/ggml-org/llama.cpp/pull/6414) was added to `llama.cpp`, it received 92 :+1:, 32 :tada:, 34 :heart:, and 30 :rocket:. It only supported `Q4_0` and `Q8_0`, and speedup compared to the master branch at the time was in the range of 40-50%, for a PP-512 of **135 t/s** on the Ryzen-7950X CPU used for the above table.  There was a [blog post](https://justine.lol/matmul/) received with [great fanfare on HN](https://news.ycombinator.com/item?id=39890262). 



