### PR TITLE
QoL/bugfixes for llama-bench

### DIFF
--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1701,6 +1701,12 @@ struct markdown_printer : public printer {
         if (field == "tensor_split") {
             return "ts";
         }
+        if (field == "cuda_params") {
+            return "cuda";
+        }
+        if (field == "override_tensor") {
+            return "ot";
+        }
         return field;
     }
 
@@ -1761,6 +1767,12 @@ struct markdown_printer : public printer {
         }
         if (params.embeddings.size() > 1 || params.embeddings != cmd_params_defaults.embeddings) {
             fields.emplace_back("embeddings");
+        }
+        if (params.cuda_params != cmd_params_defaults.cuda_params) {
+            fields.emplace_back("cuda_params");
+        }
+        if (params.buft_overrides != cmd_params_defaults.buft_overrides) {
+            fields.emplace_back("override_tensor");
         }
         if (params.repack != cmd_params_defaults.repack) {
             fields.emplace_back("repack");


### PR DESCRIPTION
I have been doing a bunch of testing with different quants and whatnot lately, and had noticed that there seemed to be a couple quirks with `llama-bench`. Additionally, I couldn't find any mention of a specific reason why the `--override-tensors` and `--cuda-params` options weren't being handled the same as the other options (apologies if there actually is a reason, lol). So, I thought I would try to help out with some small QoL changes and, hopefully, fixes for a couple bugs that I was able to find. :)

Also, this PR currently includes a change to the column headers for the weird `-no-fug` and `-no-ooae` "inverse" options that sometimes require me to think embarrassingly hard about, but - thinking now - that very well could just be a me problem. Either way, I feel like updating them might be more intuitive, e.g. at a quick glance between tests, but obviously no worries if you disagree :).
  
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
