### PR TITLE
server: fix crash from adaptive p

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -143,6 +143,9 @@ void common_sampler_reset(common_sampler * ctx) {
 }
 
 void common_sampler_review(common_sampler * ctx) {
+    if (!ctx->adapt_p_ctx) {
+        return;
+    }
     const bool record = ctx->record_samplers;
     const bool rewind = ctx->rewind_samplers;
 


### PR DESCRIPTION
`adapt_p_ctx` not initialized leading to the crash. 