### PR TITLE
ggml : add ARM Grace Blackwell support for IQK operations

### DIFF
--- a/ggml/src/iqk/iqk_cpu_ops.cpp
+++ b/ggml/src/iqk/iqk_cpu_ops.cpp
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+#define IQK_IMPLEMENT
+
 #include "iqk_cpu_ops.h"
 #include "iqk_utils.h"
 #include "ggml.h"
@@ -13,6 +15,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif
 
 namespace {
 // Playing around with group scores: use sum of probabilities in the group


### PR DESCRIPTION
## Summary
Enables IQK quantization operations on ARM-based systems, specifically NVIDIA DGX Spark with GB10 Grace Blackwell architecture.

## Changes
**File**: `ggml/src/iqk/iqk_cpu_ops.cpp`
- Added `IQK_IMPLEMENT` macro definition to enable IQK functions on ARM
- Added `arm_neon.h` header include for ARM NEON SIMD intrinsics

## Build Instructions for ARM
```bash
  cmake .. -DGGML_CUDA=ON \
           -DCMAKE_CXX_FLAGS="-march=armv8.2-a+dotprod+fp16" \
           -DCMAKE_C_FLAGS="-march=armv8.2-a+dotprod+fp16"
  cmake --build . --config Release

```
Fixes build errors:
- 'float32x4_t' does not name a type
- 'vld1q_f32' was not declared in this scope
- 'v_expf' was not declared in this scope
- Missing FP16 NEON intrinsics

Testing

Platform: NVIDIA DGX Spark
  - Architecture: aarch64 (ARM)
  - CPU: GB10 Grace Blackwell 
  - Memory: 128GB unified memory
  - GPU: NVIDIA GB10

  Verification:
  - Build completes successfully with CUDA support
  -  Model loading tested with Kimi-K2-Thinking (219GB GGUF, IQ1_KT quantization)
  - CUDA backend correctly detects GB10 GPU
  - IQK quantization types properly recognized

Note: Full CI pipeline not run locally due to ARM hardware requirement. Available for ongoing ARM-specific testing and maintenance.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x ] Medium
  - [ ] High
