### PR TITLE
Fuse sum_rows and div with topk-moe

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3336,8 +3336,16 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
                 cgraph->nodes[i+4]->op == GGML_OP_GET_ROWS &&
                 ggml_cuda_should_use_topk_moe(cgraph->nodes[i], cgraph->nodes[i+4]) &&
                 ops_are_same_device(cgraph, i, i+4)) {
-                ggml_cuda_op_topk_moe(ctx, cgraph->nodes[i], cgraph->nodes[i+4], cgraph->nodes[i+3]);
-                i += 4;
+                if (i + 7 < cgraph->n_nodes &&
+                    cgraph->nodes[i+5]->op == GGML_OP_RESHAPE  &&
+                    cgraph->nodes[i+6]->op == GGML_OP_SUM_ROWS &&
+                    cgraph->nodes[i+7]->op == GGML_OP_DIV) {
+                    ggml_cuda_op_topk_moe(ctx, cgraph->nodes[i], cgraph->nodes[i+7], cgraph->nodes[i+3]);
+                    i += 7;
+                } else {
+                    ggml_cuda_op_topk_moe(ctx, cgraph->nodes[i], cgraph->nodes[i+4], cgraph->nodes[i+3]);
+                    i += 4;
+                }
             } else {
                 ggml_cuda_op_soft_max(ctx, dst);
             }

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -865,10 +865,6 @@ llm_expert_gating_func_type   gating_op,
         cb(weights, "ffn_moe_weights_softmax", il);
     }
 
-    if (graph) {
-        ggml_build_forward_expand(graph, weights);
-    }
-
     if (norm_w) {
         weights = ggml_reshape_2d(ctx, weights, n_expert_used, n_tokens);
 
@@ -888,6 +884,10 @@ llm_expert_gating_func_type   gating_op,
     if (scale_w && std::abs(w_scale-1) > 1e-5f) {
         weights = ggml_scale(ctx, weights, w_scale);
         cb(weights, "ffn_moe_weights_scaled", il);
+    }
+
+    if (graph) {
+        ggml_build_forward_expand(graph, weights);
     }
 
     cur = ggml_reshape_3d(ctx, cur, n_embd, 1, n_tokens);


### PR DESCRIPTION

This optimization applies to, e.g., Qwen3-MoE models (including Qwen3-MoE-VL).

We get ~1% TG performance improvement.