### PR TITLE
Allow quantization of ffn_gate_inp

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -151,7 +151,7 @@ static bool try_parse_ftype(const std::string & ftype_str_in, llama_ftype & ftyp
 //
 [[noreturn]]
 static void usage(const char * executable) {
-    printf("usage: %s [--help] [--allow-requantize] [--leave-output-tensor] [--pure] [--imatrix] [--hide-imatrix] [--include-weights] [--exclude-weights] [--output-tensor-type] [--token-embedding-type] [--attn-q-type] [--attn-k-type] [--attn-v-type] [--attn-qkv-type] [--attn-output-type] [--ffn-gate-type] [--ffn-down-type] [--ffn-up-type] [--keep-split] [--override-kv] model-f32.gguf [model-quant.gguf] type [nthreads]\n\n", executable);
+    printf("usage: %s [--help] [--allow-requantize] [--leave-output-tensor] [--pure] [--imatrix] [--hide-imatrix] [--include-weights] [--exclude-weights] [--output-tensor-type] [--token-embedding-type] [--ffn-gate-inp-type] [--attn-q-type] [--attn-k-type] [--attn-v-type] [--attn-qkv-type] [--attn-output-type] [--ffn-gate-type] [--ffn-down-type] [--ffn-up-type] [--keep-split] [--override-kv] model-f32.gguf [model-quant.gguf] type [nthreads]\n\n", executable);
     printf("  --allow-requantize: Allows requantizing tensors that have already been quantized. Warning: This can severely reduce quality compared to quantizing from 16bit or 32bit\n");
     printf("  --leave-output-tensor: Will leave output.weight un(re)quantized. Increases model size but may also increase quality, especially when requantizing\n");
     printf("  --pure: Disable k-quant mixtures and quantize all tensors to the same type\n");
@@ -161,6 +161,7 @@ static void usage(const char * executable) {
     printf("  --exclude-weights tensor_name: use importance matrix for this/these tensor(s)\n");
     printf("  --output-tensor-type ggml_type: use this ggml_type for the output.weight tensor.\n");
     printf("  --token-embedding-type ggml_type: use this ggml_type for the token_embd.weight tensor.\n\n");
+    printf("  --ffn-gate-inp-type ggml_type: use this ggml_type for the ffn_gate_inp tensors.\n\n");
     printf("  --custom-q regex1=type1,regex2=type2...: use this to specify custom quantization type rules.\n\n");
     printf("  --repack Repack all tensors to the corresponding _r4/8 variant if available.\n\n");
     printf("  --repack-pattern Comma separated list of regexs to use for matching tensor names to be repacked.\n\n");
@@ -372,6 +373,12 @@ int main(int argc, char ** argv) {
         } else if (strcmp(argv[arg_idx], "--token-embedding-type") == 0) {
             if (arg_idx < argc-1) {
                 params.token_embedding_type = parse_ggml_type(argv[++arg_idx]);
+            } else {
+                usage(argv[0]);
+            }
+        } else if (strcmp(argv[arg_idx], "--ffn-gate-inp-type") == 0) {
+            if (arg_idx < argc-1) {
+                params.ffn_gate_inp_type = parse_ggml_type(argv[++arg_idx]);
             } else {
                 usage(argv[0]);
             }

--- a/include/llama.h
+++ b/include/llama.h
@@ -454,6 +454,7 @@ extern "C" {
         enum ggml_type ffn_gate_type;        // feedforward network gate type
         enum ggml_type ffn_down_type;        // feedforward network down type
         enum ggml_type ffn_up_type;          // feedforward network up type
+        enum ggml_type ffn_gate_inp_type;    // routed experts probabilities typy (relevant for MoE models only)
         bool allow_requantize;               // allow quantizing non-f32/f16 tensors
         bool quantize_output_tensor;         // quantize output.weight
         bool only_copy;                      // only copy tensors - ftype, allow_requantize and quantize_output_tensor are ignored

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3859,6 +3859,7 @@ struct llama_model_quantize_params llama_model_quantize_default_params() {
         /*.ffn_gate_type               =*/ GGML_TYPE_COUNT,
         /*.ffn_down_type               =*/ GGML_TYPE_COUNT,
         /*.ffn_up_type                 =*/ GGML_TYPE_COUNT,
+        /*.ffn_gat_inp_type            =*/ GGML_TYPE_COUNT,
         /*.allow_requantize            =*/ false,
         /*.quantize_output_tensor      =*/ true,
         /*.only_copy                   =*/ false,


### PR DESCRIPTION
Recent MoE models have a lot of experts. This means that the `ffn_gate_inp` tensors, which multiplies the output of self attention to create experts routing probabilities, is not really small (size of embedding times number of experts). On the main branch (and also in mainline `llama.cpp`) this tensor is left as `f32` and there is no provision to quantize it. The result is that the `ffn_gate_inp` matrix multiplication represents a non-negligible fraction of overall computation and data that needs to be fetched from memory during token generation (TG).

This PR adds the ability to quantize the `ffn_gate_inp` tensors by adding
```
--ffn-gate-inp-type type
```
to the `llama-quantize` command.

Here is a benchmark example of Qwen3-30B-A3B running on a Ryzen-7950X CPU with `ffn_gate_inp` left as `f32` or quantized to `Q8_0`

| model            |       size |      test |    t/s (f32)     |     t/s (Q8_0)    |  Speedup |
| ---------------- | ---------: | --------: | ---------------: | ---------------: | -------- |
| qwen3moe IQ4_KS  |  15.83 GiB |    pp2048 |    517.21 ± 2.81 |    521.49 ± 2.89 |  1.008   |   
| qwen3moe IQ4_KS  |  15.83 GiB |     tg128 |     26.36 ± 0.02 |     27.02 ± 0.10 |  1.025   |   
| qwen3moe IQ2_XXS |   8.05 GiB |    pp2048 |    517.82 ± 3.36 |    527.56 ± 4.61 |  1.019   |   
| qwen3moe IQ2_XXS |   8.05 GiB |     tg128 |     41.07 ± 0.43 |     43.62 ± 0.07 |  1.062   |

We observe non-negligible TG performance gain. In terms of model quality, the `f32` and `Q8_0` models are indistinguishable based on `PPL` and quick evaluation of responses to a set of prompts. Obviously, anyone who wants to take advantage of this option should make their own evaluation of potential quality degradation due to `ffn_gate_inp` quantization.

On CUDA the performance gain is less, about 1% in TG performance for the `IQ2_XXS` version of Qwen3-30B-A3B (which I can run fully offloaded on my RTX-4080 GPU).

 
 