### PR TITLE
Fix assistant prefill in OAI chat API

### DIFF
--- a/examples/server/utils.hpp
+++ b/examples/server/utils.hpp
@@ -591,6 +591,17 @@ static json oaicompat_chat_params_parse(
 
     // Apply chat template to the list of messages
     auto chat_params = common_chat_templates_apply(opt.tmpls, inputs);
+    
+    /* Append assistant prefilled message */
+    if (prefill_assistant_message) {
+        if (!last_message.content_parts.empty()) {
+            for (auto & p : last_message.content_parts) {
+                chat_params.prompt += p.text;
+            }
+        } else {
+            chat_params.prompt += last_message.content;
+        }
+    }
 
     llama_params["chat_format"] = static_cast<int>(chat_params.format);
     llama_params["prompt"] = chat_params.prompt;


### PR DESCRIPTION
Support for prefilling assistant messages in the v1/chat/completions endpoint was added in #723 (directly ported over from mainline), but until now it has not been functional. I had a look and realised the author missed a few lines from the source implementation, responsible for actually appending the prefilled content to the chat. This change simply restores them.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
