### PR TITLE
Add mqkv and rcache for Gemma3

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -4952,8 +4952,6 @@ ggml_cgraph * llm_build_context::build_gemma2() {
 ggml_cgraph * llm_build_context::build_gemma3() {
     struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, llama_model_max_nodes(model), false);
 
-    const int64_t n_embd_head_k = hparams.n_embd_head_k;
-
     struct ggml_tensor * cur;
     struct ggml_tensor * inpL;
 
@@ -4977,6 +4975,15 @@ ggml_cgraph * llm_build_context::build_gemma3() {
     // 5 layers of local attention followed by 1 layer of global attention
     static const int sliding_window_pattern = 6;
 
+    ggml_tensor * rope_cache   = nullptr;
+    ggml_tensor * rope_cache_l = nullptr;
+    if (cparams.rope_cache && (rope_type == LLAMA_ROPE_TYPE_NEOX || rope_type == LLAMA_ROPE_TYPE_NORM)) {
+        rope_cache = ggml_rope_cache(ctx0, inp_pos, nullptr, n_rot, n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+            ext_factor, attn_factor, beta_fast, beta_slow);
+        rope_cache_l = ggml_rope_cache(ctx0, inp_pos, nullptr, n_rot, n_rot, rope_type, n_ctx_orig, 10000.0f, 1.0f,
+            ext_factor, attn_factor, beta_fast, beta_slow);
+    }
+
     for (int il = 0; il < n_layer; ++il) {
         const bool is_sliding          = (il + 1) % sliding_window_pattern;
         const float freq_base_l        = is_sliding ? 10000.0f    : freq_base;
@@ -4989,24 +4996,24 @@ ggml_cgraph * llm_build_context::build_gemma3() {
 
         // self-attention
         {
-            auto [Qcur, Kcur, Vcur] = llm_build_mul_mat_qkv(gf, cur, model.layers[il].wq, nullptr,
-                    model.layers[il].wk, nullptr,
-                    model.layers[il].wv, nullptr, 0, il);
+            auto [Qcur, Kcur, Vcur] = llm_build_mul_mat_qkv(gf, cur,
+                    model.layers[il].wqkv, nullptr,
+                    model.layers[il].wqk, nullptr,
+                    model.layers[il].wq, nullptr, model.layers[il].wk, nullptr, model.layers[il].wv, nullptr,
+                    model.layers[il].attn_q_norm, model.layers[il].attn_k_norm, 0, il);
 
-            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head_k, n_head,    n_tokens);
-            Qcur = llm_build_norm(ctx0, Qcur, hparams, model.layers[il].attn_q_norm, NULL, LLM_NORM_RMS, cb, il);
-            cb(Qcur, "Qcur_normed", il);
+            if (rope_cache) {
+                auto rcache = is_sliding ? rope_cache_l : rope_cache;
+                Qcur = ggml_rope_fast(ctx0, Qcur, rcache);
+                Kcur = ggml_rope_fast(ctx0, Kcur, rcache);
+            } else {
+                Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, nullptr, n_rot, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
+                        ext_factor, attn_factor, beta_fast, beta_slow);
 
-            Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, nullptr, n_rot, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                    ext_factor, attn_factor, beta_fast, beta_slow);
+                Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, nullptr, n_rot, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
+                        ext_factor, attn_factor, beta_fast, beta_slow);
+            }
             cb(Qcur, "Qcur", il);
-
-            Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head_k, n_head_kv, n_tokens);
-            Kcur = llm_build_norm(ctx0, Kcur, hparams, model.layers[il].attn_k_norm, NULL, LLM_NORM_RMS, cb, il);
-            cb(Kcur, "Kcur_normed", il);
-
-            Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, nullptr, n_rot, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                    ext_factor, attn_factor, beta_fast, beta_slow);
             cb(Kcur, "Kcur", il);
 
             cur = llm_build_kv(ctx0, lctx, kv_self, gf, model.layers[il].wo, NULL,


### PR DESCRIPTION

I was fixing #967 and, once at it, decided to add the ability to merge Q, K, V, and the ability to use RoPE cache to Gemma3 models.

Here `sweep-bench` results for the model quoted in #967 (finetune of Gemma3-12B) on RTX-4080

### PR 

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    128 |      0 |    0.187 |  5464.86 |    1.532 |    83.57 |
|  1024 |    128 |   1024 |    0.189 |  5431.70 |    1.633 |    78.40 |
|  1024 |    128 |   2048 |    0.193 |  5303.58 |    1.641 |    78.00 |
|  1024 |    128 |   3072 |    0.196 |  5234.83 |    1.653 |    77.43 |
|  1024 |    128 |   4096 |    0.196 |  5215.97 |    1.667 |    76.77 |
|  1024 |    128 |   5120 |    0.199 |  5144.02 |    1.684 |    76.01 |
|  1024 |    128 |   6144 |    0.201 |  5101.56 |    1.694 |    75.57 |
|  1024 |    128 |   7168 |    0.203 |  5047.44 |    1.713 |    74.73 |
|  1024 |    128 |   8192 |    0.204 |  5027.96 |    1.722 |    74.35 |
|  1024 |    128 |   9216 |    0.206 |  4964.13 |    1.734 |    73.82 |
|  1024 |    128 |  10240 |    0.209 |  4907.86 |    1.751 |    73.12 |
|  1024 |    128 |  11264 |    0.211 |  4862.67 |    1.761 |    72.70 |
|  1024 |    128 |  12288 |    0.211 |  4847.73 |    1.779 |    71.95 |
|  1024 |    128 |  13312 |    0.213 |  4799.74 |    1.789 |    71.57 |
|  1024 |    128 |  14336 |    0.217 |  4719.89 |    1.802 |    71.04 |
|  1024 |    128 |  15360 |    0.217 |  4725.65 |    1.815 |    70.51 |

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    128 |      0 |    0.189 |  5417.36 |    1.581 |    80.97 |
|  1024 |    128 |   1024 |    0.190 |  5382.84 |    1.683 |    76.04 |
|  1024 |    128 |   2048 |    0.196 |  5236.38 |    1.690 |    75.72 |
|  1024 |    128 |   3072 |    0.197 |  5189.12 |    1.702 |    75.22 |
|  1024 |    128 |   4096 |    0.199 |  5143.04 |    1.716 |    74.61 |
|  1024 |    128 |   5120 |    0.201 |  5094.25 |    1.732 |    73.89 |
|  1024 |    128 |   6144 |    0.213 |  4806.23 |    1.859 |    68.86 |
|  1024 |    128 |   7168 |    0.213 |  4813.21 |    1.863 |    68.72 |
|  1024 |    128 |   8192 |    0.207 |  4938.03 |    1.810 |    70.73 |
|  1024 |    128 |   9216 |    0.208 |  4921.63 |    1.784 |    71.74 |
|  1024 |    128 |  10240 |    0.210 |  4887.22 |    1.799 |    71.14 |
|  1024 |    128 |  11264 |    0.212 |  4839.04 |    1.815 |    70.51 |
|  1024 |    128 |  12288 |    0.213 |  4810.22 |    1.872 |    68.38 |
|  1024 |    128 |  13312 |    0.215 |  4761.11 |    1.976 |    64.77 |
|  1024 |    128 |  14336 |    0.216 |  4740.26 |    1.852 |    69.11 |
|  1024 |    128 |  15360 |    0.218 |  4690.28 |    1.866 |    68.61 |
 
### llama.cpp (416e7c7f477c06b3ad208067ace057c8d8be745f)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    128 |      0 |    0.198 |  5172.92 |    1.588 |    80.60 |
|  1024 |    128 |   1024 |    0.206 |  4973.63 |    1.682 |    76.12 |
|  1024 |    128 |   2048 |    0.211 |  4847.70 |    1.756 |    72.89 |
|  1024 |    128 |   3072 |    0.214 |  4777.12 |    1.771 |    72.27 |
|  1024 |    128 |   4096 |    0.220 |  4652.05 |    1.787 |    71.62 |
|  1024 |    128 |   5120 |    0.224 |  4572.59 |    1.803 |    71.00 |
|  1024 |    128 |   6144 |    0.229 |  4464.89 |    1.818 |    70.40 |
|  1024 |    128 |   7168 |    0.233 |  4400.69 |    1.833 |    69.81 |
|  1024 |    128 |   8192 |    0.243 |  4215.38 |    1.848 |    69.25 |
|  1024 |    128 |   9216 |    0.243 |  4210.23 |    1.862 |    68.74 |
|  1024 |    128 |  10240 |    0.247 |  4150.02 |    1.878 |    68.16 |
|  1024 |    128 |  11264 |    0.253 |  4043.26 |    1.894 |    67.58 |
|  1024 |    128 |  12288 |    0.260 |  3934.19 |    1.909 |    67.04 |
|  1024 |    128 |  13312 |    0.264 |  3876.50 |    1.925 |    66.48 |
|  1024 |    128 |  14336 |    0.266 |  3845.65 |    1.940 |    65.96 |
|  1024 |    128 |  15360 |    0.272 |  3767.24 |    1.958 |    65.38 |
