### PR TITLE
Optimize Q8_0 dequantization for AVX2

### DIFF
--- a/ggml/src/iqk/fa/iqk_fa_templates.h
+++ b/ggml/src/iqk/fa/iqk_fa_templates.h
@@ -216,8 +216,9 @@ struct HelperQ8KV final : public BaseHelper {
         v1 = _mm512_mul_ps(vd, _mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(_mm_loadu_si128((const __m128i *)q8->qs+i+0))));
         v2 = _mm512_mul_ps(vd, _mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(_mm_loadu_si128((const __m128i *)q8->qs+i+1))));
 #else
-        v1 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(q8->qs+8*i+0)))));
-        v2 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(q8->qs+8*i+8)))));
+        auto q16 = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i *)(q8->qs + 8*i)));
+        v1 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_castsi256_si128(q16))));
+        v2 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_extracti128_si256(q16, 1))));
 #endif
 #endif
     }
@@ -253,8 +254,9 @@ struct HelperQ80 final : public BaseHelper {
         v2 = _mm512_mul_ps(vd, _mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(_mm_loadu_si128((const __m128i *)dl->qs+1))));
 #else
         int ii = j%QK8_0;
-        v1 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(dl->qs+ii+0)))));
-        v2 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(dl->qs+ii+8)))));
+        auto q16 = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i *)(dl->qs + ii)));
+        v1 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_castsi256_si128(q16))));
+        v2 = _mm256_mul_ps(vd, _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_extracti128_si256(q16, 1))));
 #endif
 #endif
     }


### PR DESCRIPTION
This PR optimizes the Q8_0 dequantization kernel for CPUs with AVX2 support (but without AVX512).

**The Change:**

   - Replaced two separate 64-bit load instructions (_mm_loadl_epi64) with a single 128-bit load (_mm_loadu_si128).
   - Replaced the multi-step sign extension logic with optimized AVX2 intrinsics (_mm256_cvtepi8_epi16).

**Performance Impact:**
Benchmarks show ~24% improvement in Prompt Processing (PP512) for Gemma 3 12B when using the Q8_0 KV cache. Other models and text generation speeds remain the same.

(Might need further testing with different setup, which I have no access to.)


Model | Metric | Baseline | This PR | Diff
-- | -- | -- | -- | --
Gemma 3 12B (Q8_KV) | PP512 | 46.08 t/s | 57.13 t/s | +23.98%
Gemma 3 12B (Q8_KV) | TG128 | 3.57 t/s | 3.57 t/s | 0.00%
Deepseek2 30B (Q8_KV) | PP512 | 71.30 t/s | 71.38 t/s | +0.11%
Llama 3.1 3B (Q8_KV) | PP512 | 5701 t/s | 5708 t/s | +0.12%


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
