### PR TITLE
Add missing AVX512 operators for MSVC

### DIFF
--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -1,9 +1,11 @@
 #include "iqk_gemm_legacy_quants.h"
+
 #include <type_traits>
 
 #ifdef IQK_IMPLEMENT
 
 #include "ggml-impl.h"
+#include "iqk_utils.h"
 
 #define GGML_COMMON_IMPL_C
 #include "ggml-common.h"

--- a/ggml/src/iqk/iqk_utils.h
+++ b/ggml/src/iqk/iqk_utils.h
@@ -80,6 +80,14 @@ static inline float32x4_t v_gelu(float32x4_t x, float32x4_t c1, float32x4_t c2) 
 
 #endif // __ARN_NEON
 
+#if defined(__AVX512F__) && defined(_MSC_VER)
+#include <immintrin.h>
+
+static inline __m512i operator|(__m512i a, __m512i b) { return _mm512_or_si512(a, b); }
+static inline __m512i operator&(__m512i a, __m512i b) { return _mm512_and_si512(a, b); }
+static inline __m512i operator^(__m512i a, __m512i b) { return _mm512_xor_si512(a, b); }
+#endif
+
 #if defined(__AVX512F__) && defined(__AVX512DQ__)
 
 // copy-pasted from Justine Tunney's contribution to llama.cpp


### PR DESCRIPTION

Fixes Windows `AVX512` build.

Thanks to @moooV252 for reporting and providing a fix (#946)

Closes #946 