### PR TITLE
Be able to set reduce op data type for split mode "graph"

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1436,6 +1436,14 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.split_mode_graph_scheduling = true;
         return true;
     }
+    if (arg == "-smf16" || arg == "--split-mode-f16") {
+        params.split_mode_f16 = true;
+        return true;
+    }
+    if (arg == "-smf32" || arg == "--split-mode-f32") {
+        params.split_mode_f16 = false;
+        return true;
+    }
     if (arg == "--numa") {
         CHECK_ARG
         std::string value(argv[i]);
@@ -2122,6 +2130,8 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",         "-ser,  --smart-expert-reduction", "experts reduction (default: %d,%g)", params.min_experts, params.thresh_experts});
     options.push_back({ "*",         "-mqkv,  --merge-qkv,",            "merge Q,K,V (default: %d)", params.merge_qkv});
     options.push_back({ "*",         "-khad,  --k-cache-hadamard,",     "Use Hadamard transform for K-cache (default: %d)", params.k_cache_hadamard});
+    options.push_back({ "*",         "-smf16, --split-mode-f16,",       "Use f16 for data exchange between GPUs (default: %d)", params.split_mode_f16});
+    options.push_back({ "*",         "-smf32, --split-mode-f32,",       "Use f32 for data exchange between GPUs (default: %d)", !params.split_mode_f16});
     options.push_back({ "*",         "-smgs, --split-mode-graph-scheduling,", "Force Split Mode Graph Scheduling (default: %d)", params.split_mode_graph_scheduling});
     options.push_back({ "*",         "-vq, --validate-quants",          "validate quantized data while loading the model (default: %d)", params.validate_quants});
     options.push_back({ "*",           "-p,    --prompt PROMPT",        "prompt to start generation with\n"
@@ -3156,6 +3166,7 @@ struct llama_context_params llama_context_params_from_gpt_params(const gpt_param
     cparams.graph_reuse       = params.graph_reuse;
     cparams.k_cache_hadamard  = params.k_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
+    cparams.split_mode_f16    = params.split_mode_f16;
     cparams.min_experts       = params.min_experts;
     cparams.thresh_experts    = params.thresh_experts;
     cparams.only_active_experts = params.only_active_exps;
@@ -4138,6 +4149,7 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "graph_reuse: %s # default: false\n", params.graph_reuse ? "true" : "false");
     fprintf(stream, "k_cache_hadamard: %s # default: false\n", params.k_cache_hadamard ? "true" : "false");
     fprintf(stream, "split_mode_graph_scheduling: %s # default: false\n", params.split_mode_graph_scheduling ? "true" : "false");
+    fprintf(stream, "split_mode_f16: %s # default: true\n", params.split_mode_f16 ? "true" : "false");
     fprintf(stream, "ser: %d,%g # defaulr: -1,0\n", params.min_experts, params.thresh_experts);
     fprintf(stream, "temp: %f # default: 0.8\n", sparams.temp);
 

--- a/common/common.h
+++ b/common/common.h
@@ -289,6 +289,7 @@ struct gpt_params {
     bool merge_qkv         = false; // if true, merge separate Q, K, V tensors into a single, contiguous tensor
     bool k_cache_hadamard  = false; // if true, use Hadamard transform for the K-cache (only makes sense with quantized cache)
     bool split_mode_graph_scheduling = false; // if true, force split mode graph scheduling
+    bool split_mode_f16    = true;  // if true, intermediate results will be cast to f16 before copying to other GPUs to perform reduce ops
 
     std::string cache_type_k = "f16"; // KV cache data type for the K
     std::string cache_type_v = "f16"; // KV cache data type for the V

--- a/include/llama.h
+++ b/include/llama.h
@@ -444,6 +444,7 @@ extern "C" {
         bool only_active_experts;
         bool k_cache_hadamard;  // if true, apply Hadamard transfrom to K-cache
         bool split_mode_graph_scheduling; // if true, force split mode graph scheduling
+        bool split_mode_f16;    // if true, cast intermediate results to f16 before copying to other GPUs
 
         // Abort callback
         // if it returns true, execution of llama_decode() will be aborted

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -697,7 +697,7 @@ ggml_tensor * llm_build_context::llm_build_ffn(
                 // GLM4 and GLM4_MOE seem to have numerical issues with half-precision accumulators
                 ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
             }
-            if (cur->ne[1] >= 32) {
+            if (cur->ne[1] > 32 && lctx.cparams.split_mode_f16) {
                 cur = ggml_cast(ctx, cur, GGML_TYPE_F16);
             }
             if (graph) {
@@ -1185,7 +1185,7 @@ llm_expert_gating_func_type   gating_op,
                             split_down_shexp->splits[id], split_down_b_shexp ? split_down_b_shexp->splits[id] : nullptr, nullptr,
                             nullptr, type_op_shexp, LLM_FFN_PAR, cb, il);
                     cb(shared_out, "ffn_shexp_out", il_cb);
-                    if (shared_out->ne[1] > 32) {
+                    if (shared_out->ne[1] > 32 && lctx.cparams.split_mode_f16) {
                         shared_out = ggml_cast(ctx, shared_out, GGML_TYPE_F16);
                     }
                     results.push_back(shared_out);
@@ -1202,7 +1202,7 @@ llm_expert_gating_func_type   gating_op,
                         cb(cur, "ffn_shared_combined", il);
                     }
                 }
-                if (routed_out->ne[1] > 32) {
+                if (routed_out->ne[1] > 32 && lctx.cparams.split_mode_f16) {
                     auto routed_out_f16 = ggml_cast(ctx, routed_out, GGML_TYPE_F16);
                     cur = ggml_add(ctx, routed_out_f16, cur);
                 } else {
@@ -1279,7 +1279,7 @@ llm_expert_gating_func_type   gating_op,
         } else {
             cur = routed_out;
         }
-        if (cur->ne[1] >= 32) {
+        if (cur->ne[1] > 32 && lctx.cparams.split_mode_f16) {
             cur = ggml_cast(ctx, cur, GGML_TYPE_F16);
             cb(cur, "ffn_out_f16", il_cb);
         }
@@ -9513,7 +9513,7 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                     cur = ggml_add(ctx0, cur, bo->splits[id]);
                     cb(cur, "kqv_wo_biased", il_cb);
                 }
-                if (cur->ne[1] >= 32) {
+                if (cur->ne[1] > 32 && lctx.cparams.split_mode_f16) {
                     cur = ggml_cast(ctx0, cur, GGML_TYPE_F16);
                 }
                 ggml_build_forward_expand(gf, cur);

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -41,6 +41,7 @@ struct llama_cparams {
     bool graph_reuse;
     bool k_cache_hadamard;
     bool split_mode_graph_scheduling;
+    bool split_mode_f16;
     int  min_experts;
     float thresh_experts;
 

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2265,7 +2265,6 @@ bool create_tensors_helper::create_cohere2_tensors(const LLM_TN & tn) {
     for (int i = 0; i < n_layer; ++i) {
         auto & layer = model.layers[i];
         ggml_context * ctx_split = ctx_for_layer_split(i);
-        ggml_context * ctx_layer = ctx_for_layer(i);
 
         layer.attn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_NORM, "weight", i), { n_embd }, 0);
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4055,6 +4055,7 @@ struct llama_context_params llama_context_default_params() {
         /*.only_active_experts         =*/ false,
         /*.k_cache_hadamard            =*/ false,
         /*.split_mode_graph_scheduling =*/ false,
+        /*.split_mode_f16              =*/ true,
         /*.abort_callback              =*/ nullptr,
         /*.abort_callback_data         =*/ nullptr,
         /*.offload_policy              =*/ nullptr,
@@ -4344,6 +4345,7 @@ struct llama_context * llama_new_context_with_model(
     cparams.graph_reuse      = params.graph_reuse;
     cparams.k_cache_hadamard = params.k_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
+    cparams.split_mode_f16   = params.split_mode_f16;
     cparams.min_experts      = params.min_experts;
     cparams.thresh_experts   = params.thresh_experts;
     cparams.cuda_params      = params.cuda_params;
@@ -4433,6 +4435,7 @@ struct llama_context * llama_new_context_with_model(
     LLAMA_LOG_INFO("%s: graph_reuse   = %d\n",     __func__, cparams.graph_reuse);
     LLAMA_LOG_INFO("%s: k_cache_hadam = %d\n",     __func__, cparams.k_cache_hadamard);
     LLAMA_LOG_INFO("%s: split_mode_graph_scheduling = %d\n",   __func__, cparams.split_mode_graph_scheduling);
+    LLAMA_LOG_INFO("%s: split_mode_f16= %d\n",     __func__, cparams.split_mode_f16);
     LLAMA_LOG_INFO("%s: ser           = %d, %g\n", __func__, cparams.min_experts, cparams.thresh_experts);
     LLAMA_LOG_INFO("%s: freq_base     = %.1f\n",   __func__, cparams.rope_freq_base);
     LLAMA_LOG_INFO("%s: freq_scale    = %g\n",     __func__, cparams.rope_freq_scale);


### PR DESCRIPTION

On the main branch when using split mode "graph", intermediate results are cast to `f16` before being copied to other GPUs to perform reduce operations. This is done to reduce the amount of data that needs to be exchanged between the GPUs, which can be quite significant for prompt processing. But for some models `f16` may not have enough precision and/or range, thus resulting in gibberish output. It seems GLM-4.7 may be one such model as per [this comment](https://github.com/ikawrakow/ik_llama.cpp/issues/1085#issuecomment-3688987129). Hence, this PR adds the ability to control the data type being used for data exchange between GPUs when using split mode "graph":
```
-smf16 or --split-mode-f16
```
will set the exchange data type to `f16`. This is the default.
```
-smf32 or --split-mode-f32
```
will make `ik_llama.cpp` use `f32` for exchanging data between GPUs. This will double the amount of data being exchanged  and hence result is a somewhat lower PP performance (how much lower depends on the model).

**Note:** for TG the cast to `f16` is never done as the amount of data to be exchanged is very small, so the extra latency added by having to launch 2 additional data conversion kernels per model layer does not pay off (or even results in a slightly lower performance). Hence, `-smf16` or `-smf32` has no effect on TG performance.  

To provide an idea of the impact of using `-smf32`, below are sweep bench results for LlaMA-3-70B on a 4x3090 system

### F16 (the default)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.369 |  1495.72 |    2.811 |    45.53 |
|  2048 |    128 |   2048 |    1.371 |  1493.54 |    2.622 |    48.82 |
|  2048 |    128 |   4096 |    1.406 |  1456.91 |    2.690 |    47.59 |
|  2048 |    128 |   6144 |    1.440 |  1422.41 |    2.691 |    47.56 |
|  2048 |    128 |   8192 |    1.480 |  1384.08 |    2.739 |    46.73 |
|  2048 |    128 |  10240 |    1.513 |  1353.45 |    2.791 |    45.86 |
|  2048 |    128 |  12288 |    1.549 |  1322.22 |    2.891 |    44.28 |
|  2048 |    128 |  14336 |    1.587 |  1290.85 |    2.868 |    44.64 |
|  2048 |    128 |  16384 |    1.622 |  1262.31 |    2.920 |    43.83 |
|  2048 |    128 |  18432 |    1.659 |  1234.62 |    2.896 |    44.20 |
|  2048 |    128 |  20480 |    1.698 |  1205.78 |    2.924 |    43.78 |
|  2048 |    128 |  22528 |    1.731 |  1183.27 |    2.981 |    42.93 |
|  2048 |    128 |  24576 |    1.764 |  1161.10 |    2.994 |    42.75 |
|  2048 |    128 |  26624 |    1.801 |  1137.03 |    3.001 |    42.65 |
|  2048 |    128 |  28672 |    1.837 |  1115.15 |    3.024 |    42.32 |
|  2048 |    128 |  30720 |    1.876 |  1091.66 |    3.046 |    42.02 |

### F32 (-smf32)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.989 |  1029.73 |    2.767 |    46.26 |
|  2048 |    128 |   2048 |    1.984 |  1032.25 |    2.636 |    48.57 |
|  2048 |    128 |   4096 |    2.022 |  1012.89 |    2.654 |    48.23 |
|  2048 |    128 |   6144 |    2.054 |   996.87 |    2.693 |    47.53 |
|  2048 |    128 |   8192 |    2.095 |   977.60 |    2.734 |    46.83 |
|  2048 |    128 |  10240 |    2.124 |   964.00 |    2.862 |    44.72 |
|  2048 |    128 |  12288 |    2.161 |   947.72 |    2.854 |    44.85 |
|  2048 |    128 |  14336 |    2.197 |   932.08 |    2.852 |    44.88 |
|  2048 |    128 |  16384 |    2.228 |   919.39 |    2.865 |    44.67 |
|  2048 |    128 |  18432 |    2.264 |   904.66 |    2.934 |    43.62 |
|  2048 |    128 |  20480 |    2.305 |   888.60 |    2.940 |    43.53 |
|  2048 |    128 |  22528 |    2.376 |   861.88 |    2.974 |    43.04 |
|  2048 |    128 |  24576 |    2.371 |   863.89 |    2.983 |    42.91 |
|  2048 |    128 |  26624 |    2.399 |   853.51 |    2.999 |    42.69 |
|  2048 |    128 |  28672 |    2.436 |   840.64 |    3.019 |    42.40 |
|  2048 |    128 |  30720 |    2.476 |   827.20 |    3.049 |    41.99 |
