### PR TITLE
Bump GGML_MAX_CONTEXTS to allow loading more shards

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -234,7 +234,7 @@
 
 #define GGML_MAX_DIMS           4
 #define GGML_MAX_PARAMS         2048
-#define GGML_MAX_CONTEXTS       64
+#define GGML_MAX_CONTEXTS       2048 // Bump from 64 to allow loading more than 64 model shards - https://github.com/ggml-org/whisper.cpp/discussions/2520
 #define GGML_MAX_SRC            10
 #ifndef GGML_MAX_NAME
 #define GGML_MAX_NAME           64


### PR DESCRIPTION
This var prevents more than 64 shards from being loaded - Specifically relevant for large models such as DeepSeek R1.

I have tested it extensively for a few weeks - see https://github.com/Thireus/ik_llama.cpp/commit/a66490410a366a9605234b94d67f3d9b7b389140

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
