### PR TITLE
Split mode 'graph' for Qwen3-VL

### DIFF
--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -413,6 +413,7 @@ llm_expert_gating_func_type   gating_op,
 
     ggml_tensor * build_std_attention(ggml_cgraph * gf, ggml_tensor * attn_norm, ggml_tensor * cur, ggml_tensor * inp_pos, ggml_tensor * rope_factors,
             ggml_tensor * KQ_mask, ggml_tensor * sinks, ggml_tensor * inp_attn_scale, float KQ_scale, float f_attn_scale,
-            int n_swa, int il, bool do_rope = true, bool add_graph_split = false, bool add_input = false, bool is_norm = false);
+            int n_swa, int il, bool do_rope = true, bool add_graph_split = false, bool add_input = false, bool is_norm = false,
+            bool is_multi = false);
 
 };

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1732,6 +1732,7 @@ static bool is_model_split_supported(const llama_model & model) {
         LLM_ARCH_COHERE2,
         LLM_ARCH_MIMO2,
         LLM_ARCH_QWEN3,
+        LLM_ARCH_QWEN3VL,
     };
     auto it =  k_supported.find(model.arch);
     return it != k_supported.end();


### PR DESCRIPTION

Only the text part for now.

Below `sweep-bench` results for the Q4_K_M Qwen3-VL-32B model from Bartowski on a 2x3090 system. At a context of 64k tokens we observe 89% better PP and 60% better TG performance for split mode 'graph' compared to the default 'layer'. Compared to mainline's attempt at tensor parallel (split mode 'row'), at zero context we see 3X better PP and  2.15X better TG. At a context of 64k tokens the performance gap is still 2.4X (PP) or 2.05X (TG).

<img width="792" height="612" alt="q3vl_pp" src="https://github.com/user-attachments/assets/286bbc98-1fe4-42af-8036-accd8bf30cb7" />

<img width="792" height="612" alt="q3vl_tg" src="https://github.com/user-attachments/assets/e9c29423-acbd-45b2-8fed-877a7890904a" />


<details>
<summary>ik_llama.cpp, split mode 'layer'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.530 |  1338.34 |    3.024 |    42.33 |
|  2048 |    128 |   2048 |    1.629 |  1256.87 |    3.085 |    41.49 |
|  2048 |    128 |   4096 |    1.734 |  1181.42 |    3.177 |    40.29 |
|  2048 |    128 |   6144 |    1.840 |  1113.27 |    3.264 |    39.21 |
|  2048 |    128 |   8192 |    1.943 |  1054.17 |    3.339 |    38.33 |
|  2048 |    128 |  10240 |    2.049 |   999.48 |    3.396 |    37.69 |
|  2048 |    128 |  12288 |    2.153 |   951.27 |    3.473 |    36.86 |
|  2048 |    128 |  14336 |    2.260 |   906.12 |    3.548 |    36.07 |
|  2048 |    128 |  16384 |    2.366 |   865.59 |    3.641 |    35.16 |
|  2048 |    128 |  18432 |    2.473 |   828.25 |    3.716 |    34.44 |
|  2048 |    128 |  20480 |    2.577 |   794.60 |    3.757 |    34.07 |
|  2048 |    128 |  22528 |    2.688 |   761.99 |    3.839 |    33.34 |
|  2048 |    128 |  24576 |    2.797 |   732.29 |    3.921 |    32.64 |
|  2048 |    128 |  26624 |    2.904 |   705.21 |    4.012 |    31.90 |
|  2048 |    128 |  28672 |    3.014 |   679.60 |    4.076 |    31.41 |
|  2048 |    128 |  30720 |    3.121 |   656.29 |    4.125 |    31.03 |
|  2048 |    128 |  32768 |    3.228 |   634.42 |    4.207 |    30.42 |
|  2048 |    128 |  34816 |    3.344 |   612.39 |    4.295 |    29.80 |
|  2048 |    128 |  36864 |    3.467 |   590.67 |    4.392 |    29.14 |
|  2048 |    128 |  38912 |    3.596 |   569.56 |    4.423 |    28.94 |
|  2048 |    128 |  40960 |    3.729 |   549.17 |    4.499 |    28.45 |
|  2048 |    128 |  43008 |    3.857 |   531.00 |    4.583 |    27.93 |
|  2048 |    128 |  45056 |    3.978 |   514.78 |    4.670 |    27.41 |
|  2048 |    128 |  47104 |    4.101 |   499.33 |    4.765 |    26.86 |
|  2048 |    128 |  49152 |    4.228 |   484.43 |    4.796 |    26.69 |
|  2048 |    128 |  51200 |    4.353 |   470.44 |    4.870 |    26.28 |
|  2048 |    128 |  53248 |    4.473 |   457.90 |    4.959 |    25.81 |
|  2048 |    128 |  55296 |    4.595 |   445.69 |    5.040 |    25.40 |
|  2048 |    128 |  57344 |    4.714 |   434.41 |    5.087 |    25.16 |
|  2048 |    128 |  59392 |    4.832 |   423.80 |    5.173 |    24.74 |
|  2048 |    128 |  61440 |    4.947 |   414.00 |    5.244 |    24.41 |
|  2048 |    128 |  63488 |    5.069 |   404.02 |    5.333 |    24.00 |

</details>

<details>
<summary>ik_llama.cpp, split mode 'graph' - this PR</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.918 |  2231.30 |    2.070 |    61.82 |
|  2048 |    128 |   2048 |    0.963 |  2126.68 |    2.122 |    60.33 |
|  2048 |    128 |   4096 |    1.018 |  2012.28 |    2.172 |    58.94 |
|  2048 |    128 |   6144 |    1.072 |  1909.72 |    2.253 |    56.81 |
|  2048 |    128 |   8192 |    1.128 |  1814.95 |    2.260 |    56.65 |
|  2048 |    128 |  10240 |    1.183 |  1731.76 |    2.305 |    55.53 |
|  2048 |    128 |  12288 |    1.238 |  1654.45 |    2.365 |    54.13 |
|  2048 |    128 |  14336 |    1.295 |  1581.79 |    2.387 |    53.63 |
|  2048 |    128 |  16384 |    1.359 |  1506.67 |    2.447 |    52.30 |
|  2048 |    128 |  18432 |    1.422 |  1440.37 |    2.457 |    52.10 |
|  2048 |    128 |  20480 |    1.477 |  1386.86 |    2.486 |    51.49 |
|  2048 |    128 |  22528 |    1.534 |  1334.67 |    2.561 |    49.99 |
|  2048 |    128 |  24576 |    1.590 |  1287.87 |    2.573 |    49.74 |
|  2048 |    128 |  26624 |    1.649 |  1241.64 |    2.636 |    48.56 |
|  2048 |    128 |  28672 |    1.702 |  1203.63 |    2.652 |    48.27 |
|  2048 |    128 |  30720 |    1.758 |  1164.97 |    2.678 |    47.80 |
|  2048 |    128 |  32768 |    1.817 |  1126.84 |    2.751 |    46.53 |
|  2048 |    128 |  34816 |    1.875 |  1092.06 |    2.765 |    46.30 |
|  2048 |    128 |  36864 |    1.936 |  1058.03 |    2.828 |    45.27 |
|  2048 |    128 |  38912 |    1.995 |  1026.72 |    2.849 |    44.93 |
|  2048 |    128 |  40960 |    2.053 |   997.60 |    2.879 |    44.47 |
|  2048 |    128 |  43008 |    2.111 |   970.17 |    2.947 |    43.43 |
|  2048 |    128 |  45056 |    2.169 |   944.08 |    2.960 |    43.24 |
|  2048 |    128 |  47104 |    2.228 |   919.29 |    3.013 |    42.49 |
|  2048 |    128 |  49152 |    2.289 |   894.68 |    3.047 |    42.01 |
|  2048 |    128 |  51200 |    2.355 |   869.73 |    3.066 |    41.74 |
|  2048 |    128 |  53248 |    2.417 |   847.18 |    3.141 |    40.76 |
|  2048 |    128 |  55296 |    2.483 |   824.83 |    3.158 |    40.53 |
|  2048 |    128 |  57344 |    2.549 |   803.40 |    3.186 |    40.17 |
|  2048 |    128 |  59392 |    2.620 |   781.69 |    3.240 |    39.51 |
|  2048 |    128 |  61440 |    2.686 |   762.49 |    3.257 |    39.30 |
|  2048 |    128 |  63488 |    2.756 |   743.10 |    3.334 |    38.39 |

</details>

<details>
<summary>llama.cpp, split mode 'layer'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    512 |      0 |    1.537 |  1332.64 |   12.176 |    42.05 |
|  2048 |    512 |   2048 |    1.661 |  1232.98 |   12.603 |    40.63 |
|  2048 |    512 |   4096 |    1.793 |  1142.49 |   12.876 |    39.76 |
|  2048 |    512 |   6144 |    1.939 |  1056.36 |   13.211 |    38.76 |
|  2048 |    512 |   8192 |    2.054 |   997.08 |   13.491 |    37.95 |
|  2048 |    512 |  10240 |    2.208 |   927.45 |   13.816 |    37.06 |
|  2048 |    512 |  12288 |    2.315 |   884.65 |   14.108 |    36.29 |
|  2048 |    512 |  14336 |    2.447 |   837.06 |   14.408 |    35.54 |
|  2048 |    512 |  16384 |    2.576 |   795.09 |   14.726 |    34.77 |
|  2048 |    512 |  18432 |    2.707 |   756.54 |   14.984 |    34.17 |
|  2048 |    512 |  20480 |    2.843 |   720.37 |   15.274 |    33.52 |
|  2048 |    512 |  22528 |    2.976 |   688.25 |   15.607 |    32.81 |
|  2048 |    512 |  24576 |    3.116 |   657.33 |   15.887 |    32.23 |
|  2048 |    512 |  26624 |    3.258 |   628.52 |   16.185 |    31.63 |
|  2048 |    512 |  28672 |    3.396 |   603.09 |   16.466 |    31.10 |
|  2048 |    512 |  30720 |    3.537 |   579.04 |   16.729 |    30.61 |
|  2048 |    512 |  32768 |    3.673 |   557.53 |   17.063 |    30.01 |
|  2048 |    512 |  34816 |    3.812 |   537.27 |   17.346 |    29.52 |
|  2048 |    512 |  36864 |    3.946 |   519.04 |   17.665 |    28.98 |
|  2048 |    512 |  38912 |    4.147 |   493.84 |   17.924 |    28.56 |
|  2048 |    512 |  40960 |    4.225 |   484.77 |   18.208 |    28.12 |
|  2048 |    512 |  43008 |    4.359 |   469.85 |   18.512 |    27.66 |
|  2048 |    512 |  45056 |    4.495 |   455.60 |   18.805 |    27.23 |
|  2048 |    512 |  47104 |    4.634 |   441.97 |   19.152 |    26.73 |
|  2048 |    512 |  49152 |    4.770 |   429.34 |   19.390 |    26.41 |
|  2048 |    512 |  51200 |    4.904 |   417.60 |   19.688 |    26.01 |
|  2048 |    512 |  53248 |    5.040 |   406.33 |   19.997 |    25.60 |
|  2048 |    512 |  55296 |    5.176 |   395.69 |   20.272 |    25.26 |
|  2048 |    512 |  57344 |    5.315 |   385.36 |   20.547 |    24.92 |
|  2048 |    512 |  59392 |    5.451 |   375.72 |   20.856 |    24.55 |
|  2048 |    512 |  61440 |    5.589 |   366.43 |   21.134 |    24.23 |
|  2048 |    512 |  63488 |    5.725 |   357.75 |   21.442 |    23.88 |

</details>

<details>
<summary>llama.cpp, split mode 'row'</summary>

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    512 |      0 |    2.760 |   741.99 |   17.813 |    28.74 |
|  2048 |    512 |   2048 |    2.880 |   711.22 |   18.319 |    27.95 |
|  2048 |    512 |   4096 |    2.992 |   684.38 |   18.615 |    27.51 |
|  2048 |    512 |   6144 |    3.105 |   659.50 |   18.954 |    27.01 |
|  2048 |    512 |   8192 |    3.217 |   636.67 |   19.227 |    26.63 |
|  2048 |    512 |  10240 |    3.338 |   613.59 |   19.573 |    26.16 |
|  2048 |    512 |  12288 |    3.478 |   588.92 |   19.867 |    25.77 |
|  2048 |    512 |  14336 |    3.582 |   571.74 |   20.166 |    25.39 |
|  2048 |    512 |  16384 |    3.693 |   554.63 |   20.456 |    25.03 |
|  2048 |    512 |  18432 |    3.822 |   535.83 |   20.729 |    24.70 |
|  2048 |    512 |  20480 |    3.939 |   519.99 |   21.050 |    24.32 |
|  2048 |    512 |  22528 |    4.061 |   504.36 |   21.364 |    23.97 |
|  2048 |    512 |  24576 |    4.185 |   489.33 |   21.605 |    23.70 |
|  2048 |    512 |  26624 |    4.323 |   473.71 |   21.913 |    23.37 |
|  2048 |    512 |  28672 |    4.440 |   461.26 |   22.218 |    23.04 |
|  2048 |    512 |  30720 |    4.572 |   447.94 |   22.538 |    22.72 |
|  2048 |    512 |  32768 |    4.699 |   435.85 |   22.870 |    22.39 |
|  2048 |    512 |  34816 |    4.825 |   424.42 |   23.145 |    22.12 |
|  2048 |    512 |  36864 |    4.944 |   414.23 |   23.501 |    21.79 |
|  2048 |    512 |  38912 |    5.078 |   403.34 |   23.744 |    21.56 |
|  2048 |    512 |  40960 |    5.197 |   394.09 |   24.037 |    21.30 |
|  2048 |    512 |  43008 |    5.390 |   379.94 |   24.339 |    21.04 |
|  2048 |    512 |  45056 |    5.465 |   374.73 |   24.664 |    20.76 |
|  2048 |    512 |  47104 |    5.603 |   365.55 |   24.975 |    20.50 |
|  2048 |    512 |  49152 |    5.758 |   355.70 |   25.213 |    20.31 |
|  2048 |    512 |  51200 |    5.865 |   349.19 |   25.522 |    20.06 |
|  2048 |    512 |  53248 |    5.992 |   341.81 |   25.829 |    19.82 |
|  2048 |    512 |  55296 |    6.144 |   333.36 |   26.118 |    19.60 |
|  2048 |    512 |  57344 |    6.276 |   326.31 |   26.410 |    19.39 |
|  2048 |    512 |  59392 |    6.413 |   319.36 |   26.708 |    19.17 |
|  2048 |    512 |  61440 |    6.585 |   311.01 |   27.021 |    18.95 |
|  2048 |    512 |  63488 |    6.690 |   306.14 |   27.316 |    18.74 |

</details>