### PR TITLE
CUDA: faster prompt processing for 4-bit quants

### DIFF
--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -246,6 +246,25 @@ __device__ __forceinline__ void vec_dot_iq4_k_q8_1(
 }
 
 static __device__ __forceinline__ int2 get_int_from_table_16(const int & q4, const int8_t * values) {
+#if defined(__CUDA_ARCH__)
+    uint32_t v1, v2, v3, v4, mask;
+    const uint32_t * values32 = (const uint32_t *)values;
+
+    mask = (0x32103210 | ((q4 & 0x88888888) >> 1));
+    // Perform lookups in the lower half of the table (indices 0-7).
+    v1 = __byte_perm(values32[0], values32[1], q4);
+    // Perform lookups in the upper half of the table (indices 8-15).
+    v2 = __byte_perm(values32[2], values32[3], q4);
+    // Select between the low and high results based on the MSB of each index nibble.
+    v3 = __byte_perm(v1, v2, mask);
+    // Same for the upper part of q4.
+    v1 = __byte_perm(values32[0], values32[1], q4 >> 16);
+    v2 = __byte_perm(values32[2], values32[3], q4 >> 16);
+    v4 = __byte_perm(v1, v2, mask >> 16);
+
+    // Mix the results to get the final int2.
+    return make_int2(__byte_perm(v3, v4, 0x6420), __byte_perm(v3, v4, 0x7531));
+#else
     const int      q0_32  = (q4 >> 0) & 0x0F0F0F0F;
     const int8_t * q0_8   = (const int8_t *) &q0_32;
     const char4    val0_8 = make_char4(values[q0_8[0]], values[q0_8[1]], values[q0_8[2]], values[q0_8[3]]);
@@ -255,6 +274,7 @@ static __device__ __forceinline__ int2 get_int_from_table_16(const int & q4, con
     const char4    val1_8 = make_char4(values[q1_8[0]], values[q1_8[1]], values[q1_8[2]], values[q1_8[3]]);
 
     return make_int2(*((const int *) &val0_8), *((const int *) &val1_8));
+#endif
 }
 
 __device__ __forceinline__ void vec_dot_iq4_k_r4_q8_1(
@@ -389,19 +409,30 @@ __device__ __forceinline__ void vec_dot_iq4_ks_q8_1(
 
     float scale = *(const float *)vbq;
     const block_iq4_ks * bq4 = (const block_iq4_ks *)((const char *)vbq + sizeof(float)) + kbx;
-    const uint8_t * all_values = (const uint8_t *)iq4k_values;
+    //const uint8_t * all_values = (const uint8_t *)iq4k_values;
 
     // iqs is 0...28
     const int ib32 = iqs/4; // Why iqs/4 ?
     const int32_t  * q8 = (const int *)bq8_1[ib32].qs;
     const uint32_t * q4 = (const uint32_t *)bq4->qs + 4*ib32;
     const float dl = scale * ((bq4->scales[ib32] & 254) - 127);
-    int v1, v2;
+    auto values = iq4k_values + ((bq4->scales[ib32] & 1) << 4);
+    //auto values = iq4k_table + ((bq4->scales[ib32] & 1) << 8);
+    //uint32_t aux32[2];
+    //auto a8 = (const uint8_t *)aux32;
+    //int v1, v2;
     int sumi = 0;
     for (int j = 0; j < 4; ++j) {
-        get_int_from_table_16_shift(q4[j], bq4->scales[ib32] & 1, all_values, v1, v2);
-        sumi = ggml_cuda_dp4a(v1, q8[j+0], sumi);
-        sumi = ggml_cuda_dp4a(v2, q8[j+4], sumi);
+        //aux32[0] = (q4[j] >> 0) & 0x0f0f0f0f;
+        //aux32[1] = (q4[j] >> 4) & 0x0f0f0f0f;
+        //sumi = ggml_cuda_dp4a(int_from_table_x(a8+0, values), q8[j+0], sumi);
+        //sumi = ggml_cuda_dp4a(int_from_table_x(a8+4, values), q8[j+4], sumi);
+        auto v = get_int_from_table_16(q4[j], values);
+        sumi = ggml_cuda_dp4a(v.x, q8[j+0], sumi);
+        sumi = ggml_cuda_dp4a(v.y, q8[j+4], sumi);
+        ////get_int_from_table_16_shift(q4[j], bq4->scales[ib32] & 1, all_values, v1, v2);
+        ////sumi = ggml_cuda_dp4a(v1, q8[j+0], sumi);
+        ////sumi = ggml_cuda_dp4a(v2, q8[j+4], sumi);
     }
     *result += dl * __low2float(bq8_1[ib32].ds) * sumi;
 }

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -2842,8 +2842,8 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
     const int kqsx = threadIdx.x / 4;
 
-    uint32_t aux32[2];
-    auto a8 = (const uint8_t *)aux32;
+    //uint32_t aux32[2];
+    //auto a8 = (const uint8_t *)aux32;
 
 #pragma unroll
     for (int i0 = 0; i0 < mmq_y; i0 += 4*nwarps) {
@@ -2857,19 +2857,21 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         const block_iq4_ks * bxi = (const block_iq4_ks *)(dptr + 1) + kbx0;
         const int ls = (bxi->scales[kqsx] & 254) - 127;
 
-        auto values = iq4k_table + ((bxi->scales[kqsx] & 1) << 8);
+        auto values = iq4k_values + ((bxi->scales[kqsx] & 1) << 4);
+        //auto values = iq4k_table + ((bxi->scales[kqsx] & 1) << 8);
 
         #pragma unroll
         for (int j = 0; j < 4; ++j) {
             const int q4 = get_int_b4(bxi->qs, 4*kqsx+j);
-            aux32[0] = (q4 >> 0) & 0x0f0f0f0f;
-            aux32[1] = (q4 >> 4) & 0x0f0f0f0f;
+            const int2 v = get_int_from_table_16(q4, values);
+            //aux32[0] = (q4 >> 0) & 0x0f0f0f0f;
+            //aux32[1] = (q4 >> 4) & 0x0f0f0f0f;
 #ifdef INT8_MMA_AVAILABLE
-            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 0] = int_from_table_x(a8+0, values);
-            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 4] = int_from_table_x(a8+4, values);
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 0] = v.x; //int_from_table_x(a8+0, values);
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 4] = v.y; //int_from_table_x(a8+4, values);
 #else
-            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 0] = int_from_table_x(a8+0, values);
-            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 4] = int_from_table_x(a8+4, values);
+            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 0] = v.x; //int_from_table_x(a8+0, values);
+            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 4] = v.y; //int_from_table_x(a8+4, values);
 #endif // INT8_MMA_AVAILABLE
         }
 #ifdef INT8_MMA_AVAILABLE

--- a/ggml/src/ggml-cuda/template-instances/mmq-instance-iq4_kss.cu
+++ b/ggml/src/ggml-cuda/template-instances/mmq-instance-iq4_kss.cu
@@ -14,9 +14,6 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
 
     const int kqsx = threadIdx.x / 4;
 
-    uint32_t aux32[2];
-    auto a8 = (const uint8_t *)aux32;
-
 #pragma unroll
     for (int i0 = 0; i0 < mmq_y; i0 += 4*nwarps) {
         int i = i0 + 4*threadIdx.y + threadIdx.x%4;
@@ -31,20 +28,19 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         uint32_t s32 = (q4[0] & 0x00010001) | ((q4[1] & 0x00010001) << 2) | ((q4[2] & 0x00010001) << 4) | ((q4[3] & 0x00010001) << 6);
         uint8_t ls = (s32 | (s32 >> 15)) & 0xff;
 
-        auto values = iq4k_table + ((ls & 1) << 8);
+        auto values = iq4k_values + ((ls & 1) << 4);
 
         #pragma unroll
         for (int j = 0; j < 4; ++j) {
             uint32_t val = q4[j] & 0xfffefffe;
             val = val ^ (val >> 1);
-            aux32[0] = (val >> 0) & 0x0f0f0f0f;
-            aux32[1] = (val >> 4) & 0x0f0f0f0f;
+            auto v = get_int_from_table_16(val, values);
 #ifdef INT8_MMA_AVAILABLE
-            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 0] = int_from_table_x(a8+0, values);
-            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 4] = int_from_table_x(a8+4, values);
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 0] = v.x;
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 8*kqsx + j + 4] = v.y;
 #else
-            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 0] = int_from_table_x(a8+0, values);
-            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 4] = int_from_table_x(a8+4, values);
+            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 0] = v.x;
+            x_qs[i*(2*WARP_SIZE + 1)     + 8*kqsx + j + 4] = v.y;
 #endif // INT8_MMA_AVAILABLE
         }
 #ifdef INT8_MMA_AVAILABLE


### PR DESCRIPTION

There is [this PR](https://github.com/ggml-org/llama.cpp/pull/15451) in mainline `llama.cpp`. It uses the `__byte_perm` Nvidia intrinsics to more efficiently assemble a 32-bit integer when each byte requires a lookup in a table of 16 values. These are the newly added `MXFP4`, along with `IQ4_NL, IQ4_XS, IQ4_KS, IQ4_KS_R4, IQ4_KSS`. I had noticed the `__byte_perm` instruction when searching for other SIMD instrinsics in the CUDA manual and had made a mental note to investigate the use of this instruction for handling lookup tables, but mainline PR 15451 already did it, so I could just take it from there.

As `IQ4_K` (and `IQ4_K_R4`) use blocks of 16, so the first 2 and second 2 bytes require different lookup tables, the trick is not directly applicable to these quantization types.

Here a quick performance comparison between the main branch and this PR on RTX-4080 

| model              |          test |   t/s (main)     |   t/s (PR)       |     Speedup |
| ------------------ | ------------: | ---------------: | ---------------: | ----------: |
| llama 8B IQ4_XS    |        pp1024 |  8206.24 ± 30.15 |  8887.15 ± 30.74 |  1.083      |   
| llama 8B IQ4_NL    |        pp1024 |  7692.93 ± 68.09 |  8597.81 ± 49.93 |  1.118      |   
| llama 8B IQ4_KS    |        pp1024 |  8191.36 ± 23.05 |   8618.85 ± 8.96 |  1.052      |   
| llama 8B IQ4_KS_R4 |        pp1024 |  8290.62 ± 21.63 |  8672.20 ± 10.09 |  1.046      |   
| llama 8B IQ4_KSS   |        pp1024 |  8139.23 ± 14.06 |  8685.01 ± 28.51 |  1.067      |   
| gpt-oss 20B MXFP4  |        pp2048 | 9618.83 ± 107.95 | 10355.26 ± 113.48|  1.077      |   
| llama 8B IQ4_XS    |         tg128 |    128.23 ± 0.08 |    129.05 ± 0.06 |  1.006      |
| llama 8B IQ4_NL    |         tg128 |    122.62 ± 0.05 |    123.68 ± 0.04 |  1.009      |
| llama 8B IQ4_KS    |         tg128 |    128.08 ± 0.04 |    128.68 ± 0.07 |  1.005      |
| llama 8B IQ4_KS_R4 |         tg128 |    124.45 ± 0.05 |    123.59 ± 0.03 |  0.993      |
| llama 8B IQ4_KSS   |         tg128 |    133.26 ± 0.08 |    134.02 ± 0.04 |  1.006      |
| gpt-oss 20B MXFP4  |         tg128 |    178.30 ± 0.11 |    180.72 ± 0.07 |  1.014      |

We see noticeable gains for PP. TG is severely memory bandwidth limited on the 4080, so much less impact there (but I wouldn't be surprised if the gain is somewhat larger on a 4090 or 5090).

As I had already done an optimized table lookup for the IQK quants, PP performance gains are somewhat lower than `MXFP4` and `IQ4_NL`. 
