### PR TITLE
Fix ncols_max in MoE matmul args for vision models (fixed by claude.ai)

### DIFF
--- a/ggml/src/ggml-cuda/mmq_id.cu
+++ b/ggml/src/ggml-cuda/mmq_id.cu
@@ -487,11 +487,8 @@ void ggml_cuda_mul_mat_q_id(ggml_backend_cuda_context & ctx, const ggml_tensor *
         ne00, ne01, ne_get_rows, s01, ne_get_rows, s1,
         ne02, ne02, s02, s12, s2,
         ne03, ne13, s03, s13, s3,
-        use_stream_k, ne12};
+        use_stream_k, ne_get_rows};
 
-    //printf("ne00 = %ld, ne01 = %ld, ne_get_rows = %ld, s01 = %ld, s1 = %ld\n", ne00, ne01, ne_get_rows, s01, s1);
-    //printf("ne02 = %ld, s02 = %ld, s12 = %ld, s2 = %ld\n", ne02, s02, s12, s2);
-    //printf("ne03 = %ld, s03 = %ld, s13 = %ld, s3 = %ld\n", ne03, s03, s13, s3);
 
     ggml_cuda_mul_mat_q_switch_type_id(ctx, args, stream);
 }


### PR DESCRIPTION
## Problem

When running MoE VLMs (Qwen3-VL-30B, Qwen3-VL-235B) with image input on CUDA, the server crashes immediately after image decoding with:
CUDA error: an illegal memory access was encountered
current device: 0, in function launch_mul_mat_q_id at mmq_id_common.cuh:3976

## Root cause

In `mmq_id.cu`, the MoE path passes `ne12` (number of channels = 2) as `ncols_max` to `mmq_args_id`, instead of `ne_get_rows` (actual token count = 16).

`ncols_max` is used in `mul_mat_q_case_id` to select `mmq_x_best` (tile width). With `ncols_max=2`, the loop exits immediately at `mmq_x=8` (`ntiles_x=1`), but the kernel then processes `ne_get_rows=16` tokens — causing an out-of-bounds memory access.

The non-MoE path (line ~383) correctly passes `ne1`. The MoE path (line ~485) incorrectly passes `ne12`.

## Fix

- use_stream_k, ne12};
+ use_stream_k, ne_get_rows};

## Tested

- Model: Qwen3VL-30B-A3B-Instruct-Q4_K_M.gguf
- GPU: RTX 3090 (single)
- Image input: confirmed working after fix