### PR TITLE
Fix ggml_is_contiguously_allocated

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4743,7 +4743,9 @@ GGML_CALL bool ggml_is_permuted(const struct ggml_tensor * tensor) {
 }
 
 GGML_CALL bool ggml_is_contiguously_allocated(const struct ggml_tensor * tensor) {
-    return ggml_nbytes(tensor) == ggml_nelements(tensor) * ggml_type_size(tensor->type)/ggml_blck_size(tensor->type);
+    return ggml_nbytes(tensor) == ggml_nrows(tensor)*ggml_row_size(tensor->type, tensor->ne[0]);
+    // The ongoing mainline obsession with blocks of quants does not work with per tensor row scales
+    //return ggml_nbytes(tensor) == ggml_nelements(tensor) * ggml_type_size(tensor->type)/ggml_blck_size(tensor->type);
 }
 
 GGML_CALL bool ggml_is_contiguous_channels(const struct ggml_tensor * tensor) {


### PR DESCRIPTION

Otherwise hybrid inference with quants that have per row scales leads to an assert for MoE models. 