### PR TITLE
Disable ring reduction for now

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1111,7 +1111,7 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #endif
 
 #ifndef GGML_SCHED_MAX_COPIES
-#define GGML_SCHED_MAX_COPIES 4
+#define GGML_SCHED_MAX_COPIES 1
 #endif
 
 struct ggml_backend_sched_split {

--- a/ggml/src/ggml-cuda/reduce.cu
+++ b/ggml/src/ggml-cuda/reduce.cu
@@ -196,7 +196,7 @@ void ggml_cuda_op_reduce([[maybe_unused]] ggml_backend_cuda_context & ctx, ggml_
     //   i = 0, peer = 1, ichunk = 1 -> copy part 1 from device 1, device 0 now has parts 0, 1, 2, 3
     //   etc.
     //
-    if (dst->ne[1] >= 32) {
+    if (false && dst->ne[1] >= 32) {
         auto nelem = ggml_nelements(dst);
         auto elem_size = ggml_element_size(dst);
         auto nelem_per_device = (nelem + nhave - 1)/nhave;


### PR DESCRIPTION
There is a race in the reduce implementation that uses ring topology (added in #1092). It reliably shows up with `--max-gpu 4` in a 5x3090 system, and I'm not able to see where the issue is. Hence, disabling this optimization for now.

Closes #1108 