### PR TITLE
Disable RoPE cache

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1178,7 +1178,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "-rcache" || arg == "--rope-cache") {
-        params.rope_cache = true;
+        fprintf(stderr, "=================================================================================\n");
+        fprintf(stderr, "  -rcache, --rope-cache is no longer supported\n");
+        fprintf(stderr, "=================================================================================\n");
+        //params.rope_cache = true;
         return true;
     }
     if (arg == "-gr" || arg == "--graph-reuse") {
@@ -2041,7 +2044,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-ger,  --grouped-expert-routing", "enable grouped expert routing (default: %s)", params.grouped_expert_routing ? "enabled" : "disabled" });
     options.push_back({ "*",           "-no-fug, --no-fused-up-gate",   "disaable fused up-gate (default: %s)", params.fused_up_gate ? "enabled" : "disabled" });
     options.push_back({ "*",           "-no-mmad, --no-fused-mul-multiadd", "disable fused mul-multi_add (default: %s)", params.fused_mmad? "enabled" : "disabled" });
-    options.push_back({ "*",           "-rcache, --rope-cache",         "enable RoPE cache (default: %s)", params.rope_cache ? "enabled" : "disabled" });
+    //options.push_back({ "*",           "-rcache, --rope-cache",         "enable RoPE cache (default: %s)", params.rope_cache ? "enabled" : "disabled" });
     options.push_back({ "*",           "-gr, --graph-reuse",            "enable graph reuse (default: %s)", params.graph_reuse ? "enabled" : "disabled" });
     options.push_back({ "*",         "-ser,  --smart-expert-reduction", "experts reduction (default: %d,%g)", params.min_experts, params.thresh_experts});
     options.push_back({ "*",         "-mqkv,  --merge-qkv,",            "merge Q,K,V (default: %d)", params.merge_qkv});


### PR DESCRIPTION

Seems to be causing problems, yet people continue to try it, so let's just disable it.