### PR TITLE
Allow empty splits

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -1668,10 +1668,15 @@ static ggml_tensor * build_output(llama_context & lctx, ggml_context * ctx, ggml
             }
             cb(o.back(), "output", id);
         }
-        if (o.size() == 1) cur = o.front();
-        cur = ggml_concat(ctx, o[0], o[1], 0);
-        for (int id = 2; id < int(o.size()); ++id) {
-            cur = ggml_concat(ctx, cur, o[id], 0);
+        GGML_ASSERT(!o.empty());
+        if (o.size() == 1) {
+            cur = o.front();
+        }
+        else {
+            cur = ggml_concat(ctx, o[0], o[1], 0);
+            for (int id = 2; id < int(o.size()); ++id) {
+                cur = ggml_concat(ctx, cur, o[id], 0);
+            }
         }
     } else {
         if (output_norm) {


### PR DESCRIPTION

The main purpose of this PR is to allow empty splits when using split mode "graph". If, for instance, one has 4 GPUs, and this leads to a bad performance with split mode "graph", one could try using
```
-sm graph -ts 100,100,0,0 -ot "...=GPU2,...=GPU3"
```
to put all attention tensors, shared experts tensors, and KV cache on GPU 0 and 1, and then use GPU 2 and 3 to offload MoE tensors. In that case tensor parallel (and corresponding synchronization plus data exchange overhead) for attention and shared experts is done on only 2 GPUs, hopefully resulting in a better performance.

@Ph0rk0z Can you try this? Hopefully I have not forgotten to add checks for empty splits everywhere where needed. Perhaps also worth trying with @magikRukkola's system with 3 GPUs. 