### PR TITLE
Fix llm_arch_is_hybrid

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -259,7 +259,7 @@ bool llm_arch_is_recurrent(const llm_arch & arch) {
 bool llm_arch_is_hybrid(const llm_arch & arch) {
     switch (arch) {
     case LLM_ARCH_QWEN3NEXT:
-    case LLM_ARCH_QWEN3MOE: 
+    case LLM_ARCH_QWEN35MOE:
         return true;
     default:
         return false;


### PR DESCRIPTION
Fixes hybrid model detection. There was a typo (`QWEN3MOE` instead of `QWEN35MOE`).

Thanks to @MrHills-rs for noticing.  