### PR TITLE
CUDA: prompt processing optimizations for MoE models

### DIFF
--- a/ggml/src/ggml-cuda/mmq_id.cu
+++ b/ggml/src/ggml-cuda/mmq_id.cu
@@ -314,7 +314,7 @@ void compute_row_ids(const int32_t * ids, int32_t * ids_src1, int32_t * ids_dst,
 }
 
 void ggml_cuda_mul_mat_q_id(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
-        const ggml_tensor * ids_tensor, ggml_tensor * dst, char * ids_data, char * src1_quantized_data) {
+        const ggml_tensor * ids_tensor, ggml_tensor * dst, char * ids_data, char * src1_quantized_data, bool is_next) {
     GGML_ASSERT(       src1->type == GGML_TYPE_F32);
     GGML_ASSERT(       dst->type  == GGML_TYPE_F32);
     GGML_ASSERT(ids_tensor->type  == GGML_TYPE_I32); // Optional, used for batched GGML_MUL_MAT_ID.
@@ -377,6 +377,7 @@ void ggml_cuda_mul_mat_q_id(ggml_backend_cuda_context & ctx, const ggml_tensor *
         ids_src1 = (int32_t *)ids_data;
         ids_dst  = ids_src1 + ne_get_rows;
         expert_bounds = ids_dst + ne_get_rows;
+        if (is_next) ids_src1 = ids_dst;
     }
     else {
         GGML_ASSERT(ids_tensor->nb[0] == ggml_element_size(ids_tensor));

--- a/ggml/src/ggml-cuda/mmq_id.cu
+++ b/ggml/src/ggml-cuda/mmq_id.cu
@@ -507,7 +507,7 @@ void ggml_cuda_mul_mat_q_id(ggml_backend_cuda_context & ctx, const ggml_tensor *
         ne00, ne01, ne_get_rows, s01, ne_get_rows, s1,
         ne02, ne02, s02, s12, s2,
         ne03, ne13, s03, s13, s3,
-        use_stream_k, ne12};
+        use_stream_k, ne12, (int)n_expert_used, (int)ne02};
 
     //printf("ne00 = %ld, ne01 = %ld, ne_get_rows = %ld, s01 = %ld, s1 = %ld\n", ne00, ne01, ne_get_rows, s01, s1);
     //printf("ne02 = %ld, s02 = %ld, s12 = %ld, s2 = %ld\n", ne02, s02, s12, s2);

--- a/ggml/src/ggml-cuda/mmq_id.cu
+++ b/ggml/src/ggml-cuda/mmq_id.cu
@@ -103,7 +103,8 @@ static __global__ void mmq_ids_helper(
         const mmq_ids_helper_store store_it = store[itc];
         const int it       = store_it.it();
         const int iex_used = store_it.iex_used();
-        ids_src1[nex_prev + itc] = it*sis1          + iex_used % nchannels_y;
+        //ids_src1[nex_prev + itc] = it*sis1          + iex_used % nchannels_y;
+        ids_src1[nex_prev + itc] = it;
         ids_dst [nex_prev + itc] = it*n_expert_used + iex_used;
     }
 

--- a/ggml/src/ggml-cuda/mmq_id.cuh
+++ b/ggml/src/ggml-cuda/mmq_id.cuh
@@ -4,7 +4,7 @@
 
 void ggml_cuda_mul_mat_q_id(
         ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids,
-        ggml_tensor * dst, char * ids_data, char * src1_quantized_data);
+        ggml_tensor * dst, char * ids_data, char * src1_quantized_data, bool is_next);
 
 void compute_row_ids(const int32_t * ids, int32_t * ids_src1, int32_t * ids_dst, int32_t * expert_bounds,
         int64_t ne02, int64_t ne12, int64_t n_expert_used, int64_t ne11, int64_t nb11, int64_t nb12, int64_t nb21, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/mmq_id.cuh
+++ b/ggml/src/ggml-cuda/mmq_id.cuh
@@ -9,4 +9,9 @@ void ggml_cuda_mul_mat_q_id(
 void compute_row_ids(const int32_t * ids, int32_t * ids_src1, int32_t * ids_dst, int32_t * expert_bounds,
         int64_t ne02, int64_t ne12, int64_t n_expert_used, int64_t ne11, int64_t nb11, int64_t nb12, int64_t nb21, cudaStream_t stream);
 
+
+struct mmid_row_mapping;
+void compute_row_ids2(const int32_t * ids, mmid_row_mapping * rmapping, int32_t * expert_bounds,
+        int64_t ne02, int64_t ne12, int64_t n_expert_used, int64_t ne11, int64_t nb11, int64_t nb12, int64_t nb21, cudaStream_t stream);
+
 bool ggml_cuda_can_use_mmq_id(enum ggml_type type, int cc, int64_t ne11);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -13342,7 +13342,7 @@ struct llm_build_context {
 
         // whether to use n_tokens as the matrix dimension during multiplication or n_head
         // n_tokens is higher during prompt processing, this allows to optimize for this case
-        bool pp_opt = n_tokens >= 128; // Is it a fixed constant or is it somehow relared to n_head? original: n_tokens > n_head;
+        bool pp_opt = n_tokens >= 32; //128; // Is it a fixed constant or is it somehow relared to n_head? original: n_tokens > n_head;
 
         for (int il = 0; il < n_layer; ++il) {
             struct ggml_tensor * inpSA = inpL;


### PR DESCRIPTION

This PR adds additional PP optimizations for MoE models on CUDA:
* Don't repeat preparation of row ID's
* Better block size for smallish batch sizes

Not a major improvement, but quite significant for some batch sizes. Here 3 examples running fully offloaded to an RTX-4080

| model                | n_ubatch |          test |    t/s (main)    |    t/s (PR)      |  Speedup |
| -------------------- | -------: | ------------: | ---------------: | ---------------: | -------: |
| qwen3moe 30B IQ2_XXS |       32 |        pp4096 |   1288.84 ± 4.70 |   1293.91 ± 4.74 |  1.004   |   
| qwen3moe 30B IQ2_XXS |       64 |        pp4096 |  1920.23 ± 16.74 |   2030.87 ± 7.62 |  1.058   |   
| qwen3moe 30B IQ2_XXS |      128 |        pp4096 |  2493.96 ± 23.17 |  2854.37 ± 19.33 |  1.145   |   
| qwen3moe 30B IQ2_XXS |      256 |        pp4096 |  3954.87 ± 37.19 |  4295.92 ± 40.61 |  1.086   |   
| qwen3moe 30B IQ2_XXS |      512 |        pp4096 |  5541.13 ± 59.37 |   5607.92 ± 7.17 |  1.012   |   
| qwen3moe 30B IQ2_XXS |     1024 |        pp4096 |  6482.04 ± 15.25 |  6489.29 ± 78.17 |  1.001   |   
| qwen3moe 30B IQ2_XXS |     2048 |        pp4096 |  6553.18 ± 14.51 | 6569.46 ± 122.07 |  1.002   |   
| qwen3moe 30B IQ2_XXS |     4096 |        pp4096 |   6233.57 ± 6.11 |   6264.04 ± 7.99 |  1.005   |   

| model              | n_ubatch |          test |     t/s (main)   |     t/s (PR)     |  Speedup |
| ------------------ | -------: | ------------: | ---------------: | ---------------: | -------: |
| gpt-oss 20B MXFP4  |       32 |        pp3072 |  1829.59 ± 14.08 |  1846.63 ± 10.01 |  1.009   |   
| gpt-oss 20B MXFP4  |       64 |        pp3072 |  2718.86 ± 14.46 |  2850.96 ± 12.68 |  1.049   |   
| gpt-oss 20B MXFP4  |      128 |        pp3072 |  3605.42 ± 22.74 |  4172.56 ± 18.51 |  1.157   |   
| gpt-oss 20B MXFP4  |      256 |        pp3072 |  5585.75 ± 23.18 |  5613.02 ± 21.73 |  1.005   |   
| gpt-oss 20B MXFP4  |      512 |        pp3072 |  7515.52 ± 29.98 |  7550.16 ± 34.97 |  1.005   |   
| gpt-oss 20B MXFP4  |     1024 |        pp3072 |  8564.83 ± 27.95 |  8607.61 ± 26.29 |  1.005   |   
| gpt-oss 20B MXFP4  |     1536 |        pp3072 |  9842.09 ± 43.56 |  9913.19 ± 45.32 |  1.007   |   
| gpt-oss 20B MXFP4  |     3072 |        pp3072 | 10150.96 ± 19.07 | 10233.19 ± 24.86 |  1.008   |   

| model               | n_ubatch |          test |       t/s (main)  |       t/s (PR)    |  Speedup |
| ------------------- | -------: | ------------: | ----------------: | ----------------: | -------: |
| deepseek2 16B Q4_0  |       32 |        pp4096 |    935.59 ± 7.12  |  1317.92 ± 17.30  |  1.409   |   
| deepseek2 16B Q4_0  |       64 |        pp4096 |   1536.07 ± 3.37  |   2312.58 ± 6.17  |  1.506   |   
| deepseek2 16B Q4_0  |      128 |        pp4096 |  3045.47 ± 48.22  |  3637.98 ± 11.88  |  1.195   |   
| deepseek2 16B Q4_0  |      256 |        pp4096 |  5163.37 ± 58.35  |  5578.81 ± 33.57  |  1.080   |   
| deepseek2 16B Q4_0  |      512 |        pp4096 |  7573.41 ± 55.78  |  7919.14 ± 62.49  |  1.046   |   
| deepseek2 16B Q4_0  |     1024 |        pp4096 | 9661.28 ± 104.69  | 9732.25 ± 102.30  |  1.007   |   
| deepseek2 16B Q4_0  |     2048 |        pp4096 | 10369.55 ± 106.44 | 10432.49 ± 107.87 |  1.006   |   
| deepseek2 16B Q4_0  |     4096 |        pp4096 | 10235.64 ± 30.57  | 10374.08 ± 18.66  |  1.014   |   

