### PR TITLE
CUDA: faster IQ2_K, IQ2_KS, IQ2_K_R4

### DIFF
--- a/ggml/src/ggml-cuda/iqk_cuda_common.h
+++ b/ggml/src/ggml-cuda/iqk_cuda_common.h
@@ -127,3 +127,12 @@ __device__ __forceinline__ int int_from_table_x(const uint8_t * a8, const uint16
     return values[a8[0] | (a8[1] << 4)] | (values[a8[2] | (a8[3] << 4)] << 16);
 }
 
+#ifdef __CUDA_ARCH__
+static __device__ __forceinline__ int2 get_int_from_table_8(const int & q4, const int8_t * values) {
+    const uint32_t * values32 = (const uint32_t *)values;
+    uint32_t v1 = __byte_perm(values32[0], values32[1], q4);
+    uint32_t v2 = __byte_perm(values32[0], values32[1], q4 >> 16);
+    return make_int2(__byte_perm(v1, v2, 0x6420), __byte_perm(v1, v2, 0x7531));
+}
+#endif
+

--- a/ggml/src/ggml-cuda/iqk_mmvq.cu
+++ b/ggml/src/ggml-cuda/iqk_mmvq.cu
@@ -908,13 +908,7 @@ __device__ __forceinline__ void vec_dot_iq2_ks_q8_1(
     const uint16_t * q2 = (const uint16_t *)bq2->qs + 16*(i4/4) + 4*(i4%4);
     const uint16_t extra = bq2->extra >> 4*(i4/4);
 
-    const int * all_values = (const int *)iq2k_table;
-    const int * values;
-
     uint32_t val1 = q2[0] | (q2[1] << 16), val2 = q2[2] | (q2[3] << 16);
-
-    uint32_t aux32[2];
-    int v1, v2;
 
     int32_t scales32;
     const uint16_t * scales16 = (const uint16_t *)bq2->scales;
@@ -924,6 +918,35 @@ __device__ __forceinline__ void vec_dot_iq2_ks_q8_1(
     s8[1] += ((extra >> 6) & 0x10);
     s8[2] += ((extra >> 5) & 0x10);
     s8[3] += ((extra >> 7) & 0x10);
+
+#ifdef __CUDA_ARCH__
+
+    uint32_t extra32 = uint32_t(extra & 0xf) * 0x01010101;
+
+    uint32_t this_extra = ((extra32 << 2) & 0x04040404) | ((extra32 << 4) & 0x40404040);
+    uint32_t idx1 = ((val1 >> 0) & 0x33333333) | this_extra;
+    uint32_t idx2 = ((val2 >> 0) & 0x33333333) | this_extra;
+    int2 v1 = get_int_from_table_8(idx1, iq2nl_values);
+    int2 v2 = get_int_from_table_8(idx2, iq2nl_values);
+
+    int sumi1 = ggml_cuda_dp4a(v2.x, q8_1[1], ggml_cuda_dp4a(v1.x, q8_1[0], 0)) * s8[0];
+    int sumi3 = ggml_cuda_dp4a(v2.y, q8_3[1], ggml_cuda_dp4a(v1.y, q8_3[0], 0)) * s8[1];
+
+    this_extra = ((extra32 << 1) & 0x04040404) | ((extra32 << 3) & 0x40404040);
+    idx1 = ((val1 >> 2) & 0x33333333) | this_extra;
+    idx2 = ((val2 >> 2) & 0x33333333) | this_extra;
+    v1 = get_int_from_table_8(idx1, iq2nl_values);
+    v2 = get_int_from_table_8(idx2, iq2nl_values);
+
+    int sumi2 = ggml_cuda_dp4a(v2.x, q8_2[1], ggml_cuda_dp4a(v1.x, q8_2[0], 0)) * s8[2];
+    int sumi4 = ggml_cuda_dp4a(v2.y, q8_4[1], ggml_cuda_dp4a(v1.y, q8_4[0], 0)) * s8[3];
+
+#else
+
+    uint32_t aux32[2];
+    int v1, v2;
+    const int * all_values = (const int *)iq2k_table;
+    const int * values;
 
     aux32[0] = ((val1 >> 0) & 0x03030303); aux32[1] = ((val2 >> 0) & 0x03030303); values = all_values + ((extra & 0x01) << 8);
     v1 = int_from_table_4(aux32[0], values);
@@ -944,6 +967,7 @@ __device__ __forceinline__ void vec_dot_iq2_ks_q8_1(
     v1 = int_from_table_4(aux32[0], values);
     v2 = int_from_table_4(aux32[1], values);
     int sumi4 = ggml_cuda_dp4a(v2, q8_4[1], ggml_cuda_dp4a(v1, q8_4[0], 0)) * s8[3];
+#endif
 
     *result += scale * (__low2float(bq8_1[4*(i4/4)+0].ds) * sumi1
                      +  __low2float(bq8_1[4*(i4/4)+1].ds) * sumi2

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -187,7 +187,7 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11) {
             break;
         case GGML_TYPE_IQ2_K:
         case GGML_TYPE_IQ2_K_R4:
-            mmq_supported = ne11 < 2048;
+            mmq_supported = ne11 <= 3072;
             break;
         case GGML_TYPE_IQ3_K:
         case GGML_TYPE_IQ4_K:

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -2554,6 +2554,15 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
     }
 }
 
+#ifdef __CUDA_ARCH__
+static __device__ __forceinline__ int2 get_int_from_table_8(const int & q4, const int8_t * values) {
+    const uint32_t * values32 = (const uint32_t *)values;
+    uint32_t v1 = __byte_perm(values32[0], values32[1], q4);
+    uint32_t v2 = __byte_perm(values32[0], values32[1], q4 >> 16);
+    return make_int2(__byte_perm(v1, v2, 0x6420), __byte_perm(v1, v2, 0x7531));
+}
+#endif
+
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_iq2_ks(
     const char * __restrict__ x, int * __restrict__ x_tile, const int & kbx0, const int & i_max, const int & stride) {
 
@@ -2566,11 +2575,45 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
     float * x_df = (float *) (x_qs + txs.qs);
 #endif // INT8_MMA_AVAILABLE
 
-    const int * all_values = (const int *)iq2k_table;
-
     const int kqsx = threadIdx.x%16;
 
-#pragma unroll
+#ifdef __CUDA_ARCH__
+    #pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += 2*nwarps) {
+        int i = i0 + 2*threadIdx.y + threadIdx.x/16;
+
+        if (need_check) {
+            i = min(i, i_max);
+        }
+
+        const block_iq2_ks * bxi = (const block_iq2_ks *)(x + i*stride + sizeof(half)) + kbx0;
+
+        uint16_t extra = bxi->extra >> 4*(kqsx/8);
+        int q2 = get_int_b2(bxi->qs, kqsx);
+
+        uint32_t extra32 = uint32_t(extra & 0xf) * 0x01010101;
+        uint32_t val1 = ((q2 >> 0) & 0x33333333) | ((extra32 << 2) & 0x04040404) | ((extra32 << 4) & 0x40404040);
+        uint32_t val2 = ((q2 >> 2) & 0x33333333) | ((extra32 << 1) & 0x04040404) | ((extra32 << 3) & 0x40404040);
+        int2 v1 = get_int_from_table_8(val1, iq2nl_values);
+        int2 v2 = get_int_from_table_8(val2, iq2nl_values);
+
+#ifdef INT8_MMA_AVAILABLE
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + kqsx%8 + 32*(kqsx/8) +  0] = v1.x;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + kqsx%8 + 32*(kqsx/8) +  8] = v2.x;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + kqsx%8 + 32*(kqsx/8) + 16] = v1.y;
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + kqsx%8 + 32*(kqsx/8) + 24] = v2.y;
+#else
+        x_qs[i*(2*WARP_SIZE + 1)     + kqsx%8 + 32*(kqsx/8) +  0] = v1.x;
+        x_qs[i*(2*WARP_SIZE + 1)     + kqsx%8 + 32*(kqsx/8) +  8] = v2.x;
+        x_qs[i*(2*WARP_SIZE + 1)     + kqsx%8 + 32*(kqsx/8) + 16] = v1.y;
+        x_qs[i*(2*WARP_SIZE + 1)     + kqsx%8 + 32*(kqsx/8) + 24] = v2.y;
+#endif // INT8_MMA_AVAILABLE
+    }
+
+#else // __CUDA_ARCH__
+
+    const int * all_values = (const int *)iq2k_table;
+    #pragma unroll
     for (int i0 = 0; i0 < mmq_y; i0 += 2*nwarps) {
         int i = i0 + 2*threadIdx.y + threadIdx.x/16;
 
@@ -2595,6 +2638,7 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
         x_qs[i*(2*WARP_SIZE + 1)     + kqsx%8 + 32*(kqsx/8) + 24] = int_from_table_4((q2 >> 6) & 0x03030303, all_values + ((extra & 8) << 5));
 #endif // INT8_MMA_AVAILABLE
     }
+#endif // __CUDA_ARCH__
 
 #pragma unroll
     for (int i0 = 0; i0 < mmq_y; i0 += nwarps * 8) {

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -2554,15 +2554,6 @@ template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinlin
     }
 }
 
-#ifdef __CUDA_ARCH__
-static __device__ __forceinline__ int2 get_int_from_table_8(const int & q4, const int8_t * values) {
-    const uint32_t * values32 = (const uint32_t *)values;
-    uint32_t v1 = __byte_perm(values32[0], values32[1], q4);
-    uint32_t v2 = __byte_perm(values32[0], values32[1], q4 >> 16);
-    return make_int2(__byte_perm(v1, v2, 0x6420), __byte_perm(v1, v2, 0x7531));
-}
-#endif
-
 template <int mmq_y, int nwarps, bool need_check> static __device__ __forceinline__ void load_tiles_iq2_ks(
     const char * __restrict__ x, int * __restrict__ x_tile, const int & kbx0, const int & i_max, const int & stride) {
 


### PR DESCRIPTION

This PR is a follow up of #713, #714, and applies a similar trick to 2-bit quants that need a table lookup (`IQ2_K, IQ2_KS, IQ2_K_R4`).

| model              |          test |    t/s (main)    |    t/s (PR)      |  Speedup  |
| ------------------ | ------------: | ---------------: | ---------------: | --------: |
| llama 8B IQ2_KS    |         pp512 |  8673.51 ± 56.38 |  9289.24 ± 64.59 |  1.071    |
| llama 8B IQ2_K     |         pp512 |  7230.06 ± 37.36 |  7569.58 ± 64.24 |  1.047    |
| llama 8B IQ2_K_R4  |         pp512 |  7414.71 ± 47.02 |  7611.86 ± 41.09 |  1.027    |
| llama 8B IQ2_KS    |         tg128 |    178.04 ± 0.16 |    190.74 ± 0.25 |  1.071    |
| llama 8B IQ2_K     |         tg128 |    183.20 ± 0.24 |    188.78 ± 0.11 |  1.030    |
| llama 8B IQ2_K_R4  |         tg128 |    172.98 ± 0.21 |    184.66 ± 0.08 |  1.068    |

`IQ2_KS` is now the new prompt processing speed champion (previous was `IQ2_KT`).