### PR TITLE
Do not use split mode graph scheduling if there are tensor overrides

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4771,7 +4771,7 @@ struct llama_context * llama_new_context_with_model(
         LLAMA_LOG_INFO("XXXXXXXXXXXXXXXXXXXXX Setting only active experts offload\n");
         ggml_backend_sched_set_only_active_experts(ctx->sched, true);
     }
-    if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+    if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH && !model->has_tensor_overrides()) {
         ggml_backend_sched_set_split_mode_graph(ctx->sched, true);
     }
 


### PR DESCRIPTION

In my testing PR #1049 also worked with tensor overrides. But as per [this comment](https://github.com/ikawrakow/ik_llama.cpp/pull/1049#issuecomment-3646065291) it can fail. As there are infinitely many ways in which users can use tensor overrides, testing all of it is simply impossible. Hence, it is best to just disable the #1049 sync reduction when there are tensor overrides.