### PR TITLE
Add Falcon-Edge support

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -108,6 +108,8 @@ extern "C" {
         LLAMA_VOCAB_PRE_TYPE_TRILLION       = 31,
         LLAMA_VOCAB_PRE_TYPE_BAILINGMOE     = 32,
         LLAMA_VOCAB_PRE_TYPE_LLAMA4         = 33,
+        LLAMA_VOCAB_PRE_TYPE_FALCON_3       = 34,
+        LLAMA_VOCAB_PRE_TYPE_FALCON_E       = 35,
     };
 
     // note: these values should be synchronized with ggml_rope

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -393,6 +393,20 @@ struct llm_tokenizer_bpe {
                     "[0-9][0-9][0-9]",
                 };
                 break;
+            case LLAMA_VOCAB_PRE_TYPE_FALCON_3:
+               regex_exprs = {
+                    "[\\p{P}\\$\\+<=>\\^~\\|`]+",
+                    "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)",
+                    "[0-9]",
+                };
+                break;
+            case LLAMA_VOCAB_PRE_TYPE_FALCON_E:
+                regex_exprs = {
+                    "[\\p{P}\\$\\+<=>\\^~\\|`]+",
+                    "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)",
+                    "[0-9]",
+                };
+                break;
             case LLAMA_VOCAB_PRE_TYPE_STARCODER:
             case LLAMA_VOCAB_PRE_TYPE_REFACT:
             case LLAMA_VOCAB_PRE_TYPE_COMMAND_R:


### PR DESCRIPTION

Closes #551 

How to use:

1. Grab a GGUF containing Microsoft's `i2_s` quant packing. E.g.,
```
huggingface-cli download --local-dir falcon tiiuae/Falcon-E-3B-Instruct-GGUF
```

2. Convert to `ik_llama.cpp` quants `iq2_bn` or `iq1_bn`. `iq2_bn` uses 2 bits per weight (bpw), `iq1_bn` uses 1.625 bpw. `iq2_bn` is faster for prompt processing, and may also be faster for token generation (TG) on devices with limited computing power. `iq1_bn` uses 20% less RAM, so that if TG is memory bound, it will be slightly faster than `iq2_bn`. Command to convert is
```
./bin/llama-quantize --allow-requantize falcon/ggml-model-i2_s.gguf falcon_iq2_bn.gguf iq2_bn 
```
(replace `iq2_bn` with `iq1_bn` if you prefer the smaller variant.

3. Utilize the just created model file in the usual way with `llama-cli, llama-server`, etc.