### PR TITLE
Don't disable CUDA graphs for Qwen3-Next

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3956,7 +3956,8 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_cuda_graph 
             }
         }
 
-        if (node->op == GGML_OP_ADD &&
+        // Why was this needed? Leaving it in place but disabled in case it is actually needed.
+        if (false && node->op == GGML_OP_ADD &&
             node->src[1] && node->src[1]->ne[1] > 1 &&
             (node->src[0] ? node->src[0]->name != gemma3n_per_layer_proj_src0_name : true) &&
             (node->src[1] ? node->src[1]->name != gemma3n_per_layer_proj_src1_name : true) &&


### PR DESCRIPTION
In #1277 I wrote that there weren't low-hanging fruits left. 

Haha, there is indeed one: CUDA graphs were getting disabled for Qwen3-Next. This PR fixes that, and this gives us a ~15% boost in CUDA TG performance (with full offload).

Here the current state of affairs compared to today's `llama.cpp` version (`build: afa6bfe4f (8084)`). CPU performance is on a Ryzen-3995WX, GPU performance is on 2x3090 in the Ryzen-3995WX box (worth mentioning as single-threaded CPU performance is not completely irrelevant for CUDA performance due to the huge number of nodes in a Qwen3-Next compute graph). 

| model                     | backend    |            test |   t/s (llama.cpp)    |  t/s (ik_llama.cpp) |  Speedup |
| ------------------------- | ---------- | --------------: | -------------------: | ------------------: | -------: |
| qwen3next 80B.A3B IQ4_XS  | CUDA       |           tg256 |        104.01 ± 0.41 |    109.93 ± 0.12    |  1.057   |   
| qwen3next 80B.A3B IQ4_XS  | CUDA       |          pp2048 |       2137.03 ± 2.68 |  2620.42 ± 51.14    |  1.226   |   
| qwen3next 80B.A3B IQ4_XS  | CPU        |           tg256 |         10.33 ± 0.07 |     22.62 ± 0.05    |  2.190   |   
| qwen3next 80B.A3B IQ4_XS  | CPU        |           pp512 |         97.39 ± 1.30 |    275.42 ± 3.11    |  2.828   |   
