### PR TITLE
Use standard attention for Ministral3

### DIFF
--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -407,6 +407,6 @@ llm_expert_gating_func_type   gating_op,
     static ggml_cgraph * llama_build_graph(llama_context & lctx, const llama_batch & batch, bool worst_case);
 
     ggml_tensor * build_std_attention(ggml_cgraph * gf, ggml_tensor * cur, ggml_tensor * inp_pos, ggml_tensor * rope_factors,
-            ggml_tensor * KQ_mask, ggml_tensor * sinks, float KQ_scale, float f_attn_scale, int n_swa, int il);
+            ggml_tensor * KQ_mask, ggml_tensor * sinks, ggml_tensor * inp_attn_scale, float KQ_scale, float f_attn_scale, int n_swa, int il);
 
 };

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1728,6 +1728,7 @@ static bool is_model_split_supported(const llama_model & model) {
         LLM_ARCH_LLAMA,
         LLM_ARCH_QWEN3MOE,
         LLM_ARCH_GLM4_MOE,
+        LLM_ARCH_MISTRAL3,
     };
     auto it =  k_supported.find(model.arch);
     return it != k_supported.end();


### PR DESCRIPTION
Required adding the "temperature scaling" to the standard attention implementation.

But in this way split mode "graph" is automatically supported.
