### PR TITLE
Bump Windows max open files from 512 to 2048

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4246,13 +4246,22 @@ struct llama_model_loader {
         }
 
         #ifdef _WIN32
-        int _setmaxstdio_ret = _setmaxstdio(2048); // 8,192 may be supported - https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160
-        if (_setmaxstdio_ret == -1) {
-            LLAMA_LOG_INFO("%s: failed to set max stdio to 2048.\n", __func__);
-        } else {
-            LLAMA_LOG_INFO("%s: Max stdio successfully set to %d\n", __func__, _setmaxstdio_ret);
-        }
-        #endif
+            // Only bump maxstdio if the user really wants large contexts:
+            #if defined(GGML_MAX_CONTEXTS) && (GGML_MAX_CONTEXTS > 512)
+                // Cap at MSVC's hard limit of 8192 - https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160
+                #if (GGML_MAX_CONTEXTS > 8192)
+                    #define _GGML_STDIO_TARGET 8192
+                #else
+                    #define _GGML_STDIO_TARGET GGML_MAX_CONTEXTS
+                #endif
+                int _setmaxstdio_ret = _setmaxstdio(_GGML_STDIO_TARGET);
+                if (_setmaxstdio_ret == -1) {
+                    LLAMA_LOG_INFO("%s: failed to set max stdio to %d. (setmaxstdio returned -1)\n", __func__, _GGML_STDIO_TARGET);
+                } else {
+                    LLAMA_LOG_INFO("%s: max stdio successfully set to %d\n", __func__, _setmaxstdio_ret);
+                }
+            #endif // GGML_MAX_CONTEXTS > 512
+        #endif // _WIN32
 
         if (param_overrides_p != nullptr) {
             for (const struct llama_model_kv_override * p = param_overrides_p; p->key[0] != 0; p++) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4245,6 +4245,15 @@ struct llama_model_loader {
             trace = atoi(getenv("LLAMA_TRACE"));
         }
 
+        #ifdef _WIN32
+        int _setmaxstdio_ret = _setmaxstdio(2048); // 8,192 may be supported - https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160
+        if (_setmaxstdio_ret == -1) {
+            LLAMA_LOG_INFO("%s: failed to set max stdio to 2048.\n", __func__);
+        } else {
+            LLAMA_LOG_INFO("%s: Max stdio successfully set to %d\n", __func__, _setmaxstdio_ret);
+        }
+        #endif
+
         if (param_overrides_p != nullptr) {
             for (const struct llama_model_kv_override * p = param_overrides_p; p->key[0] != 0; p++) {
                 kv_overrides.insert({std::string(p->key), *p});


### PR DESCRIPTION
Allows up to 2048 shards to be loaded on Windows builds, from the current default of 512. This change is specific to Windows, it instructs the Windows OS that the binary requires 2048 of max opened files. This is the equivalent to Linux's `ulimit -n`.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
