### PR TITLE
Better GLM-4.7-Flash long context TG performance

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -13,6 +13,7 @@
 #include "fattn-mma-f16-interface.cuh"
 #include "fattn-new-mma.cuh"
 #include "fattn.cuh"
+#include "convert.cuh"
 
 #include <cstdint>
 
@@ -111,6 +112,31 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
         // GLM-4.7-Flash TG hack: split 20 heads into 16+4 heads
         auto local_Q   = *Q;
         auto local_dst = *dst;
+
+        ggml_tensor local_K, local_V;
+        ggml_cuda_pool_alloc<half> K_f16(ctx.pool());
+        if (ggml_is_quantized(K->type)) {
+            // We need to dequantize here, else we will dequantize the same cache twice
+            K_f16.alloc(ggml_nelements(K));
+            to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(K->type);
+            to_fp16(K->data, K_f16.ptr, 1, ggml_nelements(K), ctx.stream());
+
+            auto bs = ggml_blck_size(K->type);
+            auto ts = ggml_type_size(K->type);
+
+            local_K = *K;
+            local_K.data = K_f16.get();
+            local_K.type  = GGML_TYPE_F16;
+            local_K.nb[0] = sizeof(half);
+            local_K.nb[1] = local_K.nb[1]*bs*sizeof(half)/ts;
+            local_K.nb[2] = local_K.nb[2]*bs*sizeof(half)/ts;
+            local_K.nb[3] = local_K.nb[3]*bs*sizeof(half)/ts;
+            local_dst.src[1] = &local_K;
+
+            local_V = local_K;
+            local_V.ne[0] = V->ne[0];
+            local_dst.src[2] = &local_V;
+        }
 
         local_Q.ne[2]  = 16;
         local_dst.ne[1] = 16;


### PR DESCRIPTION

GLM-4.7-Flash suffers from strong performance degradation for long context. This is due to the strange GQA ratio of 20, which does not play well with the 576x512 FA kernel used for MLA attention token generation.

This PR is a quick hack to remedy the situation by splitting the FA computation into two FA computations with 16+4 heads. 

On my test system (2x3090), the 16+4 split is only worth i(i.e., has better performance) above KV cache sizes of more than 8k tokens. My guess is that the optimum split threshold will be at least somewhat system dependent, but without having access to a multitude of GPU configurations the split threshold is simply hard-coded to 8192. 

Here some `sweep-bench` results for `IQ4_XS` quantized GLM-4.7-Flash on a 2x3090 system. We see 56% TG improvement at a context of 64k tokens!

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.448 |  4568.27 |    1.045 |   122.49 |
|  2048 |    128 |   2048 |    0.469 |  4367.93 |    1.204 |   106.34 |
|  2048 |    128 |   4096 |    0.560 |  3660.18 |    1.252 |   102.24 |
|  2048 |    128 |   6144 |    0.666 |  3074.69 |    1.272 |   100.62 |
|  2048 |    128 |   8192 |    0.756 |  2710.39 |    1.425 |    89.80 |
|  2048 |    128 |  10240 |    0.844 |  2425.55 |    1.569 |    81.58 |
|  2048 |    128 |  12288 |    0.933 |  2194.23 |    1.591 |    80.45 |
|  2048 |    128 |  14336 |    1.027 |  1994.57 |    1.742 |    73.48 |
|  2048 |    128 |  16384 |    1.114 |  1838.34 |    1.889 |    67.77 |
|  2048 |    128 |  18432 |    1.208 |  1695.60 |    1.908 |    67.08 |
|  2048 |    128 |  20480 |    1.302 |  1573.47 |    2.052 |    62.38 |
|  2048 |    128 |  22528 |    1.394 |  1469.46 |    2.068 |    61.89 |
|  2048 |    128 |  24576 |    1.482 |  1382.24 |    2.210 |    57.92 |
|  2048 |    128 |  26624 |    1.576 |  1299.72 |    2.350 |    54.48 |
|  2048 |    128 |  28672 |    1.673 |  1223.93 |    2.371 |    53.98 |
|  2048 |    128 |  30720 |    1.763 |  1161.67 |    2.521 |    50.78 |
|  2048 |    128 |  32768 |    1.857 |  1102.97 |    2.653 |    48.25 |
|  2048 |    128 |  34816 |    1.950 |  1050.39 |    2.681 |    47.74 |
|  2048 |    128 |  36864 |    2.039 |  1004.46 |    2.827 |    45.28 |
|  2048 |    128 |  38912 |    2.133 |   960.26 |    2.838 |    45.11 |
|  2048 |    128 |  40960 |    2.226 |   920.16 |    2.986 |    42.87 |
|  2048 |    128 |  43008 |    2.321 |   882.25 |    3.127 |    40.94 |
|  2048 |    128 |  45056 |    2.418 |   846.82 |    3.144 |    40.72 |
|  2048 |    128 |  47104 |    2.512 |   815.18 |    3.292 |    38.88 |
|  2048 |    128 |  49152 |    2.602 |   787.08 |    3.425 |    37.37 |
|  2048 |    128 |  51200 |    2.699 |   758.71 |    3.454 |    37.05 |
|  2048 |    128 |  53248 |    2.795 |   732.85 |    3.599 |    35.57 |
|  2048 |    128 |  55296 |    2.891 |   708.51 |    3.611 |    35.45 |
|  2048 |    128 |  57344 |    2.984 |   686.25 |    3.758 |    34.06 |
|  2048 |    128 |  59392 |    3.078 |   665.27 |    3.900 |    32.82 |
|  2048 |    128 |  61440 |    3.173 |   645.35 |    3.917 |    32.68 |
|  2048 |    128 |  63488 |    3.264 |   627.41 |    4.063 |    31.50 |

### PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.438 |  4674.20 |    1.015 |   126.05 |
|  2048 |    128 |   2048 |    0.468 |  4376.50 |    1.196 |   107.00 |
|  2048 |    128 |   4096 |    0.557 |  3676.63 |    1.247 |   102.62 |
|  2048 |    128 |   6144 |    0.662 |  3092.48 |    1.266 |   101.07 |
|  2048 |    128 |   8192 |    0.751 |  2727.49 |    1.472 |    86.93 |
|  2048 |    128 |  10240 |    0.839 |  2440.53 |    1.521 |    84.18 |
|  2048 |    128 |  12288 |    0.927 |  2209.84 |    1.549 |    82.63 |
|  2048 |    128 |  14336 |    1.022 |  2003.85 |    1.589 |    80.57 |
|  2048 |    128 |  16384 |    1.112 |  1841.98 |    1.838 |    69.63 |
|  2048 |    128 |  18432 |    1.201 |  1705.27 |    1.927 |    66.44 |
|  2048 |    128 |  20480 |    1.297 |  1579.21 |    1.944 |    65.86 |
|  2048 |    128 |  22528 |    1.388 |  1475.42 |    1.976 |    64.77 |
|  2048 |    128 |  24576 |    1.477 |  1386.48 |    1.976 |    64.78 |
|  2048 |    128 |  26624 |    1.575 |  1300.17 |    1.975 |    64.82 |
|  2048 |    128 |  28672 |    1.668 |  1228.14 |    1.963 |    65.22 |
|  2048 |    128 |  30720 |    1.754 |  1167.74 |    1.964 |    65.19 |
|  2048 |    128 |  32768 |    1.848 |  1108.02 |    2.153 |    59.44 |
|  2048 |    128 |  34816 |    1.940 |  1055.58 |    2.247 |    56.97 |
|  2048 |    128 |  36864 |    2.031 |  1008.43 |    2.271 |    56.36 |
|  2048 |    128 |  38912 |    2.128 |   962.40 |    2.298 |    55.69 |
|  2048 |    128 |  40960 |    2.223 |   921.21 |    2.302 |    55.61 |
|  2048 |    128 |  43008 |    2.312 |   885.93 |    2.298 |    55.71 |
|  2048 |    128 |  45056 |    2.408 |   850.50 |    2.283 |    56.07 |
|  2048 |    128 |  47104 |    2.495 |   820.96 |    2.281 |    56.12 |
|  2048 |    128 |  49152 |    2.594 |   789.43 |    2.473 |    51.76 |
|  2048 |    128 |  51200 |    2.691 |   761.18 |    2.565 |    49.90 |
|  2048 |    128 |  53248 |    2.781 |   736.33 |    2.597 |    49.29 |
|  2048 |    128 |  55296 |    2.874 |   712.51 |    2.614 |    48.96 |
|  2048 |    128 |  57344 |    2.967 |   690.22 |    2.620 |    48.85 |
|  2048 |    128 |  59392 |    3.063 |   668.66 |    2.623 |    48.80 |
|  2048 |    128 |  61440 |    3.154 |   649.36 |    2.610 |    49.04 |
|  2048 |    128 |  63488 |    3.252 |   629.79 |    2.607 |    49.09 |
