### PR TITLE
Adding cmake option to disable CUDA fusion

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -133,6 +133,7 @@ option(GGML_CUDA_NO_PEER_COPY               "ggml: do not use peer to peer copie
 option(GGML_CUDA_NO_VMM                     "ggml: do not try to use CUDA VMM"                OFF)
 option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     OFF)
 option(GGML_CUDA_USE_GRAPHS                 "ggml: use CUDA graphs (llama.cpp only)"          ON)
+set   (GGML_CUDA_FUSION  "1" CACHE STRING   "ggml: enable/disable fusion")
 
 option(GGML_IQK_FLASH_ATTENTION             "ggml: enable the IQK FlashAttention CPU kernels" ON)
 option(GGML_IQK_FA_ALL_QUANTS               "ggml: compile all quants for IQK FlashAttention" OFF)

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -388,6 +388,7 @@ if (GGML_CUDA)
         add_compile_definitions(K_QUANTS_PER_ITERATION=${GGML_CUDA_KQUANTS_ITER})
         add_compile_definitions(GGML_CUDA_PEER_MAX_BATCH_SIZE=${GGML_CUDA_PEER_MAX_BATCH_SIZE})
         add_compile_definitions(GGML_CUDA_MIN_BATCH_OFFLOAD=${GGML_CUDA_MIN_BATCH_OFFLOAD})
+        add_compile_definitions(GGML_CUDA_FUSION=${GGML_CUDA_FUSION})
 
         if (GGML_CUDA_USE_GRAPHS)
             add_compile_definitions(GGML_CUDA_USE_GRAPHS)


### PR DESCRIPTION

There have been reports about issues in recent `ik_llama.cpp` versions (#893, #895). My hypothesis is that they are caused by bugs in one or more of the op fusions on CUDA introduced in recent PRs. To test this hypothesis, this PR adds the ability to enable or disable CUDA fusion via `cmake`

To disable
```
cmake -DGGML_CUDA_FUSION=0 $other_cmake_args
```
