### PR TITLE
Disable add + fused_rms_norm fusion

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3102,7 +3102,7 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
                 ggml_cuda_op_fused_add_add_rms_norm(ctx, dst, cgraph->nodes[i+1], cgraph->nodes[i+2]);
                 i += 2;
             }
-            else if (fusion && i + 1 < cgraph->n_nodes &&
+            else if (false && fusion && i + 1 < cgraph->n_nodes &&
                 cgraph->nodes[i+1]->op == GGML_OP_FUSED_RMS_NORM &&
                 ggml_is_contiguous(dst->src[0]) &&
                 ggml_is_contiguous(dst->src[1]) &&


### PR DESCRIPTION

This fused kernel computes two things at once that are both needed later
* `c = a + b`
* `d = fused_rms_norm(c)`

It turns out the back-end allocates `c` to go into `a`, and `d` to go into `b` (they are all the same shape and `a` and `b` are not needed after `c` has been computed). This somehow leads to a data race (I don't really understand why we get a race, but I observe it in practice as results changing from run to run).

Hence, this PR disables this fusion. This should hopefully solve the issues with GLM-4.5/6/Air and fusion. 