### PR TITLE
Add special FA handling for dense Qwen3.5

### DIFF
--- a/ggml/src/ggml-cuda/fattn-new-mma.cu
+++ b/ggml/src/ggml-cuda/fattn-new-mma.cu
@@ -227,46 +227,46 @@ struct fattn_mma_f16_config<128, 128> {
         return 64;
     }
 };
-//
-//template <>
-//struct fattn_mma_f16_config<256, 256> {
-//    static constexpr int  nbatch_fa      = 32;
-//    static constexpr int  nwarps_max     = 4;
-//    static constexpr bool Q_in_reg       = true;
-//    static constexpr int  nstages_target = 2;
-//
-//    static int get_nbatch_K2_host(const int /*cc*/, const int /*ncols*/) {
-//        return 128;
-//    }
-//
-//    static constexpr __device__ int get_nbatch_K2_device(int /*ncols*/) {
-//        return 128;
-//    }
-//
-//    static int get_nbatch_V2_host(const int /*cc*/, const int /*ncols*/) {
-//        return 128;
-//    }
-//
-//    static constexpr __device__ int get_nbatch_V2_device(int /*ncols*/) {
-//        return 128;
-//    }
-//
-//    static int get_nbatch_combine_host(const int cc, const int ncols) {
-//        if (ggml_cuda_highest_compiled_arch(cc) == CC_TURING) {
-//            return ncols <= 16 ? 128 : 64;
-//        }
-//        return 64;
-//    }
-//
-//    static constexpr __device__ int get_nbatch_combine_device(int ncols) {
-//#if __CUDA_ARCH__ == CC_TURING
-//        return ncols <= 16 ? 128 : 64;
-//#else
-//        GGML_UNUSED(ncols);
-//        return 128;
-//#endif // __CUDA_ARCH__ == CC_TURING
-//    }
-//};
+
+template <>
+struct fattn_mma_f16_config<256, 256> {
+    static constexpr int  nbatch_fa      = 32;
+    static constexpr int  nwarps_max     = 4;
+    static constexpr bool Q_in_reg       = true;
+    static constexpr int  nstages_target = 2;
+
+    static int get_nbatch_K2_host(const int /*cc*/, const int /*ncols*/) {
+        return 128;
+    }
+
+    static constexpr __device__ int get_nbatch_K2_device(int /*ncols*/) {
+        return 128;
+    }
+
+    static int get_nbatch_V2_host(const int /*cc*/, const int /*ncols*/) {
+        return 128;
+    }
+
+    static constexpr __device__ int get_nbatch_V2_device(int /*ncols*/) {
+        return 128;
+    }
+
+    static int get_nbatch_combine_host(const int cc, const int ncols) {
+        if (ggml_cuda_highest_compiled_arch(cc) == CC_TURING) {
+            return ncols <= 16 ? 128 : 64;
+        }
+        return 64;
+    }
+
+    static constexpr __device__ int get_nbatch_combine_device(int ncols) {
+#if __CUDA_ARCH__ == CC_TURING
+        return ncols <= 16 ? 128 : 64;
+#else
+        GGML_UNUSED(ncols);
+        return 128;
+#endif // __CUDA_ARCH__ == CC_TURING
+    }
+};
 
 template <>
 struct fattn_mma_f16_config<192, 128> {
@@ -2144,6 +2144,15 @@ void ggml_cuda_flash_attn_ext_mma_new(ggml_backend_cuda_context & ctx, ggml_tens
             ggml_cuda_flash_attn_ext_mma_f16_case<128, 128, 1, 8>(ctx, dst);
         } else if (gqa_ratio == 10) {
             ggml_cuda_flash_attn_ext_mma_f16_case<128, 128, 1, 16>(ctx, dst);
+        } else {
+            GGML_ABORT("Not implemented");
+        }
+        return;
+    }
+    if (K->ne[0] == 256) {
+        GGML_ASSERT(Q->ne[0] == 256 && V->ne[0] == 256);
+        if (gqa_ratio == 6) {
+            ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
         } else {
             GGML_ABORT("Not implemented");
         }

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -95,6 +95,11 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
         return;
     }
 
+    if (new_mma_available(cc) && K->ne[0] == 256 && V->ne[0] == 256 && Q->ne[0] == 256 && Q->ne[1] == 1 && Q->ne[2] / K->ne[2] == 6) {
+        ggml_cuda_flash_attn_ext_mma_new(ctx, dst);
+        return;
+    }
+
     const bool gqa_opt_applies = ((Q->ne[2] / K->ne[2]) % 2 == 0) && mask; // The mma-based kernels have GQA-specific optimizations
     // So, not sure why in mainline they thought that for CC_ADA_LOVELACE or when KV cache is not f16 the vector kernels are faster.
     // On my GPU (RTX-4080) MMA is efinitely faster for GQA, both for f16 and for quantized KV cache.


### PR DESCRIPTION
The dense Qwen3.5 models have a GQA ratio of 6 for the non-recurrent attention layers, which leads to a stronger TG performance decline with context length than necessary. GQA=6 is handled in `ik_llama.cpp` but only for head size of 128, while the Qwen3.5 models have a head size of 256.

This PR adds special CUDA FA handling for the dense Qwen3.5 case. 
 
The graph shows the effect for Qwen-3.5-27B quantized with `Q4_K_S` on a 2x3090 system. For the heck of it also adding `llama.cpp` results with today's build (`build: 2943210c1 (8157)`). `sweep-bench` does not work with `llama.cpp`, so the results there were obtained using `llama-bench -d` (but one needs to be very patient).

The PR improves TG performance by 33% for a context of 64k tokens. Compared to `llama.cpp` it is ~1.9X times faster.

<img width="792" height="612" alt="q35dense_tg" src="https://github.com/user-attachments/assets/20d97701-abf8-4cea-bf20-717ea04b4ed0" />

