### PR TITLE
Fix pauses after a comma

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -17488,7 +17488,7 @@ static struct ggml_cgraph * llama_build_graph(
     const llama_vocab * vocab = llama_get_vocab(&lctx);
     llama_token bos = llama_token_bos_impl(*vocab);
     llama_token eos = llama_token_eos_impl(*vocab);
-    bool is_warming_up = (batch.n_tokens == 1 && (batch.token[0] == ((bos != -1) ? bos : eos)));
+    bool is_warming_up = lctx.n_eval == 0 && (batch.n_tokens == 1 && (batch.token[0] == ((bos != -1) ? bos : eos)));
     struct llm_build_context llm(lctx, batch, cb, worst_case, is_warming_up);
 
     llm.init();


### PR DESCRIPTION

Closes #464.

It seems there are models out there where the BOS token id is the same as the token ID of a comma (11 in the case of Qwen3 MoE models). This results in interpreting a comma during token generation as warm up run, which then results in using all experts, which makes the run time for the next token much longer, which then looks like a pause in the generation. The logic to use all experts during warm up was added in #198 to improve the user experience with very large MoE models.  

This PR fixes the issue by checking how many tokens have been evaluated in the given context and only creating a warm up graph if this is zero (in addition to the other conditions to detect a warm up run). 