### PR TITLE
server: bug fix for preserved_tokens not preserved in process_token

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1977,7 +1977,7 @@ struct server_context {
 
     bool process_token(completion_token_output & result, server_slot & slot) {
         // remember which tokens were sampled - used for repetition penalties during sampling
-        const std::string token_str = llama_token_to_piece(ctx, result.tok, params.special);
+        const std::string token_str = result.text_to_send;
         slot.sampled = result.tok;
 
         // search stop word and delete it
@@ -3447,7 +3447,7 @@ struct server_context {
                     completion_token_output result;
 
                     result.tok = ids[i];
-                    result.text_to_send = llama_token_to_piece(ctx, result.tok, params.special);
+                    result.text_to_send = llama_token_to_piece(ctx, result.tok, accept_special_token(slot, result.tok));
                     result.prob         = 1.0f; // set later
 
                     if (slot.sparams.n_probs > 0) {


### PR DESCRIPTION
Address https://github.com/ikawrakow/ik_llama.cpp/issues/925.
Thanks to @KiruyaMomochi, this PR fixes DeepSeek V3.1 function calling. Don't have the model to test, but should be good as it follows mainline. 
