### PR TITLE
gpt-oss: duplicate experts biases when necessary

### DIFF
--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -178,6 +178,9 @@ struct llama_layer {
     struct ggml_tensor * ffn_gate_exps_b = nullptr;
     struct ggml_tensor * ffn_down_exps_b = nullptr;
     struct ggml_tensor * ffn_up_exps_b = nullptr;
+    struct ggml_tensor * ffn_gate_exps_b_dup = nullptr;
+    struct ggml_tensor * ffn_down_exps_b_dup = nullptr;
+    struct ggml_tensor * ffn_up_exps_b_dup = nullptr;
 
     // ff shared expert (shexp)
     struct ggml_tensor * ffn_gate_inp_shexp = nullptr;


### PR DESCRIPTION

While experimenting with hybrid GPU/CPU inference with GPT-OSS-120B on RTX-4080 in a Ryzen-5975WX rig, I noticed a significant performance difference depending on which tensors are overridden to the CPU:

Using
```
-ngl 100 -ot exps=CPU or -n-cpu-moe 100
```
which results in all `ffn_(up|gate|down)_exps.weight` and `ffn_(up|gate|down)_exps.bias` tensors to be stored on the CPU, we get these `llama-sweep-bench` results

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |   1024 |      0 |    3.903 |  1049.37 |   41.022 |    24.96 |
|  4096 |   1024 |   4096 |    4.012 |  1020.91 |   41.252 |    24.82 |
|  4096 |   1024 |   8192 |    3.994 |  1025.61 |   41.569 |    24.63 |
|  4096 |   1024 |  12288 |    4.042 |  1013.45 |   41.877 |    24.45 |
|  4096 |   1024 |  16384 |    4.112 |   996.11 |   42.164 |    24.29 |
|  4096 |   1024 |  20480 |    4.173 |   981.62 |   42.464 |    24.11 |
|  4096 |   1024 |  24576 |    4.208 |   973.43 |   42.751 |    23.95 |
|  4096 |   1024 |  28672 |    4.263 |   960.94 |   43.046 |    23.79 |

Using instead
```
-ngl 100 -ot "exps_(up|gate|down)_exps\.weight"
```
so that the `ffn_(up|gate|down)_exps.bias` tensors are stored on the GPU, we get these `llama-sweep-bench` results

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |   1024 |      0 |    3.091 |  1325.28 |   45.181 |    22.66 |
|  4096 |   1024 |   4096 |    3.180 |  1288.24 |   45.632 |    22.44 |
|  4096 |   1024 |   8192 |    3.204 |  1278.46 |   45.846 |    22.34 |
|  4096 |   1024 |  12288 |    3.252 |  1259.72 |   46.154 |    22.19 |
|  4096 |   1024 |  16384 |    3.320 |  1233.67 |   46.413 |    22.06 |
|  4096 |   1024 |  20480 |    3.384 |  1210.36 |   46.704 |    21.93 |
|  4096 |   1024 |  24576 |    3.423 |  1196.59 |   46.862 |    21.85 |
|  4096 |   1024 |  28672 |    3.468 |  1180.93 |   47.159 |    21.71 |

I.e., in the latter case we get 20-25% better PP performance but ~10% lower TG generation speed.

It is understandable that there will be some performance difference:
* When the experts are stored on the CPU, for TG the `ffn` portions of the compute graph are evaluated on the CPU, which requires copying the `ffn_(up|gate|down)_exps.bias` tensors from the GPU, so we get a lower TG performance in the latter case
*  For PP it is the other way around. When `ffn_(up|gate|down)_exps.bias` are not stored on the GPU, they need to be copied, so we get a lower PP performance in the former case.

But the PP performance difference is surprisingly large, considering that the `ffn_(up|gate|down)_exps.bias`  tensors are quite small (about 152 MiB for GPT-OSS-120B). On a 30 GB/s PCE-E it takes in the range of 5 ms to copy these tensors. The above results are for batch and u-batch size of 4096 tokens. At ~1300 tokens/second computing one u-batch takes 3+ seconds, so the 5 ms added for copying the experts biases are completely negligible. The difference in TG performance is more in line with the expectation: at 25 t/s a token generation requires ~40 ms, so the added 5 ms for copying the biases from the GPU to the CPU should lead to a ~10% drop in performance.

As I wasn't able to figure out why PP performance is impacted so much, this PR duplicates the  `ffn_(up|gate|down)_exps.bias` tensors when the corresponding ``ffn_(up|gate|down)_exps.weight` tensor is on a different device. When building the compute graph, and the duplicated tensors are present, they are used when batch size is less than 32 tokens. With this change we get the following `llama-sweep-bench` results

```
./bin/llama-sweep-bench -m $model -t 32 -ngl 100 -c 32768 -b 4096 -ub 4096 -ot "ffn_(up|gate|down)_exps\.weight=CPU" -fa -fmoe -ooae
```

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |   1024 |      0 |    3.172 |  1291.49 |   40.803 |    25.10 |
|  4096 |   1024 |   4096 |    3.264 |  1254.77 |   41.165 |    24.88 |
|  4096 |   1024 |   8192 |    3.283 |  1247.61 |   41.389 |    24.74 |
|  4096 |   1024 |  12288 |    3.332 |  1229.26 |   41.692 |    24.56 |
|  4096 |   1024 |  16384 |    3.399 |  1205.15 |   41.952 |    24.41 |
|  4096 |   1024 |  20480 |    3.467 |  1181.36 |   42.262 |    24.23 |
|  4096 |   1024 |  24576 |    3.495 |  1171.92 |   42.509 |    24.09 |
|  4096 |   1024 |  28672 |    3.548 |  1154.57 |   42.789 |    23.93 |

I.e., we now get the better PP performance and the better TG performance.
 
If you are using GPT-OSS-120B with `ik_llama.cpp` and hybrid inference, `-ot "ffn_(up|gate|down)_exps\.weight=CPU"` is the recommended tensor override option after this PR has been merged.

**Note**: the PR only affects the GPT-OSS models as other common MoE models to not use experts biases.





