### PR TITLE
Split mode graph for Qwen3

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -1116,8 +1116,8 @@ bool create_tensors_helper::create_qwen3_tensors(const LLM_TN & tn) {
 
     // output
     {
-        model.output_norm = create_tensor(ctx_output,       tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd});
-        model.output      = create_tensor(ctx_output_split, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_NOT_REQUIRED);
+        model.output_norm = create_tensor(ctx_output, tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd});
+        model.output      = create_tensor(ctx_output, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_NOT_REQUIRED);
         // if output is NULL, init from the input tok embed
         if (model.output == NULL) {
             model.output = create_tensor(ctx_output, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_DUPLICATED);
@@ -1125,21 +1125,20 @@ bool create_tensors_helper::create_qwen3_tensors(const LLM_TN & tn) {
     }
 
     for (int i = 0; i < n_layer; ++i) {
-        ggml_context * ctx_layer = ctx_for_layer(i);
         ggml_context * ctx_split = ctx_for_layer_split(i);
 
         auto & layer = model.layers[i];
 
-        layer.attn_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd});
+        layer.attn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd});
 
         use_mmap_buffer &= !merge_qkv(tn, i, 0);
 
         layer.wo = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd});
 
-        layer.attn_k_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k});
-        layer.attn_q_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k});
+        layer.attn_k_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k});
+        layer.attn_q_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k});
 
-        layer.ffn_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd});
+        layer.ffn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd});
         create_std_ffn(i, tn, layer, n_ff, n_embd, ctx_split);
     }
     return use_mmap_buffer;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1731,6 +1731,7 @@ static bool is_model_split_supported(const llama_model & model) {
         LLM_ARCH_MISTRAL3,
         LLM_ARCH_COHERE2,
         LLM_ARCH_MIMO2,
+        LLM_ARCH_QWEN3,
     };
     auto it =  k_supported.find(model.arch);
     return it != k_supported.end();


### PR DESCRIPTION

Closes #1102 

The following graphs show PP and TG performance for `Q4_0` quantized Qwen3-14B on a 2x3090 system. `llama.cpp` results using today's version are also shown, including mainline's attempt at tensor parallel (split mode "row"). At 40k tokens split mode 'graph' added by this PR outperforms the default split mode 'layer' by 77% (PP) and 53% (TG). Comparing to mainline's attempt at tensor parallel, this PR is 2.35X (PP) and 2X (TG) faster.

<img width="792" height="612" alt="q3_14b" src="https://github.com/user-attachments/assets/053f9603-ff68-41e3-9b09-193f8a743bcd" />

<img width="792" height="612" alt="q3_14b_tg" src="https://github.com/user-attachments/assets/8d98589d-b0e9-46e2-81fe-d1da82e2ed4a" />

<details>
<summary>ik_llama.cpp, split mode 'layer'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.624 |  3280.56 |    1.340 |    95.54 |
|  2048 |    128 |   2048 |    0.634 |  3231.17 |    1.378 |    92.90 |
|  2048 |    128 |   4096 |    0.685 |  2988.50 |    1.482 |    86.39 |
|  2048 |    128 |   6144 |    0.736 |  2784.45 |    1.573 |    81.37 |
|  2048 |    128 |   8192 |    0.788 |  2599.43 |    1.670 |    76.65 |
|  2048 |    128 |  10240 |    0.841 |  2435.74 |    1.768 |    72.40 |
|  2048 |    128 |  12288 |    0.894 |  2289.88 |    1.865 |    68.63 |
|  2048 |    128 |  14336 |    0.949 |  2159.15 |    1.964 |    65.17 |
|  2048 |    128 |  16384 |    1.001 |  2046.48 |    2.057 |    62.22 |
|  2048 |    128 |  18432 |    1.056 |  1939.59 |    2.153 |    59.44 |
|  2048 |    128 |  20480 |    1.108 |  1848.92 |    2.249 |    56.93 |
|  2048 |    128 |  22528 |    1.163 |  1760.83 |    2.345 |    54.58 |
|  2048 |    128 |  24576 |    1.215 |  1685.10 |    2.442 |    52.41 |
|  2048 |    128 |  26624 |    1.270 |  1613.17 |    2.539 |    50.41 |
|  2048 |    128 |  28672 |    1.322 |  1548.99 |    2.637 |    48.55 |
|  2048 |    128 |  30720 |    1.378 |  1486.49 |    2.735 |    46.80 |
|  2048 |    128 |  32768 |    1.428 |  1433.75 |    2.835 |    45.15 |
|  2048 |    128 |  34816 |    1.486 |  1377.96 |    2.936 |    43.60 |
|  2048 |    128 |  36864 |    1.541 |  1329.39 |    3.039 |    42.13 |
|  2048 |    128 |  38912 |    1.592 |  1286.28 |    3.141 |    40.76 |

</details>

<details>
<summary>ik_llama.cpp, split mode 'graph'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.390 |  5253.37 |    1.014 |   126.17 |
|  2048 |    128 |   2048 |    0.406 |  5046.83 |    1.049 |   122.05 |
|  2048 |    128 |   4096 |    0.432 |  4744.94 |    1.108 |   115.50 |
|  2048 |    128 |   6144 |    0.457 |  4477.45 |    1.160 |   110.36 |
|  2048 |    128 |   8192 |    0.484 |  4234.16 |    1.216 |   105.29 |
|  2048 |    128 |  10240 |    0.509 |  4021.49 |    1.271 |   100.75 |
|  2048 |    128 |  12288 |    0.537 |  3815.12 |    1.325 |    96.63 |
|  2048 |    128 |  14336 |    0.564 |  3631.38 |    1.378 |    92.86 |
|  2048 |    128 |  16384 |    0.591 |  3463.12 |    1.432 |    89.38 |
|  2048 |    128 |  18432 |    0.619 |  3310.00 |    1.487 |    86.09 |
|  2048 |    128 |  20480 |    0.647 |  3163.34 |    1.541 |    83.04 |
|  2048 |    128 |  22528 |    0.677 |  3026.46 |    1.596 |    80.22 |
|  2048 |    128 |  24576 |    0.703 |  2914.75 |    1.650 |    77.55 |
|  2048 |    128 |  26624 |    0.729 |  2808.83 |    1.706 |    75.05 |
|  2048 |    128 |  28672 |    0.758 |  2701.47 |    1.762 |    72.65 |
|  2048 |    128 |  30720 |    0.785 |  2609.06 |    1.817 |    70.44 |
|  2048 |    128 |  32768 |    0.815 |  2513.21 |    1.875 |    68.26 |
|  2048 |    128 |  34816 |    0.843 |  2428.43 |    1.933 |    66.23 |
|  2048 |    128 |  36864 |    0.869 |  2355.98 |    1.989 |    64.34 |
|  2048 |    128 |  38912 |    0.897 |  2282.16 |    2.047 |    62.53 |

</details>

<details>
<summary>llama.cpp, split mode 'layer'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    512 |      0 |    0.647 |  3167.48 |    5.298 |    96.65 |
|  2048 |    512 |   2048 |    0.721 |  2840.21 |    5.654 |    90.56 |
|  2048 |    512 |   4096 |    0.789 |  2596.79 |    5.988 |    85.50 |
|  2048 |    512 |   6144 |    0.863 |  2373.71 |    6.336 |    80.81 |
|  2048 |    512 |   8192 |    0.940 |  2179.82 |    6.675 |    76.70 |
|  2048 |    512 |  10240 |    1.016 |  2015.99 |    7.015 |    72.98 |
|  2048 |    512 |  12288 |    1.093 |  1874.00 |    7.361 |    69.55 |
|  2048 |    512 |  14336 |    1.170 |  1750.94 |    7.702 |    66.48 |
|  2048 |    512 |  16384 |    1.247 |  1641.75 |    8.041 |    63.67 |
|  2048 |    512 |  18432 |    1.324 |  1546.68 |    8.381 |    61.09 |
|  2048 |    512 |  20480 |    1.399 |  1464.38 |    8.729 |    58.66 |
|  2048 |    512 |  22528 |    1.479 |  1384.56 |    9.089 |    56.33 |
|  2048 |    512 |  24576 |    1.608 |  1273.32 |    9.431 |    54.29 |
|  2048 |    512 |  26624 |    1.634 |  1253.62 |    9.780 |    52.35 |
|  2048 |    512 |  28672 |    1.713 |  1195.45 |   10.142 |    50.48 |
|  2048 |    512 |  30720 |    1.791 |  1143.69 |   10.491 |    48.80 |
|  2048 |    512 |  32768 |    1.867 |  1096.86 |   10.848 |    47.20 |
|  2048 |    512 |  34816 |    1.945 |  1052.69 |   11.210 |    45.67 |
|  2048 |    512 |  36864 |    2.030 |  1008.92 |   11.570 |    44.25 |
|  2048 |    512 |  38912 |    2.110 |   970.71 |   11.920 |    42.95 |

</details>

<details>
<summary>llama.cpp, split mode 'row'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    512 |      0 |    1.267 |  1616.40 |    9.836 |    52.05 |
|  2048 |    512 |   2048 |    1.335 |  1533.63 |   10.184 |    50.27 |
|  2048 |    512 |   4096 |    1.401 |  1461.73 |   10.512 |    48.71 |
|  2048 |    512 |   6144 |    1.475 |  1388.88 |   10.883 |    47.05 |
|  2048 |    512 |   8192 |    1.545 |  1325.84 |   11.221 |    45.63 |
|  2048 |    512 |  10240 |    1.616 |  1267.49 |   11.561 |    44.29 |
|  2048 |    512 |  12288 |    1.685 |  1215.36 |   11.939 |    42.89 |
|  2048 |    512 |  14336 |    1.760 |  1163.95 |   12.285 |    41.68 |
|  2048 |    512 |  16384 |    1.865 |  1098.21 |   12.604 |    40.62 |
|  2048 |    512 |  18432 |    1.921 |  1066.16 |   12.965 |    39.49 |
|  2048 |    512 |  20480 |    1.973 |  1038.02 |   13.326 |    38.42 |
|  2048 |    512 |  22528 |    2.047 |  1000.38 |   13.691 |    37.40 |
|  2048 |    512 |  24576 |    2.119 |   966.67 |   14.036 |    36.48 |
|  2048 |    512 |  26624 |    2.198 |   931.83 |   14.390 |    35.58 |
|  2048 |    512 |  28672 |    2.267 |   903.44 |   14.784 |    34.63 |
|  2048 |    512 |  30720 |    2.344 |   873.89 |   15.141 |    33.82 |
|  2048 |    512 |  32768 |    2.419 |   846.57 |   15.490 |    33.05 |
|  2048 |    512 |  34816 |    2.495 |   820.99 |   15.855 |    32.29 |
|  2048 |    512 |  36864 |    2.567 |   797.81 |   16.203 |    31.60 |
|  2048 |    512 |  38912 |    2.664 |   768.84 |   16.573 |    30.89 |

</details>

