### PR TITLE
Hadamard transforms for K-cache (CPU only)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1394,6 +1394,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.merge_qkv = true;
         return true;
     }
+    if (arg == "-khad" || arg == "--k-cache-hadamard") {
+        params.k_cache_hadamard = true;
+        return true;
+    }
     if (arg == "--numa") {
         CHECK_ARG
         std::string value(argv[i]);
@@ -2074,6 +2078,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-gr, --graph-reuse",            "enable graph reuse (default: %s)", params.graph_reuse ? "enabled" : "disabled" });
     options.push_back({ "*",         "-ser,  --smart-expert-reduction", "experts reduction (default: %d,%g)", params.min_experts, params.thresh_experts});
     options.push_back({ "*",         "-mqkv,  --merge-qkv,",            "merge Q,K,V (default: %d)", params.merge_qkv});
+    options.push_back({ "*",         "-khad,  --k-cache-hadamard,",     "Use Hadamard transform for K-cache (default: %d)", params.k_cache_hadamard});
     options.push_back({ "*",         "-vq, --validate-quants",          "validate quantized data while loading the model (default: %d)", params.validate_quants});
     options.push_back({ "*",           "-p,    --prompt PROMPT",        "prompt to start generation with\n"
                                                                         "in conversation mode, this will be used as system prompt\n"
@@ -3063,9 +3068,11 @@ struct llama_context_params llama_context_params_from_gpt_params(const gpt_param
     cparams.fused_mmad        = params.fused_mmad;
     cparams.rope_cache        = params.rope_cache;
     cparams.graph_reuse       = params.graph_reuse;
+    cparams.k_cache_hadamard  = params.k_cache_hadamard;
     cparams.min_experts       = params.min_experts;
     cparams.thresh_experts    = params.thresh_experts;
     cparams.only_active_experts = params.only_active_exps;
+    cparams.k_cache_hadamard  = params.k_cache_hadamard;
 
     cparams.type_k = kv_cache_type_from_str(params.cache_type_k);
     cparams.type_v = kv_cache_type_from_str(params.cache_type_v);
@@ -4209,6 +4216,7 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "fused_mmad: %s # default: true\n", params.fused_mmad ? "true" : "false");
     fprintf(stream, "rope_cache: %s # default: false\n", params.rope_cache ? "true" : "false");
     fprintf(stream, "graph_reuse: %s # default: false\n", params.graph_reuse ? "true" : "false");
+    fprintf(stream, "k_cache_hadamard: %s # default: false\n", params.k_cache_hadamard ? "true" : "false");
     fprintf(stream, "ser: %d,%g # defaulr: -1,0\n", params.min_experts, params.thresh_experts);
     fprintf(stream, "temp: %f # default: 0.8\n", sparams.temp);
 

--- a/common/common.h
+++ b/common/common.h
@@ -276,6 +276,7 @@ struct gpt_params {
     bool validate_quants   = false; // if true, check for NaNs while loading the model
     bool only_active_exps  = true;  // if true, offload only active experts (relevant only for hybrid CPU/GPU)
     bool merge_qkv         = false; // if true, merge separate Q, K, V tensors into a single, contiguous tensor
+    bool k_cache_hadamard  = false; // if true, use Hadamard transform for the K-cache (only makes sense with quantized cache)
 
     std::string cache_type_k = "f16"; // KV cache data type for the K
     std::string cache_type_v = "f16"; // KV cache data type for the V

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -621,6 +621,7 @@ extern "C" {
         GGML_OP_FUSED_UP_GATE,
         GGML_OP_MOE_FUSED_UP_GATE,
         GGML_OP_MUL_MULTI_ADD,
+        GGML_OP_HADAMARD,
 
         GGML_OP_SCALE,
         GGML_OP_SET,
@@ -1091,6 +1092,11 @@ extern "C" {
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             struct ggml_tensor  * b);
+
+    GGML_API struct ggml_tensor * ggml_hadamard(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            int                   n);
 
     // dst = a
     // view(dst, nb1, nb2, nb3, offset) += b

--- a/ggml/src/iqk/iqk_common.h
+++ b/ggml/src/iqk/iqk_common.h
@@ -922,3 +922,22 @@ static IQK_ALWAYS_INLINE void prepare_iq4_nl_quants_r8(const int8x16_t& values, 
 #endif
 
 #endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#include <intrin.h>
+#include <ammintrin.h>
+#include <nmmintrin.h>
+#include <immintrin.h>
+#include <stdlib.h>
+inline int popcount(uint8_t x) { return __popcnt(x); }
+inline int popcount(uint16_t x) { return __popcnt(x); }
+inline int popcount(uint32_t x) { return __popcnt(x); }
+inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
+#else
+constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
+constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }
+constexpr int popcount(uint32_t x) { return __builtin_popcount(x); }
+constexpr int popcount(uint64_t x) { return __builtin_popcountll(x); }
+#endif
+

--- a/ggml/src/iqk/iqk_cpu_ops.h
+++ b/ggml/src/iqk/iqk_cpu_ops.h
@@ -28,6 +28,8 @@ void iqk_openai_experts(struct ggml_tensor * topk, struct ggml_tensor * softmax,
 
 void iqk_mul_multi_add(struct ggml_tensor * dst, int ith, int nth);
 
+void iqk_hadamard(struct ggml_tensor * dst, int ith, int nth);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -32,24 +32,6 @@
 #include <string>
 #include <functional>
 
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244 4267) // possible loss of data
-#include <intrin.h>
-#include <ammintrin.h>
-#include <nmmintrin.h>
-#include <immintrin.h>
-#include <stdlib.h>
-inline int popcount(uint8_t x) { return __popcnt(x); }
-inline int popcount(uint16_t x) { return __popcnt(x); }
-inline int popcount(uint32_t x) { return __popcnt(x); }
-inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
-#else
-constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
-constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }
-constexpr int popcount(uint32_t x) { return __builtin_popcount(x); }
-constexpr int popcount(uint64_t x) { return __builtin_popcountll(x); }
-#endif
-
 namespace {
 
 inline int nearest_int(float fval) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -440,6 +440,7 @@ extern "C" {
         int  min_experts;
         float thresh_experts;
         bool only_active_experts;
+        bool k_cache_hadamard;  // if true, apply Hadamard transfrom to K-cache
 
         // Abort callback
         // if it returns true, execution of llama_decode() will be aborted

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -82,6 +82,7 @@ struct llm_build_context {
     const bool fused_up_gate;
     const bool fused_mmad;
     const bool rope_cache;
+    const bool k_cache_hadamard;
     const int  min_experts;
     const float thresh_experts;
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -39,6 +39,7 @@ struct llama_cparams {
     bool fused_mmad;
     bool rope_cache;
     bool graph_reuse;
+    bool k_cache_hadamard;
     int  min_experts;
     float thresh_experts;
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4048,6 +4048,7 @@ struct llama_context_params llama_context_default_params() {
         /*.min_experts                 =*/ -1,
         /*.thtesh_experts              =*/ 0.0f,
         /*.only_active_experts         =*/ false,
+        /*.k_cache_hadamard            =*/ false,
         /*.abort_callback              =*/ nullptr,
         /*.abort_callback_data         =*/ nullptr,
         /*.offload_policy              =*/ nullptr,
@@ -4297,6 +4298,11 @@ struct llama_context * llama_new_context_with_model(
         return nullptr;
     }
 
+    if (params.k_cache_hadamard && !ggml_is_quantized(params.type_k)) {
+        LLAMA_LOG_WARN("%s: there is no point in Hadamard transforms with not quantized K-cache. Turning Hadamard off\n", __func__);
+        params.k_cache_hadamard = false;
+    }
+
     llama_context * ctx = new llama_context(*model);
 
     // add devices to ctx->cparams from model
@@ -4330,6 +4336,7 @@ struct llama_context * llama_new_context_with_model(
     cparams.fused_mmad       = params.fused_mmad;
     cparams.rope_cache       = params.rope_cache;
     cparams.graph_reuse      = params.graph_reuse;
+    cparams.k_cache_hadamard = params.k_cache_hadamard;
     cparams.min_experts      = params.min_experts;
     cparams.thresh_experts   = params.thresh_experts;
     cparams.cuda_params      = params.cuda_params;
@@ -4417,6 +4424,7 @@ struct llama_context * llama_new_context_with_model(
     LLAMA_LOG_INFO("%s: fused_mmad    = %d\n",     __func__, cparams.fused_mmad);
     LLAMA_LOG_INFO("%s: rope_cache    = %d\n",     __func__, cparams.rope_cache);
     LLAMA_LOG_INFO("%s: graph_reuse   = %d\n",     __func__, cparams.graph_reuse);
+    LLAMA_LOG_INFO("%s: k_cache_hadam = %d\n",     __func__, cparams.k_cache_hadamard);
     LLAMA_LOG_INFO("%s: ser           = %d, %g\n", __func__, cparams.min_experts, cparams.thresh_experts);
     LLAMA_LOG_INFO("%s: freq_base     = %.1f\n",   __func__, cparams.rope_freq_base);
     LLAMA_LOG_INFO("%s: freq_scale    = %g\n",     __func__, cparams.rope_freq_scale);


### PR DESCRIPTION
There is the claim that applying [Hadamard transforms](https://en.wikipedia.org/wiki/Hadamard_transform) to tensors involved in Transformer models improves quantization accuracy that is quite prevalent in certain groups on the Internet.

I have tried using Hadamard transforms for model weight quantization with zero success (i.e., no improvement, or even worse outcomes, compared to not using Hadmard transforms).  Hence, I have been skeptical that using Hadamard transforms for quantized KV cache would move the needle in any meaningful way.

If so, why try this now?

Well, DeepSeek-V3.2-Exp has been released, and it is being claimed that this model is exceptionally good at reasoning and tool calling. We have issue #834 asking for support, so I was reviewing the attention implementation today to see what will it take to add support. Guess what? They do use a Hadamard transform before converting the activations to be stored in the KV cache to `fp8`. Hence, to support the DeepSeek-V3.2-Exp attention mechanism, we do need to be able to handle Hadamard transforms. So, I decided to add this ability, just for the CPU backend for now. Once at it, I decided to see if this really reduces quantization error when using quantized KV cache. This PR is the result.

A Hadamard transform can be easily applied to the K-cache: just apply to `K` and `Q`, store the Hadamard-transformed `K` in the K-cache, and then proceed with the self attention calculation as usual. The V cache is much more involved: one needs to either apply a backward transformation to **the entire** V cache before multiplying with `softmax(K*Q)` (slow, a lot of extra RAM/VRAM required), or incorporate the Hadamard transform directly into the `softmax(K*Q)` computation in the flash attention kernel (complicated). Hence, the PR only adds the ability to use Hadamard transforms for the K-cache. This should not be a big issue as it is well known that K-cache quantization errors have a much bigger impact on model quality degradation than V-cache. 

The results are, at least to me, quite astounding. The table below shows PPL for LlaMA-3-8B (model is quantized with `Q4_0`) for 3 different K-cache quantization types with and without a Hadamard transform. The V-cache is always `f16`. As the implementation is only for the CPU, it takes quite a bit of time to run these PPL calculations, so just one model for now. I have left a more detailed comparison for a future PR adding Hadamard transforms to the CUDA backend.

| K-cache | PPL (no Hadamard) | PPL (Hadamard) | Diff to f16 (no Hadamard) | Diff to f16 (Hadamard) |
| ---: | ---: | ---: | ---: | ---: |
| f16    |  7.6077 | N/A | N/A | N/A |
| Q8_0 | 7.6090 |  7.6083  | 0.02% | 0.008% | 
| Q6_0 | 7.6192 | 7.6123 |  0.15% | 0.06% |
| IQ4_NL | 7.7252 | 7.6717 | 1.54% | 0.84% |
| Q4_0 | 7.8131 | 7.6789 | 2.70% | 0.94% |

~I did not run `Q8_0` K-cache with a Hadamard transform as any difference will be basically within the noise.~ `Q6_0` K-cache is already quite good without Hadamard, but using a Hadamard transform reduces the quantization error by more than a factor of 2. The most astounding result is the nearly 3X reduction in quantization error for `Q4_0` K-cache, thus making it a viable option when really short on memory. Also interesting to note that with a  Hadamard transform applied the benefit of the non-linear `IQ4_NL` quantization is much smaller compared to no-Hadamard.

To use it: add `-khad` or `--k-cache-hadamard` to the command line. As mentioned, CPU-only for now. It will run on CUDA, but self-attention will be done on the CPU, so it will be much slower.

Performance impact is negligible when running CPU-only. 

**Caveat**: the attention head size must be a power of 2. This is true for almost all relevant models, with the notable exception of DeepSeek-V2/V3/R1 (and by extension Kimi-2)