### PR TITLE
Fix slot selection logic in get_available_slot

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3107,9 +3107,6 @@ void server_context::extend_context(const int32_t n_tokens) {
         if (slot.ga_n != 1) {
             // context extension via Self-Extend
             // TODO: simplify and/or abstract this
-            // Note: when MoE layers run on CPU with self-extend, ensure proper KV cache sync
-            // by calling llama_kv_cache_defrag after context extension to ensure all
-            // layers (including CPU-based MoE) have consistent state
             while (slot.n_past_se >= slot.ga_i + slot.ga_w) {
                 const int ib = (slot.ga_n * slot.ga_i) / slot.ga_w;
                 const int bd = (slot.ga_w / slot.ga_n) * (slot.ga_n - 1);
@@ -3132,7 +3129,6 @@ void server_context::extend_context(const int32_t n_tokens) {
             }
 
             slot.n_past_se += n_tokens;
-            llama_kv_cache_defrag(ctx);
         }
     }
 }

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3107,6 +3107,9 @@ void server_context::extend_context(const int32_t n_tokens) {
         if (slot.ga_n != 1) {
             // context extension via Self-Extend
             // TODO: simplify and/or abstract this
+            // Note: when MoE layers run on CPU with self-extend, ensure proper KV cache sync
+            // by calling llama_kv_cache_defrag after context extension to ensure all
+            // layers (including CPU-based MoE) have consistent state
             while (slot.n_past_se >= slot.ga_i + slot.ga_w) {
                 const int ib = (slot.ga_n * slot.ga_i) / slot.ga_w;
                 const int bd = (slot.ga_w / slot.ga_n) * (slot.ga_n - 1);
@@ -3129,6 +3132,7 @@ void server_context::extend_context(const int32_t n_tokens) {
             }
 
             slot.n_past_se += n_tokens;
+            llama_kv_cache_defrag(ctx);
         }
     }
 }


### PR DESCRIPTION
The bug was likely introduced in PR #973 when the similarity calculation was changed from LCP to token-level similarity, but sim_best was still initialized to 0 instead of -1.0f.

When slot_prompt_similarity threshold was set high (e.g., 0.8) and no slot met the threshold, sim_best stayed at 0, causing ret to remain nullptr. This led to the system getting stuck without selecting any slot.

This fix:
- Changed sim_best initialization from 0 to -1.0f
- Added best_slot variable to track the best slot found during similarity search
- Only set ret = best_slot after the loop completes
- Removed redundant ret == nullptr check

This ensures that even when no slot meets the slot_prompt_similarity threshold, the system still identifies the best available slot and falls back to LRU correctly.

Related: PR #973 (Server: Handle context shift better), PR #1285 (Fix slot prompt updating)



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
