### PR TITLE
Add GLM 4.6 support

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6741,7 +6741,7 @@ static bool llm_load_tensors(
                             layer.nextn.embed_tokens     = create_tensor(ctx_for_layer(final_layer),
                                         tn(LLM_TENSOR_NEXTN_EMBED_TOKENS, "weight", final_layer),
                                         { n_embd, n_vocab },
-                                        flags);
+                                        flags | TENSOR_NOT_REQUIRED);
                             // ENORM, HNORM: [embd]
                             layer.nextn.enorm            = create_tensor(ctx_for_layer(final_layer),
                                         tn(LLM_TENSOR_NEXTN_ENORM, "weight", final_layer),
@@ -6755,12 +6755,12 @@ static bool llm_load_tensors(
                             layer.nextn.shared_head_head = create_tensor(ctx_for_layer(final_layer),
                                         tn(LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD, "weight", final_layer),
                                         { n_embd, n_vocab },
-                                        flags);
+                                        flags | TENSOR_NOT_REQUIRED);
                             // SHARED_HEAD_NORM: [embd]
                             layer.nextn.shared_head_norm = create_tensor(ctx_for_layer(final_layer),
                                         tn(LLM_TENSOR_NEXTN_SHARED_HEAD_NORM, "weight", final_layer),
                                         { n_embd },
-                                        flags);
+                                        flags | TENSOR_NOT_REQUIRED);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes: https://github.com/ikawrakow/ik_llama.cpp/issues/812

By marking a few tensors as optional. GLM 4.6 loads and inferences for me, if you wish to test: https://huggingface.co/Downtown-Case/GLM-4.6-128GB-RAM-IK-GGUF

Plucked from: https://github.com/ggml-org/llama.cpp/pull/16359

***

Random aside, but this might be a good opportunity to make sure the MTP (multi-token prediction) tensors are never loaded into RAM, since they are not used anyway? Their size is on the order of ~2GB quantized, I think, which is signficant when squeezing in a >3bpw quant.



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
