### PR TITLE
Fix q6_0 dequantize

### DIFF
--- a/ggml/src/ggml-cuda/dequantize.cuh
+++ b/ggml/src/ggml-cuda/dequantize.cuh
@@ -91,7 +91,7 @@ static __device__ __forceinline__ void dequantize_q6_0(const void * vx, const in
 
     const dfloat d = x[ib].d;
 
-    const uint8_t h = x[ib].qh[iqs%8] >> 2*(iqs/8);
+    const uint8_t h = x[ib].qh[iqs%8] >> 4*(iqs/8);
     v.x = ((x[ib].qs[iqs] & 0xf) | ((h & 0x3) << 4));
     v.y = ((x[ib].qs[iqs] >>  4) | ((h & 0xc) << 2));
 


### PR DESCRIPTION
After PR #1001 one can use K-cache quantized with `Q4_0 ... Q8_0` also for models with MLA attention. However, there was a bug in the `Q6_0` dequantize function, resulting in high PPL and gibberish output. This PR fixes the bug.

Here a PPL table for `IQ4_KS` quantized GigaChat3-10B for the various K-cache quantization types available

| K-cache | PPL |
| ---: | ---: |
| f16 | 6.8681 |
| Q8_0 | 6.8753 |
| Q6_0 | 6.9817 |
| Q5_1 | 7.0920 |
| Q5_0 | 7.2281 |
| Q4_1 | 8.0686 |
| Q4_0 | 8.5041 |