### PR TITLE
Remove duplicate 99% KLD output, add additional percentiles to match mainline

### DIFF
--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -1925,11 +1925,13 @@ static void kl_divergence(llama_context * ctx, const gpt_params & params) {
     printf("Maximum KLD: %10.6f\n", kld_values.back());
     printf("99.9%%   KLD: %10.6f\n", percentile(kld_values, 0.999f));
     printf("99.0%%   KLD: %10.6f\n", percentile(kld_values, 0.990f));
-    printf("99.0%%   KLD: %10.6f\n", percentile(kld_values, 0.990f));
+    printf("95.0%%   KLD: %10.6f\n", percentile(kld_values, 0.950f));
+    printf("90.0%%   KLD: %10.6f\n", percentile(kld_values, 0.900f));
     printf("Median  KLD: %10.6f\n", kld_median);
     printf("10.0%%   KLD: %10.6f\n", percentile(kld_values, 0.100f));
     printf(" 5.0%%   KLD: %10.6f\n", percentile(kld_values, 0.050f));
     printf(" 1.0%%   KLD: %10.6f\n", percentile(kld_values, 0.010f));
+    printf(" 0.1%%   KLD: %10.6f\n", percentile(kld_values, 0.001f));
     printf("Minimum KLD: %10.6f\n", kld_values.front());
 
     printf("\n");


### PR DESCRIPTION
There was a PR recently on mainline to add the additional percentiles to `llama-perplexity` [here](https://github.com/ggml-org/llama.cpp/pull/16321) and since I was doing some perplexity testing with ik_llama, I figured I'd put up a PR to fix the 90% being listed twice, and add in the other percentiles to match mainline.

I compiled ran a `llama-perplexity` run to verify that the output is showing correctly:
```
...
====== KL divergence statistics ======
Mean    KLD:   0.017475 ±   0.000763
Maximum KLD:  11.152802
99.9%   KLD:   1.098822
99.0%   KLD:   0.221226
95.0%   KLD:   0.055542
90.0%   KLD:   0.029520
Median  KLD:   0.004062
10.0%   KLD:   0.000020
 5.0%   KLD:   0.000005
 1.0%   KLD:   0.000000
 0.1%   KLD:  -0.000003
Minimum KLD:  -0.000423
...
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
