### PR TITLE
Fix run time repacking when Q, K, V have been merged

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1907,9 +1907,9 @@ static bool llm_load_tensors(
         for (auto& it : model.tensors_by_name) {
             if (ggml_backend_buffer_is_host(it.second->buffer)) {
                 auto orig_type = it.second->type;
+                if (it.second->view_src) continue;
                 iqk_repack_tensor(it.second);
                 if (it.second->type != orig_type) ++n_repacked;
-                //printf("Repacking tensor %s\n", it.first.c_str());
             }
         }
         if (n_repacked > 0) printf("============ Repacked %d tensors\n", n_repacked);


### PR DESCRIPTION

When Q, K, V have been merged, we have in the list of tensors the merged `QKV` (or merged `QK)`, along with `Q, K, V`, which are now views into `QKV` (or `QK`) This list is used to iterate over all tensors when the user has requested run-time repacking (`-rtr`). The results is that the repacking is done twice, once on `QKV` and once on the views, so we get garbage, which typically leads to a crash due to an assert in flash attention.

This PR fixes the issue. I guess, nobody has yet tried to use `-mqkv` and `-rtr` together.  