### PR TITLE
Faster CPU PP performance for Qwen3-Next - optimize concat

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -14661,6 +14661,18 @@ static void ggml_compute_forward_concat_f32(
         return;
     }
 
+    if (ggml_is_contiguous(src0) && ggml_is_contiguous(src1) && ggml_is_contiguous(dst) && dim == 2 && dst->ne[3] > 1 && src1->ne[2] == 1) {
+        for (int i3 = ith; i3 < (int)dst->ne[3]; i3 += nth) {
+            char * dst_ptr = (char *)dst->data  + i3*dst->nb[3];
+            char * src_ptr = (char *)src0->data + i3*src0->nb[3];
+            memcpy(dst_ptr, src_ptr, src0->nb[3]);
+            dst_ptr += src0->nb[3];
+            src_ptr = (char *)src1->data + i3*src1->nb[3];
+            memcpy(dst_ptr, src_ptr, src1->nb[3]);
+        }
+        return;
+    }
+
     int64_t o[4] = {0, 0, 0, 0};
     o[dim] = src0->ne[dim];
 


### PR DESCRIPTION

Similar to #1275, but for the CPU concat implementation.

On a Ryzen-3995WX, PP-512 performance goes from 240 t/s to 260 t/s.

I'm noticing that on the CPU PP performance decreases with increasing u-batch size for u-batch sizes > 512. Which means that there is still something far from optimum in the chunked delta-net compute graph, as normally CPU PP performance for MoE models tends to improve with u-batch size up to u_batch = 2048 or so (depending to some extent on the CPU and the number of total vs number of active experts).  