### PR TITLE
Fix GLM-4.5 attention

### DIFF
--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cuh
@@ -96,7 +96,7 @@ static __global__ void flash_attn_ext_f16(
     const half  * V_h   = (const half  *) (V + nb22*(blockIdx.y / gqa_ratio)); // K and V have same shape
     const half  * maskh = (const half  *)  mask + (nb31/sizeof(half))* ic0;
     const half2 * mask2 = (const half2 *)  mask + (nb31/sizeof(half))*(ic0/2);
-    const float * sinks_f = sinks ? (const float *)sinks + blockIdx.y : nullptr;
+    [[maybe_unused]] const float * sinks_f = sinks ? (const float *)sinks + blockIdx.y : nullptr;
 
     const int stride_Q = nb01 / sizeof(float);
     const int stride_K = nb11 / sizeof(half);


### PR DESCRIPTION

There have been reports of `llama.cpp` being faster than `ik_llama.cpp` for the GLM-4.5 MoE models, see e.g. [here](https://github.com/ikawrakow/ik_llama.cpp/pull/689#issuecomment-3191092917) or [here](https://huggingface.co/ubergarm/GLM-4.5-Air-GGUF/discussions/2#68980a066bc7e6a3fcef131c), with the `llama.cpp` advantage increasing with context length, which points to a problem with the self-attention implementation in `ik_llama.cpp` for this specific model.

After wasting a lot of time scrutinizing the various kernels involved, I finally located the problem in [this  function](https://github.com/ikawrakow/ik_llama.cpp/blob/4bf5c8184b177ee5bbd77fc7fde34f57613c1f6b/ggml/src/ggml-cuda/fattn.cu#L72), where we have:
```c++
    if (use_gqa_opt && gqa_ratio % 8 == 0) {
        ggml_cuda_flash_attn_ext_mma_f16_switch_hs<8>(ctx, dst);
        return;
    }   

    if (use_gqa_opt && gqa_ratio == 4) {
        ggml_cuda_flash_attn_ext_mma_f16_switch_hs<4>(ctx, dst);
        return;
    }   

    if (use_gqa_opt && gqa_ratio == 2) {
        ggml_cuda_flash_attn_ext_mma_f16_switch_hs<2>(ctx, dst);
        return;
    }   
```
 
Hahaha. GLM-4.5 has a GQA ratio of 12, hence none of the conditions for GQA-related optimizations takes effect, so the slow path is taken, resulting in a poor performance for this, or any other model that does not have GQA of 2, 4, or 8.

This PR fixes it. I'm RAM (64 GB) and VRAM (16 GB) poor, so testing using Unsloth's `GLM-4.5-Air-UD-IQ2_XXS.gguf` with all experts left on the CPU (but even then, I can only go up to a context of 32k tokens). As attention is computed on the GPU where we have the problem at hand, this should still be representative for what VRAM-rich people can expect with full GPU offload after this PR. CPU is Ryzen-7950X, GPU is RTX-4080. OS is Linux.

### TG performance

<img width="792" height="612" alt="glm_tg" src="https://github.com/user-attachments/assets/6474dbdd-c8c5-4f1b-b770-2385bfd5c864" />

### PP performance

<img width="792" height="612" alt="glm_pp" src="https://github.com/user-attachments/assets/17c9cd3f-3f4b-49f8-8578-b4fe4ea25b95" />

<details>
<summary>ik_llama.cpp, main</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |   1024 |      0 |    3.914 |  1046.63 |   61.736 |    16.59 |
|  4096 |   1024 |   4096 |    4.272 |   958.91 |   67.199 |    15.24 |
|  4096 |   1024 |   8192 |    4.724 |   867.11 |   72.536 |    14.12 |
|  4096 |   1024 |  12288 |    5.174 |   791.59 |   77.991 |    13.13 |
|  4096 |   1024 |  16384 |    5.629 |   727.63 |   83.358 |    12.28 |
|  4096 |   1024 |  20480 |    6.107 |   670.75 |   93.370 |    10.97 |
|  4096 |   1024 |  24576 |    6.622 |   618.51 |  108.825 |     9.41 |
|  4096 |   1024 |  28672 |    7.067 |   579.62 |  122.549 |     8.36 |
</details>

<details>
<summary>ik_llama.cpp PR</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |   1024 |      0 |    3.770 |  1086.43 |   60.162 |    17.02 |
|  4096 |   1024 |   4096 |    4.102 |   998.45 |   62.571 |    16.37 |
|  4096 |   1024 |   8192 |    4.458 |   918.74 |   64.041 |    15.99 |
|  4096 |   1024 |  12288 |    4.853 |   844.04 |   66.053 |    15.50 |
|  4096 |   1024 |  16384 |    5.254 |   779.60 |   68.412 |    14.97 |
|  4096 |   1024 |  20480 |    5.684 |   720.62 |   76.075 |    13.46 |
|  4096 |   1024 |  24576 |    6.156 |   665.36 |   81.268 |    12.60 |
|  4096 |   1024 |  28672 |    6.592 |   621.37 |   85.233 |    12.01 |
</details>

<details>
<summary>llama.cpp, build: 6181 (de2192794)</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |   1024 |      0 |    4.350 |   941.71 |   65.528 |    15.63 |
|  4096 |   1024 |   4096 |    4.757 |   861.03 |   70.442 |    14.54 |
|  4096 |   1024 |   8192 |    5.103 |   802.67 |   69.448 |    14.74 |
|  4096 |   1024 |  12288 |    5.382 |   761.11 |   71.500 |    14.32 |
|  4096 |   1024 |  16384 |    5.935 |   690.15 |   73.830 |    13.87 |
|  4096 |   1024 |  20480 |    6.470 |   633.05 |   81.029 |    12.64 |
|  4096 |   1024 |  24576 |    6.626 |   618.18 |   86.152 |    11.89 |
|  4096 |   1024 |  28672 |    7.145 |   573.27 |   90.104 |    11.36 |
</details>

@Thireus It would be great if you could repeat you GLM-4.5-Air sweep bench with this PR. Thanks in advance!