### PR TITLE
CUDA: FA optimization for models using SWA

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1035,9 +1035,6 @@ static __global__ void flash_attn_mma_ext_f16(
     int kb0_start_kernel = kb0_start * kb_niter;
     int kb0_stop_kernel  = kb0_stop  * kb_niter;
     if (bounds) {
-        if (kb0_start_kernel*KQ_per_iter >= bounds[jt].y || kb0_stop_kernel*KQ_per_iter < bounds[jt].x) {
-            return;
-        }
         kb0_start_kernel = max(kb0_start_kernel, bounds[jt].x / KQ_per_iter);
         kb0_stop_kernel  = min(kb0_stop_kernel,  bounds[jt].y / KQ_per_iter);
     }

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1400,7 +1400,7 @@ void launch_fattn_mma(
     dim3 blocks_num;
     if (stream_k) {
         // For short contexts it can be faster to have the SMs work on whole tiles because this lets us skip the fixup.
-        const int max_blocks = 2*nsm;
+        const int max_blocks = Q->ne[1] > 1 ? 2*nsm : nsm;
         const int tiles_nwaves = (ntiles_total + max_blocks - 1) / max_blocks;
         const int tiles_efficiency_percent = 100 * ntiles_total / (max_blocks*tiles_nwaves);
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -9008,6 +9008,8 @@ struct ggml_tensor * ggml_flash_attn_ext(
     float params[] = { scale, max_bias, softcap };
     ggml_set_op_params(result, params, sizeof(params));
 
+    ggml_set_op_params_i32(result, 4, 0);
+
     result->op   = GGML_OP_FLASH_ATTN_EXT;
     result->grad = is_node ? ggml_dup_tensor(ctx, result) : NULL;
     result->src[0] = q;


### PR DESCRIPTION

This PR is analogous to #702 and implements the optimization for the CUDA back-end.

Here performance comparisons between the main branch and this PR for `Q4_0`-quantized GPT-OSS-20B running on an RTX-4080 GPU:

### Prompt processing

<img width="792" height="612" alt="u2pp" src="https://github.com/user-attachments/assets/eb879ab8-b1c5-4e1a-ab3e-4bb2269d8bc6" />

### Token generation

<img width="792" height="612" alt="u2tg" src="https://github.com/user-attachments/assets/3be6ccb3-17aa-4891-86bc-7f69b51b8ab6" />
