### PR TITLE
CUDA: Fuse Q and K RoPE

### DIFF
--- a/ggml/src/ggml-cuda/rope.cuh
+++ b/ggml/src/ggml-cuda/rope.cuh
@@ -13,3 +13,5 @@ void ggml_cuda_op_rope_fast(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 bool ggml_cuda_op_fused_rope_fast(ggml_backend_cuda_context & ctx, ggml_tensor * dst1, ggml_tensor * dst2);
 
 bool ggml_cuda_op_fused_rms_rope_fast(ggml_backend_cuda_context & ctx, ggml_tensor * dst1, ggml_tensor * dst2);
+
+bool ggml_cuda_op_rope_rope(ggml_backend_cuda_context & ctx, ggml_tensor * dst1, ggml_tensor * dst2);


### PR DESCRIPTION

This PR fuses Q and K RoPE for the **regular** RoPE operation (without RoPE cache). This is useful when RoPE cache cannot be used (e.g., LlaMA models).

We see ~1% performance gains for TG.