### PR TITLE
Don't split the output tensor

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -388,7 +388,7 @@ void create_tensors_helper::create_std_ffn(int i, const LLM_TN & tn, llama_layer
 
 bool create_tensors_helper::create_llama_tensors(const LLM_TN & tn) {
     LOADING_PRELUDE
-    create_embd_output(tn, n_embd, n_vocab, true, true);
+    create_embd_output(tn, n_embd, n_vocab, true, false); //true);
 
     for (int i = 0; i < n_layer; ++i) {
         ggml_context * ctx_layer = ctx_for_layer(i);
@@ -1843,7 +1843,7 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
     GGML_ASSERT(hparams.n_expert > 0 && "n_expert must be > 0 for GLM4_MOE MoE layers");
     GGML_ASSERT(hparams.n_expert_used > 0 && "n_expert_used must be > 0 for GLM4_MOE MoE layers");
 
-    create_embd_output(tn, n_embd, n_vocab, true, true);
+    create_embd_output(tn, n_embd, n_vocab, true, false); //true);
 
     for (int i = 0; i < n_layer; ++i) {
         ggml_context * ctx_layer = ctx_for_layer(i);


### PR DESCRIPTION

I have noticed that compute buffers are unreasonably large for GLM-4.5/4.6/AIR when using split mode "graph".

Turns out this is due to splitting the output tensor. When the "worst case" graph is processed during initialization, the full ubatch size is used as result output, which means that the result of the multiplication of the output tensor with the result output is `n_vocab x n_ubath`. For the GLM models the vocabulary is 155k, so for u-bath of 4096 the size of the result is 2.36 GiB! if the output tensor is split, each GPU creates the 2.36 GiB result and sends it to the main GPU to compute the final result. Hence, for 2 GPUs the main GPU (or the GPU computing the final result) needs 2 times that, so 4.72 GiB!

Based on quick testing, not computing the output matrix multiplication in parallel has negligible performance impact. I suspect for people with slow P2P copy not having to copy 2.4 GiB per additional GPU may even slightly improve PP performance. Hence, I'm disabling the output tensor slitting with this PR.