### PR TITLE
Argghh

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -544,6 +544,10 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
             CUBLAS_CHECK(cublasDestroy(cublas_handles[i]));
         }
     }
+    auto info = const_cast<ggml_cuda_device_info*>(&ggml_cuda_info());
+    if (info->all_ctx[device] == this) {
+        info->all_ctx[device] = nullptr;
+    }
 
 }
 


### PR DESCRIPTION

It is a bit of a mess, but hopefully this works.

Basically for split mode graph we need some persistent state in the CUDA context. But the whole `ggml/llama` thing does not really foresee such use case, so it all becomes very hacky.

I fixed split mode `graph` not working when an `mmproj` file is loaded in #1392. The reason it wasn't working was that when the `mmproj` file was being loaded, it created a new CUDA context, which overwrote the CUDA context of the main model. I removed the overwrite. But when one loads the main model using `--no-mmap` (something I never use myself), that creates a CUDA context to load the main model, but that is not the context that gets created later that we actually need. So, that makes split mode `graph` fail.

Hopefully this PR covers all use cases.