### PR TITLE
Fix iqk_mul_mat when number of rows is not multiple of repack rows

### DIFF
--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -502,7 +502,8 @@ extern "C" IQK_API bool iqk_mul_mat(long Nx, long Ny, long ne00,
 
     auto etypeA = ggml_type(typeA);
     if (auto dequant_type = MulMat::is_dequant_better(etypeA, Ny);
-             dequant_type != etypeA && MulMat::prepare(dequant_type, typeB, ne00, mm, Ny)) {
+             dequant_type != etypeA && MulMat::prepare(dequant_type, typeB, ne00, mm, Ny) &&
+             Nx%MulMat::num_rows(ggml_type(dequant_type)) == 0) {
 
         constexpr int k_x_step = 32;
 


### PR DESCRIPTION

I was playing with Qwen3-0.6B and got an assert when running CPU only. The issue is that this model used the token embedding tensor as the output tensor, and the number of rows (which is the number of tokens in the vocabulary) is 151669. When performing the final matrix multiplication with this tensor we decide that it is useful to repack it on the fly, to `Q8_0_R8` in that case. But the number of rows is not a multiple of 8, so we hit an assert.

The PR fixes this by avoiding to go the repacked route if the number of rows is not a multiple of interleaved rows. 