### PR TITLE
Faster long context TG on CUDA for GLM-4.5/4.6/4.7/AIR

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -1442,7 +1442,8 @@ static ggml_tensor * llm_build_kqv(
         cb(v, "v", il);
 
         if (q->ne[1] == 1 && k->ne[1] >= 8192 && q->ne[2] / k->ne[2] == 12 && !sinks && n_swa == 0 &&
-            k->view_src && k->view_src->buffer && !ggml_backend_buffer_is_host(k->view_src->buffer)) {
+            k->view_src && k->view_src->buffer && !ggml_backend_buffer_is_host(k->view_src->buffer) &&
+            k->type == GGML_TYPE_F16 && v->type == GGML_TYPE_F16) {
             cur = build_glm45_fa(ctx, q, k, v, kq_mask, kq_scale, should_use_f32_precision);
         } else {
 
@@ -9390,7 +9391,8 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                 cb(v, "v", il_cb);
 
                 if (q->ne[1] == 1 && k->ne[1] >= 65536/k->ne[2] && q->ne[2] / k->ne[2] == 12 && !sinks && n_swa == 0 &&
-                    k->view_src && k->view_src->buffer && !ggml_backend_buffer_is_host(k->view_src->buffer)) {
+                    k->view_src && k->view_src->buffer && !ggml_backend_buffer_is_host(k->view_src->buffer) &&
+                    k->type == GGML_TYPE_F16 && v->type == GGML_TYPE_F16) {
                     cur = build_glm45_fa(ctx0, q, k, v, KQ_mask, KQ_scale, should_use_f32_precision);
                 } else {
                     cur = ggml_flash_attn_ext(ctx0, q, k, v, KQ_mask, KQ_scale, hparams.f_max_alibi_bias,


### PR DESCRIPTION
The GLM4-MoE models are notorious for strong inference performance decline with increasing context length, which is due to the unfortunate GQA ratio of 12.

This PR remedies the situation to some extent. It uses a similar technique as in PR #1182 to improve long-context TG performance on CUDA for the GLM4-MoE series of models. But unlike #1182, where there is a single KV head and hence simple views are sufficient to split the FA computation in two parts, here we have 8 KV heads (fewer with split mode `graph`), so one needs to incarnate two contiguous copies of the `Q` tensor to obtain the required splits.

**Caveat**: the PR does not improve the performance when quantized KV cache is used. Implementing the optimization for quantized KV cache is a bit more involved, so it is left for a follow up PR. 

The following graph shows TG performance as a function of context length for GLM-4.5-AIR-IQ1_KT on a 4x3090 system (but for the 2x3090 data points only 2 GPUs are selected). Mani branch and PR coincide up to a certain point because the split is only done above a given threshold that depends on the number of participating GPUs. For 8 GPUs the split only kicks above 64k tokens, so is not shown here. For split mode `layer` we gain ~30% at context of 64k. For 2 GPUs and split mode graph, where we can only go up to context of 32k tokens with this model, the gain is about 13%. For 4 GPUs and split mode `graph` speedup is ~10% at 64k tokens.

<img width="792" height="612" alt="glm45" src="https://github.com/user-attachments/assets/b7b63e15-2b1e-4be1-89b0-a85e217f2a49" />
