### PR TITLE
Remove what appears to be unnecessary asserts in ggml_cuda_cpy

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -570,8 +570,12 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
     const int64_t ne = ggml_nelements(src0);
     GGML_ASSERT(ne == ggml_nelements(src1));
 
-    GGML_ASSERT(ggml_nbytes(src0) <= INT_MAX);
-    GGML_ASSERT(ggml_nbytes(src1) <= INT_MAX);
+    //if (ggml_nbytes(src0) > INT_MAX) {
+    //    printf("%s: %s has %zu bytes\n", __func__, src0->name, ggml_nbytes(src0));
+    //}
+    // These asserts appear to be unnecessary. Why were they added?
+    //GGML_ASSERT(ggml_nbytes(src0) <= INT_MAX);
+    //GGML_ASSERT(ggml_nbytes(src1) <= INT_MAX);
 
     const int64_t ne00 = src0->ne[0];
     const int64_t ne01 = src0->ne[1];


### PR DESCRIPTION

Not sure why the assert were there as it seems the code should handle tensor sizes greater than `INT_MAX`.

The funny part is that the assert is triggered when copying the KQ mask! I was able to trigger it using batch/u-batch of 16k tokens with a context of 32k tokens. Which means I should resurrect PR #28 as it is kind of ridiculous to be copying over 2 GB of data from the CPU to the GPU that could be 16X smaller if one used 1 bit per mask entry instead of a `fp16` value (or even `fp32` if not using FA).

After removing the assert everything seems to work fine.

But please test!