### PR TITLE
Server: exclude thinking tokens when finding the slot

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -119,6 +119,15 @@ enum common_webui {
 
 common_webui common_webui_from_name(const std::string& format);
 
+struct thinking_tokens {
+    bool exclude = true;
+    std::string begin = "<think>";
+    std::string end = "</think>";
+};
+
+thinking_tokens thinking_tokens_from_string(const std::string& format);
+
+
 struct model_paths {
     std::string path        = ""; // model local path                                       // NOLINT
     std::string url         = ""; // model url to download                                  // NOLINT
@@ -314,6 +323,7 @@ struct gpt_params {
     std::string system_prompt = "";
     bool enable_chat_template = true;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
+    thinking_tokens think_tokens;
     int reasoning_budget = -1;
     bool prefill_assistant = true;
 

--- a/examples/server/server-common.h
+++ b/examples/server/server-common.h
@@ -171,6 +171,7 @@ std::string tokens_to_str(llama_context* ctx, const llama_tokens& tokens);
 // format incomplete utf-8 multibyte character for output
 std::string tokens_to_output_formatted_string(const llama_context* ctx, const llama_token token);
 
+
 struct common_prefix {
     size_t first = 0;
     size_t second = 0;
@@ -389,6 +390,7 @@ public:
 
     size_t get_common_prefix_exact(const server_tokens& b) const;
 
+    llama_tokens get_text_tokens_exclude_think(const llama_context* ctx, const thinking_tokens& think_token) const;
 
     common_prefix get_common_prefix(const llama_context* ctx, const server_tokens& b, bool exact = false) const;
     // take first n tokens of tokens list a

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -34,6 +34,8 @@ struct slot_params {
     int32_t  n_discard = 0; // number of tokens after n_keep that may be discarded when shifting context, 0 defaults to half
     int32_t  n_predict = -1; // new tokens to predict
 
+    thinking_tokens think_tokens;
+    
     std::vector<std::string> antiprompt;
 
     bool timings_per_token = false;
@@ -259,6 +261,12 @@ struct server_context {
 
     server_slot* get_slot_by_id(int id);
 
+    float calculate_slot_f_keep(const server_slot& slot, llama_context* ctx, const server_tokens& a, const server_tokens& b);
+
+    std::pair<common_prefix, float> calculate_slot_similarity(const server_slot& slot, llama_context* ctx, const server_tokens& a, const server_tokens& b);
+
+    void copy_data_to_cached_prompt(const server_tokens& tokens, server_slot& slot);
+
     server_slot* get_available_slot(const server_task& task);
 
     bool launch_slot_with_task(server_slot& slot, server_task& task);
@@ -302,12 +310,14 @@ struct server_context {
 
     void print_tokens(const server_tokens& prompt, const server_tokens& cache, size_t start1 = 0, size_t start2 = 0, size_t length = 10);
 
+    // discard tokens in kv cache and cached tokens
     void discard_n_kv_and_cache_tokens(llama_context* ctx, server_slot& slot, int32_t n_keep, int32_t n_discard);
 
     // convert keep first few and discard next tokens in a to b
     void context_shift_find_n_tokens(llama_context* ctx, const server_tokens& a, const server_tokens& b, int32_t n_keep,
         int32_t n_discard, int32_t& n_kept, int32_t& n_discarded, bool exact = false);
 
+    // handle context shift for prompt
     void context_shift_prompt(llama_context* ctx, server_slot& slot, bool exact = false);
 
     void update_slots();

--- a/examples/server/server-task.h
+++ b/examples/server/server-task.h
@@ -177,6 +177,7 @@ struct server_prompt {
     server_tokens tokens;
     int n_kept_prompt;
     int n_discarded_prompt;
+    thinking_tokens think_tokens;
 
     std::vector<uint8_t> data;
 


### PR DESCRIPTION
When using a thinking model with prompt save feature's default config, it's very easy to trigger the prompt save behavior because thinking tokens are usually removed from the prompt while they are still kept in the kv cache. This PR removes thinking tokens from the tokens cached in server and the prompt when calculating `f_keep`. This results in much better experience for prompt save with thinking models. It's enabled by default so there is not much need to set `--cache-ram-similarity` and `--cache-ram-n-min` specifically. 

`--reasoning-tokens none`: disable this feature
`--reasoning-tokens auto`: exclude anything between `<think>` and `</think>` including `<think>` and `</think>`
For models that does not use `<think>` and `</think>` to mark the start and end of thinking tokens, use `--reasoning-tokens think_start,think_end` to customize it.

