### PR TITLE
Add abbility to merge up/gate expert tensors to Qwen3.5-MoE/Qwen3-Next

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -1378,7 +1378,7 @@ bool create_tensors_helper::create_qwen3next_tensors(const LLM_TN & tn) {
             if (n_expert_used == 0) {
                 throw std::runtime_error("n_expert_used must be > 0 when QWEN3NEXT MoE tensors are present");
             }
-            use_mmap_buffer &= !create_std_ffn_exps(n_embd, tn, i, llama_model_loader::TENSOR_NOT_REQUIRED, n_ff_exp);
+            use_mmap_buffer &= !create_std_ffn_exps(n_embd, tn, i, 0, n_ff_exp);
         }
 
         // Shared expert path (optional per-layer)
@@ -1450,9 +1450,7 @@ bool create_tensors_helper::create_qwen35moe_tensors(const LLM_TN & tn) {
         }
 
         layer.ffn_gate_inp  = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), { n_embd, n_expert }, 0);
-        layer.ffn_gate_exps = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE_EXPS, "weight", i), { n_embd, n_ff_exp, n_expert }, 0);
-        layer.ffn_down_exps = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), { n_ff_exp, n_embd, n_expert }, 0);
-        layer.ffn_up_exps   = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", i), { n_embd, n_ff_exp, n_expert }, 0);
+        use_mmap_buffer &= !create_std_ffn_exps(n_embd, tn, i, 0, n_ff_exp);
 
         // Shared experts
         const int64_t n_ff_shexp = hparams.n_ff_shexp ? hparams.n_ff_shexp : n_ff;
@@ -3137,7 +3135,7 @@ bool create_tensors_helper::merge_up_gate_exps(const LLM_TN & tn, int i, int bia
     auto g_meta = ml.require_tensor_meta(g_name.c_str());
 
     if (u_meta->type != g_meta->type || u_meta->ne[0] != g_meta->ne[0] || u_meta->ne[2] != g_meta->ne[2]) {
-        LLAMA_LOG_INFO("%s: not merging because up/fate meta info is different\n", __func__);
+        LLAMA_LOG_INFO("%s: not merging because up/gate meta info is different\n", __func__);
         return false;
     }
 


### PR DESCRIPTION

See #1137 for more details. Enabled via `-muge` on the command line. Only works for split mode `layer`.

We get a few percent PP performance improvement. For instance, for Qwen3.5-35B-A3B on a 3090 GPU

### ffn_up_exps and ffn_gate_exps not merged

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.456 |  4491.79 |    0.880 |   145.44 |
|  2048 |    128 |   2048 |    0.424 |  4827.55 |    0.861 |   148.64 |
|  2048 |    128 |   4096 |    0.433 |  4733.82 |    0.856 |   149.61 |
|  2048 |    128 |   6144 |    0.445 |  4604.26 |    0.869 |   147.35 |
|  2048 |    128 |   8192 |    0.451 |  4541.44 |    0.879 |   145.69 |
|  2048 |    128 |  10240 |    0.461 |  4443.35 |    0.889 |   144.05 |
|  2048 |    128 |  12288 |    0.471 |  4351.20 |    0.899 |   142.41 |
|  2048 |    128 |  14336 |    0.482 |  4250.46 |    0.904 |   141.61 |
|  2048 |    128 |  16384 |    0.492 |  4165.51 |    0.907 |   141.07 |
|  2048 |    128 |  18432 |    0.502 |  4075.81 |    0.915 |   139.84 |
|  2048 |    128 |  20480 |    0.510 |  4016.34 |    0.928 |   137.98 |
|  2048 |    128 |  22528 |    0.520 |  3936.46 |    0.938 |   136.40 |
|  2048 |    128 |  24576 |    0.529 |  3869.91 |    0.940 |   136.11 |
|  2048 |    128 |  26624 |    0.542 |  3779.71 |    0.944 |   135.57 |
|  2048 |    128 |  28672 |    0.551 |  3718.36 |    0.950 |   134.75 |
|  2048 |    128 |  30720 |    0.559 |  3661.77 |    0.955 |   134.09 |

### ffn_up_exps and ffn_gate_exps  merged

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.424 |  4834.69 |    0.845 |   151.42 |
|  2048 |    128 |   2048 |    0.405 |  5057.39 |    0.856 |   149.58 |
|  2048 |    128 |   4096 |    0.412 |  4969.45 |    0.860 |   148.77 |
|  2048 |    128 |   6144 |    0.423 |  4843.44 |    0.864 |   148.12 |
|  2048 |    128 |   8192 |    0.431 |  4750.75 |    0.874 |   146.53 |
|  2048 |    128 |  10240 |    0.440 |  4649.82 |    0.885 |   144.69 |
|  2048 |    128 |  12288 |    0.451 |  4537.33 |    0.901 |   142.11 |
|  2048 |    128 |  14336 |    0.462 |  4435.39 |    0.903 |   141.67 |
|  2048 |    128 |  16384 |    0.470 |  4357.42 |    0.907 |   141.09 |
|  2048 |    128 |  18432 |    0.481 |  4253.48 |    0.913 |   140.19 |
|  2048 |    128 |  20480 |    0.489 |  4187.76 |    0.919 |   139.27 |
|  2048 |    128 |  22528 |    0.499 |  4101.41 |    0.937 |   136.56 |
|  2048 |    128 |  24576 |    0.510 |  4016.21 |    0.939 |   136.25 |
|  2048 |    128 |  26624 |    0.520 |  3942.09 |    0.943 |   135.67 |
|  2048 |    128 |  28672 |    0.529 |  3868.80 |    0.949 |   134.94 |
|  2048 |    128 |  30720 |    0.539 |  3798.25 |    0.952 |   134.47 |


Note: in `ik_llama.cpp` the merge happens on-the-fly as the model gets loaded. This is unlike mainline `llama.cpp`, which requires a pre-merged model. Such pre-merged models **will not work with `ik_llama.cpp`**.