### PR TITLE
Make vision work with Qwen-3.5 models

### DIFF
--- a/examples/mtmd/clip.cpp
+++ b/examples/mtmd/clip.cpp
@@ -1099,7 +1099,9 @@ struct clip_graph {
             model.mm_1_w, model.mm_1_b,
             ffn_op_type::FFN_GELU, -1);
 
-        embeddings = ggml_concat(ctx0, embeddings, deepstack_features, 0); // concat along the feature dimension
+        if (deepstack_features) {
+            embeddings = ggml_concat(ctx0, embeddings, deepstack_features, 0); // concat along the feature dimension
+        }
 
         // build the graph
         ggml_build_forward_expand(gf, embeddings);


### PR DESCRIPTION

It seems this one-liner is all it takes to make the vision part work with Qwen-3.5 models.

Closes #1344 