### PR TITLE
cuda: add missing backwards RoPE op

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3315,6 +3315,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_ROPE:
             ggml_cuda_op_rope(ctx, dst);
             break;
+        case GGML_OP_ROPE_BACK:
+            ggml_cuda_op_rope_back(ctx, dst);
+            break;
         case GGML_OP_IM2COL:
             ggml_cuda_op_im2col(ctx, dst);
             break;
@@ -4373,6 +4376,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
         case GGML_OP_SOFT_MAX:
         case GGML_OP_SOFT_CAP_MAX:
         case GGML_OP_ROPE:
+        case GGML_OP_ROPE_BACK:
             return true;
         //case GGML_OP_ROPE:
         //    return ggml_is_contiguous(op->src[0]);


### PR DESCRIPTION

While working on the RoPE cache PR (#887), I noticed that the backwards RoPE (needed for k-shift) is missing on CUDA. Someone was mentioning that k-shift was unbearably slow. Well, this explains it.

This PR adds the backwards RoPE to the CUDA back-end. It was just a matter of adding a call to the appropriate function and answering with "yes" the question if `ROPE_BACK` is supported.