### PR TITLE
Change default RPC order and fix wrong RPC server order in --device arg

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4090,7 +4090,7 @@ struct llama_model * llama_load_model_from_file(
         device_names.insert(device_names.end(), gpu_names.begin(), gpu_names.end());
     }
 
-    for (auto device : device_names) {
+    for (auto & device : device_names) {
         if (buffer_names.count(device)) {
             model->devices.push_back(buffer_names[device]);
         }


### PR DESCRIPTION
Address [Add](https://github.com/ikawrakow/ik_llama.cpp/issues/978#issuecomment-3558267096)
This PR fix the issue when using --device for rpc server, the order is not correct. This also changes the default placement of rpc device, by putting it at the first, which is the same as mainline. The default reduces network transfer.