### PR TITLE
Fix bug in ggml_cuda_op_scale_tensor

### DIFF
--- a/ggml/src/ggml-cuda/binbcast.cu
+++ b/ggml/src/ggml-cuda/binbcast.cu
@@ -360,9 +360,7 @@ static void ggml_cuda_op_scale_tensor(ggml_backend_cuda_context & ctx, ggml_tens
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT( dst->type == GGML_TYPE_F32);
-
-    float scale;
-    memcpy(&scale, dst->src[1]->data, sizeof(float));
+    GGML_ASSERT(dst->src[1]->type == GGML_TYPE_F32);
 
     scale_f32_cuda_l(src0_d, dst_d, dst->src[1]->data, ggml_nelements(src0), stream);
 }


### PR DESCRIPTION

It was using `memcpy` on the host with a device buffer as source, resulting in a crash. Showed up in Ministral3, where `Q` is scaled with "attention temperature". Not quite sure why I did not get the crash on my other box where I prepared the Ministral3 PR.