### PR TITLE
Change KQ mask padding to 64

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -1957,7 +1957,7 @@ extern "C" {
             int                   min_entries,
             float                 thresh);
 
-#define GGML_KQ_MASK_PAD 32
+#define GGML_KQ_MASK_PAD 64
 
     // q:    [n_embd, n_batch,     n_head,    1]
     // k:    [n_embd, n_kv,        n_head_kv, 1]


### PR DESCRIPTION

This is needed by the Vulkan back-end when coopmat2 is enabled.

It is 64 in mainline too.