### PR TITLE
Fix: Register missing /apply-template endpoint

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -5432,6 +5432,7 @@ int main(int argc, char ** argv) {
     svr->Post("/v1/embeddings",       handle_embeddings);
     svr->Post("/tokenize",            handle_tokenize);
     svr->Post("/detokenize",          handle_detokenize);
+    svr->Post("/apply-template",      handle_apply_template);
     // LoRA adapters hotswap
     svr->Get ("/lora-adapters",       handle_lora_adapters_list);
     svr->Post("/lora-adapters",       handle_lora_adapters_apply);


### PR DESCRIPTION
## Summary
Fixes the missing `/apply-template` endpoint registration that was causing 404 errors.

## Problem 

The handle_apply_template handler was defined but never registered as
an HTTP endpoint, causing 404 errors when calling POST /apply-template.

This commit adds the missing endpoint registration to match the
functionality available in llama.cpp mainline.

## Example Usage

```
curl -X POST http://127.0.0.1:8080/apply-template --json '{
  "messages": [
    {"role": "user", "content": "Hi"}
  ]
}'
```

**Response:**
```
{"prompt":"<|im_system|>system<|im_middle|>You are Kimi, an AI assistant created by Moonshot AI.<|im_end|><|im_user|>user<|im_middle|>Hi<|im_end|><|im_assistant|>assistant<|im_middle|>"}
```

This is helpful when troubleshooting chat templates and tool calling with new models.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High