### PR TITLE
Remove duplicate/misplaced cmake find_package for Vulkan

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -643,8 +643,6 @@ if (GGML_RPC)
     set(GGML_SOURCES_RPC ggml-rpc.cpp)
 endif()
 
-find_package(Vulkan COMPONENTS glslc REQUIRED)
-
 function(detect_host_compiler)
     if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
         find_program(HOST_C_COMPILER NAMES cl gcc clang NO_CMAKE_FIND_ROOT_PATH)


### PR DESCRIPTION
This line `find_package(Vulkan COMPONENTS glslc REQUIRED)` prevented to build anything on MSVS 2022 if the package was not present on the system, this even if Vulkan was not selected.

It's already present in the Vulkan conditionality.

```
if (GGML_VULKAN)
find_package(Vulkan COMPONENTS glslc REQUIRED)
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
