### PR TITLE
Fix Nix Depreciation: addOpenGLRunpath -> autoAddDriverRunpath in .devops/nix/package.nix

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -13,6 +13,7 @@
   mpi,
   blas,
   cudaPackages,
+  autoAddDriverRunpath,
   darwin,
   rocmPackages,
   vulkan-headers,
@@ -192,10 +193,7 @@ effectiveStdenv.mkDerivation (
       ]
       ++ optionals useCuda [
         cudaPackages.cuda_nvcc
-
-        # TODO: Replace with autoAddDriverRunpath
-        # once https://github.com/NixOS/nixpkgs/pull/275241 has been merged
-        cudaPackages.autoAddOpenGLRunpathHook
+        autoAddDriverRunpath
       ]
       ++ optionals (effectiveStdenv.hostPlatform.isGnu && enableStatic) [
         glibc.static


### PR DESCRIPTION
This is an easy one. Nix depreciated addOpenGLRunpath and replaced it with autoAddDriverRunpath.

Cuda support is broken without the change.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
