### PR TITLE
Fixup kimi-k2 convert indentation

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3436,7 +3436,7 @@ class DeepseekV2Model(Model):
             special_vocab = gguf.SpecialVocab(self.dir_model, load_merges=False)
             special_vocab.add_to_gguf(self.gguf_writer)
         else:
-        self._set_vocab_gpt2()
+            self._set_vocab_gpt2()
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()


### PR DESCRIPTION
Fixup a copy-paste python indent bug on the convert_hf_to_gguf.py script for kimi-k2-instruct. Thanks @anikifoss for testing and if you have success let me know here to confirm this patch is good.

https://github.com/ikawrakow/ik_llama.cpp/pull/612#issuecomment-3076684820