### PR TITLE
server: propagate task index to response objects for batch requests

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -1644,6 +1644,7 @@ void server_context::send_partial_response(server_slot& slot, completion_token_o
     res->final_result = false;
     res->id = slot.id_task;
     res->id_multi = slot.id_multi;
+    res->index = slot.task->index;
     res->error = false;
     res->stop = false;
     res->stream = slot.params.stream;
@@ -1715,6 +1716,7 @@ void server_context::send_final_response(server_slot& slot) {
     res->final_result = true;
     res->id = slot.id_task;
     res->id_multi = slot.id_multi;
+    res->index = slot.task->index;
     res->error = false;
     res->stop = true; // to do: set value
     res->stream = slot.params.stream;
@@ -1770,6 +1772,8 @@ void server_context::send_final_response(server_slot& slot) {
 void server_context::send_embedding(const server_slot& slot, const llama_batch& batch) {
     auto res = std::make_unique<server_task_result_embd>();
     res->id = slot.task->id;
+    res->index = slot.task->index;
+    res->server_task_result::index = slot.task->index;
     res->n_tokens = slot.prompt_tokens.size();
     res->oaicompat = slot.task->params.oaicompat;
 


### PR DESCRIPTION
## Summary

When multiple prompts are sent in a single `/v1/completions` request (batch mode), each response object should carry the correct `index` so the client can match results to their corresponding input prompts.

Currently, `res->index` is not set in `send_partial_response`, `send_final_response`, or `send_embedding`, causing all responses in a batch to report `index: 0`.

This PR sets `res->index = slot.task->index` in all three code paths.

### Reproduction

```bash
curl -s http://127.0.0.1:8083/v1/completions   -H "Content-Type: application/json"   -d '{"prompt":["Hello world","Goodbye world","Test prompt"],"max_tokens":1,"temperature":0,"logprobs":5}'
```

Before this fix, all three response objects had `index: 0`. After, they correctly report `index: 0`, `index: 1`, `index: 2`.

#### Test plan

- [x] Batch `/v1/completions` with 3 prompts returns correct indices
- [x] Streaming mode returns correct indices on partial responses
- [x] `/v1/embeddings` batch returns correct indices

Generated with [Devin](https://cli.devin.ai/docs)