### PR TITLE
POC: CUDA tensor parallel (MoE models)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1276,12 +1276,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         else if (arg_next == "layer") {
             params.split_mode = LLAMA_SPLIT_MODE_LAYER;
         }
-        else if (arg_next == "row") {
-            //fprintf(stderr, "\n\n=====================================================================================\n");
-            //fprintf(stderr, " Split mode row is no longer supported\n");
-            //fprintf(stderr, "=====================================================================================\n\n\n");
-            //GGML_ABORT("fatal error");
-            params.split_mode = LLAMA_SPLIT_MODE_ROW;
+        else if (arg_next == "graph") {
+            params.split_mode = LLAMA_SPLIT_MODE_GRAPH;
         }
         else {
             invalid_param = true;
@@ -2249,6 +2245,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
         options.push_back({ "*",           "-sm,   --split-mode SPLIT_MODE",
                                                                         "how to split the model across multiple GPUs, one of:\n"
                                                                         "  - none: use one GPU only\n"
+                                                                        "  - graph: split model tensors and computation graph across GPUs\n"
                                                                         "  - layer (default): split layers and KV across GPUs\n" });
         options.push_back({ "*",           "-ts,   --tensor-split SPLIT",
                                                                         "fraction of the model to offload to each GPU, comma-separated list of proportions, e.g. 3,1" });

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1276,6 +1276,9 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         else if (arg_next == "layer") {
             params.split_mode = LLAMA_SPLIT_MODE_LAYER;
         }
+        else if (arg_next == "attn") {
+            params.split_mode = LLAMA_SPLIT_MODE_ATTN;
+        }
         else if (arg_next == "graph") {
             params.split_mode = LLAMA_SPLIT_MODE_GRAPH;
         }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1277,10 +1277,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
             params.split_mode = LLAMA_SPLIT_MODE_LAYER;
         }
         else if (arg_next == "row") {
-            fprintf(stderr, "\n\n=====================================================================================\n");
-            fprintf(stderr, " Split mode row is no longer supported\n");
-            fprintf(stderr, "=====================================================================================\n\n\n");
-            GGML_ABORT("fatal error");
+            //fprintf(stderr, "\n\n=====================================================================================\n");
+            //fprintf(stderr, " Split mode row is no longer supported\n");
+            //fprintf(stderr, "=====================================================================================\n\n\n");
+            //GGML_ABORT("fatal error");
             params.split_mode = LLAMA_SPLIT_MODE_ROW;
         }
         else {

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -334,7 +334,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -ngl, --n-gpu-layers <n>            (default: %s)\n", join(cmd_params_defaults.n_gpu_layers, ",").c_str());
     printf("  --n-cpu-moe <n>                     (default: none)\n");
     printf("  -rpc, --rpc <rpc_servers>           (default: %s)\n", join(cmd_params_defaults.rpc_servers, ",").c_str());
-    printf("  -sm, --split-mode <none|layer>      (default: %s)\n", join(transform_to_str(cmd_params_defaults.split_mode, split_mode_str), ",").c_str());
+    printf("  -sm, --split-mode <none|row|layer>  (default: %s)\n", join(transform_to_str(cmd_params_defaults.split_mode, split_mode_str), ",").c_str());
     printf("  -mg, --main-gpu <i>                 (default: %s)\n", join(cmd_params_defaults.main_gpu, ",").c_str());
     printf("  -nkvo, --no-kv-offload <0|1>        (default: %s)\n", join(cmd_params_defaults.no_kv_offload, ",").c_str());
     printf("  -fa, --flash-attn <0|1>             (default: %s)\n", join(cmd_params_defaults.flash_attn, ",").c_str());
@@ -631,11 +631,12 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 } else if (m == "layer") {
                     mode = LLAMA_SPLIT_MODE_LAYER;
                 } else if (m == "row") {
-                    fprintf(stderr, "\n\n=======================================================================\n");
-                    fprintf(stderr, "Split mode 'row' is no longer supported\n");
-                    fprintf(stderr, "=======================================================================\n\n\n");
-                    invalid_param = true;
-                    break;
+                    mode = LLAMA_SPLIT_MODE_ROW;
+                    //fprintf(stderr, "\n\n=======================================================================\n");
+                    //fprintf(stderr, "Split mode 'row' is no longer supported\n");
+                    //fprintf(stderr, "=======================================================================\n\n\n");
+                    //invalid_param = true;
+                    //break;
                 } else {
                     invalid_param = true;
                     break;

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -217,7 +217,7 @@ static const char * split_mode_str(llama_split_mode mode) {
     switch (mode) {
         case LLAMA_SPLIT_MODE_NONE:  return "none";
         case LLAMA_SPLIT_MODE_LAYER: return "layer";
-        case LLAMA_SPLIT_MODE_ROW:   return "row";
+        case LLAMA_SPLIT_MODE_GRAPH: return "graph";
         default: GGML_ABORT("invalid split mode");
     }
 }
@@ -630,13 +630,8 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                     mode = LLAMA_SPLIT_MODE_NONE;
                 } else if (m == "layer") {
                     mode = LLAMA_SPLIT_MODE_LAYER;
-                } else if (m == "row") {
-                    mode = LLAMA_SPLIT_MODE_ROW;
-                    //fprintf(stderr, "\n\n=======================================================================\n");
-                    //fprintf(stderr, "Split mode 'row' is no longer supported\n");
-                    //fprintf(stderr, "=======================================================================\n\n\n");
-                    //invalid_param = true;
-                    //break;
+                } else if (m == "graph") {
+                    mode = LLAMA_SPLIT_MODE_GRAPH;
                 } else {
                     invalid_param = true;
                     break;

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -3021,6 +3021,13 @@ extern "C" {
 
     GGML_API ggml_type_traits_t ggml_internal_get_type_traits(enum ggml_type type);
 
+    typedef struct {
+        int                   n_device;
+        int                   split_dim;
+        struct ggml_tensor *  tensor;
+        struct ggml_tensor ** splits;
+    } ggml_split_tensor_t;
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1632,7 +1632,10 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
 
             // check if we should start a new split based on the sources of the current node
             bool need_new_split = false;
-            if (node_backend_id == cur_backend_id && split->n_inputs > 0) {
+            if (node->op == GGML_OP_ADD && node->op_params[0] == 0xff) {
+                need_new_split = true;
+            }
+            else if (node_backend_id == cur_backend_id && split->n_inputs > 0) {
                 for (int j = 0; j < GGML_MAX_SRC; j++) {
                     struct ggml_tensor * src = node->src[j];
                     if (src == NULL) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1216,8 +1216,10 @@ static int ggml_backend_sched_backend_from_buffer(ggml_backend_sched_t sched, co
         return -1;
     }
 
+    //printf("%s: have %d backends, buffer is %s\n", __func__, sched->n_backends, ggml_backend_buffer_name(buffer));
     // find highest prio backend that supports the buffer type and the op
     for (int i = 0; i < sched->n_backends; i++) {
+        //printf("  Checking bacckend %d (%s)\n", i, ggml_backend_name(sched->backends[i]));
         if (ggml_backend_supports_buft(sched->backends[i], buffer->buft) &&
             ggml_backend_supports_op(sched->backends[i], op)) {
             return i;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -43,7 +43,7 @@ GGML_CALL size_t ggml_backend_buft_get_alloc_size(ggml_backend_buffer_type_t buf
     // get_alloc_size is optional, defaults to ggml_nbytes
     if (buft->iface.get_alloc_size) {
         size_t size = buft->iface.get_alloc_size(buft, tensor);
-        assert(size >= ggml_nbytes(tensor));
+        //assert(size >= ggml_nbytes(tensor));
         return size;
     }
     return ggml_nbytes(tensor);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1395,6 +1395,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         // do not overwrite user assignments
         if (*leaf_backend_id == -1) {
             *leaf_backend_id = ggml_backend_sched_backend_id_from_cur(sched, leaf);
+            //printf("Pass 1: assigned backend %d to leaf %d, %s\n", *leaf_backend_id, i, graph->leafs[i]->name);
         }
     }
 
@@ -1404,6 +1405,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
         // do not overwrite user assignments
         if (*node_backend_id == -1) {
             *node_backend_id = ggml_backend_sched_backend_id_from_cur(sched, node);
+            //printf("Pass 1: assigned backend %d to node %d, %s(%s)\n", *node_backend_id, i, ggml_op_name(node->op), node->name);
 
 #if 0
             // src
@@ -1447,6 +1449,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     cur_backend_id = *node_backend_id;
                 }
             } else if (cur_backend_id != -1) {
+                //printf("(u1) invoking ggml_backend_sched_set_if_supported for node %d, %s with cur_backend_id = %d, node_backend_id = %d\n", i, node->name, cur_backend_id, *node_backend_id);
                 ggml_backend_sched_set_if_supported(sched, node, cur_backend_id, node_backend_id);
             }
         }
@@ -1468,6 +1471,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     cur_backend_id = *node_backend_id;
                 }
             } else if (cur_backend_id != -1) {
+                //printf("(d1) invoking ggml_backend_sched_set_if_supported for node %d, %s with cur_backend_id = %d, node_backend_id = %d\n", i, node->name, cur_backend_id, *node_backend_id);
                 ggml_backend_sched_set_if_supported(sched, node, cur_backend_id, node_backend_id);
             }
         }
@@ -1484,6 +1488,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             if (*node_backend_id != -1) {
                 cur_backend_id = *node_backend_id;
             } else if (cur_backend_id != -1) {
+                //printf("(u2) invoking ggml_backend_sched_set_if_supported for node %d, %s with cur_backend_id = %d, node_backend_id = %d\n", i, node->name, cur_backend_id, *node_backend_id);
                 ggml_backend_sched_set_if_supported(sched, node, cur_backend_id, node_backend_id);
             }
         }
@@ -1500,6 +1505,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
             if (*node_backend_id != -1) {
                 cur_backend_id = *node_backend_id;
             } else if (cur_backend_id != -1) {
+                //printf("(d2) invoking ggml_backend_sched_set_if_supported for node %d, %s with cur_backend_id = %d, node_backend_id = %d\n", i, node->name, cur_backend_id, *node_backend_id);
                 ggml_backend_sched_set_if_supported(sched, node, cur_backend_id, node_backend_id);
             }
         }
@@ -1537,6 +1543,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     if (n_supported > n_supported_best) {
                         n_supported_best = n_supported;
                         *node_backend_id = b;
+                        //printf("Pass 3: assigned backend %d to unassigned node %d, %s\n", b, i, node->name);
                         SET_CAUSE(node, "3.best");
                     }
                 }
@@ -1557,6 +1564,7 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                         }
                     }
                     if (supported) {
+                        //printf("Pass 3: assigned backend %d to node %d, %s previously assigned to backend %d\n", b, i, node->name, *node_backend_id);
                         *node_backend_id = b;
                         SET_CAUSE(node, "3.upg");
                         break;
@@ -1585,9 +1593,11 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                     // views are always on the same backend as the source
                     *src_backend_id = tensor_backend_id(src->view_src);
                     SET_CAUSE(src, "4.vsrc");
+                    //printf("Pass 4: assigned backend %d to src %d, %s in node %d, %s frpm view_src\n", *src_backend_id, j, src->name, i, node->name);
                 } else {
                     *src_backend_id = *cur_backend_id;
                     SET_CAUSE(src, "4.cur");
+                    //printf("Pass 4: assigned backend %d to src %d, %s in node %d, %s frpm current\n", *src_backend_id, j, src->name, i, node->name);
                 }
             }
         }

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2989,6 +2989,7 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
                 cgraph->nodes[i+2]->op == GGML_OP_FUSED_RMS_NORM &&
                 ggml_is_contiguous(dst->src[0]) &&
                 ggml_is_contiguous(dst->src[1]) &&
+                dst->src[0]->type == GGML_TYPE_F32 &&               // with split mode "attn" we can end up having f16
                 ggml_are_same_shape(dst->src[0], dst->src[1]) &&
                 dst == cgraph->nodes[i+1]->src[0] &&
                 ggml_is_contiguous(cgraph->nodes[i+1]->src[1]) &&

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -844,7 +844,7 @@ GGML_CALL static void ggml_backend_cuda_split_buffer_set_tensor([[maybe_unused]]
     }
     else if (extra->split_dim == 0) {
         int n_interleave = 1;
-        if (auto it = k_map.find(tensor->type); it != k_map.end()) n_interleave = 1;
+        if (auto it = k_map.find(tensor->type); it != k_map.end()) n_interleave = it->second;
         //if (tensor->type >= GGML_TYPE_Q4_0_R8) {
         //    GGML_ABORT("Dim 0 copy of row-interleaved quants is not supported yet");
         //}
@@ -901,10 +901,13 @@ GGML_CALL static void ggml_backend_cuda_split_buffer_set_tensor([[maybe_unused]]
                 ne1 += split->ne[1];
             }
         } else {
+            int n_interleave = 1;
+            if (auto it = k_map.find(tensor->type); it != k_map.end()) n_interleave = it->second;
             size_t cur_offset = 0;
             for (int i = 0; i < extra->n_device; ++i) {
                 auto split = extra->splits[i];
                 if (!split) continue;
+                GGML_ASSERT(split->ne[1]%n_interleave == 0);
                 ggml_cuda_set_device(i);
                 auto size = ggml_nbytes(split);
                 const char * buf_host = (const char *)data + cur_offset;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -7284,7 +7284,19 @@ static struct ggml_tensor * ggml_fused_rms_norm_impl(
         is_node = true;
     }
 
-    struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
+    struct ggml_tensor * result;
+    if (inplace) {
+        GGML_ASSERT(a->type == GGML_TYPE_F32);
+        result = ggml_view_tensor(ctx, a);
+    } else {
+        if (a->type == GGML_TYPE_F32) {
+            result = ggml_dup_tensor(ctx, a);
+        } else {
+            result = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0], a->ne[1], a->ne[2], a->ne[3]);
+        }
+    }
+
+    //struct ggml_tensor * result = inplace ? ggml_view_tensor(ctx, a) : ggml_dup_tensor(ctx, a);
 
     ggml_set_op_params(result, &eps, sizeof(eps));
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -275,7 +275,8 @@ extern "C" {
     enum llama_split_mode {
         LLAMA_SPLIT_MODE_NONE    = 0, // single GPU
         LLAMA_SPLIT_MODE_LAYER   = 1, // split layers and KV across GPUs
-        LLAMA_SPLIT_MODE_GRAPH   = 2, // splits computations across GPUs
+        LLAMA_SPLIT_MODE_ATTN    = 2, // splits self-attention computations across GPUs
+        LLAMA_SPLIT_MODE_GRAPH   = 3, // splits computations across GPUs
     };
 
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -275,7 +275,7 @@ extern "C" {
     enum llama_split_mode {
         LLAMA_SPLIT_MODE_NONE    = 0, // single GPU
         LLAMA_SPLIT_MODE_LAYER   = 1, // split layers and KV across GPUs
-        LLAMA_SPLIT_MODE_ROW     = 2, // split rows across GPUs
+        LLAMA_SPLIT_MODE_GRAPH   = 2, // splits computations across GPUs
     };
 
 

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -1122,6 +1122,7 @@ llm_expert_gating_func_type   gating_op,
     GGML_ASSERT(split_gate_inp && split_gate_inp->n_device == split_up_exps->n_device);
     auto split_exp_probs_b = exp_probs_b ? (ggml_split_tensor_t *)exp_probs_b->extra : nullptr;
     GGML_ASSERT(!split_exp_probs_b || split_exp_probs_b->n_device == split_up_exps->n_device);
+    if (gate_inp_b || up_exps_b || gate_exps_b || down_exps_b) printf("Have expert biases %p, %p, %p, %p\n", (void *)gate_inp_b, (void *)up_exps_b, (void *)gate_exps_b, (void *)down_exps_b);
     for (int id = 0; id < split_up_exps->n_device; ++id) {
         int il_cb = 1000*(id + 1) + il;
         auto cur = input;

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -9220,11 +9220,15 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                 else if (cur->type != GGML_TYPE_F32) {
                     cur = ggml_cast(ctx0, cur, GGML_TYPE_F32);
                 }
+                auto the_q_norm = model.layers[il].attn_q_norm ? model.layers[il].attn_q_norm->extra ?
+                    ((ggml_split_tensor_t *)model.layers[il].attn_q_norm->extra)->splits[id] : model.layers[il].attn_q_norm : nullptr;
+                auto the_k_norm = model.layers[il].attn_k_norm ? model.layers[il].attn_k_norm->extra ?
+                    ((ggml_split_tensor_t *)model.layers[il].attn_k_norm->extra)->splits[id] : model.layers[il].attn_k_norm : nullptr;
                 auto [Qcur, Kcur, Vcur] = llm_build_mul_mat_qkv(gf, cur, nullptr, nullptr, nullptr, nullptr,
                         split_wq, bq ? bq->splits[id] : nullptr,
                         split_wk, bk ? bk->splits[id] : nullptr,
                         split_wv, bv ? bv->splits[id] : nullptr,
-                        model.layers[il].attn_q_norm, model.layers[il].attn_k_norm, f_attn_scale, il_cb);
+                        the_q_norm, the_k_norm, f_attn_scale, il_cb);
                 auto rope_factors = rope_factors_in;
                 if (!rope_factors && model.layers[il].rope_freqs && model.layers[il].rope_freqs->extra) {
                     auto extra = (ggml_split_tensor_t *)model.layers[il].rope_freqs->extra;

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -691,9 +691,9 @@ ggml_tensor * llm_build_context::llm_build_ffn(
         if (ffn.size() > 2) {
             cur->op_params[0] = 0xff;
         }
-        if (cur->type != GGML_TYPE_F32) {
-            cur = ggml_cast(ctx, cur, GGML_TYPE_F32);
-        }
+        //if (cur->type != GGML_TYPE_F32) {
+        //    cur = ggml_cast(ctx, cur, GGML_TYPE_F32);
+        //}
 
         return cur;
     }
@@ -9001,6 +9001,9 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                     auto split_norm = attn_norm->splits[id];
                     cur = llm_build_norm(ctx0, cur, hparams, split_norm, NULL, LLM_NORM_RMS, cb, il);
                     cb(cur, "attn_norm", il_cb);
+                }
+                else if (cur->type != GGML_TYPE_F32) {
+                    cur = ggml_cast(ctx0, cur, GGML_TYPE_F32);
                 }
                 auto [Qcur, Kcur, Vcur] = llm_build_mul_mat_qkv(gf, cur, nullptr, nullptr, nullptr, nullptr,
                         split_wq, nullptr, split_wk, nullptr, split_wv, nullptr,

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -680,6 +680,7 @@ ggml_tensor * llm_build_context::llm_build_ffn(
             cur = ggml_add(ctx, cur, ffn[id]);
             cb(cur, "combine_ffn", il);
         }
+        cur->op_params[0] = 0xff;
         return cur;
     }
 
@@ -9088,6 +9089,7 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                 cur = ggml_add(ctx0, cur, attn[id]);
                 cb(cur, "combine_attn", il);
             }
+            cur->op_params[0] = 0xff;
             return cur;
         }
     }

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -375,6 +375,27 @@ llm_expert_gating_func_type   gating_op,
                 gating_op, cb, il, graph);
     }
 
+    static ggml_tensor * llm_build_std_moe_ffn(ggml_context * ctx, llama_context & lctx,
+         ggml_tensor * ffn_norm,
+         ggml_tensor * input,
+         ggml_tensor * gate_inp,   ggml_tensor * gate_inp_b,
+         ggml_tensor * up_exps,    ggml_tensor * up_exps_b,
+         ggml_tensor * gate_exps,  ggml_tensor * gate_exps_b,
+         ggml_tensor * down_exps,  ggml_tensor * down_exps_b,
+         ggml_tensor * exp_probs_b,
+         ggml_tensor * up_shexp,   ggml_tensor * up_b_shexp,
+         ggml_tensor * gate_shexp, ggml_tensor * gate_b_shexp,
+         ggml_tensor * down_shexp, ggml_tensor * down_b_shexp,
+                    int64_t   n_expert,
+                    int64_t   n_expert_used,
+            llm_ffn_op_type   type_op,
+                       bool   norm_w,
+                       bool   scale_w,
+                      float   w_scale,
+llm_expert_gating_func_type   gating_op,
+            llm_ffn_op_type   type_op_shexp,
+         const llm_build_cb & cb, int il, ggml_cgraph * graph);
+
     static ggml_cgraph * llama_build_graph_defrag(llama_context & lctx, const std::vector<uint32_t> & ids);
 
     static ggml_cgraph * llama_build_graph_k_shift(llama_context & lctx);

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -317,7 +317,7 @@ struct llm_build_context {
                     float     kq_scale,
          const llm_build_cb & cb, int il, ggml_tensor * sinks = nullptr, int n_swa = 0);
 
-    static ggml_tensor * llm_build_ffn(ggml_context * ctx, llama_context & lctx,
+    static ggml_tensor * llm_build_ffn(ggml_context * ctx, llama_context & lctx, ggml_tensor * ffn_norm,
          ggml_tensor * cur,
          ggml_tensor * up,
          ggml_tensor * up_b,

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -148,7 +148,7 @@ struct llm_build_context {
             ggml_tensor * wq, ggml_tensor * bq,
             ggml_tensor * wk, ggml_tensor * bk,
             ggml_tensor * wv, ggml_tensor * bv,
-            float attention_scale, int il);
+            float attention_scale, int il) const;
 
     std::tuple<ggml_tensor*, ggml_tensor*, ggml_tensor*> llm_build_mul_mat_qkv(ggml_cgraph * gf, ggml_tensor * cur,
             ggml_tensor * wqkv, ggml_tensor * bqkv,
@@ -156,7 +156,7 @@ struct llm_build_context {
             ggml_tensor * wq, ggml_tensor * bq,
             ggml_tensor * wk, ggml_tensor * bk,
             ggml_tensor * wv, ggml_tensor * bv,
-            ggml_tensor * q_norm, ggml_tensor * k_norm, float attention_scale, int il);
+            ggml_tensor * q_norm, ggml_tensor * k_norm, float attention_scale, int il) const;
 
     ggml_cgraph * build_llama();
 
@@ -382,5 +382,8 @@ llm_expert_gating_func_type   gating_op,
     static ggml_cgraph * llama_build_graph_s_copy(llama_context & lctx);
 
     static ggml_cgraph * llama_build_graph(llama_context & lctx, const llama_batch & batch, bool worst_case);
+
+    ggml_tensor * build_std_attention(ggml_cgraph * gf, ggml_tensor * cur, ggml_tensor * inp_pos, ggml_tensor * rope_factors,
+            ggml_tensor * KQ_mask, ggml_tensor * sinks, float KQ_scale, float f_attn_scale, int n_swa, int il);
 
 };

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -331,7 +331,7 @@ struct llm_build_context {
          ggml_tensor * act_scales,
             llm_ffn_op_type   type_op,
           llm_ffn_gate_type   type_gate,
-         const llm_build_cb & cb, int il);
+         const llm_build_cb & cb, int il, ggml_cgraph * graph = nullptr);
 
     static ggml_tensor * llm_build_moe_ffn(ggml_context * ctx, llama_context & lctx,
          ggml_tensor * cur,

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -57,6 +57,9 @@ struct llama_kv_cache {
     std::vector<struct ggml_tensor *> k_l; // per layer
     std::vector<struct ggml_tensor *> v_l;
 
+    std::vector<llama_split_tensor> split_k_l;
+    std::vector<llama_split_tensor> split_v_l;
+
     std::vector<struct ggml_context *> ctxs;
     std::vector<ggml_backend_buffer_t> bufs;
 

--- a/src/llama-impl.h
+++ b/src/llama-impl.h
@@ -224,3 +224,8 @@ struct gguf_context;
 std::string gguf_kv_to_str(const gguf_context * ctx_gguf, int i);
 
 ggml_backend_buffer_type_t llama_default_buffer_type_cpu(bool host_buffer);
+
+struct llama_split_tensor {
+    std::vector<ggml_tensor *> tensor_splits;
+    ggml_split_tensor_t        ggml;
+};

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -309,7 +309,7 @@ ggml_tensor * create_tensors_helper::create_tensor(ggml_context * ctx, const std
     if (actual_context) *actual_context = ctx;
     auto tensor = ml.create_tensor(ctx, name, ne, flags);
     if (tensor && ctx == requested_ctx) {
-        printf("%s: adding tensor %s to split tensors\n", __func__, tensor->name);
+        //printf("%s: adding tensor %s to split tensors\n", __func__, tensor->name);
         split_tensors.insert(tensor);
     }
     return tensor;

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2750,13 +2750,11 @@ static void prepare_split_tensors(int split_dim, ggml_context * ctx, ggml_tensor
     std::string name{tensor->name};
     split_tensor.tensor_splits.resize(splits.size());
     if (split_dim == 1) {
-        size_t offset = 0;
         for (int i = 0; i < int(splits.size()); ++i) {
             if (splits[i] > 0) {
-                split_tensor.tensor_splits[i] = ggml_view_3d(ctx, tensor, tensor->ne[0], splits[i], tensor->ne[2], tensor->nb[1], tensor->nb[2], offset);
+                split_tensor.tensor_splits[i] = ggml_new_tensor_3d(ctx, tensor->type, tensor->ne[0], splits[i], tensor->ne[2]);
                 auto name_i = name + '.' + std::to_string(i);
                 ggml_set_name(split_tensor.tensor_splits[i], name_i.c_str());
-                offset += tensor->nb[1]*splits[i];
             } else {
                 split_tensor.tensor_splits[i] = nullptr;
             }

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -1858,9 +1858,9 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
         layer.wo = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_k * n_head, n_embd }, flags);
 
         // K/Q norm tensors (optional for GLM-4.5 355B variant)
-        layer.attn_q_norm = create_tensor(ctx_layer,
+        layer.attn_q_norm = create_tensor(ctx_split,
                 tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), { n_embd_head_k }, llama_model_loader::TENSOR_NOT_REQUIRED | flags);
-        layer.attn_k_norm = create_tensor(ctx_layer,
+        layer.attn_k_norm = create_tensor(ctx_split,
                 tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), { n_embd_head_k }, llama_model_loader::TENSOR_NOT_REQUIRED | flags);
 
         // Why are we adding an additional tensor type?
@@ -2945,6 +2945,9 @@ bool create_tensors_helper::create_tensors() {
                 if (layer.bq) {
                     prepare_split_tensors(0, ctx_split, layer.bq, layer.split_bq, split, mem_used);
                 }
+                if (layer.attn_q_norm) {
+                    prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split, mem_used);
+                }
                 for (auto & s : split) s /= gqa_ratio;
                 prepare_split_tensors(1, ctx_split, layer.wk, layer.split_wk, split, mem_used);
                 prepare_split_tensors(1, ctx_split, layer.wv, layer.split_wv, split, mem_used);
@@ -2953,6 +2956,9 @@ bool create_tensors_helper::create_tensors() {
                 }
                 if (layer.bv) {
                     prepare_split_tensors(0, ctx_split, layer.bv, layer.split_bv, split, mem_used);
+                }
+                if (layer.attn_k_norm) {
+                    prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split, mem_used);
                 }
             }
 

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2789,6 +2789,13 @@ static void prepare_split_tensors(int split_dim, ggml_context * ctx, ggml_tensor
 bool create_tensors_helper::create_tensors() {
     const auto tn = LLM_TN(model.arch);
     bool use_mmap_buffer = true;
+    if (ml.merge_qkv && model.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+        LLAMA_LOG_WARN("\n========================================================\n");
+        LLAMA_LOG_WARN("merge_qkv is not compatible with split model 'graph'\n");
+        LLAMA_LOG_WARN("  => turning off merge_qkv\n");
+        LLAMA_LOG_WARN("========================================================\n\n");
+        ml.merge_qkv = false;
+    }
     switch (model.arch) {
         case LLM_ARCH_LLAMA:
         case LLM_ARCH_REFACT:

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -230,7 +230,7 @@ create_tensors_helper::create_tensors_helper(llama_model_loader & _ml, llama_mod
             printf("  Oops: null buft for debvice %d\n", device);
         }
     }
-    if (model.split_mode == LLAMA_SPLIT_MODE_ROW) {
+    if (model.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
         printf("model.splits:");
         for (auto s : model.splits) printf(" %g", s);
         printf("\n");
@@ -305,7 +305,7 @@ ggml_tensor * create_tensors_helper::create_tensor(ggml_context * ctx, const std
     }
     if (actual_context) *actual_context = ctx;
     auto tensor = ml.create_tensor(ctx, name, ne, flags);
-    //if (tensor && requested_ctx == ctx && model.split_mode == LLAMA_SPLIT_MODE_ROW) {
+    //if (tensor && requested_ctx == ctx && model.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
     //    int i_layer = -1;
     //    if (auto pos = name.find("blk."); pos == 0) {
     //        GGML_ASSERT(sscanf(name.c_str(), "blk.%d.", &i_layer) == 1);
@@ -2929,7 +2929,7 @@ bool create_tensors_helper::create_tensors() {
         default:
             throw std::runtime_error("unknown architecture");
     }
-    if (model.split_mode == LLAMA_SPLIT_MODE_ROW) {
+    if (model.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
         std::vector<size_t> mem_used(model.splits.size(), 0);
         const auto & hparams = model.hparams;
         int gqa_ratio = hparams.n_head() / hparams.n_head_kv();

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2984,11 +2984,6 @@ bool create_tensors_helper::create_tensors() {
             if (layer.ffn_norm) {
                 auto split = create_split(ggml_nrows(layer.ffn_norm), -1, model.splits);
                 prepare_split_tensors(-1, ctx_split, layer.ffn_norm, layer.split_ffn_norm, split, mem_used);
-                printf("Created splits for %s\n", layer.ffn_norm->name);
-                auto splits = (ggml_split_tensor_t *)layer.ffn_norm->extra;
-                if (!splits) {
-                    printf("Oops: null extra?\n"); exit(1);
-                }
             }
 
             if (layer.ffn_down && layer.ffn_up && layer.ffn_gate) {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -183,6 +183,21 @@ struct llama_layer {
     struct ggml_tensor * bqk  = nullptr;
     struct ggml_tensor * bkv  = nullptr;
 
+    llama_split_tensor split_wq;
+    llama_split_tensor split_wk;
+    llama_split_tensor split_wv;
+    llama_split_tensor split_wo;
+    llama_split_tensor split_wqkv;
+    llama_split_tensor split_wqk;
+    llama_split_tensor split_wkv;
+    llama_split_tensor split_bq;
+    llama_split_tensor split_bk;
+    llama_split_tensor split_bv;
+    llama_split_tensor split_bo;
+    llama_split_tensor split_bqkv;
+    llama_split_tensor split_bqk;
+    llama_split_tensor split_bkv;
+
     // relative position bias
     struct ggml_tensor * attn_rel_b = nullptr;
     struct ggml_tensor * attn_rel_b_enc = nullptr;
@@ -205,11 +220,19 @@ struct llama_layer {
     struct ggml_tensor * ffn_down_enc = nullptr;
     struct ggml_tensor * ffn_up_enc = nullptr;
 
+    llama_split_tensor split_ffn_up;
+    llama_split_tensor split_ffn_gate;
+    llama_split_tensor split_ffn_down;
+
     // ff MoE
     struct ggml_tensor * ffn_gate_inp = nullptr;
     struct ggml_tensor * ffn_gate_exps = nullptr;
     struct ggml_tensor * ffn_down_exps = nullptr;
     struct ggml_tensor * ffn_up_exps  = nullptr;
+
+    llama_split_tensor split_ffn_up_exps;
+    llama_split_tensor split_ffn_gate_exps;
+    llama_split_tensor split_ffn_down_exps;
 
     // ff MoE bias
     struct ggml_tensor * ffn_gate_inp_b = nullptr;
@@ -225,6 +248,10 @@ struct llama_layer {
     struct ggml_tensor * ffn_gate_shexp = nullptr;
     struct ggml_tensor * ffn_down_shexp = nullptr;
     struct ggml_tensor * ffn_up_shexp = nullptr;
+
+    llama_split_tensor split_ffn_up_shexp;
+    llama_split_tensor split_ffn_gate_shexp;
+    llama_split_tensor split_ffn_down_shexp;
 
     // ff bias
     struct ggml_tensor * ffn_gate_b = nullptr;
@@ -298,6 +325,8 @@ struct llama_model {
     struct ggml_tensor * output_b;
     struct ggml_tensor * output_norm_enc;
 
+    llama_split_tensor split_output;
+
     std::vector<llama_layer> layers;
 
     llama_split_mode split_mode;
@@ -358,6 +387,11 @@ struct llama_model {
     }
 
     void set_tensor_overrides(const llama_model_params& params);
+
+    int device_count() const;
+    ggml_backend_buffer_type_t default_buffer_type_offload(int device) const;
+
+    std::vector<float> splits;
 };
 
 struct llama_lora_weight {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -344,6 +344,7 @@ struct llama_model {
     struct ggml_tensor * output_norm_enc;
 
     llama_split_tensor split_output;
+    llama_split_tensor split_output_norm;
 
     std::vector<llama_layer> layers;
 

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -198,6 +198,8 @@ struct llama_layer {
     llama_split_tensor split_bqkv;
     llama_split_tensor split_bqk;
     llama_split_tensor split_bkv;
+    llama_split_tensor split_q_norm;
+    llama_split_tensor split_k_norm;
 
     // relative position bias
     struct ggml_tensor * attn_rel_b = nullptr;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -410,6 +410,7 @@ struct llama_model {
     ggml_backend_buffer_type_t default_buffer_type_offload(int device) const;
 
     std::vector<float> splits;
+    ggml_backend_buffer_type_t split_buft = nullptr;
 };
 
 struct llama_lora_weight {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -232,6 +232,7 @@ struct llama_layer {
     struct ggml_tensor * ffn_down_exps = nullptr;
     struct ggml_tensor * ffn_up_exps  = nullptr;
 
+    llama_split_tensor split_ffn_gate_inp;
     llama_split_tensor split_ffn_up_exps;
     llama_split_tensor split_ffn_gate_exps;
     llama_split_tensor split_ffn_down_exps;
@@ -255,12 +256,23 @@ struct llama_layer {
     llama_split_tensor split_ffn_gate_shexp;
     llama_split_tensor split_ffn_down_shexp;
 
+    llama_split_tensor split_ffn_gate_inp_b;
+    llama_split_tensor split_ffn_gate_exps_b;
+    llama_split_tensor split_ffn_down_exps_b;
+    llama_split_tensor split_ffn_up_exps_b;
+
     // ff bias
     struct ggml_tensor * ffn_gate_b = nullptr;
     struct ggml_tensor * ffn_down_b = nullptr; // b2
     struct ggml_tensor * ffn_up_b   = nullptr; // b3
     struct ggml_tensor * ffn_act = nullptr;
     struct ggml_tensor * ffn_exp_probs_b = nullptr;
+
+    llama_split_tensor split_ffn_gate_b;
+    llama_split_tensor split_ffn_down_b;
+    llama_split_tensor split_ffn_up_b;
+    llama_split_tensor split_ffn_act;
+    llama_split_tensor split_ffn_exp_probs_b;
 
     // mamba proj
     struct ggml_tensor * ssm_in = nullptr;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -183,6 +183,7 @@ struct llama_layer {
     struct ggml_tensor * bqk  = nullptr;
     struct ggml_tensor * bkv  = nullptr;
 
+    llama_split_tensor split_attn_norm;
     llama_split_tensor split_wq;
     llama_split_tensor split_wk;
     llama_split_tensor split_wv;
@@ -279,6 +280,8 @@ struct llama_layer {
     struct ggml_tensor * rope_long  = nullptr;
     struct ggml_tensor * rope_short = nullptr;
     struct ggml_tensor * rope_freqs = nullptr;
+
+    llama_split_tensor split_rope_freqs;
 
     // bitnet scale
     struct ggml_tensor * wq_scale = nullptr;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -224,6 +224,7 @@ struct llama_layer {
     llama_split_tensor split_ffn_up;
     llama_split_tensor split_ffn_gate;
     llama_split_tensor split_ffn_down;
+    llama_split_tensor split_ffn_norm;
 
     // ff MoE
     struct ggml_tensor * ffn_gate_inp = nullptr;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -806,6 +806,7 @@ static bool llama_kv_cache_init(
         cache.bufs.push_back(buf);
     }
 
+#if 0
     for (int il = 0; il < n_layer; ++il) {
         if (cache.k_l[il]->extra) {
             printf("Layer %2d, K-buffer: %p:", il, (void *)cache.k_l[il]->buffer);
@@ -824,6 +825,7 @@ static bool llama_kv_cache_init(
             printf("\n");
         }
     }
+#endif
 
     return true;
 }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1726,6 +1726,7 @@ static void ggml_backend_add_from_device(llama_context* ctx, ggml_backend_t back
 static bool is_model_split_supported(const llama_model & model) {
     static std::unordered_set<llm_arch> k_supported = {
         LLM_ARCH_LLAMA,
+        LLM_ARCH_QWEN3MOE,
         LLM_ARCH_GLM4_MOE,
     };
     auto it =  k_supported.find(model.arch);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -770,6 +770,8 @@ static bool llama_kv_cache_init(
                     split_v_l.ggml.n_device  = extra_V->n_device;
                     split_v_l.ggml.split_dim = 0;
                     split_v_l.ggml.splits    = split_v_l.tensor_splits.data();
+                    k->extra = (void *)&split_k_l.ggml;
+                    v->extra = (void *)&split_v_l.ggml;
                 } else {
                     printf("Oops: don't have yet K and V for layer %d\n", i);
                 }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -740,8 +740,12 @@ static bool llama_kv_cache_init(
         else {
             k = ggml_new_tensor_2d(ctx, type_k, n_embd_head_k, n_head_kv*kv_size);
             v = ggml_new_tensor_1d(ctx, type_v, n_embd_v_gqa*kv_size);
-            ggml_format_name(k, "cache_k_l%d", i);
-            ggml_format_name(v, "cache_v_l%d", i);
+            auto k_name = std::string{"cache_k_l"} + std::to_string(i);
+            auto v_name = std::string{"cache_v_l"} + std::to_string(i);
+            ggml_set_name(k, k_name.c_str());
+            ggml_set_name(v, v_name.c_str());
+            //ggml_format_name(k, "cache_k_l%d", i);
+            //ggml_format_name(v, "cache_v_l%d", i);
             cache.k_l.push_back(k);
             cache.v_l.push_back(v);
             if (split_cache) {
@@ -758,6 +762,8 @@ static bool llama_kv_cache_init(
                         auto split = extra_K->splits[is];
                         if (!split) continue;
                         split_k_l.tensor_splits[is] = ggml_new_tensor_2d(ctx, type_k, n_embd_head_k, split->ne[1]/n_embd_head_k * kv_size);
+                        auto split_name = k_name + '.' + std::to_string(is);
+                        ggml_set_name(split_k_l.tensor_splits[is], split_name.c_str());
                     }
                     split_k_l.ggml.n_device  = extra_K->n_device;
                     split_k_l.ggml.split_dim = 0;
@@ -766,6 +772,8 @@ static bool llama_kv_cache_init(
                         auto split = extra_V->splits[is];
                         if (!split) continue;
                         split_v_l.tensor_splits[is] = ggml_new_tensor_1d(ctx, type_v, split->ne[1] * kv_size);
+                        auto split_name = v_name + '.' + std::to_string(is);
+                        ggml_set_name(split_v_l.tensor_splits[is], split_name.c_str());
                     }
                     split_v_l.ggml.n_device  = extra_V->n_device;
                     split_v_l.ggml.split_dim = 0;
@@ -796,6 +804,25 @@ static bool llama_kv_cache_init(
         ggml_backend_buffer_clear(buf, 0);
         LLAMA_LOG_INFO("%s: %10s KV buffer size = %8.2f MiB\n", __func__, ggml_backend_buffer_name(buf), ggml_backend_buffer_get_size(buf)/1024.0/1024.0);
         cache.bufs.push_back(buf);
+    }
+
+    for (int il = 0; il < n_layer; ++il) {
+        if (cache.k_l[il]->extra) {
+            printf("Layer %2d, K-buffer: %p:", il, (void *)cache.k_l[il]->buffer);
+            auto split_kl = (ggml_split_tensor_t *)cache.k_l[il]->extra;
+            for (int id = 0; id < split_kl->n_device; ++id) {
+                if (split_kl->splits[id]) printf(" %p,%p", (void *)split_kl->splits[id]->data, (void *)split_kl->splits[id]->buffer);
+            }
+            printf("\n");
+        }
+        if (cache.v_l[il]->extra) {
+            printf("Layer %2d, V-buffer: %p:", il, (void *)cache.v_l[il]->buffer);
+            auto split_vl = (ggml_split_tensor_t *)cache.v_l[il]->extra;
+            for (int id = 0; id < split_vl->n_device; ++id) {
+                if (split_vl->splits[id]) printf(" %p,%p", (void *)split_vl->splits[id]->data, (void *)split_vl->splits[id]->buffer);
+            }
+            printf("\n");
+        }
     }
 
     return true;
@@ -4350,7 +4377,7 @@ struct llama_context * llama_new_context_with_model(
             ggml_backend_add_from_device(ctx,  ctx->backend_metal);
         }
 #elif defined(GGML_USE_CUDA)
-        if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_ROW) {
+        if (model->split_mode == LLAMA_SPLIT_MODE_NONE) {
             // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_ROW, only the main GPU backend is used
             ggml_backend_t backend = ggml_backend_cuda_init(model->main_gpu, cparams.cuda_params);
             if (backend == nullptr) {
@@ -4361,7 +4388,7 @@ struct llama_context * llama_new_context_with_model(
             ggml_backend_add_from_device(ctx, backend);
 
         } else {
-            // LLAMA_SPLIT_MODE_LAYER requires a backend for each GPU
+            // LLAMA_SPLIT_MODE_LAYER and LLAMA_SPLIT_MODE_ROW require a backend for each GPU
             for (int device = 0; device < ggml_backend_cuda_get_device_count(); ++device) {
                 ggml_backend_t backend = ggml_backend_cuda_init(device, cparams.cuda_params);
                 if (backend == nullptr) {
@@ -4370,7 +4397,6 @@ struct llama_context * llama_new_context_with_model(
                     return nullptr;
                 }
                 ggml_backend_add_from_device(ctx, backend);
-
             }
         }
 #elif defined(GGML_USE_VULKAN)

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -483,6 +483,14 @@ static ggml_backend_buffer_type_t llama_default_buffer_type_split(const llama_mo
     GGML_UNUSED(tensor_split);
 }
 
+int llama_model::device_count() const {
+    return llama_get_device_count(*this);
+}
+
+ggml_backend_buffer_type_t llama_model::default_buffer_type_offload(int device) const {
+    return llama_default_buffer_type_offload(*this, device);
+}
+
 static size_t llama_get_device_memory(const llama_model & model, int device) {
 #if defined(GGML_USE_RPC)
     int dev_count = (int)llama_get_device_count(model);
@@ -626,42 +634,35 @@ static bool llama_kv_cache_init(
         }
     }
 
+    bool split_cache   = false;
+    if (model.split_mode == LLAMA_SPLIT_MODE_ROW && model.arch != LLM_ARCH_DEEPSEEK2 && offload) {
+        cache.split_k_l.reserve(n_layer);
+        cache.split_v_l.reserve(n_layer);
+        split_cache = true;
+    }
+
     // count used buffer types
     std::map<ggml_backend_buffer_type_t, int> buft_layer_count;
     if (offload) {
         for (int64_t i = 0; i < n_layer; ++i) {
-            buft_layer_count[model.buft_layer[i].buft]++;
+            if (split_cache) {
+                buft_layer_count[model.buft_layer[i].buft_matrix]++;
+            } else {
+                buft_layer_count[model.buft_layer[i].buft]++;
+            }
         }
     } else {
         buft_layer_count[llama_default_buffer_type_cpu(true)] = n_layer;
     }
 
-    //if (cparams.fused_moe_up_gate) {
-    //    int nbad = 0;
-    //    for (int i = 0; i < (int) n_layer; i++) {
-    //        auto& layer = model.layers[i];
-    //        if (layer.ffn_gate_exps && layer.ffn_up_exps && layer.ffn_gate_exps->type != layer.ffn_up_exps->type) {
-    //            ++nbad;
-    //        }
-    //    }
-    //    if (nbad > 0) {
-    //        if (nbad == (int)n_layer) {
-    //            LLAMA_LOG_WARN("=============== ffn_up and ffn_gate are of different type => disabling fmoe\n");
-    //            const_cast<llama_cparams&>(cparams).fused_moe_up_gate = false;
-    //        }
-    //        else {
-    //            LLAMA_LOG_WARN("=============== ffn_up and ffn_gate are of different in %d out of %d layers, where fmoe will be disabled\n",
-    //                    nbad, (int)n_layer);
-    //        }
-    //    }
-    //}
-
     // create a context for each buffer type
     std::map<ggml_backend_buffer_type_t, ggml_context *> ctx_map;
     for (auto & it : buft_layer_count) {
         int n_layers = it.second;
+        size_t ctx_mem_size = 5u*n_layers*ggml_tensor_overhead();
+        if (split_cache) ctx_mem_size += 2*model.splits.size()*n_layers*ggml_tensor_overhead();
         struct ggml_init_params params = {
-            /*.mem_size   =*/ 5u*n_layers*ggml_tensor_overhead(),
+            /*.mem_size   =*/ ctx_mem_size,
             /*.mem_buffer =*/ NULL,
             /*.no_alloc   =*/ true,
         };
@@ -698,8 +699,8 @@ static bool llama_kv_cache_init(
         }
     }
 
-    cache.k_l.reserve(n_layer);
     bool needs_v_cache = true;
+    cache.k_l.reserve(n_layer);
     if (model.arch == LLM_ARCH_DEEPSEEK2 && cparams.mla_attn) {
         needs_v_cache = cparams.mla_attn == 1 && !cparams.flash_attn;
     }
@@ -711,11 +712,10 @@ static bool llama_kv_cache_init(
         const uint32_t n_head_kv    = hparams.n_head_kv(i);
         const uint32_t n_embd_head_k= hparams.n_embd_head_k;
 
-
-        struct ggml_context * ctx = offload ? ctx_map.at(model.buft_layer[i].buft) : cache.ctxs.front();
+        struct ggml_context * ctx = split_cache ? ctx_map.at(model.buft_layer[i].buft_matrix) : offload ? ctx_map.at(model.buft_layer[i].buft) : cache.ctxs.front();
         ggml_tensor * k;
         ggml_tensor * v;
-        if (cparams.mla_attn) {
+        if (model.arch == LLM_ARCH_DEEPSEEK2 && cparams.mla_attn) {
             // DeepSeek MLA
             const uint32_t n_embd_head_qk_rope = hparams.n_rot;
             const uint32_t kv_lora_rank = hparams.n_lora_kv;
@@ -744,6 +744,36 @@ static bool llama_kv_cache_init(
             ggml_format_name(v, "cache_v_l%d", i);
             cache.k_l.push_back(k);
             cache.v_l.push_back(v);
+            if (split_cache) {
+                auto K = model.layers[i].wk;
+                auto V = model.layers[i].wv;
+                if (K && V && K->extra && V->extra) {
+                    auto extra_K = (const ggml_split_tensor_t *)K->extra;
+                    auto extra_V = (const ggml_split_tensor_t *)V->extra;
+                    auto & split_k_l = cache.split_k_l.emplace_back();
+                    auto & split_v_l = cache.split_v_l.emplace_back();
+                    split_k_l.tensor_splits.resize(extra_K->n_device, nullptr);
+                    split_v_l.tensor_splits.resize(extra_V->n_device, nullptr);
+                    for (int is = 0; is < extra_K->n_device; ++is) {
+                        auto split = extra_K->splits[is];
+                        if (!split) continue;
+                        split_k_l.tensor_splits[is] = ggml_new_tensor_2d(ctx, type_k, n_embd_head_k, split->ne[1]/n_embd_head_k * kv_size);
+                    }
+                    split_k_l.ggml.n_device  = extra_K->n_device;
+                    split_k_l.ggml.split_dim = 0;
+                    split_k_l.ggml.splits    = split_k_l.tensor_splits.data();
+                    for (int is = 0; is < extra_V->n_device; ++is) {
+                        auto split = extra_V->splits[is];
+                        if (!split) continue;
+                        split_v_l.tensor_splits[is] = ggml_new_tensor_1d(ctx, type_v, split->ne[1] * kv_size);
+                    }
+                    split_v_l.ggml.n_device  = extra_V->n_device;
+                    split_v_l.ggml.split_dim = 0;
+                    split_v_l.ggml.splits    = split_v_l.tensor_splits.data();
+                } else {
+                    printf("Oops: don't have yet K and V for layer %d\n", i);
+                }
+            }
         }
     }
     if (model.arch == LLM_ARCH_DEEPSEEK2 && cparams.mla_attn && n_mla < n_layer && n_mla > 0) {
@@ -1652,10 +1682,7 @@ static bool llm_load_tensors(
         model.buft_layer[i] = llama_default_buffer_type_cpu(true);
     }
 
-    if (split_mode == LLAMA_SPLIT_MODE_LAYER) {
-        // calculate the split points
-        // int device_count = llama_get_device_count(model);
-        int device_count = model.devices.size();
+    if (int device_count = model.devices.size(); device_count > 1) {
         bool all_zero = tensor_split == nullptr || std::all_of(tensor_split, tensor_split + device_count, [](float x) { return x == 0.0f; });
         std::vector<float> splits(device_count);
         if (all_zero) {
@@ -1676,36 +1703,31 @@ static bool llm_load_tensors(
         for (int i = 0; i < device_count; ++i) {
             splits[i] /= split_sum;
         }
+        model.splits = std::move(splits);
+    } else {
+        model.splits = { 1.0f };
+    }
 
+    if (split_mode == LLAMA_SPLIT_MODE_LAYER) {
+
+        int device_count = model.splits.size();
         // assign the repeating layers to the devices according to the splits
         int act_gpu_layers = std::min(n_gpu_layers, (int)n_layer + 1);
         for (int i = i_gpu_start; i < n_layer; ++i) {
-            int layer_gpu = std::upper_bound(splits.begin(), splits.begin() + device_count, float(i - i_gpu_start)/act_gpu_layers) - splits.begin();
-#ifndef NDEBUG
-            ggml_backend_buffer_type_t buft = llama_default_buffer_type_offload(model, model.devices[layer_gpu]);
-            const char* name = ggml_backend_buft_name(buft);
-            LLAMA_LOG_DEBUG("load_tensors: layers %3d assigned to backend %s\n", i,
-                name);
-#endif
+            int layer_gpu = std::upper_bound(model.splits.begin(), model.splits.begin() + device_count, float(i - i_gpu_start)/act_gpu_layers) - model.splits.begin();
             model.buft_layer[i] = llama_default_buffer_type_offload(model, model.devices[layer_gpu]);
         }
         // assign the output layer
         if (n_gpu_layers > n_layer) {
-            int layer_gpu = std::upper_bound(splits.begin(), splits.begin() + device_count, float(act_gpu_layers - 1)/act_gpu_layers) - splits.begin();
-#ifndef NDEBUG
-            ggml_backend_buffer_type_t buft = llama_default_buffer_type_offload(model, model.devices[layer_gpu]);
-            const char* name = ggml_backend_buft_name(buft);
-            LLAMA_LOG_DEBUG("load_tensors: output layers assigned to backend %s\n", 
-                name);
-#endif
+            int layer_gpu = std::upper_bound(model.splits.begin(), model.splits.begin() + device_count, float(act_gpu_layers - 1)/act_gpu_layers) - model.splits.begin();
             model.buft_output = llama_default_buffer_type_offload(model, model.devices[layer_gpu]);
         } else {
             model.buft_output = llama_default_buffer_type_cpu(true);
         }
     } else {
         ggml_backend_buffer_type_t split_buft;
-        if (split_mode == LLAMA_SPLIT_MODE_ROW) {
-            split_buft = llama_default_buffer_type_split(model, model.devices[main_gpu], tensor_split);
+        if (split_mode == LLAMA_SPLIT_MODE_ROW && model.splits.size() > 1) {
+            split_buft = llama_default_buffer_type_split(model, model.devices[main_gpu], model.splits.data());
         } else {
             // LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_LAYER in backends where it is not supported
             split_buft = llama_default_buffer_type_offload(model, model.devices[main_gpu]);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -635,7 +635,7 @@ static bool llama_kv_cache_init(
     }
 
     bool split_cache   = false;
-    if (model.split_mode == LLAMA_SPLIT_MODE_ROW && model.arch != LLM_ARCH_DEEPSEEK2 && offload) {
+    if (model.split_mode == LLAMA_SPLIT_MODE_GRAPH && model.arch != LLM_ARCH_DEEPSEEK2 && offload) {
         cache.split_k_l.reserve(n_layer);
         cache.split_v_l.reserve(n_layer);
         split_cache = true;
@@ -1772,7 +1772,7 @@ static bool llm_load_tensors(
         }
     } else {
         ggml_backend_buffer_type_t split_buft;
-        if (split_mode == LLAMA_SPLIT_MODE_ROW && model.splits.size() > 1) {
+        if (split_mode == LLAMA_SPLIT_MODE_GRAPH && model.splits.size() > 1) {
             split_buft = llama_default_buffer_type_split(model, model.devices[main_gpu], model.splits.data());
         } else {
             // LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_LAYER in backends where it is not supported
@@ -4404,7 +4404,7 @@ struct llama_context * llama_new_context_with_model(
         }
 #elif defined(GGML_USE_CUDA)
         if (model->split_mode == LLAMA_SPLIT_MODE_NONE) {
-            // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_ROW, only the main GPU backend is used
+            // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_GRAPH, only the main GPU backend is used
             ggml_backend_t backend = ggml_backend_cuda_init(model->main_gpu, cparams.cuda_params);
             if (backend == nullptr) {
                 LLAMA_LOG_ERROR("%s: failed to initialize CUDA%d backend\n", __func__, model->main_gpu);
@@ -4414,7 +4414,7 @@ struct llama_context * llama_new_context_with_model(
             ggml_backend_add_from_device(ctx, backend);
 
         } else {
-            // LLAMA_SPLIT_MODE_LAYER and LLAMA_SPLIT_MODE_ROW require a backend for each GPU
+            // LLAMA_SPLIT_MODE_LAYER and LLAMA_SPLIT_MODE_GRAPH require a backend for each GPU
             for (int device = 0; device < ggml_backend_cuda_get_device_count(); ++device) {
                 ggml_backend_t backend = ggml_backend_cuda_init(device, cparams.cuda_params);
                 if (backend == nullptr) {
@@ -4426,7 +4426,7 @@ struct llama_context * llama_new_context_with_model(
             }
         }
 #elif defined(GGML_USE_VULKAN)
-        if (model->split_mode == LLAMA_SPLIT_MODE_ROW) {
+        if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
             LLAMA_LOG_ERROR("%s: Row split not supported. Failed to initialize Vulkan backend\n", __func__);
             llama_free(ctx);
             return nullptr;
@@ -4451,8 +4451,8 @@ struct llama_context * llama_new_context_with_model(
             }
         }
 #elif defined(GGML_USE_SYCL)
-        // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_ROW, only the main GPU backend is used
-        if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_ROW) {
+        // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_GRAPH, only the main GPU backend is used
+        if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
             ggml_backend_t backend = ggml_backend_sycl_init(model->main_gpu);
             if (backend == nullptr) {
                 LLAMA_LOG_ERROR("%s: failed to initialize SYCL%d backend\n", __func__, model->main_gpu);
@@ -4483,9 +4483,9 @@ struct llama_context * llama_new_context_with_model(
             ggml_backend_add_from_device(ctx, backend);
         }
 #elif defined(GGML_USE_CANN)
-    // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_ROW, only the main GPU backend is used
+    // with split_mode LLAMA_SPLIT_MODE_NONE or LLAMA_SPLIT_MODE_GRAPH, only the main GPU backend is used
     // TODO: ggml_backend_cann is not support split tensor now, just leave code here.
-    if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_ROW) {
+    if (model->split_mode == LLAMA_SPLIT_MODE_NONE || model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
         ggml_backend_t backend = ggml_backend_cann_init(model->main_gpu);
         if (backend == nullptr) {
             LLAMA_LOG_ERROR("%s: failed to initialize CANN%d backend\n", __func__, model->main_gpu);


### PR DESCRIPTION
This is a very rough around the edges POC for tensor parallelism (TP) for MoE models. It is a follow up of PR #1018.

I have the necessary graph building changes only for GLM-4.5/4.6 just to see how it performs. On a 2x3090 system I can only fully offload a low-bpw quantized GLM-4.5-AIR (full offload is needed as tensor overrides are not yet implemented in this new scheme). I'm using @ubergarm's `IQ1_KT` model, which is 38.7 GB, and allows me to go to about 32k tokens of context (with f16 KV cache).

Here performance results are mixed. For PP-2048 the new split mode "graph" implementation beats split mode "layer" for all context lengths, being as much as 60% faster at a context of 30k tokens. TG on the other hand is significantly slower at zero context, and only becomes faster than "layer" around a context of 20k tokens. Here are the `sweep-bench` results

### Split mode "graph"

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    256 |      0 |    0.897 |  2283.44 |    4.231 |    60.51 |
|  2048 |    256 |   2048 |    0.928 |  2207.16 |    4.368 |    58.61 |
|  2048 |    256 |   4096 |    0.984 |  2081.52 |    4.482 |    57.12 |
|  2048 |    256 |   6144 |    1.044 |  1962.07 |    4.626 |    55.33 |
|  2048 |    256 |   8192 |    1.102 |  1858.33 |    4.808 |    53.24 |
|  2048 |    256 |  10240 |    1.161 |  1763.85 |    5.028 |    50.91 |
|  2048 |    256 |  12288 |    1.222 |  1676.09 |    5.224 |    49.00 |
|  2048 |    256 |  14336 |    1.279 |  1601.86 |    5.368 |    47.69 |
|  2048 |    256 |  16384 |    1.348 |  1518.93 |    5.502 |    46.53 |
|  2048 |    256 |  18432 |    1.406 |  1456.80 |    5.653 |    45.28 |
|  2048 |    256 |  20480 |    1.464 |  1399.11 |    5.805 |    44.10 |
|  2048 |    256 |  22528 |    1.523 |  1344.63 |    6.144 |    41.66 |
|  2048 |    256 |  24576 |    1.586 |  1291.57 |    6.174 |    41.47 |
|  2048 |    256 |  26624 |    1.651 |  1240.34 |    6.318 |    40.52 |
|  2048 |    256 |  28672 |    1.714 |  1194.88 |    6.634 |    38.59 |

### Split mode "layer"

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    256 |      0 |    1.018 |  2011.77 |    2.789 |    91.78 |
|  2048 |    256 |   2048 |    1.118 |  1831.98 |    3.088 |    82.89 |
|  2048 |    256 |   4096 |    1.226 |  1670.15 |    3.417 |    74.92 |
|  2048 |    256 |   6144 |    1.350 |  1517.54 |    3.776 |    67.80 |
|  2048 |    256 |   8192 |    1.468 |  1395.53 |    4.064 |    62.99 |
|  2048 |    256 |  10240 |    1.586 |  1291.43 |    4.370 |    58.59 |
|  2048 |    256 |  12288 |    1.707 |  1200.09 |    4.700 |    54.47 |
|  2048 |    256 |  14336 |    1.829 |  1119.91 |    4.990 |    51.31 |
|  2048 |    256 |  16384 |    1.958 |  1046.17 |    5.318 |    48.14 |
|  2048 |    256 |  18432 |    2.083 |   982.99 |    5.635 |    45.43 |
|  2048 |    256 |  20480 |    2.217 |   923.75 |    5.943 |    43.08 |
|  2048 |    256 |  22528 |    2.351 |   871.13 |    6.290 |    40.70 |
|  2048 |    256 |  24576 |    2.478 |   826.47 |    6.582 |    38.89 |
|  2048 |    256 |  26624 |    2.604 |   786.61 |    6.888 |    37.17 |
|  2048 |    256 |  28672 |    2.732 |   749.63 |    7.255 |    35.29 |
|  2048 |    256 |  30720 |    2.852 |   718.04 |    7.539 |    33.96 |

<img width="792" height="612" alt="tp_glmair_pp" src="https://github.com/user-attachments/assets/1ecead89-6b02-4f04-a85d-3df328c1eda1" />

<img width="792" height="612" alt="tp_glmair_tg" src="https://github.com/user-attachments/assets/543563bb-2451-4603-a50a-5ea34e24741e" />


