### PR TITLE
Much faster long context TG for Minimax-M2

### DIFF
--- a/ggml/src/ggml-cuda/fattn-new-mma.cu
+++ b/ggml/src/ggml-cuda/fattn-new-mma.cu
@@ -2148,11 +2148,15 @@ void ggml_cuda_flash_attn_ext_mma_new(ggml_backend_cuda_context & ctx, ggml_tens
     GGML_ASSERT(Q->ne[2] % K->ne[2] == 0);
     const int gqa_ratio = Q->ne[2] / K->ne[2];
 
-    if (K->ne[0] == 128 && gqa_ratio == 12) {
+    if (K->ne[0] == 128 && (gqa_ratio == 12 || gqa_ratio == 6)) {
         GGML_ASSERT(Q->ne[0] == 128 && V->ne[0] == 128);
         //GGML_ASSERT(Q->ne[1] <= 4);
         //ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<128, 128, 16>(ctx, dst);
-        ggml_cuda_flash_attn_ext_mma_f16_case<128, 128, 1, 16>(ctx, dst);
+        if (gqa_ratio == 12) {
+            ggml_cuda_flash_attn_ext_mma_f16_case<128, 128, 1, 16>(ctx, dst);
+        } else {
+            ggml_cuda_flash_attn_ext_mma_f16_case<128, 128, 1, 8>(ctx, dst);
+        }
         return;
     }
     //if (K->ne[0] == 64 && V->ne[0] == 64) {

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -90,7 +90,7 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
     }
 
     if (new_mma_available(cc) && K->ne[0] == 128 && V->ne[0] == 128 && Q->ne[0] == 128 && Q->ne[1] == 1 &&
-            Q->ne[2] / K->ne[2] == 12) {
+            (Q->ne[2] / K->ne[2] == 12 || Q->ne[2] / K->ne[2] == 6)) {
         ggml_cuda_flash_attn_ext_mma_new(ctx, dst);
         return;
     }


### PR DESCRIPTION

Minimax-M2 has a GQA ratio of 6, which makes FA very slow on the current main branch. This PR does the same as #1193 for GQA = 6, resulting in massively better long context TG performance.

Here some `sweep-bench` performance comparisons between the main branch and this PR on a 6x3090 system. Model is `MiniMax-M2.1-UD-Q2_K_XL` from Unsloth. In both cases split mode `layer` is used as there is no split mode `graph` support for Minimax-M2 (not yet). We observe 2.2X better performance at a context of 64k tokens!

### This PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |    1.477 |  1386.60 |    0.697 |    91.79 |
|  2048 |     64 |   2048 |    1.499 |  1366.15 |    0.750 |    85.32 |
|  2048 |     64 |   4096 |    1.584 |  1293.08 |    0.803 |    79.66 |
|  2048 |     64 |   6144 |    1.665 |  1229.94 |    0.831 |    77.03 |
|  2048 |     64 |   8192 |    1.751 |  1169.85 |    0.877 |    73.02 |
|  2048 |     64 |  10240 |    1.847 |  1108.83 |    0.904 |    70.82 |
|  2048 |     64 |  12288 |    1.940 |  1055.54 |    0.950 |    67.36 |
|  2048 |     64 |  14336 |    2.028 |  1009.98 |    0.977 |    65.52 |
|  2048 |     64 |  16384 |    2.127 |   962.86 |    1.023 |    62.58 |
|  2048 |     64 |  18432 |    2.215 |   924.55 |    1.049 |    61.00 |
|  2048 |     64 |  20480 |    2.312 |   885.85 |    1.096 |    58.39 |
|  2048 |     64 |  22528 |    2.404 |   852.02 |    1.122 |    57.04 |
|  2048 |     64 |  24576 |    2.487 |   823.45 |    1.170 |    54.72 |
|  2048 |     64 |  26624 |    2.577 |   794.69 |    1.195 |    53.56 |
|  2048 |     64 |  28672 |    2.685 |   762.86 |    1.241 |    51.57 |
|  2048 |     64 |  30720 |    2.762 |   741.53 |    1.273 |    50.29 |
|  2048 |     64 |  32768 |    2.851 |   718.28 |    1.315 |    48.68 |
|  2048 |     64 |  34816 |    2.952 |   693.76 |    1.346 |    47.54 |
|  2048 |     64 |  36864 |    3.040 |   673.71 |    1.390 |    46.06 |
|  2048 |     64 |  38912 |    3.143 |   651.64 |    1.416 |    45.20 |
|  2048 |     64 |  40960 |    3.227 |   634.73 |    1.459 |    43.87 |
|  2048 |     64 |  43008 |    3.324 |   616.06 |    1.488 |    43.02 |
|  2048 |     64 |  45056 |    3.410 |   600.60 |    1.533 |    41.74 |
|  2048 |     64 |  47104 |    3.512 |   583.10 |    1.562 |    40.99 |
|  2048 |     64 |  49152 |    3.594 |   569.77 |    1.608 |    39.81 |
|  2048 |     64 |  51200 |    3.679 |   556.69 |    1.632 |    39.21 |
|  2048 |     64 |  53248 |    3.770 |   543.31 |    1.678 |    38.13 |
|  2048 |     64 |  55296 |    3.865 |   529.82 |    1.708 |    37.47 |
|  2048 |     64 |  57344 |    3.953 |   518.08 |    1.753 |    36.50 |
|  2048 |     64 |  59392 |    4.040 |   506.98 |    1.781 |    35.94 |
|  2048 |     64 |  61440 |    4.133 |   495.49 |    1.824 |    35.09 |
|  2048 |     64 |  63488 |    4.217 |   485.70 |    1.853 |    34.54 |

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |    1.650 |  1241.02 |    0.733 |    87.33 |
|  2048 |     64 |   2048 |    1.542 |  1328.25 |    0.825 |    77.57 |
|  2048 |     64 |   4096 |    1.628 |  1257.80 |    0.931 |    68.76 |
|  2048 |     64 |   6144 |    1.718 |  1191.79 |    1.054 |    60.75 |
|  2048 |     64 |   8192 |    1.805 |  1134.77 |    1.154 |    55.46 |
|  2048 |     64 |  10240 |    1.901 |  1077.50 |    1.261 |    50.75 |
|  2048 |     64 |  12288 |    1.995 |  1026.69 |    1.377 |    46.48 |
|  2048 |     64 |  14336 |    2.093 |   978.72 |    1.479 |    43.26 |
|  2048 |     64 |  16384 |    2.184 |   937.55 |    1.589 |    40.28 |
|  2048 |     64 |  18432 |    2.279 |   898.49 |    1.701 |    37.62 |
|  2048 |     64 |  20480 |    2.381 |   860.11 |    1.801 |    35.54 |
|  2048 |     64 |  22528 |    2.478 |   826.36 |    1.921 |    33.31 |
|  2048 |     64 |  24576 |    2.572 |   796.33 |    2.023 |    31.64 |
|  2048 |     64 |  26624 |    2.663 |   768.96 |    2.126 |    30.11 |
|  2048 |     64 |  28672 |    2.753 |   743.99 |    2.244 |    28.52 |
|  2048 |     64 |  30720 |    2.843 |   720.26 |    2.345 |    27.29 |
|  2048 |     64 |  32768 |    2.953 |   693.59 |    2.447 |    26.16 |
|  2048 |     64 |  34816 |    3.048 |   671.91 |    2.567 |    24.93 |
|  2048 |     64 |  36864 |    3.135 |   653.32 |    2.670 |    23.97 |
|  2048 |     64 |  38912 |    3.242 |   631.75 |    2.776 |    23.05 |
|  2048 |     64 |  40960 |    3.344 |   612.42 |    2.887 |    22.17 |
|  2048 |     64 |  43008 |    3.438 |   595.67 |    2.995 |    21.37 |
|  2048 |     64 |  45056 |    3.533 |   579.60 |    3.098 |    20.66 |
|  2048 |     64 |  47104 |    3.625 |   564.97 |    3.216 |    19.90 |
|  2048 |     64 |  49152 |    3.719 |   550.76 |    3.338 |    19.17 |
|  2048 |     64 |  51200 |    3.811 |   537.37 |    3.424 |    18.69 |
|  2048 |     64 |  53248 |    3.911 |   523.68 |    3.547 |    18.04 |
|  2048 |     64 |  55296 |    4.010 |   510.76 |    3.647 |    17.55 |
|  2048 |     64 |  57344 |    4.099 |   499.61 |    3.749 |    17.07 |
|  2048 |     64 |  59392 |    4.181 |   489.88 |    3.869 |    16.54 |
|  2048 |     64 |  61440 |    4.282 |   478.25 |    3.970 |    16.12 |
|  2048 |     64 |  63488 |    4.368 |   468.83 |    4.076 |    15.70 |
