### PR TITLE
Reduce back-end syncs

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1953,6 +1953,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                         ggml_backend_tensor_get_async(ids_backend, ids_tensor, ids.data(), 0, ggml_nbytes(ids_tensor));
 
                         ggml_backend_synchronize(ids_backend);
+                        needs_sync[tensor_backend_id(ids_tensor)] = false;
 
                         unique_ids.resize((n_expert + 31)/32);
                         std::memset(unique_ids.data(), 0, unique_ids.size()*sizeof(uint32_t));
@@ -2009,7 +2010,11 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 // try async copy, but if not possible, we can still use a sync copy without synchronizing the dst backend, since we handle the synchronization here with multiple copies and events
                 // TODO: add public function to facilitate this, since applications do not have direct access to the backend interface
                 if (!split_backend->iface.cpy_tensor_async || !split_backend->iface.cpy_tensor_async(input_backend, split_backend, input, input_cpy)) {
-                    ggml_backend_synchronize(input_backend);
+                    int input_backend_id = tensor_backend_id(input);
+                    if (needs_sync[input_backend_id]) {
+                        ggml_backend_synchronize(input_backend);
+                        needs_sync[input_backend_id] = false;
+                    }
                     if (needs_sync[split_backend_id]) {
                         if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                             ggml_backend_event_synchronize(sched->events[split_backend_id][sched->cur_copy]);
@@ -2023,7 +2028,9 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             }
         }
 
-        needs_sync[split_backend_id] = true;
+        if (split->n_inputs > 0) {
+            needs_sync[split_backend_id] = true;
+        }
         if (!sched->callback_eval) {
 #if IK_PRINT_TIMING
             int64_t tim2 = ggml_time_us();


### PR DESCRIPTION

This PR brings a small TG performance improvement for split mode "graph" with more than 2 GPUs by reducing the number of compute back-end synchronization calls during graph evaluation.

@magikRUKKOLA gracefully provided access to their 4x3090 system so I can test 2+ GPU performance. As an example, here is a `sweep-bench` comparison between the main branch and this PR running a `Q4_0`-quantized LlaMA-3-70B on the 4x3090 system.

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.883 |   543.94 |   11.908 |    21.50 |
|  1024 |    256 |   1024 |    1.876 |   545.82 |   11.780 |    21.73 |
|  1024 |    256 |   2048 |    1.886 |   542.90 |   11.903 |    21.51 |
|  1024 |    256 |   3072 |    1.885 |   543.15 |   12.022 |    21.29 |
|  1024 |    256 |   4096 |    1.897 |   539.84 |   11.938 |    21.44 |
|  1024 |    256 |   5120 |    1.908 |   536.76 |   11.971 |    21.38 |
|  1024 |    256 |   6144 |    1.920 |   533.39 |   11.990 |    21.35 |
|  1024 |    256 |   7168 |    1.933 |   529.74 |   11.903 |    21.51 |
|  1024 |    256 |   8192 |    1.932 |   530.14 |   12.080 |    21.19 |
|  1024 |    256 |   9216 |    1.949 |   525.36 |   12.045 |    21.25 |
|  1024 |    256 |  10240 |    1.955 |   523.67 |   12.174 |    21.03 |
|  1024 |    256 |  11264 |    1.979 |   517.34 |   12.202 |    20.98 |
|  1024 |    256 |  12288 |    1.977 |   517.83 |   12.282 |    20.84 |
|  1024 |    256 |  13312 |    1.982 |   516.69 |   12.257 |    20.89 |
|  1024 |    256 |  14336 |    2.000 |   511.88 |   12.299 |    20.81 |
|  1024 |    256 |  15360 |    2.008 |   510.03 |   12.209 |    20.97 |
|  1024 |    256 |  16384 |    2.009 |   509.65 |   12.201 |    20.98 |

### PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.884 |   543.51 |   10.977 |    23.32 |
|  1024 |    256 |   1024 |    1.872 |   546.95 |   11.170 |    22.92 |
|  1024 |    256 |   2048 |    1.887 |   542.54 |   11.107 |    23.05 |
|  1024 |    256 |   3072 |    1.900 |   538.94 |   11.065 |    23.14 |
|  1024 |    256 |   4096 |    1.913 |   535.16 |   11.385 |    22.49 |
|  1024 |    256 |   5120 |    1.919 |   533.56 |   11.055 |    23.16 |
|  1024 |    256 |   6144 |    1.924 |   532.36 |   11.065 |    23.14 |
|  1024 |    256 |   7168 |    1.948 |   525.79 |   11.358 |    22.54 |
|  1024 |    256 |   8192 |    1.947 |   525.92 |   11.152 |    22.96 |
|  1024 |    256 |   9216 |    1.956 |   523.58 |   11.353 |    22.55 |
|  1024 |    256 |  10240 |    1.962 |   521.97 |   11.251 |    22.75 |
|  1024 |    256 |  11264 |    1.981 |   517.00 |   11.390 |    22.48 |
|  1024 |    256 |  12288 |    1.993 |   513.69 |   11.571 |    22.13 |
|  1024 |    256 |  13312 |    2.003 |   511.18 |   11.576 |    22.12 |
|  1024 |    256 |  14336 |    2.010 |   509.57 |   11.724 |    21.84 |
|  1024 |    256 |  15360 |    2.037 |   502.69 |   11.588 |    22.09 |
|  1024 |    256 |  16384 |    2.022 |   506.48 |   11.516 |    22.23 |

We see 7-8% TG performance improvement. This is still far from ideal, as the table below obtained by using 2 GPUs via `CUDA_VISIBLE_DEVICES=0,1` shows, but at least we have some progress.

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.158 |   884.17 |    8.889 |    28.80 |
|  1024 |    256 |   1024 |    1.165 |   878.66 |    8.878 |    28.84 |
|  1024 |    256 |   2048 |    1.182 |   866.01 |    8.920 |    28.70 |
|  1024 |    256 |   3072 |    1.200 |   853.16 |    8.972 |    28.53 |
|  1024 |    256 |   4096 |    1.217 |   841.28 |    9.043 |    28.31 |
|  1024 |    256 |   5120 |    1.233 |   830.33 |    9.204 |    27.82 |
|  1024 |    256 |   6144 |    1.250 |   819.06 |    9.413 |    27.20 |
|  1024 |    256 |   7168 |    1.267 |   808.11 |    9.247 |    27.68 |
|  1024 |    256 |   8192 |    1.284 |   797.63 |    9.256 |    27.66 |
|  1024 |    256 |   9216 |    1.300 |   787.84 |    9.301 |    27.52 |
|  1024 |    256 |  10240 |    1.316 |   777.86 |    9.389 |    27.27 |
|  1024 |    256 |  11264 |    1.334 |   767.89 |    9.504 |    26.94 |
|  1024 |    256 |  12288 |    1.350 |   758.73 |    9.501 |    26.94 |
|  1024 |    256 |  13312 |    1.367 |   749.31 |    9.523 |    26.88 |
|  1024 |    256 |  14336 |    1.385 |   739.35 |    9.569 |    26.75 |
|  1024 |    256 |  15360 |    1.400 |   731.40 |    9.778 |    26.18 |
|  1024 |    256 |  16384 |    1.417 |   722.76 |    9.705 |    26.38 |
   