### PR TITLE
Slightly better graph split strategy

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -1133,7 +1133,10 @@ llm_expert_gating_func_type   gating_op,
                     results[id] = shared_out;
                 }
                 cur = ggml_add(ctx, results[0], results[1]);
-                cur->op_params[0] = 0xff;
+                if (cur->ne[1] > 32) {
+                    // Force a graph split
+                    cur->op_params[0] = 0xff;
+                }
                 cb(cur, "ffn_shared_combined", il);
                 for (int id = 2; id < int(results.size()); ++id) {
                     cur = ggml_add(ctx, cur, results[id]);


### PR DESCRIPTION

This change seems to result in slightly better TG performance with split mode "graph" and tensor overrides. Basically, for TG just remove the forced graph split when combining partial shared expert results. 

Here an example of running a 5.5 Thireus quantization of GLM-4.6 on a 2x3090 system with a Ryzen-3995WX CPU. Command line was
```
./bin/llama-sweep-bench -m $model -t 64 -ngl 100 -sm graph -b 4096 -ub 4096 -n 64 -gr -c 65536 -ctk q8_0 -ctv q8_0
```

    
<img width="792" height="612" alt="x" src="https://github.com/user-attachments/assets/b5bef370-0883-4e17-b1c8-825b4787f31d" />
