### PR TITLE
Check for NaNs while loading the model.

### DIFF
--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -9838,3 +9838,63 @@ void vec_dot_iq4_kt_q8_k(int n, float * s, size_t bs, const void * vx, size_t bx
 #endif
 
 }
+
+namespace {
+template <typename Block>
+inline int check_row_for_blocks_256_fp16(int nblock, const Block * x) {
+    int nbad = 0;
+    for (int ib = 0; ib < nblock; ++ib) {
+        float d = GGML_FP16_TO_FP32(x[ib].d);
+        if (isnan(d)) ++nbad;
+    }
+    return nbad;
+}
+template <typename Block>
+bool check_tensor_for_blocks_256_fp16(const ggml_tensor * tensor) {
+    int nblock = tensor->ne[0]/QK_K;
+    int nbad = 0;
+    for (int row = 0; row < ggml_nrows(tensor); ++row) {
+        auto x = (const Block *)((const char *)tensor->data + tensor->nb[1]*row);
+        nbad += check_row_for_blocks_256_fp16(nblock, x);
+    }
+    if (nbad > 0) {
+        fprintf(stderr, "%s: found %d NaN block scales out of %ld blocks in tensor %s\n", __func__,
+                nbad, ggml_nrows(tensor)*nblock, tensor->name);
+        return false;
+    }
+    return true;
+}
+}
+
+bool iqk_validate_tensor(const ggml_tensor * tensor) {
+    if (!tensor) return true;
+    if (!ggml_is_contiguous(tensor)) return true;
+    //if (tensor->type != GGML_TYPE_IQ3_K) return true;
+
+    switch (tensor->type) {
+        case GGML_TYPE_IQ2_K: return check_tensor_for_blocks_256_fp16<block_iq2_k>(tensor);
+        case GGML_TYPE_IQ3_K: return check_tensor_for_blocks_256_fp16<block_iq3_k>(tensor);
+        case GGML_TYPE_IQ4_K: return check_tensor_for_blocks_256_fp16<block_iq4_k>(tensor);
+        case GGML_TYPE_IQ5_K: return check_tensor_for_blocks_256_fp16<block_iq5_k>(tensor);
+        case GGML_TYPE_IQ6_K: return check_tensor_for_blocks_256_fp16<block_iq6_k>(tensor);
+        case GGML_TYPE_IQ2_XXS: return check_tensor_for_blocks_256_fp16<block_iq2_xxs>(tensor);
+        case GGML_TYPE_IQ2_XS:  return check_tensor_for_blocks_256_fp16<block_iq2_xs>(tensor);
+        case GGML_TYPE_IQ2_S:   return check_tensor_for_blocks_256_fp16<block_iq2_s>(tensor);
+        case GGML_TYPE_IQ3_XXS: return check_tensor_for_blocks_256_fp16<block_iq3_xxs>(tensor);
+        case GGML_TYPE_IQ3_S:   return check_tensor_for_blocks_256_fp16<block_iq3_s>(tensor);
+        case GGML_TYPE_IQ4_XS:  return check_tensor_for_blocks_256_fp16<block_iq4_xs>(tensor);
+        default: break;
+    }
+    //int nblock = tensor->ne[0]/QK_K;
+    //for (int row = 0; row < ggml_nrows(tensor); ++row) {
+    //    auto x = (const block_iq3_k *)((const char *)tensor->data + tensor->nb[1]*row);
+    //    for (int ib = 0; ib < nblock; ++ib) {
+    //        float d = GGML_FP16_TO_FP32(x[ib].d);
+    //        if (isnan(d)) {
+    //            fprintf(stderr, "%s: found NaN in %s\n", __func__, tensor->name);
+    //            return false;
+    //        }
+    //    }
+    //}
+    return true;
+}

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -326,6 +326,8 @@ void iqk_quantize_any(int from_type, int to_type,
                       const void * GGML_RESTRICT x, void * GGML_RESTRICT y, void * work_buffer,
                       to_float_t to_float, from_float_t from_float, int ith, int nth);
 
+bool iqk_validate_tensor(const struct ggml_tensor * src);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7261,6 +7261,19 @@ static bool llm_load_tensors(
         if (n_modified > 0) printf("============ Modified %d tensors\n", n_modified);
     }
 
+    if (true) {
+        int nbad = 0;
+        for (auto& it : model.tensors_by_name) {
+            if (ggml_backend_buffer_is_host(it.second->buffer)) {
+                if (!iqk_validate_tensor(it.second)) ++nbad;
+            }
+        }
+        if (nbad > 0) {
+            LLAMA_LOG_ERROR("Found %d bad tensors in model\n", nbad);
+            throw std::runtime_error("Bad tensors in model");
+        }
+    }
+
     if (!ml.use_mmap && ml.repack_tensors) {
         int n_repacked = 0;
         for (auto& it : model.tensors_by_name) {


### PR DESCRIPTION

Add a check for NaNs while loading a model.

This is just a quick hack to check if there are NaNs in models where people are reporting issues.

The check is done unconditionally for all tensors stored on the CPU.
It would be better to have an option to turn on/off this check as it does trigger actual loading into RAM in a single thread, which may not really be what we want. 