### PR TITLE
Fix ggml_cuda_fattn_is_supported

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -169,7 +169,7 @@ bool ggml_cuda_fattn_is_supported(ggml_backend_cuda_context & ctx, const ggml_te
     const bool mma_faster_for_bs1 = new_mma_available(cc) && gqa_opt_applies && !(Q->ne[1] == 1 && n_swa > 0);
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % (2*WARP_SIZE) == 0;
     if (Q->ne[1] == 1 && can_use_vector_kernel && !mma_faster_for_bs1 && !ggml_is_quantized(K->type) && !ggml_is_quantized(V->type)) {
-        return ggml_cuda_fattn_tile_f32_is_supported(ctx, dst);
+        return ggml_cuda_fattn_vec_f32_is_supported(ctx, dst);
     }
 
     if (new_mma_available(cc) && (Q->ne[0] == 576 || (K->ne[0] == 192 && V->ne[0] == 128))) {


### PR DESCRIPTION

It was calling the tile `is_supported` function instead of the vector one, which returns `false` for a head size of 256, which causes models with head size of 256 (e.g., Gemma) to run FA on the CPU for TG.