### PR TITLE
Split mode graph: max number of GPUs per layer

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1267,6 +1267,11 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
 #endif // GGML_USE_CUDA_SYCL_VULKAN
         return true;
     }
+    else if (arg == "--max-gpu") {
+        CHECK_ARG
+        params.max_gpu = std::stoi(argv[i]);
+        return true;
+    }
     if (arg == "--split-mode" || arg == "-sm") {
         CHECK_ARG
         std::string arg_next = argv[i];
@@ -2265,6 +2270,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
                                                                          "Example: CUDA0,CUDA1,RPC[192.168.0.1:8080]\n" });
         options.push_back({ "*",           "-mg,   --main-gpu i",       "the GPU to use for the model (with split-mode = none),\n"
                                                                         "or for intermediate results and KV (with split-mode = row) (default: %d)", params.main_gpu });
+        options.push_back({ "*",           "--max-gpu i",               "max. number of GPUs to use at a time with split mode 'graph', (default: %d)", params.max_gpu });
     }
 
     options.push_back({ "model" });
@@ -2973,6 +2979,7 @@ struct llama_model_params llama_model_params_from_gpt_params(const gpt_params & 
     mparams.mla             = params.mla_attn;
     mparams.rpc_servers     = params.rpc_servers.c_str();
     mparams.main_gpu        = params.main_gpu;
+    mparams.max_gpu         = params.max_gpu;
     mparams.split_mode      = params.split_mode;
     mparams.tensor_split    = params.tensor_split;
     mparams.use_mmap        = params.use_mmap;
@@ -4173,6 +4180,7 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     }
     fprintf(stream, "lora_init_without_apply: %s # default: false\n", params.lora_init_without_apply ? "true" : "false");
     fprintf(stream, "main_gpu: %d # default: 0\n", params.main_gpu);
+    fprintf(stream, "max_gpu: %d # default: 0\n", params.max_gpu);
     fprintf(stream, "min_keep: %d # default: 0 (disabled)\n", sparams.min_keep);
     fprintf(stream, "mirostat: %d # default: 0 (disabled)\n", sparams.mirostat);
     fprintf(stream, "mirostat_ent: %f # default: 5.0\n", sparams.mirostat_tau);

--- a/common/common.h
+++ b/common/common.h
@@ -154,6 +154,7 @@ struct gpt_params {
     int32_t n_gpu_layers          =    -1; // number of layers to store in VRAM (-1 - use default)
     int32_t n_gpu_layers_draft    =    -1; // number of layers to store in VRAM for the draft model (-1 - use default)
     int32_t main_gpu              =     0; // the GPU that is used for scratch and small tensors
+    int32_t max_gpu               =     0; // max number of GPUs to use at a time for split mode "graph"
     float   tensor_split[128]     =   {0}; // how split tensors should be distributed across GPUs
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width

--- a/include/llama.h
+++ b/include/llama.h
@@ -362,6 +362,7 @@ extern "C" {
         // LLAMA_SPLIT_ROW: the GPU that is used for small tensors and intermediate results
         // LLAMA_SPLIT_LAYER: ignored
         int32_t main_gpu;
+        int32_t max_gpu;
 
         // proportion of the model (layers or rows) to offload to each GPU, size: llama_max_devices()
         const float * tensor_split;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -350,6 +350,7 @@ struct llama_model {
 
     llama_split_mode split_mode;
     int main_gpu;
+    int max_gpu = 0; // max. number of GPUs to use per layer for aplit mode "graph"
     int n_gpu_layers;
 
     std::vector<rpc_device> rpc_servers;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1742,6 +1742,7 @@ static bool llm_load_tensors(
         int mla_attn,
         enum llama_split_mode split_mode,
         int main_gpu,
+        int max_gpu,
         const float * tensor_split,
         bool use_mlock,
         bool validate_quants,
@@ -1763,6 +1764,7 @@ static bool llm_load_tensors(
 
     model.split_mode   = split_mode;
     model.main_gpu     = main_gpu;
+    model.max_gpu      = max_gpu;
     model.n_gpu_layers = n_gpu_layers;
 
     const int n_layer     = hparams.n_layer;
@@ -2138,7 +2140,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
 #endif
 
         if (!llm_load_tensors(
-            ml, model, params.n_gpu_layers, params.mla, params.split_mode,  params.main_gpu, params.tensor_split,
+            ml, model, params.n_gpu_layers, params.mla, params.split_mode,  params.main_gpu, params.max_gpu, params.tensor_split,
             params.use_mlock, params.validate_quants,
             params.progress_callback, params.progress_callback_user_data
         )) {
@@ -3985,6 +3987,7 @@ struct llama_model_params llama_model_default_params() {
         /*.mla                         =*/ 0,
         /*.split_mode                  =*/ LLAMA_SPLIT_MODE_LAYER,
         /*.main_gpu                    =*/ 0,
+        /*.max_gpu                     =*/ 0,
         /*.tensor_split                =*/ nullptr,
         /*.rpc_servers                 =*/ nullptr,
         /*.progress_callback           =*/ nullptr,


### PR DESCRIPTION
This PR adds the ability to define (and use) a maximum number of GPUs per layer with split mode "graph". This is of interest when there are more than 2 GPUs available, but using all of them leads to a lower performance than using just 2 (or using the default split mode "layer").

To use it, just add
```
--max-gpu N
```
to the command line, where `2 <= N < number of GPUs available`. This command line option only has an effect with split mode "graph". To clarify, all GPUs get used, it is just that only `max-gpu` GPUs are being used in any given model layer.

Here are a few examples of why this can be very useful. I'm testing on a 4x3090 system gracefully provided for testing by @magikRUKKOLA. I think this could be highly beneficial for people with slow and/or high latency peer-to-peer copy (e.g., @Ph0rk0z)


### Example 1 - LlaMA-3-70B  (Q4_0)

<img width="792" height="612" alt="l3_pp" src="https://github.com/user-attachments/assets/387e82ff-9ada-4ea1-a597-90ae8fd865d4" />

<img width="792" height="612" alt="l3_tg" src="https://github.com/user-attachments/assets/6c40bb69-4510-422c-b7de-7c1838689e0c" />

<details>
<summary>Split mode "layer"</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.363 |   751.01 |   11.382 |    22.49 |
|  1024 |    256 |   1024 |    1.392 |   735.84 |   11.449 |    22.36 |
|  1024 |    256 |   2048 |    1.423 |   719.39 |   11.605 |    22.06 |
|  1024 |    256 |   3072 |    1.455 |   703.75 |   11.728 |    21.83 |
|  1024 |    256 |   4096 |    1.497 |   684.09 |   11.794 |    21.71 |
|  1024 |    256 |   5120 |    1.524 |   672.13 |   11.995 |    21.34 |
|  1024 |    256 |   6144 |    1.557 |   657.86 |   12.009 |    21.32 |
|  1024 |    256 |   7168 |    1.594 |   642.45 |   12.060 |    21.23 |
|  1024 |    256 |   8192 |    1.628 |   628.81 |   12.190 |    21.00 |
|  1024 |    256 |   9216 |    1.660 |   617.00 |   12.217 |    20.95 |
|  1024 |    256 |  10240 |    1.690 |   605.98 |   12.335 |    20.75 |
|  1024 |    256 |  11264 |    1.721 |   595.09 |   12.468 |    20.53 |
|  1024 |    256 |  12288 |    1.750 |   585.08 |   12.525 |    20.44 |
|  1024 |    256 |  13312 |    1.788 |   572.67 |   12.658 |    20.22 |
|  1024 |    256 |  14336 |    1.823 |   561.63 |   12.711 |    20.14 |
|  1024 |    256 |  15360 |    1.845 |   555.03 |   12.788 |    20.02 |
|  1024 |    256 |  16384 |    1.876 |   545.73 |   12.929 |    19.80 |
|  1024 |    256 |  17408 |    1.913 |   535.39 |   12.981 |    19.72 |
|  1024 |    256 |  18432 |    1.952 |   524.47 |   13.115 |    19.52 |
|  1024 |    256 |  19456 |    1.984 |   516.26 |   13.155 |    19.46 |
|  1024 |    256 |  20480 |    2.007 |   510.31 |   13.229 |    19.35 |
|  1024 |    256 |  21504 |    2.044 |   500.93 |   13.401 |    19.10 |
|  1024 |    256 |  22528 |    2.076 |   493.34 |   13.476 |    19.00 |
|  1024 |    256 |  23552 |    2.123 |   482.30 |   13.577 |    18.86 |
|  1024 |    256 |  24576 |    2.142 |   478.03 |   13.640 |    18.77 |
|  1024 |    256 |  25600 |    2.176 |   470.52 |   13.706 |    18.68 |
|  1024 |    256 |  26624 |    2.206 |   464.22 |   13.843 |    18.49 |
|  1024 |    256 |  27648 |    2.249 |   455.32 |   13.877 |    18.45 |
|  1024 |    256 |  28672 |    2.282 |   448.75 |   14.012 |    18.27 |
|  1024 |    256 |  29696 |    2.305 |   444.21 |   14.082 |    18.18 |
|  1024 |    256 |  30720 |    2.337 |   438.11 |   14.132 |    18.11 |
|  1024 |    256 |  31744 |    2.379 |   430.44 |   14.319 |    17.88 |

</details>

<details>
<summary>Split mode "graph"</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.865 |   548.93 |   10.801 |    23.70 |
|  1024 |    256 |   1024 |    1.862 |   549.99 |   10.913 |    23.46 |
|  1024 |    256 |   2048 |    1.881 |   544.31 |   10.765 |    23.78 |
|  1024 |    256 |   3072 |    1.885 |   543.27 |   11.127 |    23.01 |
|  1024 |    256 |   4096 |    1.884 |   543.45 |   10.971 |    23.34 |
|  1024 |    256 |   5120 |    1.899 |   539.30 |   10.807 |    23.69 |
|  1024 |    256 |   6144 |    1.907 |   536.97 |   10.817 |    23.67 |
|  1024 |    256 |   7168 |    1.925 |   532.03 |   10.865 |    23.56 |
|  1024 |    256 |   8192 |    1.930 |   530.66 |   11.264 |    22.73 |
|  1024 |    256 |   9216 |    1.936 |   528.86 |   11.141 |    22.98 |
|  1024 |    256 |  10240 |    1.947 |   525.90 |   11.131 |    23.00 |
|  1024 |    256 |  11264 |    1.958 |   523.06 |   11.438 |    22.38 |
|  1024 |    256 |  12288 |    1.964 |   521.42 |   11.289 |    22.68 |
|  1024 |    256 |  13312 |    1.990 |   514.70 |   11.339 |    22.58 |
|  1024 |    256 |  14336 |    1.985 |   515.83 |   11.379 |    22.50 |
|  1024 |    256 |  15360 |    1.999 |   512.32 |   11.281 |    22.69 |
|  1024 |    256 |  16384 |    2.003 |   511.28 |   11.212 |    22.83 |
|  1024 |    256 |  17408 |    2.009 |   509.62 |   11.290 |    22.68 |
|  1024 |    256 |  18432 |    2.031 |   504.23 |   11.472 |    22.31 |
|  1024 |    256 |  19456 |    2.038 |   502.44 |   11.591 |    22.09 |
|  1024 |    256 |  20480 |    2.042 |   501.57 |   11.377 |    22.50 |
|  1024 |    256 |  21504 |    2.049 |   499.69 |   11.666 |    21.94 |
|  1024 |    256 |  22528 |    2.057 |   497.75 |   11.642 |    21.99 |
|  1024 |    256 |  23552 |    2.071 |   494.50 |   12.031 |    21.28 |
|  1024 |    256 |  24576 |    2.081 |   492.03 |   11.580 |    22.11 |
|  1024 |    256 |  25600 |    2.100 |   487.61 |   11.502 |    22.26 |
|  1024 |    256 |  26624 |    2.099 |   487.80 |   11.705 |    21.87 |
|  1024 |    256 |  27648 |    2.112 |   484.77 |   11.600 |    22.07 |
|  1024 |    256 |  28672 |    2.128 |   481.09 |   11.616 |    22.04 |
|  1024 |    256 |  29696 |    2.125 |   481.82 |   11.534 |    22.19 |
|  1024 |    256 |  30720 |    2.138 |   478.99 |   11.519 |    22.22 |
|  1024 |    256 |  31744 |    2.154 |   475.33 |   11.666 |    21.94 |

</details>

<details>
<summary>Split mode "graph", --max-gpu 2</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  1024 |    256 |      0 |    1.187 |   862.43 |    9.471 |    27.03 |
|  1024 |    256 |   1024 |    1.190 |   860.21 |    9.586 |    26.71 |
|  1024 |    256 |   2048 |    1.209 |   846.81 |    9.570 |    26.75 |
|  1024 |    256 |   3072 |    1.223 |   837.46 |    9.634 |    26.57 |
|  1024 |    256 |   4096 |    1.239 |   826.18 |    9.719 |    26.34 |
|  1024 |    256 |   5120 |    1.261 |   811.81 |   10.033 |    25.52 |
|  1024 |    256 |   6144 |    1.274 |   803.47 |    9.926 |    25.79 |
|  1024 |    256 |   7168 |    1.289 |   794.42 |    9.899 |    25.86 |
|  1024 |    256 |   8192 |    1.307 |   783.52 |    9.904 |    25.85 |
|  1024 |    256 |   9216 |    1.331 |   769.43 |    9.947 |    25.74 |
|  1024 |    256 |  10240 |    1.346 |   760.73 |   10.046 |    25.48 |
|  1024 |    256 |  11264 |    1.357 |   754.72 |   10.166 |    25.18 |
|  1024 |    256 |  12288 |    1.378 |   742.97 |   10.171 |    25.17 |
|  1024 |    256 |  13312 |    1.401 |   730.81 |   10.271 |    24.92 |
|  1024 |    256 |  14336 |    1.411 |   725.94 |   10.242 |    24.99 |
|  1024 |    256 |  15360 |    1.427 |   717.36 |   10.333 |    24.78 |
|  1024 |    256 |  16384 |    1.449 |   706.57 |   10.543 |    24.28 |
|  1024 |    256 |  17408 |    1.458 |   702.17 |   10.441 |    24.52 |
|  1024 |    256 |  18432 |    1.474 |   694.71 |   10.497 |    24.39 |
|  1024 |    256 |  19456 |    1.497 |   683.81 |   10.472 |    24.45 |
|  1024 |    256 |  20480 |    1.515 |   675.80 |   10.523 |    24.33 |
|  1024 |    256 |  21504 |    1.525 |   671.43 |   10.803 |    23.70 |
|  1024 |    256 |  22528 |    1.551 |   660.16 |   10.693 |    23.94 |
|  1024 |    256 |  23552 |    1.570 |   652.11 |   10.733 |    23.85 |
|  1024 |    256 |  24576 |    1.574 |   650.47 |   10.750 |    23.81 |
|  1024 |    256 |  25600 |    1.599 |   640.32 |   10.739 |    23.84 |
|  1024 |    256 |  26624 |    1.611 |   635.58 |   10.871 |    23.55 |
|  1024 |    256 |  27648 |    1.633 |   626.96 |   10.964 |    23.35 |
|  1024 |    256 |  28672 |    1.646 |   622.18 |   10.904 |    23.48 |
|  1024 |    256 |  29696 |    1.669 |   613.68 |   10.990 |    23.29 |
|  1024 |    256 |  30720 |    1.692 |   605.21 |   10.993 |    23.29 |
|  1024 |    256 |  31744 |    1.710 |   598.97 |   11.116 |    23.03 |

</details>

### Example 2: GLM-4.6, Thireus 5.5 bpw quantization mix (229 GiB)

Here we go to a larger context (98k tokens), but using `f16` KV cache. With 4x3090 we can offload 11 or 12 MoE layers to the GPUs. The CPU (where most of TG runs) is Risen 3995WX.

<img width="792" height="612" alt="glm4 6_pp" src="https://github.com/user-attachments/assets/59b10151-ed47-40bc-bacf-868a661214a7" />

<img width="792" height="612" alt="glm4 6_tg" src="https://github.com/user-attachments/assets/43d6fe22-6889-4703-b65e-7361ac057305" />

<details>
<summary>Split mode "layer"</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   17.320 |   236.48 |    6.774 |     9.45 |
|  4096 |     64 |   4096 |   18.194 |   225.13 |    7.085 |     9.03 |
|  4096 |     64 |   8192 |   19.398 |   211.16 |    7.350 |     8.71 |
|  4096 |     64 |  12288 |   20.487 |   199.93 |    7.928 |     8.07 |
|  4096 |     64 |  16384 |   21.678 |   188.95 |    8.136 |     7.87 |
|  4096 |     64 |  20480 |   22.730 |   180.20 |    8.314 |     7.70 |
|  4096 |     64 |  24576 |   23.837 |   171.83 |    8.690 |     7.36 |
|  4096 |     64 |  28672 |   25.223 |   162.39 |    9.124 |     7.01 |
|  4096 |     64 |  32768 |   26.196 |   156.36 |    9.421 |     6.79 |
|  4096 |     64 |  36864 |   27.303 |   150.02 |    9.559 |     6.70 |
|  4096 |     64 |  40960 |   28.770 |   142.37 |    9.906 |     6.46 |
|  4096 |     64 |  45056 |   30.198 |   135.64 |   10.512 |     6.09 |
|  4096 |     64 |  49152 |   31.036 |   131.98 |   10.544 |     6.07 |
|  4096 |     64 |  53248 |   32.058 |   127.77 |   10.878 |     5.88 |
|  4096 |     64 |  57344 |   33.128 |   123.64 |   11.384 |     5.62 |
|  4096 |     64 |  61440 |   35.100 |   116.69 |   11.667 |     5.49 |
|  4096 |     64 |  65536 |   35.804 |   114.40 |   11.965 |     5.35 |
|  4096 |     64 |  69632 |   37.313 |   109.77 |   12.161 |     5.26 |
|  4096 |     64 |  73728 |   38.107 |   107.49 |   12.438 |     5.15 |
|  4096 |     64 |  77824 |   39.239 |   104.39 |   12.781 |     5.01 |
|  4096 |     64 |  81920 |   40.660 |   100.74 |   13.113 |     4.88 |
|  4096 |     64 |  86016 |   42.207 |    97.05 |   13.360 |     4.79 |
|  4096 |     64 |  90112 |   43.117 |    95.00 |   13.730 |     4.66 |
|  4096 |     64 |  94208 |   45.104 |    90.81 |   13.991 |     4.57 |

</details>

<details>
<summary>Split mode "graph"</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   18.764 |   218.29 |    8.718 |     7.34 |
|  4096 |     64 |   4096 |   18.893 |   216.80 |    8.640 |     7.41 |
|  4096 |     64 |   8192 |   19.059 |   214.91 |    8.747 |     7.32 |
|  4096 |     64 |  12288 |   19.253 |   212.74 |    8.711 |     7.35 |
|  4096 |     64 |  16384 |   19.552 |   209.50 |    8.901 |     7.19 |
|  4096 |     64 |  20480 |   19.716 |   207.75 |    9.248 |     6.92 |
|  4096 |     64 |  24576 |   20.024 |   204.55 |    9.159 |     6.99 |
|  4096 |     64 |  28672 |   20.246 |   202.31 |    9.086 |     7.04 |
|  4096 |     64 |  32768 |   20.501 |   199.79 |    9.067 |     7.06 |
|  4096 |     64 |  36864 |   20.840 |   196.54 |    9.637 |     6.64 |
|  4096 |     64 |  40960 |   21.029 |   194.78 |    9.562 |     6.69 |
|  4096 |     64 |  45056 |   21.343 |   191.91 |    9.396 |     6.81 |
|  4096 |     64 |  49152 |   21.657 |   189.13 |    9.527 |     6.72 |
|  4096 |     64 |  53248 |   21.873 |   187.27 |    9.933 |     6.44 |
|  4096 |     64 |  57344 |   22.137 |   185.03 |    9.934 |     6.44 |
|  4096 |     64 |  61440 |   22.425 |   182.66 |    9.866 |     6.49 |
|  4096 |     64 |  65536 |   22.866 |   179.13 |    9.836 |     6.51 |
|  4096 |     64 |  69632 |   22.901 |   178.85 |    9.899 |     6.47 |
|  4096 |     64 |  73728 |   23.216 |   176.43 |   10.006 |     6.40 |
|  4096 |     64 |  77824 |   23.446 |   174.70 |    9.971 |     6.42 |
|  4096 |     64 |  81920 |   23.815 |   171.99 |   10.326 |     6.20 |
|  4096 |     64 |  86016 |   24.146 |   169.63 |   10.192 |     6.28 |
|  4096 |     64 |  90112 |   24.335 |   168.32 |   10.484 |     6.10 |
|  4096 |     64 |  94208 |   24.812 |   165.08 |   10.296 |     6.22 |

</details>

<details>
<summary>Split mode "graph", --max-gpu 2</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   16.628 |   246.33 |    7.598 |     8.42 |
|  4096 |     64 |   4096 |   17.222 |   237.84 |    7.616 |     8.40 |
|  4096 |     64 |   8192 |   17.573 |   233.08 |    7.950 |     8.05 |
|  4096 |     64 |  12288 |   18.005 |   227.49 |    8.074 |     7.93 |
|  4096 |     64 |  16384 |   18.524 |   221.12 |    8.350 |     7.66 |
|  4096 |     64 |  20480 |   19.129 |   214.13 |    8.651 |     7.40 |
|  4096 |     64 |  24576 |   19.594 |   209.04 |    8.622 |     7.42 |
|  4096 |     64 |  28672 |   20.323 |   201.55 |    8.642 |     7.41 |
|  4096 |     64 |  32768 |   20.688 |   197.99 |    9.059 |     7.06 |
|  4096 |     64 |  36864 |   21.312 |   192.19 |    9.103 |     7.03 |
|  4096 |     64 |  40960 |   21.987 |   186.30 |    9.287 |     6.89 |
|  4096 |     64 |  45056 |   22.689 |   180.53 |    9.353 |     6.84 |
|  4096 |     64 |  49152 |   23.037 |   177.80 |    9.682 |     6.61 |
|  4096 |     64 |  53248 |   23.421 |   174.89 |    9.613 |     6.66 |
|  4096 |     64 |  57344 |   24.047 |   170.33 |    9.647 |     6.63 |
|  4096 |     64 |  61440 |   25.052 |   163.50 |    9.894 |     6.47 |
|  4096 |     64 |  65536 |   25.272 |   162.08 |   10.097 |     6.34 |
|  4096 |     64 |  69632 |   26.075 |   157.08 |   10.256 |     6.24 |
|  4096 |     64 |  73728 |   26.276 |   155.89 |   10.418 |     6.14 |
|  4096 |     64 |  77824 |   27.018 |   151.60 |   10.633 |     6.02 |
|  4096 |     64 |  81920 |   27.757 |   147.57 |   10.624 |     6.02 |
|  4096 |     64 |  86016 |   28.668 |   142.88 |   10.955 |     5.84 |
|  4096 |     64 |  90112 |   28.938 |   141.54 |   11.100 |     5.77 |
|  4096 |     64 |  94208 |   29.800 |   137.45 |   11.167 |     5.73 |

</details>

<details>
<summary>Split mode "graph", --max-gpu 3</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   17.418 |   235.17 |    8.238 |     7.77 |
|  4096 |     64 |   4096 |   17.611 |   232.59 |    8.267 |     7.74 |
|  4096 |     64 |   8192 |   17.964 |   228.01 |    8.463 |     7.56 |
|  4096 |     64 |  12288 |   18.258 |   224.34 |    8.560 |     7.48 |
|  4096 |     64 |  16384 |   18.701 |   219.03 |    8.652 |     7.40 |
|  4096 |     64 |  20480 |   18.986 |   215.74 |    8.714 |     7.34 |
|  4096 |     64 |  24576 |   19.422 |   210.89 |    8.781 |     7.29 |
|  4096 |     64 |  28672 |   19.848 |   206.37 |    8.980 |     7.13 |
|  4096 |     64 |  32768 |   20.222 |   202.55 |    9.218 |     6.94 |
|  4096 |     64 |  36864 |   20.704 |   197.83 |    9.180 |     6.97 |
|  4096 |     64 |  40960 |   21.085 |   194.26 |    9.364 |     6.83 |
|  4096 |     64 |  45056 |   21.631 |   189.36 |    9.647 |     6.63 |
|  4096 |     64 |  49152 |   21.939 |   186.70 |    9.627 |     6.65 |
|  4096 |     64 |  53248 |   22.365 |   183.14 |    9.658 |     6.63 |
|  4096 |     64 |  57344 |   22.767 |   179.91 |    9.672 |     6.62 |
|  4096 |     64 |  61440 |   23.162 |   176.84 |    9.975 |     6.42 |
|  4096 |     64 |  65536 |   23.611 |   173.48 |    9.974 |     6.42 |
|  4096 |     64 |  69632 |   24.011 |   170.59 |   10.183 |     6.29 |
|  4096 |     64 |  73728 |   24.446 |   167.55 |   10.190 |     6.28 |
|  4096 |     64 |  77824 |   24.823 |   165.01 |   10.504 |     6.09 |
|  4096 |     64 |  81920 |   25.247 |   162.24 |   10.411 |     6.15 |
|  4096 |     64 |  86016 |   25.678 |   159.51 |   10.681 |     5.99 |
|  4096 |     64 |  90112 |   26.043 |   157.28 |   10.849 |     5.90 |
|  4096 |     64 |  94208 |   26.609 |   153.93 |   10.746 |     5.96 |

</details>

### Example 3: GLM-4.5-AIR (Ubergarm IQ1_KT, 37 GiB)

This models fits completely even on 2 GPUs, but with 4 GPUs we can go to a context of 128k tokens (using `fp16` KV cache). As in this case performance varies by almost a factor of 10, I have used a logarithmic scale for the y-axis in the plats below.

<img width="792" height="612" alt="glm4 5-air_pp" src="https://github.com/user-attachments/assets/4b218fe5-cc69-493c-8a0c-c7c002f7660c" />

<img width="792" height="612" alt="glm4 5-air_tg" src="https://github.com/user-attachments/assets/225cf3bc-f6a6-4d49-ac0c-19698755b529" />

<details>
<summary>Split mode "layer"</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.012 |  2024.41 |    1.355 |    94.47 |
|  2048 |    128 |   2048 |    1.104 |  1854.76 |    1.497 |    85.52 |
|  2048 |    128 |   4096 |    1.207 |  1696.11 |    1.667 |    76.78 |
|  2048 |    128 |   6144 |    1.324 |  1546.83 |    1.849 |    69.21 |
|  2048 |    128 |   8192 |    1.439 |  1422.81 |    1.991 |    64.27 |
|  2048 |    128 |  10240 |    1.556 |  1316.40 |    2.145 |    59.66 |
|  2048 |    128 |  12288 |    1.680 |  1218.95 |    2.318 |    55.21 |
|  2048 |    128 |  14336 |    1.802 |  1136.31 |    2.464 |    51.94 |
|  2048 |    128 |  16384 |    1.928 |  1062.44 |    2.625 |    48.76 |
|  2048 |    128 |  18432 |    2.056 |   996.33 |    2.788 |    45.92 |
|  2048 |    128 |  20480 |    2.184 |   937.52 |    2.941 |    43.52 |
|  2048 |    128 |  22528 |    2.311 |   886.33 |    3.117 |    41.06 |
|  2048 |    128 |  24576 |    2.436 |   840.83 |    3.263 |    39.22 |
|  2048 |    128 |  26624 |    2.564 |   798.87 |    3.416 |    37.47 |
|  2048 |    128 |  28672 |    2.704 |   757.35 |    3.588 |    35.67 |
|  2048 |    128 |  30720 |    2.830 |   723.79 |    3.735 |    34.27 |
|  2048 |    128 |  32768 |    2.940 |   696.57 |    3.880 |    32.99 |
|  2048 |    128 |  34816 |    3.064 |   668.36 |    4.061 |    31.52 |
|  2048 |    128 |  36864 |    3.192 |   641.70 |    4.209 |    30.41 |
|  2048 |    128 |  38912 |    3.319 |   617.14 |    4.360 |    29.36 |
|  2048 |    128 |  40960 |    3.457 |   592.50 |    4.520 |    28.32 |
|  2048 |    128 |  43008 |    3.580 |   572.04 |    4.681 |    27.34 |
|  2048 |    128 |  45056 |    3.676 |   557.07 |    4.830 |    26.50 |
|  2048 |    128 |  47104 |    3.804 |   538.38 |    5.001 |    25.60 |
|  2048 |    128 |  49152 |    3.922 |   522.14 |    5.149 |    24.86 |
|  2048 |    128 |  51200 |    4.057 |   504.85 |    5.301 |    24.15 |
|  2048 |    128 |  53248 |    4.187 |   489.09 |    5.483 |    23.34 |
|  2048 |    128 |  55296 |    4.273 |   479.25 |    5.629 |    22.74 |
|  2048 |    128 |  57344 |    4.400 |   465.50 |    5.774 |    22.17 |
|  2048 |    128 |  59392 |    4.535 |   451.57 |    5.956 |    21.49 |
|  2048 |    128 |  61440 |    4.683 |   437.35 |    6.101 |    20.98 |
|  2048 |    128 |  63488 |    4.764 |   429.93 |    6.245 |    20.50 |
|  2048 |    128 |  65536 |    4.895 |   418.40 |    6.417 |    19.95 |
|  2048 |    128 |  67584 |    5.021 |   407.88 |    6.567 |    19.49 |
|  2048 |    128 |  69632 |    5.172 |   395.97 |    6.720 |    19.05 |
|  2048 |    128 |  71680 |    5.248 |   390.23 |    6.890 |    18.58 |
|  2048 |    128 |  73728 |    5.374 |   381.10 |    7.044 |    18.17 |
|  2048 |    128 |  75776 |    5.507 |   371.91 |    7.197 |    17.79 |
|  2048 |    128 |  77824 |    5.622 |   364.30 |    7.361 |    17.39 |
|  2048 |    128 |  79872 |    5.733 |   357.25 |    7.520 |    17.02 |
|  2048 |    128 |  81920 |    5.874 |   348.63 |    7.668 |    16.69 |
|  2048 |    128 |  83968 |    5.988 |   342.02 |    7.822 |    16.36 |
|  2048 |    128 |  86016 |    6.107 |   335.37 |    7.989 |    16.02 |
|  2048 |    128 |  88064 |    6.244 |   327.98 |    8.145 |    15.71 |
|  2048 |    128 |  90112 |    6.347 |   322.67 |    8.310 |    15.40 |
|  2048 |    128 |  92160 |    6.469 |   316.59 |    8.457 |    15.14 |
|  2048 |    128 |  94208 |    6.610 |   309.82 |    8.622 |    14.84 |
|  2048 |    128 |  96256 |    6.737 |   304.01 |    8.786 |    14.57 |
|  2048 |    128 |  98304 |    6.838 |   299.52 |    8.935 |    14.33 |
|  2048 |    128 | 100352 |    6.972 |   293.75 |    9.084 |    14.09 |
|  2048 |    128 | 102400 |    7.094 |   288.70 |    9.257 |    13.83 |
|  2048 |    128 | 104448 |    7.203 |   284.34 |    9.403 |    13.61 |
|  2048 |    128 | 106496 |    7.347 |   278.74 |    9.564 |    13.38 |
|  2048 |    128 | 108544 |    7.455 |   274.70 |    9.722 |    13.17 |
|  2048 |    128 | 110592 |    7.570 |   270.53 |    9.874 |    12.96 |
|  2048 |    128 | 112640 |    7.706 |   265.78 |   10.029 |    12.76 |
|  2048 |    128 | 114688 |    7.847 |   261.00 |   10.196 |    12.55 |
|  2048 |    128 | 116736 |    7.996 |   256.12 |   10.347 |    12.37 |
|  2048 |    128 | 118784 |    8.183 |   250.27 |   10.502 |    12.19 |
|  2048 |    128 | 120832 |    8.273 |   247.57 |   10.673 |    11.99 |
|  2048 |    128 | 122880 |    8.366 |   244.79 |   10.817 |    11.83 |
|  2048 |    128 | 124928 |    8.573 |   238.89 |   10.976 |    11.66 |
|  2048 |    128 | 126976 |    8.687 |   235.75 |   11.134 |    11.50 |
|  2048 |    128 | 129024 |    8.775 |   233.38 |   11.287 |    11.34 |

</details>

<details>
<summary>Split mode "graph"</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.860 |  1100.95 |    3.645 |    35.11 |
|  2048 |    128 |   2048 |    1.835 |  1115.86 |    3.450 |    37.10 |
|  2048 |    128 |   4096 |    1.867 |  1097.02 |    3.483 |    36.75 |
|  2048 |    128 |   6144 |    1.891 |  1083.13 |    3.756 |    34.08 |
|  2048 |    128 |   8192 |    1.918 |  1067.52 |    3.600 |    35.55 |
|  2048 |    128 |  10240 |    1.943 |  1053.80 |    3.619 |    35.37 |
|  2048 |    128 |  12288 |    1.973 |  1037.90 |    3.682 |    34.76 |
|  2048 |    128 |  14336 |    2.002 |  1022.95 |    3.908 |    32.75 |
|  2048 |    128 |  16384 |    2.032 |  1007.67 |    3.907 |    32.76 |
|  2048 |    128 |  18432 |    2.063 |   992.76 |    3.808 |    33.62 |
|  2048 |    128 |  20480 |    2.086 |   981.86 |    3.846 |    33.28 |
|  2048 |    128 |  22528 |    2.125 |   963.92 |    3.896 |    32.86 |
|  2048 |    128 |  24576 |    2.148 |   953.48 |    3.946 |    32.44 |
|  2048 |    128 |  26624 |    2.175 |   941.77 |    3.983 |    32.14 |
|  2048 |    128 |  28672 |    2.212 |   926.07 |    4.020 |    31.84 |
|  2048 |    128 |  30720 |    2.239 |   914.51 |    4.044 |    31.65 |
|  2048 |    128 |  32768 |    2.267 |   903.45 |    4.103 |    31.19 |
|  2048 |    128 |  34816 |    2.303 |   889.39 |    4.321 |    29.62 |
|  2048 |    128 |  36864 |    2.336 |   876.60 |    4.190 |    30.55 |
|  2048 |    128 |  38912 |    2.371 |   863.62 |    4.248 |    30.13 |
|  2048 |    128 |  40960 |    2.399 |   853.58 |    4.310 |    29.70 |
|  2048 |    128 |  43008 |    2.438 |   839.90 |    4.341 |    29.49 |
|  2048 |    128 |  45056 |    2.480 |   825.76 |    4.512 |    28.37 |
|  2048 |    128 |  47104 |    2.506 |   817.37 |    4.683 |    27.33 |
|  2048 |    128 |  49152 |    2.533 |   808.58 |    4.456 |    28.73 |
|  2048 |    128 |  51200 |    2.573 |   796.09 |    4.488 |    28.52 |
|  2048 |    128 |  53248 |    2.604 |   786.60 |    4.534 |    28.23 |
|  2048 |    128 |  55296 |    2.631 |   778.46 |    4.575 |    27.98 |
|  2048 |    128 |  57344 |    2.666 |   768.25 |    4.611 |    27.76 |
|  2048 |    128 |  59392 |    2.707 |   756.55 |    4.661 |    27.46 |
|  2048 |    128 |  61440 |    2.724 |   751.91 |    4.862 |    26.33 |
|  2048 |    128 |  63488 |    2.755 |   743.40 |    4.749 |    26.95 |
|  2048 |    128 |  65536 |    2.799 |   731.60 |    4.787 |    26.74 |
|  2048 |    128 |  67584 |    2.836 |   722.19 |    4.825 |    26.53 |
|  2048 |    128 |  69632 |    2.880 |   711.18 |    4.981 |    25.70 |
|  2048 |    128 |  71680 |    2.905 |   705.08 |    4.913 |    26.06 |
|  2048 |    128 |  73728 |    2.936 |   697.55 |    4.943 |    25.90 |
|  2048 |    128 |  75776 |    2.975 |   688.44 |    5.008 |    25.56 |
|  2048 |    128 |  77824 |    2.999 |   682.94 |    5.050 |    25.35 |
|  2048 |    128 |  79872 |    3.036 |   674.54 |    5.225 |    24.50 |
|  2048 |    128 |  81920 |    3.078 |   665.39 |    5.287 |    24.21 |
|  2048 |    128 |  83968 |    3.099 |   660.77 |    5.161 |    24.80 |
|  2048 |    128 |  86016 |    3.148 |   650.60 |    5.195 |    24.64 |
|  2048 |    128 |  88064 |    3.187 |   642.64 |    5.261 |    24.33 |
|  2048 |    128 |  90112 |    3.225 |   635.13 |    5.297 |    24.17 |
|  2048 |    128 |  92160 |    3.234 |   633.32 |    5.333 |    24.00 |
|  2048 |    128 |  94208 |    3.268 |   626.77 |    5.386 |    23.77 |
|  2048 |    128 |  96256 |    3.305 |   619.75 |    5.410 |    23.66 |
|  2048 |    128 |  98304 |    3.346 |   612.01 |    5.448 |    23.49 |
|  2048 |    128 | 100352 |    3.383 |   605.30 |    5.486 |    23.33 |
|  2048 |    128 | 102400 |    3.410 |   600.52 |    5.716 |    22.39 |
|  2048 |    128 | 104448 |    3.445 |   594.42 |    5.625 |    22.76 |
|  2048 |    128 | 106496 |    3.471 |   590.08 |    5.672 |    22.57 |
|  2048 |    128 | 108544 |    3.502 |   584.73 |    5.666 |    22.59 |
|  2048 |    128 | 110592 |    3.532 |   579.79 |    5.697 |    22.47 |
|  2048 |    128 | 112640 |    3.572 |   573.36 |    5.736 |    22.31 |
|  2048 |    128 | 114688 |    3.608 |   567.61 |    5.909 |    21.66 |
|  2048 |    128 | 116736 |    3.632 |   563.86 |    5.835 |    21.94 |
|  2048 |    128 | 118784 |    3.667 |   558.52 |    5.866 |    21.82 |
|  2048 |    128 | 120832 |    3.683 |   556.02 |    6.104 |    20.97 |
|  2048 |    128 | 122880 |    3.735 |   548.26 |    5.960 |    21.48 |
|  2048 |    128 | 124928 |    3.741 |   547.38 |    6.029 |    21.23 |
|  2048 |    128 | 126976 |    4.079 |   502.14 |    6.023 |    21.25 |
|  2048 |    128 | 129024 |    4.102 |   499.31 |    6.097 |    20.99 |

</details>

<details>
<summary>Split mode "graph", --max-gpu 2</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.934 |  2191.62 |    2.301 |    55.64 |
|  2048 |    128 |   2048 |    0.947 |  2163.65 |    2.365 |    54.12 |
|  2048 |    128 |   4096 |    1.000 |  2048.20 |    2.417 |    52.96 |
|  2048 |    128 |   6144 |    1.057 |  1937.54 |    2.513 |    50.93 |
|  2048 |    128 |   8192 |    1.116 |  1835.19 |    2.589 |    49.45 |
|  2048 |    128 |  10240 |    1.176 |  1742.20 |    2.703 |    47.36 |
|  2048 |    128 |  12288 |    1.234 |  1659.71 |    2.803 |    45.67 |
|  2048 |    128 |  14336 |    1.291 |  1586.43 |    2.875 |    44.52 |
|  2048 |    128 |  16384 |    1.349 |  1518.41 |    2.959 |    43.26 |
|  2048 |    128 |  18432 |    1.406 |  1456.13 |    3.037 |    42.15 |
|  2048 |    128 |  20480 |    1.472 |  1390.96 |    3.119 |    41.04 |
|  2048 |    128 |  22528 |    1.530 |  1338.35 |    3.221 |    39.74 |
|  2048 |    128 |  24576 |    1.589 |  1289.05 |    3.345 |    38.27 |
|  2048 |    128 |  26624 |    1.640 |  1248.54 |    3.393 |    37.73 |
|  2048 |    128 |  28672 |    1.711 |  1197.19 |    3.465 |    36.94 |
|  2048 |    128 |  30720 |    1.773 |  1155.31 |    3.728 |    34.34 |
|  2048 |    128 |  32768 |    1.837 |  1114.79 |    3.656 |    35.02 |
|  2048 |    128 |  34816 |    1.902 |  1076.78 |    3.714 |    34.47 |
|  2048 |    128 |  36864 |    1.954 |  1047.91 |    3.910 |    32.74 |
|  2048 |    128 |  38912 |    2.035 |  1006.19 |    3.981 |    32.15 |
|  2048 |    128 |  40960 |    2.147 |   953.95 |    4.053 |    31.58 |
|  2048 |    128 |  43008 |    2.168 |   944.85 |    4.037 |    31.71 |
|  2048 |    128 |  45056 |    2.244 |   912.56 |    4.120 |    31.07 |
|  2048 |    128 |  47104 |    2.314 |   884.91 |    4.231 |    30.25 |
|  2048 |    128 |  49152 |    2.378 |   861.20 |    4.282 |    29.90 |
|  2048 |    128 |  51200 |    2.451 |   835.58 |    4.452 |    28.75 |
|  2048 |    128 |  53248 |    2.507 |   816.82 |    4.569 |    28.01 |
|  2048 |    128 |  55296 |    2.566 |   798.11 |    4.583 |    27.93 |
|  2048 |    128 |  57344 |    2.629 |   778.96 |    4.624 |    27.68 |
|  2048 |    128 |  59392 |    2.677 |   764.95 |    4.693 |    27.27 |
|  2048 |    128 |  61440 |    2.750 |   744.61 |    4.757 |    26.91 |
|  2048 |    128 |  63488 |    2.802 |   730.93 |    4.842 |    26.44 |
|  2048 |    128 |  65536 |    2.868 |   714.06 |    4.910 |    26.07 |
|  2048 |    128 |  67584 |    2.942 |   696.11 |    5.002 |    25.59 |
|  2048 |    128 |  69632 |    3.000 |   682.63 |    5.126 |    24.97 |
|  2048 |    128 |  71680 |    3.048 |   672.00 |    5.179 |    24.72 |
|  2048 |    128 |  73728 |    3.116 |   657.34 |    5.273 |    24.28 |
|  2048 |    128 |  75776 |    3.176 |   644.78 |    5.339 |    23.98 |
|  2048 |    128 |  77824 |    3.259 |   628.45 |    5.395 |    23.72 |
|  2048 |    128 |  79872 |    3.323 |   616.31 |    5.490 |    23.32 |
|  2048 |    128 |  81920 |    3.370 |   607.74 |    5.568 |    22.99 |
|  2048 |    128 |  83968 |    3.435 |   596.24 |    5.641 |    22.69 |
|  2048 |    128 |  86016 |    3.518 |   582.09 |    5.731 |    22.33 |
|  2048 |    128 |  88064 |    3.576 |   572.73 |    5.831 |    21.95 |
|  2048 |    128 |  90112 |    3.619 |   565.89 |    5.936 |    21.56 |
|  2048 |    128 |  92160 |    3.691 |   554.80 |    5.962 |    21.47 |
|  2048 |    128 |  94208 |    3.770 |   543.26 |    6.112 |    20.94 |
|  2048 |    128 |  96256 |    3.831 |   534.57 |    6.181 |    20.71 |
|  2048 |    128 |  98304 |    3.872 |   528.99 |    6.290 |    20.35 |
|  2048 |    128 | 100352 |    3.943 |   519.39 |    6.290 |    20.35 |
|  2048 |    128 | 102400 |    4.022 |   509.25 |    6.386 |    20.04 |
|  2048 |    128 | 104448 |    4.063 |   504.01 |    6.466 |    19.80 |
|  2048 |    128 | 106496 |    4.124 |   496.66 |    6.538 |    19.58 |
|  2048 |    128 | 108544 |    4.210 |   486.43 |    6.618 |    19.34 |
|  2048 |    128 | 110592 |    4.263 |   480.41 |    6.748 |    18.97 |
|  2048 |    128 | 112640 |    4.319 |   474.20 |    7.005 |    18.27 |
|  2048 |    128 | 114688 |    4.364 |   469.25 |    6.866 |    18.64 |
|  2048 |    128 | 116736 |    4.423 |   463.02 |    6.982 |    18.33 |
|  2048 |    128 | 118784 |    4.519 |   453.20 |    7.025 |    18.22 |
|  2048 |    128 | 120832 |    4.556 |   449.54 |    7.121 |    17.98 |
|  2048 |    128 | 122880 |    4.611 |   444.14 |    7.271 |    17.60 |
|  2048 |    128 | 124928 |    4.674 |   438.16 |    7.303 |    17.53 |
|  2048 |    128 | 126976 |    4.940 |   414.54 |    7.333 |    17.45 |
|  2048 |    128 | 129024 |    4.991 |   410.36 |    7.508 |    17.05 |

</details>

<details>
<summary>Split mode "graph", --max-gpu 3</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.384 |  1479.44 |    2.991 |    42.79 |
|  2048 |    128 |   2048 |    1.376 |  1488.16 |    3.016 |    42.43 |
|  2048 |    128 |   4096 |    1.401 |  1461.36 |    3.244 |    39.45 |
|  2048 |    128 |   6144 |    1.429 |  1433.32 |    3.091 |    41.42 |
|  2048 |    128 |   8192 |    1.474 |  1389.31 |    3.157 |    40.54 |
|  2048 |    128 |  10240 |    1.507 |  1358.78 |    3.429 |    37.33 |
|  2048 |    128 |  12288 |    1.553 |  1318.95 |    3.267 |    39.18 |
|  2048 |    128 |  14336 |    1.593 |  1285.71 |    3.310 |    38.67 |
|  2048 |    128 |  16384 |    1.628 |  1257.67 |    3.342 |    38.30 |
|  2048 |    128 |  18432 |    1.674 |  1223.20 |    3.398 |    37.67 |
|  2048 |    128 |  20480 |    1.717 |  1192.67 |    3.424 |    37.38 |
|  2048 |    128 |  22528 |    1.757 |  1165.33 |    3.472 |    36.87 |
|  2048 |    128 |  24576 |    1.806 |  1133.71 |    3.539 |    36.17 |
|  2048 |    128 |  26624 |    1.850 |  1106.96 |    3.568 |    35.88 |
|  2048 |    128 |  28672 |    1.893 |  1082.04 |    3.633 |    35.23 |
|  2048 |    128 |  30720 |    1.937 |  1057.09 |    3.689 |    34.70 |
|  2048 |    128 |  32768 |    1.980 |  1034.19 |    3.726 |    34.35 |
|  2048 |    128 |  34816 |    2.032 |  1007.65 |    3.809 |    33.60 |
|  2048 |    128 |  36864 |    2.085 |   982.14 |    3.828 |    33.44 |
|  2048 |    128 |  38912 |    2.132 |   960.43 |    3.893 |    32.88 |
|  2048 |    128 |  40960 |    2.181 |   939.09 |    3.971 |    32.24 |
|  2048 |    128 |  43008 |    2.244 |   912.67 |    4.033 |    31.74 |
|  2048 |    128 |  45056 |    2.284 |   896.64 |    4.135 |    30.96 |
|  2048 |    128 |  47104 |    2.335 |   876.99 |    4.159 |    30.78 |
|  2048 |    128 |  49152 |    2.384 |   859.07 |    4.238 |    30.20 |
|  2048 |    128 |  51200 |    2.429 |   843.17 |    4.291 |    29.83 |
|  2048 |    128 |  53248 |    2.480 |   825.83 |    4.431 |    28.89 |
|  2048 |    128 |  55296 |    2.525 |   811.24 |    4.382 |    29.21 |
|  2048 |    128 |  57344 |    2.584 |   792.58 |    4.484 |    28.55 |
|  2048 |    128 |  59392 |    2.635 |   777.18 |    4.512 |    28.37 |
|  2048 |    128 |  61440 |    2.675 |   765.48 |    4.594 |    27.86 |
|  2048 |    128 |  63488 |    2.714 |   754.55 |    4.665 |    27.44 |
|  2048 |    128 |  65536 |    2.895 |   707.32 |    4.769 |    26.84 |
|  2048 |    128 |  67584 |    2.811 |   728.54 |    4.931 |    25.96 |
|  2048 |    128 |  69632 |    2.875 |   712.28 |    4.832 |    26.49 |
|  2048 |    128 |  71680 |    2.920 |   701.41 |    5.103 |    25.08 |
|  2048 |    128 |  73728 |    2.980 |   687.24 |    4.934 |    25.94 |
|  2048 |    128 |  75776 |    3.053 |   670.86 |    4.987 |    25.66 |
|  2048 |    128 |  77824 |    3.069 |   667.25 |    5.080 |    25.20 |
|  2048 |    128 |  79872 |    3.118 |   656.92 |    5.266 |    24.31 |
|  2048 |    128 |  81920 |    3.268 |   626.75 |    5.178 |    24.72 |
|  2048 |    128 |  83968 |    3.330 |   614.95 |    5.240 |    24.43 |
|  2048 |    128 |  86016 |    3.278 |   624.83 |    5.308 |    24.11 |
|  2048 |    128 |  88064 |    3.330 |   614.95 |    5.482 |    23.35 |
|  2048 |    128 |  90112 |    3.361 |   609.34 |    5.469 |    23.40 |
|  2048 |    128 |  92160 |    3.501 |   584.98 |    5.532 |    23.14 |
|  2048 |    128 |  94208 |    3.474 |   589.44 |    5.588 |    22.91 |
|  2048 |    128 |  96256 |    3.522 |   581.47 |    5.598 |    22.87 |
|  2048 |    128 |  98304 |    3.573 |   573.24 |    5.798 |    22.08 |
|  2048 |    128 | 100352 |    3.636 |   563.21 |    5.750 |    22.26 |
|  2048 |    128 | 102400 |    3.653 |   560.68 |    5.786 |    22.12 |
|  2048 |    128 | 104448 |    3.717 |   550.98 |    6.004 |    21.32 |
|  2048 |    128 | 106496 |    3.856 |   531.19 |    6.001 |    21.33 |
|  2048 |    128 | 108544 |    3.871 |   529.01 |    6.039 |    21.20 |
|  2048 |    128 | 110592 |    3.878 |   528.13 |    6.160 |    20.78 |
|  2048 |    128 | 112640 |    3.917 |   522.89 |    6.124 |    20.90 |
|  2048 |    128 | 114688 |    3.964 |   516.61 |    6.294 |    20.34 |
|  2048 |    128 | 116736 |    4.013 |   510.38 |    6.329 |    20.23 |
|  2048 |    128 | 118784 |    4.135 |   495.23 |    6.382 |    20.06 |
|  2048 |    128 | 120832 |    4.115 |   497.67 |    6.425 |    19.92 |
|  2048 |    128 | 122880 |    4.222 |   485.13 |    6.459 |    19.82 |
|  2048 |    128 | 124928 |    4.179 |   490.04 |    6.613 |    19.36 |
|  2048 |    128 | 126976 |    4.531 |   452.00 |    6.697 |    19.11 |
|  2048 |    128 | 129024 |    4.688 |   436.82 |    6.598 |    19.40 |

</details>



