### PR TITLE
Fix: add string ban in speculative path

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -2996,13 +2996,17 @@ void server_context::speculative_decoding_accept() {
                 populate_token_probs(slot, result, slot.params.post_sampling_probs, params_base.special, i);
             }
 
-            if (!process_token(result, slot)) {
-                // release slot because of stop condition
-                send_final_response(slot);
-                slot.release();
-                slot.print_timings();
-                metrics.on_prediction(slot);
-                break;
+            if (slot.n_buffer == 0) {
+                if (!process_token(result, slot)) {
+                    // release slot because of stop condition
+                    send_final_response(slot);
+                    slot.release();
+                    slot.print_timings();
+                    metrics.on_prediction(slot);
+                    break;
+                }
+            } else {
+                buffer_and_check_string_ban(slot, result);
             }
         }
         SLT_DBG(slot, "accepted %d/%d draft tokens, new n_tokens = %d\n", (int)ids.size() - 1, (int)slot.drafted.size(), slot.n_past);


### PR DESCRIPTION
When speculative decoding is active alongside string bans, tokens can be delivered to the client out of order. 

The server uses `token_buffer` and `n_buffer` to hold tokens for evaluation against banned phrases or stop strings. Currently, this buffering logic is only applied during normal decoding in `process_batch_tokens`. When tokens are accepted during the speculative decoding phase, they bypass this buffer and are processed immediately. 

This results in a positional offset where buffered normal tokens are released only after subsequent speculative tokens have already been sent, breaking the sequence of the generated text.

**Example of the issue:**
Expected output:
`As the three of them made their way back to the village`

Actual output:
`As the three made their way back of them to the village`

In this scenario, `"of them"` was held in the buffer, while `"made their way back"` was generated via speculative decoding and sent immediately, bypassing the queue.

I previously encountered this offset issue in #1270 (MTP) and implemented a [workaround by resetting n_buffer to clear the state](https://github.com/ikawrakow/ik_llama.cpp/pull/1270/changes#diff-bd32b65ecf01c90ff44c66aadb6c29faad0336b119b4a8977c2b2fa587df970eR2617-R2618
). While that worked, I was just skipping the idea of string ban and only now that I'm testing self-speculative decoding that have I been able to fully understand how to fix that.