### PR TITLE
llama-quantize: --dry-run option

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -355,6 +355,8 @@ int main(int argc, char ** argv) {
             params.quantize_output_tensor = false;
         } else if (strcmp(argv[arg_idx], "--ignore-imatrix-rules") == 0) {
             params.ignore_imatrix_rules = true;
+        } else if (strcmp(argv[arg_idx], "--dry-run") == 0) {
+            params.dry_run = true;
         } else if (strcmp(argv[arg_idx], "--repack") == 0) {
             params.only_repack = true;
         } else if (strcmp(argv[arg_idx], "--repack-pattern") == 0) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -490,6 +490,7 @@ extern "C" {
         bool keep_split;                     // quantize to the same number of shards
         bool ignore_imatrix_rules;           // If set to true, the built-in rules for refusing to quantize into certain quants without imatrix are ignored
         bool only_repack;                    // Only repack tensors
+        bool dry_run;                        //
         void * imatrix;                      // pointer to importance matrix data
         void * kv_overrides;                 // pointer to vector containing overrides
         void * custom_quants;                // pointer to vector containing custom quantization rules

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4412,6 +4412,7 @@ struct llama_model_quantize_params llama_model_quantize_default_params() {
         /*.keep_split                  =*/ false,
         /*.ignore_imatrix_rules        =*/ false,
         /*.only_repack                 =*/ false,
+        /*.dry_run                     =*/ false,
         /*.imatrix                     =*/ nullptr,
         /*.kv_overrides                =*/ nullptr,
         /*.custom_quants               =*/ nullptr,


### PR DESCRIPTION
Prints the tensor types and resulting tensor sizes, but does not run the quantization, so it is very fast.

Useful for experimenting with `--custom-q` before running the actual quantization.

Enable with `--dry-run`, which needs to appear before the model name as all other optional `llama-quantize` arguments.