### PR TITLE
Fix tool call for Qwen3.5

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1256,8 +1256,8 @@ static common_chat_params common_chat_params_init_qwen3_coder_xml(const common_c
         /* form.tool_sep    = */ ">\n",
         /* form.key_start   = */ "<parameter=",
         /* form.key_val_sep = */ ">\n",
-        /* form.val_end     = */ "\n</parameter>",
-        /* form.tool_end    = */ "\n</function>\n</tool_call>",
+        /* form.val_end     = */ "\n</parameter>\n",
+        /* form.tool_end    = */ "</function>\n</tool_call>",
         /* form.scope_end   = */ "",
     };
     build_grammar_xml_tool_call(data, params.tools, form);


### PR DESCRIPTION
Loosely based on mainline changes from:
* https://github.com/ggml-org/llama.cpp/pull/19635
* https://github.com/ggml-org/llama.cpp/pull/19765

Also need to change the grammar to allow the model to make multiple tool calls in a row. This was likely broken for Qwen3 Coder prior to this commit.



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
