### PR TITLE
Fix Qwen3 content extraction breaking code formatting

### DIFF
--- a/examples/server/parsers/qwen3_parser.hpp
+++ b/examples/server/parsers/qwen3_parser.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "json.hpp"
+#include "../../common/common.h"
 #include <string>
 #include <regex>
 
@@ -102,12 +103,8 @@ static std::string extract_content_during_parsing(const std::string& text, bool 
             }
         }
         
-        // Clean up extra whitespace
-        content = std::regex_replace(content, std::regex(R"(\n\s*\n)"), "\n");
-        
-        // Trim leading/trailing whitespace
-        content.erase(0, content.find_first_not_of(" \t\n\r"));
-        content.erase(content.find_last_not_of(" \t\n\r") + 1);
+        // Only trim leading/trailing whitespace, preserve internal formatting
+        content = string_strip(content);
         
     } catch (const std::exception&) {
         // Return original text on regex errors

--- a/tests/test-function-calls.cpp
+++ b/tests/test-function-calls.cpp
@@ -2214,6 +2214,40 @@ void test_xml_tool_call_parsing() {
     std::cout << "   ✅ XML tool call parsing works correctly!" << std::endl;
 }
 
+// Test whitespace preservation in qwen3 content extraction
+void test_qwen3_whitespace_preservation() {
+    std::cout << "\n🧹 Testing Qwen3 Whitespace Preservation Fix:" << std::endl;
+    
+    // Test case with PEP 8 style: 2 empty lines between functions
+    const std::string pep8_content = R"(def celsius_to_fahrenheit(celsius):
+    return celsius * 9/5 + 32
+
+
+def fahrenheit_to_celsius(fahrenheit):
+    return (fahrenheit - 32) * 5/9)";
+
+    std::cout << "🎯 Testing PEP 8 compliance (2 empty lines between functions)..." << std::endl;
+    std::cout << "Original content has: 2 empty lines between functions" << std::endl;
+    
+    // Test the qwen3 content extraction directly
+    std::string result = qwen3::extract_content_during_parsing(pep8_content, false);
+    
+    // Check if the double newlines are preserved (should have \n\n\n for 2 empty lines)
+    bool has_double_empty_lines = result.find("\n\n\n") != std::string::npos;
+    
+    std::cout << "Result content: '" << result << "'" << std::endl;
+    std::cout << "Has 2 empty lines preserved: " << (has_double_empty_lines ? "YES" : "NO") << std::endl;
+    
+    test_assert(has_double_empty_lines, "Qwen3: PEP 8 double empty lines preserved");
+    
+    // Additional test: ensure no excessive trimming
+    test_assert(!result.empty(), "Qwen3: Content not empty after processing");
+    test_assert(result.find("celsius_to_fahrenheit") != std::string::npos, "Qwen3: Function content preserved");
+    test_assert(result.find("fahrenheit_to_celsius") != std::string::npos, "Qwen3: Second function preserved");
+    
+    std::cout << "   ✅ Qwen3 whitespace preservation working correctly!" << std::endl;
+}
+
 // Test the streaming tool calls fix implementation
 void test_streaming_tool_calls_fix() {
     std::cout << "\n=== Streaming Tool Calls Fix Validation ===" << std::endl;
@@ -2774,6 +2808,7 @@ int main() {
         test_content_cleaning();
         test_contamination_reproduction(); // Added this test
         test_mixed_formats();
+        test_qwen3_whitespace_preservation(); // Test whitespace fix
         
         std::cout << "\n🌍 Unicode & International Tests:" << std::endl;
         test_unicode_support();


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High


## Summary

Fixes a bug in Qwen3 content extraction where aggressive whitespace cleanup was breaking proper code formatting in non-tool-call streaming output.

## Problem

The `qwen3::extract_content_during_parsing()` function was using an aggressive regex pattern that collapsed multiple newlines:
```cpp
content = std::regex_replace(content, std::regex(R"(\n\s*\n)"), "\n");
```

This broke:
- **PEP 8 compliance**: 2 empty lines between Python functions were collapsed to 1
- **Code formatting**: Any intentional whitespace structure was lost
- **Streaming output**: Users requesting properly formatted code received malformed results

## Root Cause

The regex `R"(\n\s*\n)"` replaces any sequence of newline + whitespace + newline with a single newline, which is overly aggressive for content that should preserve formatting.

## Solution

✅ **Replace aggressive cleanup with gentle trimming**
- Remove `std::regex_replace(content, std::regex(R"(\n\s*\n)"), "\n")`
- Replace with `string_strip(content)` following original llama.cpp patterns
- Only trim leading/trailing whitespace, preserve internal formatting

✅ **Add proper include**
- Add `#include "../../common/common.h"` for `string_strip` access

✅ **Add regression test**
- New `test_qwen3_whitespace_preservation()` validates PEP 8 compliance
- Ensures 2 empty lines between functions are preserved

## Testing

- ✅ **PEP 8 compliance**: 2 empty lines between functions preserved
- ✅ **Tool call parsing**: All Qwen3 tests continue to pass
- ✅ **No regressions**: Existing functionality maintained
- ✅ **Follows patterns**: Matches original llama.cpp whitespace handling

## Example

**Before (broken):**
```python
def celsius_to_fahrenheit(celsius):
    return celsius * 9/5 + 32
def fahrenheit_to_celsius(fahrenheit):  # Missing empty lines\!
    return (fahrenheit - 32) * 5/9
```

**After (fixed):**
```python
def celsius_to_fahrenheit(celsius):
    return celsius * 9/5 + 32


def fahrenheit_to_celsius(fahrenheit):  # Proper PEP 8 spacing preserved\!
    return (fahrenheit - 32) * 5/9
```

## Files Changed

- `examples/server/parsers/qwen3_parser.hpp` - Fix whitespace handling
- `tests/test-function-calls.cpp` - Add regression test

## Test Results

```
🧹 Testing Qwen3 Whitespace Preservation Fix:
✅ PASS: Qwen3: PEP 8 double empty lines preserved
✅ PASS: Qwen3: Content not empty after processing
✅ PASS: Qwen3: Function content preserved
✅ PASS: Qwen3: Second function preserved
```