### PR TITLE
Split mode "graph" for Hunyuan-MoE

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2537,24 +2537,23 @@ bool create_tensors_helper::create_hunyuan_tensors(const LLM_TN & tn) {
     create_embd_output(tn, n_embd, n_vocab);
 
     for (int i = 0; i < n_layer; ++i) {
-        ggml_context * ctx_layer = ctx_for_layer(i);
         ggml_context * ctx_split = ctx_for_layer_split(i);
 
         auto & layer = model.layers[i];
 
-        layer.attn_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
+        layer.attn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
 
         layer.wq = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head_k * n_head}, 0);
         layer.wk = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k_gqa}, 0);
         layer.wv = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_v_gqa}, 0);
         layer.wo = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd}, 0);
 
-        layer.attn_k_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, 0);
-        layer.attn_q_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k}, 0);
+        layer.attn_k_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, 0);
+        layer.attn_q_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k}, 0);
 
-        layer.ffn_norm = create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
+        layer.ffn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
 
-        layer.ffn_gate_inp  = create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), {n_embd, n_expert}, 0);
+        layer.ffn_gate_inp  = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), {n_embd, n_expert}, 0);
         layer.ffn_gate_exps = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE_EXPS, "weight", i), {n_embd,   n_ff, n_expert}, 0);
         layer.ffn_down_exps = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {  n_ff, n_embd, n_expert}, 0);
         layer.ffn_up_exps   = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", i), {n_embd,   n_ff, n_expert}, 0);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1733,6 +1733,7 @@ static bool is_model_split_supported(const llama_model & model) {
         LLM_ARCH_MIMO2,
         LLM_ARCH_QWEN3,
         LLM_ARCH_QWEN3VL,
+        LLM_ARCH_HUNYUAN_MOE,
     };
     auto it =  k_supported.find(model.arch);
     return it != k_supported.end();


### PR DESCRIPTION

This model does not seem to be particularly popular, but adding split mode "graph" support was a low-hanging fruit, so here it is.

The following `sweep-bench` results are for the [IQ4_XS model from Unsloth](https://huggingface.co/unsloth/Hunyuan-A13B-Instruct-GGUF/blob/main/Hunyuan-A13B-Instruct-IQ4_XS.gguf) on a 4x3090 system. At 64k tokens we observe  2.6C better PP and 1.9X better TG. Note: the split mode "graph" run uses `-sas` (async scheduler).

### ik_llama.cpp, split mode "graph" - this PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.377 |  5428.85 |    0.920 |   139.06 |
|  2048 |    128 |   2048 |    0.339 |  6049.81 |    0.906 |   141.30 |
|  2048 |    128 |   4096 |    0.348 |  5891.19 |    0.908 |   141.02 |
|  2048 |    128 |   6144 |    0.357 |  5735.89 |    0.921 |   138.93 |
|  2048 |    128 |   8192 |    0.367 |  5586.65 |    0.939 |   136.39 |
|  2048 |    128 |  10240 |    0.376 |  5452.06 |    0.958 |   133.68 |
|  2048 |    128 |  12288 |    0.384 |  5336.79 |    0.986 |   129.75 |
|  2048 |    128 |  14336 |    0.394 |  5201.51 |    0.988 |   129.55 |
|  2048 |    128 |  16384 |    0.405 |  5059.83 |    0.997 |   128.36 |
|  2048 |    128 |  18432 |    0.415 |  4936.49 |    1.008 |   127.01 |
|  2048 |    128 |  20480 |    0.424 |  4825.82 |    1.020 |   125.49 |
|  2048 |    128 |  22528 |    0.433 |  4728.67 |    1.048 |   122.19 |
|  2048 |    128 |  24576 |    0.443 |  4622.75 |    1.054 |   121.48 |
|  2048 |    128 |  26624 |    0.452 |  4533.86 |    1.063 |   120.43 |
|  2048 |    128 |  28672 |    0.461 |  4440.73 |    1.074 |   119.14 |
|  2048 |    128 |  30720 |    0.470 |  4357.85 |    1.079 |   118.60 |
|  2048 |    128 |  32768 |    0.478 |  4282.26 |    1.108 |   115.56 |
|  2048 |    128 |  34816 |    0.490 |  4183.39 |    1.118 |   114.50 |
|  2048 |    128 |  36864 |    0.499 |  4105.93 |    1.123 |   113.93 |
|  2048 |    128 |  38912 |    0.509 |  4023.58 |    1.132 |   113.12 |
|  2048 |    128 |  40960 |    0.520 |  3939.30 |    1.144 |   111.85 |
|  2048 |    128 |  43008 |    0.529 |  3869.36 |    1.161 |   110.26 |
|  2048 |    128 |  45056 |    0.540 |  3793.38 |    1.176 |   108.82 |
|  2048 |    128 |  47104 |    0.547 |  3744.09 |    1.183 |   108.18 |
|  2048 |    128 |  49152 |    0.557 |  3676.64 |    1.195 |   107.15 |
|  2048 |    128 |  51200 |    0.568 |  3606.38 |    1.208 |   105.94 |
|  2048 |    128 |  53248 |    0.577 |  3551.94 |    1.231 |   103.99 |
|  2048 |    128 |  55296 |    0.587 |  3488.00 |    1.235 |   103.63 |
|  2048 |    128 |  57344 |    0.597 |  3428.07 |    1.250 |   102.44 |
|  2048 |    128 |  59392 |    0.606 |  3376.88 |    1.257 |   101.82 |
|  2048 |    128 |  61440 |    0.617 |  3316.71 |    1.269 |   100.90 |
|  2048 |    128 |  63488 |    0.628 |  3259.58 |    1.290 |    99.24 |

### ik_llama.cpp, split mode "layer"

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.716 |  2858.51 |    1.219 |   105.03 |
|  2048 |    128 |   2048 |    0.716 |  2859.00 |    1.240 |   103.26 |
|  2048 |    128 |   4096 |    0.741 |  2762.70 |    1.288 |    99.35 |
|  2048 |    128 |   6144 |    0.777 |  2637.27 |    1.329 |    96.28 |
|  2048 |    128 |   8192 |    0.806 |  2542.26 |    1.373 |    93.22 |
|  2048 |    128 |  10240 |    0.832 |  2460.87 |    1.400 |    91.44 |
|  2048 |    128 |  12288 |    0.859 |  2385.13 |    1.438 |    89.02 |
|  2048 |    128 |  14336 |    0.885 |  2313.11 |    1.477 |    86.64 |
|  2048 |    128 |  16384 |    0.916 |  2234.81 |    1.523 |    84.05 |
|  2048 |    128 |  18432 |    0.947 |  2162.30 |    1.565 |    81.79 |
|  2048 |    128 |  20480 |    0.975 |  2099.62 |    1.588 |    80.60 |
|  2048 |    128 |  22528 |    1.006 |  2036.09 |    1.629 |    78.58 |
|  2048 |    128 |  24576 |    1.038 |  1973.75 |    1.671 |    76.62 |
|  2048 |    128 |  26624 |    1.064 |  1924.10 |    1.716 |    74.59 |
|  2048 |    128 |  28672 |    1.098 |  1865.82 |    1.751 |    73.09 |
|  2048 |    128 |  30720 |    1.128 |  1815.38 |    1.779 |    71.94 |
|  2048 |    128 |  32768 |    1.164 |  1759.60 |    1.821 |    70.28 |
|  2048 |    128 |  34816 |    1.191 |  1719.17 |    1.866 |    68.59 |
|  2048 |    128 |  36864 |    1.223 |  1674.84 |    1.911 |    66.99 |
|  2048 |    128 |  38912 |    1.254 |  1633.41 |    1.933 |    66.21 |
|  2048 |    128 |  40960 |    1.286 |  1591.98 |    1.972 |    64.90 |
|  2048 |    128 |  43008 |    1.317 |  1554.72 |    2.017 |    63.47 |
|  2048 |    128 |  45056 |    1.346 |  1521.87 |    2.059 |    62.15 |
|  2048 |    128 |  47104 |    1.380 |  1484.17 |    2.105 |    60.81 |
|  2048 |    128 |  49152 |    1.412 |  1450.33 |    2.128 |    60.14 |
|  2048 |    128 |  51200 |    1.440 |  1422.17 |    2.169 |    59.02 |
|  2048 |    128 |  53248 |    1.472 |  1391.76 |    2.211 |    57.89 |
|  2048 |    128 |  55296 |    1.506 |  1360.23 |    2.255 |    56.77 |
|  2048 |    128 |  57344 |    1.542 |  1327.88 |    2.283 |    56.06 |
|  2048 |    128 |  59392 |    1.575 |  1300.25 |    2.324 |    55.07 |
|  2048 |    128 |  61440 |    1.604 |  1276.81 |    2.365 |    54.12 |
|  2048 |    128 |  63488 |    1.636 |  1252.04 |    2.405 |    53.22 |

### llama.cpp, split mode "layer"

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.779 |  2630.24 |    1.209 |   105.84 |
|  2048 |    128 |   2048 |    0.787 |  2602.38 |    1.251 |   102.34 |
|  2048 |    128 |   4096 |    0.829 |  2471.86 |    1.288 |    99.40 |
|  2048 |    128 |   6144 |    0.882 |  2322.98 |    1.325 |    96.59 |
|  2048 |    128 |   8192 |    0.928 |  2206.21 |    1.363 |    93.91 |
|  2048 |    128 |  10240 |    0.978 |  2093.41 |    1.400 |    91.44 |
|  2048 |    128 |  12288 |    1.027 |  1994.08 |    1.438 |    88.98 |
|  2048 |    128 |  14336 |    1.076 |  1902.64 |    1.478 |    86.60 |
|  2048 |    128 |  16384 |    1.127 |  1817.21 |    1.514 |    84.57 |
|  2048 |    128 |  18432 |    1.180 |  1735.03 |    1.551 |    82.55 |
|  2048 |    128 |  20480 |    1.230 |  1664.92 |    1.586 |    80.71 |
|  2048 |    128 |  22528 |    1.280 |  1600.26 |    1.628 |    78.65 |
|  2048 |    128 |  24576 |    1.338 |  1530.89 |    1.662 |    77.01 |
|  2048 |    128 |  26624 |    1.391 |  1472.37 |    1.701 |    75.25 |
|  2048 |    128 |  28672 |    1.442 |  1420.04 |    1.737 |    73.71 |
|  2048 |    128 |  30720 |    1.493 |  1371.34 |    1.773 |    72.19 |
|  2048 |    128 |  32768 |    1.564 |  1309.55 |    1.814 |    70.56 |
|  2048 |    128 |  34816 |    1.605 |  1275.79 |    1.848 |    69.27 |
|  2048 |    128 |  36864 |    1.645 |  1244.66 |    1.889 |    67.75 |
|  2048 |    128 |  38912 |    1.695 |  1208.05 |    1.923 |    66.56 |
|  2048 |    128 |  40960 |    1.753 |  1168.42 |    1.960 |    65.30 |
|  2048 |    128 |  43008 |    1.809 |  1132.32 |    1.997 |    64.11 |
|  2048 |    128 |  45056 |    1.867 |  1097.02 |    2.035 |    62.91 |
|  2048 |    128 |  47104 |    1.916 |  1068.74 |    2.078 |    61.60 |
|  2048 |    128 |  49152 |    1.955 |  1047.43 |    2.109 |    60.70 |
|  2048 |    128 |  51200 |    2.007 |  1020.58 |    2.150 |    59.55 |
|  2048 |    128 |  53248 |    2.060 |   994.25 |    2.187 |    58.52 |
|  2048 |    128 |  55296 |    2.113 |   969.34 |    2.222 |    57.61 |
|  2048 |    128 |  57344 |    2.162 |   947.32 |    2.261 |    56.62 |
|  2048 |    128 |  59392 |    2.221 |   922.13 |    2.295 |    55.77 |
|  2048 |    128 |  61440 |    2.331 |   878.47 |    2.331 |    54.90 |
|  2048 |    128 |  63488 |    2.327 |   880.14 |    2.370 |    54.00 |

### llama.cpp, split mode "row"

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.343 |  1524.90 |    3.070 |    41.70 |
|  2048 |    128 |   2048 |    1.179 |  1737.01 |    3.067 |    41.74 |
|  2048 |    128 |   4096 |    1.225 |  1671.96 |    3.105 |    41.23 |
|  2048 |    128 |   6144 |    1.280 |  1600.17 |    3.137 |    40.81 |
|  2048 |    128 |   8192 |    1.321 |  1550.77 |    3.182 |    40.23 |
|  2048 |    128 |  10240 |    1.416 |  1445.93 |    3.226 |    39.67 |
|  2048 |    128 |  12288 |    1.422 |  1439.81 |    3.261 |    39.25 |
|  2048 |    128 |  14336 |    1.485 |  1378.94 |    3.295 |    38.84 |
|  2048 |    128 |  16384 |    1.524 |  1344.06 |    3.347 |    38.25 |
|  2048 |    128 |  18432 |    1.575 |  1300.50 |    3.374 |    37.94 |
|  2048 |    128 |  20480 |    1.622 |  1262.80 |    3.410 |    37.53 |
|  2048 |    128 |  22528 |    1.668 |  1227.99 |    3.459 |    37.00 |
|  2048 |    128 |  24576 |    1.717 |  1192.68 |    3.493 |    36.65 |
|  2048 |    128 |  26624 |    1.806 |  1133.78 |    3.537 |    36.19 |
|  2048 |    128 |  28672 |    1.817 |  1127.04 |    3.578 |    35.77 |
|  2048 |    128 |  30720 |    1.905 |  1075.07 |    3.613 |    35.43 |
|  2048 |    128 |  32768 |    1.920 |  1066.79 |    3.663 |    34.94 |
|  2048 |    128 |  34816 |    1.968 |  1040.62 |    3.690 |    34.69 |
|  2048 |    128 |  36864 |    2.056 |   995.99 |    3.727 |    34.34 |
|  2048 |    128 |  38912 |    2.084 |   982.58 |    3.764 |    34.01 |
|  2048 |    128 |  40960 |    2.125 |   963.92 |    3.806 |    33.63 |
|  2048 |    128 |  43008 |    2.266 |   903.62 |    3.848 |    33.27 |
|  2048 |    128 |  45056 |    2.228 |   919.02 |    3.881 |    32.98 |
|  2048 |    128 |  47104 |    2.270 |   902.04 |    3.919 |    32.66 |
|  2048 |    128 |  49152 |    2.320 |   882.87 |    3.948 |    32.42 |
|  2048 |    128 |  51200 |    2.380 |   860.47 |    3.988 |    32.09 |
|  2048 |    128 |  53248 |    2.427 |   843.73 |    4.027 |    31.78 |
|  2048 |    128 |  55296 |    2.477 |   826.89 |    4.066 |    31.48 |
|  2048 |    128 |  57344 |    2.538 |   806.95 |    4.107 |    31.16 |
|  2048 |    128 |  59392 |    2.725 |   751.61 |    4.152 |    30.83 |
|  2048 |    128 |  61440 |    2.664 |   768.65 |    4.188 |    30.57 |
|  2048 |    128 |  63488 |    2.688 |   761.80 |    4.234 |    30.23 |

 