### PR TITLE
Qwen3.5-MoE: fix regenerating message error

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -414,6 +414,8 @@ struct gpt_params {
     std::string sqlite_zstd_ext_file;
 
     float slot_prompt_similarity = 0.1f;
+
+    int32_t n_ctx_checkpoints = 8;            // max number of context checkpoints per slot
     int32_t cache_ram_mib = 8192;   // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
     int32_t cache_ram_n_min = 0;     // min number of tokens required to save in the ram
     float cache_ram_similarity = 0.5f; // similarity of tokens to cached tokens

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -349,4 +349,7 @@ struct server_context {
     // Re-aggregates all active vectors and updates the model state
     bool apply_control_vectors_internal();
 
+    void create_checkpoint(server_slot & slot);
+
+    void apply_checkpoint(server_slot & slot);
 };

--- a/examples/server/server-task.h
+++ b/examples/server/server-task.h
@@ -368,6 +368,7 @@ struct server_prompt {
     int n_tokens() const {
         return tokens.size();
     }
+
 };
 
 struct server_prompt_cache {

--- a/include/llama.h
+++ b/include/llama.h
@@ -627,6 +627,12 @@ extern "C" {
     // to the decoder to start generating output sequence. For other models, it returns -1.
     LLAMA_API llama_token llama_model_decoder_start_token(const struct llama_model * model);
 
+    // Returns true if the model is recurrent (like Mamba, RWKV, etc.)
+    LLAMA_API bool llama_model_is_recurrent(const struct llama_model * model);
+
+    // Returns true if the model is hybrid (like Jamba, Granite, etc.)
+    LLAMA_API bool llama_model_is_hybrid(const struct llama_model * model);
+
     // Returns 0 on success
     LLAMA_API uint32_t llama_model_quantize(
             const char * fname_inp,

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -246,3 +246,23 @@ const char * llama_model_arch_name(llm_arch arch) {
     }
     return it->second;
 }
+
+bool llm_arch_is_recurrent(const llm_arch & arch) {
+    switch (arch) {
+    case LLM_ARCH_MAMBA:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool llm_arch_is_hybrid(const llm_arch & arch) {
+    switch (arch) {
+    case LLM_ARCH_QWEN3NEXT:
+    case LLM_ARCH_QWEN3MOE: 
+        return true;
+    default:
+        return false;
+    }
+}
+

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -342,3 +342,6 @@ enum llm_tensor {
 llm_arch llm_arch_from_string(const std::string & name);
 
 const char * llama_model_arch_name(llm_arch arch);
+
+bool llm_arch_is_recurrent(const llm_arch & arch);
+bool llm_arch_is_hybrid(const llm_arch & arch);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -37,6 +37,7 @@ struct llama_kv_cache {
     bool do_defrag = false;
     bool do_copy   = false;
     bool recurrent = false; // with recurrent state models, a cell can hold the state for more than one past token
+    bool hybrid    = false;
     bool v_trans   = true;  // the value tensor is transposed
 
     // Note: The value of head isn't only used to optimize searching

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1731,3 +1731,11 @@ const char * llama_model_type_name(e_model type) {
         default:                  return "?B";
     }
 }
+
+bool llama_model_is_recurrent(const llama_model * model) {
+    return llm_arch_is_recurrent(model->arch);
+}
+
+bool llama_model_is_hybrid(const llama_model * model) {
+    return llm_arch_is_hybrid(model->arch);
+}

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -507,3 +507,4 @@ struct LLM_TN {
 std::string llama_model_ftype_name(llama_ftype ftype);
 
 const char * llama_model_type_name(e_model type);
+

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -721,7 +721,8 @@ static bool llama_kv_cache_init(
     cache.has_shift = false;
 
     // TODO: find a nicer way to add other recurrent model architectures
-    cache.recurrent = model.arch == LLM_ARCH_MAMBA;
+    cache.recurrent = llm_arch_is_recurrent(model.arch);
+    cache.hybrid = llm_arch_is_hybrid(model.arch);
     // qwen3next uses hybrid recurrent+attention cache semantics. Keep V rows in
     // standard layout to match the mainline hybrid path when flash attention is off.
     cache.v_trans   = !cache.recurrent && !cparams.flash_attn && model.arch != LLM_ARCH_QWEN3NEXT && model.arch != LLM_ARCH_QWEN35MOE;


### PR DESCRIPTION
For hybrid model like Qwen3 Next, when I regenerated the message, it behaves like it continues from my last message. This PR ports part of the checkpoint logic from mainline. It forces full prompt processing to recalculate the cache and generate the message correctly. I tested with Qwen3 Next Coder.

Disable string ban feature as well because of its hybrid nature. 

Before the cache for hybrid model is handled correctly, which will take some time because of the divergence between here and mainline, it serves as the stopgap. 

@magikRUKKOLA, @MrHills-rs Can you test if it partly fixes the issue you have?

 