### PR TITLE
Is this better for multi-GPU and split mode "graph"?

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -688,12 +688,6 @@ ggml_tensor * llm_build_context::llm_build_ffn(
             cur = ggml_add(ctx, cur, ffn[id]);
             cb(cur, "combine_ffn", il);
         }
-        if (ffn.size() > 2) {
-            cur->op_params[0] = 0xff;
-        }
-        //if (cur->type != GGML_TYPE_F32) {
-        //    cur = ggml_cast(ctx, cur, GGML_TYPE_F32);
-        //}
 
         return cur;
     }


### PR DESCRIPTION

I only have a 2xGPU system, so no way to test the best graph splitting strategy on a multi-GPU system.
On the main branch I'm forcing a second graph split when combining partial tensor-parallel results. But this may not be the best strategy, so this PR removes the second split.

Please test with split mode "graph" on your multi-GPU system and let me know if this PR gives a better performance. 