### PR TITLE
Make biased gemv fusion optional

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2145,7 +2145,6 @@ static int ggml_cuda_mul_mat_q(ggml_backend_cuda_context & ctx, const ggml_tenso
                 cgraph->nodes[node_n+2]->src[1]->type == GGML_TYPE_F32 &&
                 ggml_nrows(cgraph->nodes[node_n+2]->src[1]) == 1) {
                 // We have a bias applied after the matrix multiplication and we can fuse it
-                printf("Fusing %s(%s) and %s(%s)\n", ggml_op_name(dst->op), dst->name, ggml_op_name(cgraph->nodes[node_n+2]->op), cgraph->nodes[node_n+2]->name);
                 ggml_cuda_op_mul_mat_vec_q_biased(ctx, dst->src[0], src1, cgraph->nodes[node_n+2], cgraph->nodes[node_n+2]->src[1],
                         (const char *)dst->src[0]->data, nullptr, src1_quantized.get(), (float *)cgraph->nodes[node_n+2]->data,
                         0, dst->src[0]->ne[1], src1->ne[1], ne10_padded, stream);


### PR DESCRIPTION

The main purpose of this PR is to see if the biased GEMV introduced in #868 is breaking things for some people. It will be disabled by default unless explicitly enabled via running with `-cuda fusion=1` or via building with `cmake -DGGML_CUDA_FUSION=1`. 