### PR TITLE
Fix PPL increase caused by mmq_id

### DIFF
--- a/ggml/src/ggml-cuda/mmq_id_common.cuh
+++ b/ggml/src/ggml-cuda/mmq_id_common.cuh
@@ -3960,7 +3960,10 @@ template <ggml_type type, int mmq_x>
 static void launch_mul_mat_q_id(ggml_backend_cuda_context & ctx, const mmq_args_id & args, cudaStream_t stream) {
     const int id = ggml_cuda_get_device();
     const int cc = ggml_cuda_info().devices[id].cc;
-    const int nsm = ggml_cuda_info().devices[id].nsm;
+    const int nsm_max = ggml_cuda_info().devices[id].nsm;
+    int nsm = 1;
+    //while (nsm*2 <= nsm_max) nsm *= 2;
+    while (nsm < nsm_max) nsm *= 2;
     const int warp_size = ggml_cuda_get_physical_warp_size_host(); //ggml_cuda_info().devices[id].warp_size;
     const int nwarps = mmq_get_nwarps_host(cc, warp_size);
     const int mmq_y = get_mmq_y_host(cc);


### PR DESCRIPTION

@Nexesenex noticed that the `mmq_id` MoE matrix multiplication approach added in #728 leads to a non-negligible increase in perplexity (https://github.com/ikawrakow/ik_llama.cpp/pull/728#issuecomment-3494522254). As PR #728 is derived from [PR 15525](https://github.com/ggml-org/llama.cpp/pull/15525) in mainline `llama.cpp`, the same issue exists there (see also https://github.com/ikawrakow/ik_llama.cpp/pull/728#issuecomment-3496574276). As a result, I added the ability to disable `mmq_id` via a command line parameter in #910. 

I don't like the #910 solution because disabling `mmq_id` leads to a significantly lower PP performance for small batch sizes. So, after some [back-and-fort](https://github.com/ikawrakow/ik_llama.cpp/pull/728#issuecomment-3501039000) with @JohannesGaessler, I went ahead and changed the `mmq_id` implementation to pretend that the number of streaming multiprocessors (SM) is a power of 2. This does in fact fix the PPL increase for all models I tried (GLM-4.5-AIR, Ling-mini-2.0, Qwen3-30B-A3B, DeepSeek-Lite). Based on experimentation with these models, it seems using the lowest power of two that is >= number of SM gives better performance than using the highest power of two that is <= number of SM.

I don't see any negative impact on performance. If anything, on my RTX-4080 GPU PP performance is very slightly better.

Please try and report any performance degradation (or performance improvement). To make sure that you are using  `mmq_id` rather than the original `ik_llama.cpp` MoE matrix multiplication implementation, add `-cuda  mmq-id-size=1000` to your command line.