### PR TITLE
Better VRAM utilization strategy for split mode graph

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -274,7 +274,7 @@ static std::vector<int> create_split(int nr, int granularity, const std::vector<
     }
     while (sum > nchunk) {
         last_split = 0;
-        float best_err = 0;
+        float best_err = -INFINITY;
         int ibest = -1;
         for (int i = 0; i < (int)splits.size(); ++i) {
             if (result[i] > 0) {
@@ -294,7 +294,7 @@ static std::vector<int> create_split(int nr, int granularity, const std::vector<
     }
     while (sum < nchunk) {
         last_split = 0;
-        float best_err = 0;
+        float best_err = -INFINITY;
         int ibest = -1;
         for (int i = 0; i < (int)splits.size(); ++i) {
             float p = splits[i] - last_split;


### PR DESCRIPTION

This PR adds a hopefully better strategy for utilizing available VRAM when using split mode "graph". It only addresses the situation where `--max-gpu` is not used (or is the same as the number of available GPUs).

@magikRUKKOLA added a 6th 3090 GPU to the system where he has granted remote access, and I was annoyed by the fact that the main branch was not optimally utilizing the available VRAM when trying to run a 2.895 bpw quantization of GLM-4.7 using all 6 GPUs. For a context of 32k I was getting
```
Estimated model buffer size per device:
    Device 0:  19913.76 MiB
    Device 1:  21130.70 MiB
    Device 2:  19916.87 MiB
    Device 3:  19916.87 MiB
    Device 4:  19913.76 MiB
    Device 5:  21130.70 MiB
llama_kv_cache_init: KV cache size per device:
    Device 0:  598 MiB
    Device 1:  1196 MiB
    Device 2:  598 MiB
    Device 3:  598 MiB
    Device 4:  598 MiB
    Device 5:  1196 MiB
```
which then results in OOM after KV cache and compute buffer allocation. Fooling around with `--tensor-split` did not help much.

With this PR we get (without any `--tensor-split` modifications)
```
Estimated model buffer size per device:
    Device 0:  20317.68 MiB
    Device 1:  20322.87 MiB
    Device 2:  20320.78 MiB
    Device 3:  20320.78 MiB
    Device 4:  20317.68 MiB
    Device 5:  20322.87 MiB
llama_kv_cache_init: KV cache size per device:
    Device 0:  793 MiB
    Device 1:  806 MiB
    Device 2:  793 MiB
    Device 3:  793 MiB
    Device 4:  793 MiB
    Device 5:  806 MiB
```
which is basically as good as it gets, given the split granularity. With that I  can run 32k  context with full GPU offload, getting quite a bit better PP and TG compared to `--max-gpu 4`:

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|   512 |    128 |      0 |    0.548 |   934.08 |    3.912 |    32.72 |
|   512 |    128 |    512 |    0.495 |  1034.68 |    3.930 |    32.57 |
|   512 |    128 |   1024 |    0.499 |  1026.36 |    3.972 |    32.22 |
|   512 |    128 |   1536 |    0.506 |  1012.35 |    3.987 |    32.11 |
|   512 |    128 |   2048 |    0.504 |  1016.07 |    4.008 |    31.94 |
|   512 |    128 |   2560 |    0.508 |  1008.44 |    4.024 |    31.81 |
|   512 |    128 |   3072 |    0.512 |  1000.07 |    4.047 |    31.63 |
|   512 |    128 |   3584 |    0.515 |   993.30 |    4.128 |    31.01 |
|   512 |    128 |   4096 |    0.522 |   981.58 |    4.157 |    30.79 |
|   512 |    128 |   4608 |    0.523 |   979.45 |    4.169 |    30.71 |
|   512 |    128 |   5120 |    0.526 |   974.01 |    4.187 |    30.57 |
|   512 |    128 |   5632 |    0.536 |   955.53 |    4.180 |    30.62 |
|   512 |    128 |   6144 |    0.535 |   956.42 |    4.202 |    30.46 |
|   512 |    128 |   6656 |    0.539 |   949.59 |    4.237 |    30.21 |
|   512 |    128 |   7168 |    0.543 |   942.49 |    4.305 |    29.73 |
|   512 |    128 |   7680 |    0.546 |   938.52 |    4.337 |    29.51 |
|   512 |    128 |   8192 |    0.550 |   930.31 |    4.367 |    29.31 |
|   512 |    128 |   8704 |    0.554 |   924.05 |    4.396 |    29.12 |
|   512 |    128 |   9216 |    0.559 |   916.30 |    4.445 |    28.80 |
|   512 |    128 |   9728 |    0.562 |   910.55 |    4.489 |    28.51 |
|   512 |    128 |  10240 |    0.565 |   906.58 |    4.529 |    28.26 |
|   512 |    128 |  10752 |    0.569 |   900.13 |    4.622 |    27.70 |
|   512 |    128 |  11264 |    0.571 |   895.91 |    4.624 |    27.68 |
|   512 |    128 |  11776 |    0.579 |   884.13 |    4.644 |    27.56 |
|   512 |    128 |  12288 |    0.581 |   881.91 |    4.675 |    27.38 |
|   512 |    128 |  12800 |    0.585 |   875.48 |    4.684 |    27.33 |
|   512 |    128 |  13312 |    0.590 |   867.58 |    4.710 |    27.18 |
|   512 |    128 |  13824 |    0.593 |   863.05 |    4.774 |    26.81 |
