### PR TITLE
Automatically disable CUDA graphs for split mode "graph"

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -840,6 +840,9 @@ struct ggml_backend_cuda_context {
     int  fusion = GGML_CUDA_FUSION;
     int  offload_batch_size = GGML_CUDA_MIN_BATCH_OFFLOAD;
     int  mmq_id_thresh = 32;
+#ifdef USE_CUDA_GRAPH
+    bool use_cuda_graph = true;
+#endif
 
     explicit ggml_backend_cuda_context(int device);
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4480,8 +4480,16 @@ struct llama_context * llama_new_context_with_model(
 
         } else {
             // LLAMA_SPLIT_MODE_LAYER and LLAMA_SPLIT_MODE_GRAPH require a backend for each GPU
+            auto params = cparams.cuda_params;
+            std::string new_params;
+            if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+                static const std::string extra_string{"graphs=0"};
+                if (params) new_params = std::string{(const char *)params} + ',';
+                new_params += extra_string;
+                params = new_params.data();
+            }
             for (int device = 0; device < ggml_backend_cuda_get_device_count(); ++device) {
-                ggml_backend_t backend = ggml_backend_cuda_init(device, cparams.cuda_params);
+                ggml_backend_t backend = ggml_backend_cuda_init(device, params);
                 if (backend == nullptr) {
                     LLAMA_LOG_ERROR("%s: failed to initialize CUDA%d backend\n", __func__, device);
                     llama_free(ctx);


### PR DESCRIPTION

CUDA graphs cannot be used with split mode "graph". Capturing CUDA graphs does get disabled after a few failed attempts, but on at least one occasion we got an actual error (manifesting as a crash) while capturing a CUDA graph, so it is better to just disable *a priori*.

Once at it, I also added the ability to disable CUDA graphs via a command line argument
```
-cuda graphs=0
```
Just in case someone wants to see the performance impact of CUDA graphs without rebuilding or fooling around with environment variables. 