### PR TITLE
DeepSeek TG optimizations

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3232,7 +3232,14 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
             ggml_cuda_op_group_norm(ctx, dst);
             break;
         case GGML_OP_CONCAT:
-            ggml_cuda_op_concat(ctx, dst);
+            if (fusion && i + 2 < cgraph->n_nodes &&
+                cgraph->nodes[i+1]->op == GGML_OP_VIEW &&
+                cgraph->nodes[i+2]->op == GGML_OP_CPY &&
+                ggml_cuda_concat_cpy(ctx, dst, cgraph->nodes[i+2])) {
+                i += 2;
+            } else {
+                ggml_cuda_op_concat(ctx, dst);
+            }
             break;
         case GGML_OP_UPSCALE:
             ggml_cuda_op_upscale(ctx, dst);

--- a/ggml/src/ggml-cuda/cpy.cuh
+++ b/ggml/src/ggml-cuda/cpy.cuh
@@ -12,3 +12,6 @@ void ggml_cuda_cpy_dest_ptrs_copy(ggml_cuda_graph * cuda_graph, char ** host_des
 
 bool ggml_cuda_cpy_2(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
         ggml_tensor * dst1, ggml_tensor * dst2, bool disable_indirection = false);
+
+bool ggml_cuda_concat_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * concat, const ggml_tensor * dst,
+        bool disable_indirection = false);

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -6268,11 +6268,13 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
                     kqv = ggml_mul_mat(ctx0, wv_b, kqv_compressed);
                     cb(kqv, "kqv", il);
 
-                    kqv = ggml_cont(ctx0, ggml_permute(ctx0, kqv, 0, 2, 1, 3));
-                    cb(kqv, "kqv_perm", il);
-
-                    cur = ggml_view_2d(ctx0, kqv, n_embd_head_v*n_head, n_tokens, ggml_row_size(kqv->type, n_embd_head_v*n_head), 0);
+                    if (n_tokens > 1) {
+                        kqv = ggml_cont(ctx0, ggml_permute(ctx0, kqv, 0, 2, 1, 3));
+                        cb(kqv, "kqv_perm", il);
+                    }
+                    cur = ggml_reshape_2d(ctx0, kqv, n_embd_head_v*n_head, n_tokens);
                     cb(cur, "kqv_2d", il);
+
                 }
 
                 ggml_build_forward_expand(gf, cur);


### PR DESCRIPTION

This PR adds some optimizations to the DeepSeek MLA attention compute graph:

* Fuse concat and copy into K cache (only enabled if `-cuda fusion=1`)
* Avoids a copy when batch size is 1 (as in TG)
 
Combined effect: about +2% in TG performance with full GPU offload (tested with DeepSeek-Lite on RTX-4080)
