### PR TITLE
Fix n_max_head fitting for --amb

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -6494,7 +6494,7 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
                     if (cparams.attn_max_batch > 0 && kv_f32_size > cparams.attn_max_batch) {
                         n_max_head = 1;
                         for (int niter = 2; niter < n_head; ++niter) {
-                            if (n_head % niter == 0 && kv_f32_size/(n_head/niter) <= cparams.attn_max_batch) {
+                            if (n_head % niter == 0 && kv_f32_size/niter <= cparams.attn_max_batch) {
                                 n_max_head = n_head/niter;
                                 break;
                             }


### PR DESCRIPTION
kv_f32_size should be fit to --amb by number of divisions, not heads per division.

Regression in b85a2a5

The might close #1298 and ~~maybe others.~~ I looked through the other recent issues with hints of long context or garbage output etc. but I don't see any usage of --amb .