### PR TITLE
Add back the fix for Kimi-K2 tool-call parsing issue

### DIFF
--- a/common/chat-parser.cpp
+++ b/common/chat-parser.cpp
@@ -918,12 +918,13 @@ static void common_chat_parse_kimi_k2(common_chat_msg_parser & builder) {
         form.tool_start  = "<|tool_call_begin|>";
         form.tool_sep    = "<|tool_call_argument_begin|>{";
         form.key_start   = "\"";
-        form.key_val_sep = "\": ";
-        form.val_end     = ", ";
+        form.key_val_sep = "\":";
+        form.val_end     = ",";
         form.tool_end    = "}<|tool_call_end|>";
         form.scope_end   = "<|tool_calls_section_end|>";
         form.raw_argval  = false;
         form.last_val_end = "";
+        form.allow_toolcall_in_think = true;
         return form;
     })();
     builder.consume_reasoning_with_xml_tool_calls(form, "<think>", "</think>");


### PR DESCRIPTION
When I refactored chat.cpp, some of the fix for Kimi-K2 tool-call parsing issues was lost. This PR brings it back.

https://github.com/ikawrakow/ik_llama.cpp/pull/1062#issuecomment-3658749435