### PR TITLE
Fix overflow in offset calculation in mmq

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3875,7 +3875,7 @@ static __device__ void mul_mat_q_process_tile(
     const int * y = (const int *) yc + jt*(mmq_x*sizeof(block_q8_1_mmq)/sizeof(int));
 
     for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
-        load_tiles(x + stride01*it*mmq_y, tile_x, kb0, tile_x_max_i, stride01);
+        load_tiles(x + int64_t(stride01)*it*mmq_y, tile_x, kb0, tile_x_max_i, stride01);
 
         {
             const int * by0 = y + stride11*(kb0*(qk*sizeof(block_q8_1_mmq) / (4*QK8_1*sizeof(int))) + 0*sizeof(block_q8_1_mmq)/sizeof(int));


### PR DESCRIPTION

Ran into this when I attempted to run a Cohere2 model. Vocabulary size is 256k, embedding size is 12k, so the maximum offset into the output tensor is 256k x 12k > 2^31, so we get integer overflow in the mmq matrix multiplication (where an `int32_t` was used to compute this offset).  

@Ph0rk0z  Do you know what this PR tells us? It tells us that the comparisons against EXL3 you posted the other day weren't between EXL3 and `ik_llama.cpp`, but were between EXL3 and `llama.cpp`. I know, for you this is the same thing, but, hey. 