### PR TITLE
Better CPU performance for Qwen3-Next 

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -11961,6 +11961,29 @@ static void ggml_compute_forward_dup_bytes(
     const int ith = params->ith; // thread index
     const int nth = params->nth; // number of threads
 
+    if (src0->op == GGML_OP_TRANSPOSE && src0->ne[2]*src0->ne[3] >= nth/2 && src0->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
+        int elem_size = ggml_element_size(src0);
+        if ((size_t)src0->ne[0]*src0->ne[1]*elem_size == src0->nb[2] &&
+            (size_t)src0->ne[0]*src0->ne[1]*src0->ne[2]*elem_size == src0->nb[3]) {
+            int counter = 0;
+            for (int i3 = 0; i3 < src0->ne[3]; ++i3) {
+                for (int i2 = 0; i2 < src0->ne[2]; ++i2) {
+                    if (counter++ % nth == ith) {
+                        const char * x = (const char *)src0->data + i2*src0->nb[2] + i3*src0->nb[3];
+                        float * y = (float *)((char *)dst->data + i2*dst->nb[2] + i3*dst->nb[3]);
+                        for (int i1 = 0; i1 < dst->ne[1]; ++i1) {
+                            for (int i0 = 0; i0 < dst->ne[0]; ++i0) {
+                                memcpy(y, x + i0*src0->nb[0] + i1*src0->nb[1], sizeof(float));
+                                ++y;
+                            }
+                        }
+                    }
+                }
+            }
+            return;
+        }
+    }
+
     // parallelize by rows
     const int nr = ne01;
     // number of rows per thread


### PR DESCRIPTION

This PR adds two more optimizations that improve Qwen3-Next performance on the CPU. The gain is larger for prompt processing.

On a Ryzen-3995WX CPU

| model                     | backend    |            test |   t/s (main)         |  t/s (PR)           |  Speedup |
| ------------------------- | ---------- | --------------: | -------------------: | ------------------: | -------: |
| qwen3next 80B.A3B IQ4_XS  | CPU        |           pp512 |     275.43 ± 3.11    |    307.66 ± 3.66    |  1.117   |
| qwen3next 80B.A3B IQ4_XS  | CPU        |           tg256 |      22.62 ± 0.05    |     23.32 ± 0.04    |  1.031   |


