### PR TITLE
Make only-active-expert-offload on by default and add to llama-bench

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1390,7 +1390,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         }
         return true;
     }
-    if (arg == "--offload-only-active-experts" || arg == "-ooae") {
+    if (arg == "--no-offload-only-active-experts" || arg == "-no-ooae") {
         params.only_active_exps = true;
         return true;
     }

--- a/common/common.h
+++ b/common/common.h
@@ -255,7 +255,7 @@ struct gpt_params {
     bool repack_tensors    = false; // repack tensors if interleaved variant is available
     bool use_thp           = false; // use transparent huge pages (linux only)
     bool validate_quants   = false; // if true, check for NaNs while loading the model
-    bool only_active_exps  = false; // if true, offload only active experts (relevant only for hybrid CPU/GPU)
+    bool only_active_exps  = true;  // if true, offload only active experts (relevant only for hybrid CPU/GPU)
 
     std::string cache_type_k = "f16"; // KV cache data type for the K
     std::string cache_type_v = "f16"; // KV cache data type for the V


### PR DESCRIPTION

It is always at least as good as offloading all experts. For some models (e.g., GPT-OSS) it is much better.
So, no reason to have the user remember to add the `-ooae` flag.

But if offloading only active experts in hybrid inference causes issues, it can be turned off via `-no-ooae` or `-=no-offload-only-active-experts`.

Also added corresponding flags to `llama-bench`.