### PR TITLE
Faster top_n_sigma sampler

### DIFF
--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -480,64 +480,37 @@ void llama_sample_top_n_sigma_impl(struct llama_sampling * smpl, llama_token_dat
 
     const int64_t t_start_sample_us = ggml_time_us();
 
-    float max = candidates->data[0].logit;
-    float mean = 0;
-    size_t count = 0;
+    double sum1 = 0, sum2 = 0;
+    float max = 0;
+    int count = 0;
     for (int i = 0; i < (int)candidates->size; ++i) {
-        // Only count non-negative infinity values
-        if (candidates->data[i].logit != -INFINITY) {
-            max = std::max(max, candidates->data[i].logit);
-            mean += candidates->data[i].logit;
+        if (auto l = candidates->data[i].logit; l != -INFINITY) {
+            max = std::max(max, l);
             ++count;
+            double dl = l;
+            sum1 += dl;
+            sum2 += dl*dl;
         }
     }
     if (count < 4) {
-        return; // again, tandard deviation is not well defined for so few logits (4 is actually pushing it)
+        return;
     }
-    mean /= count;
+    double dmean = sum1/count;
+    double dsigma2 = sum2/count - dmean*dmean;
+    if (dsigma2 <= 0) {
+        return;
+    }
+    float sigma = float(sqrt(dsigma2));
 
-    float sigma2 = 0;
-    for (int i = 0; i < (int)candidates->size; ++i) {
-        if (candidates->data[i].logit != -INFINITY) {
-            float delta = candidates->data[i].logit - mean;
-            sigma2 += delta*delta;
-        }
-    }
-    float sigma = sqrtf(sigma2/count);
     float thresh = max - top_n_sigma*sigma;
-
-    thread_local std::vector<int> indices;
-    if (indices.size() < candidates->size) {
-        indices.resize(candidates->size);
-    }
     int n_use = 0;
-    int n_masked = 0;
     for (int i = 0; i < (int)candidates->size; ++i) {
-        if (candidates->data[i].logit != -INFINITY) {
-            if (candidates->data[i].logit < thresh) {
-                candidates->data[i].logit = -INFINITY;
-                ++n_masked;
-            } else {
-                indices[n_use++] = i;
-            }
+        if (candidates->data[i].logit >= thresh) {
+            candidates->data[n_use++] = candidates->data[i];
         }
-        //if (candidates->data[i].logit != -INFINITY && candidates->data[i].logit < thresh) {
-        //    candidates->data[i].logit = -INFINITY;
-        //    ++n_masked;
-        //}
     }
-
-    if (4*n_use < (int)candidates->size) {
-        for (int i = 0; i < n_use; ++i) {
-            candidates->data[i] = candidates->data[indices[i]];
-        }
+    if (n_use < (int)candidates->size) {
         candidates->size = n_use;
-    }
-
-    // do we really want to compute softmax unconditionally?
-    // The following coresponds to mainline implementation with the minor optimization
-    // that we only call the relativly expensive softmax if we masked away some tokens.
-    if (n_masked > 0 || !candidates->sorted) {
         llama_sample_softmax_impl(nullptr, candidates);
     }
 


### PR DESCRIPTION

There are users who have the `top_n_sigma` sampler as the very first sampler in their sampling chain, see #1390.

What happens in that case on the main branch is this:
* Mean is computed over the entire vocabulary. This is $O(N)$, where $N$ is the number of tokens in the vocabulary
* $\sigma$ is computed over the entire vocabulary, so another $O(N)$ operation. As there is quite a bit of variation between the maximum and minimum logit value, the $\sigma$ will not be exactly small
* All tokens with $l_i < l_{max} - n \sigma$ get masked (i.e. $l_i \leftarrow -\infty$), where $l_i$ is the logit value of the $I$'th token. This is another $O(N)$ pass through the logits. But more notably, logits below the thrashed do not get discarded, they just get masked with negative infinity.
* `softmax` gets invoked, which triggers sorting of the logits. As the logits are still at their full size, this is an $O(N~\ln N)$ operation, so not exactly cheep with modern model vocabulary sizes
*  After sorting, `softmax` computes the probabilities $p_i = \exp(l_i - l_{max})$, again for all logits, which is a very expensive $O(N)$ operation
* Finally, `softmax` normalizes the probabilities $p_i$ to unity, so yet another $O(N)$ operation over all logits

The result? Running `GPT-OSS-20B-MXFP4` with `--samplers "penalties;top_n_sigma;temperature" --top-n-sigma 0.7` results in a sampling speed of about 270 t/s, which lowers observed TG speed from 254 t/s to about 130 t/s in my setup with 2x3090 and `-sm graph`.

This PR improves the situation by actually discarding below threshold logits before invoking `softmax`. With the above sampling settings, sampling performance becomes 4000 t/s, so observed TG performance drops to 238 t/s only. 

**Update**
I changed things a bit around. Now the `top_n_sigma` sampler achieves 8000 t/s when it is the 1st sampler (i.e., operates on the full vocabulary). Interestingly enough, it seems the fact that one can compute mean and variance of a sample with a single pass through the data is not well known among software engineers (or at least not known to those who contribute to `llama.cpp`). Here is some math: We want to compute

$$\sigma^2 = \frac{1}{N} \sum (x_i - \mu)^2$$

where the $x_i$ is our sample, $\mu = 1/N \sum x_i$ is the mean of $x_i$, and $N$ is the number of data points in the sample. We can transform the above as

$$\sigma^2 =  \frac{1}{N} \sum x_i^2 + \mu^2 - 2 \mu \frac{1}{N} \sum x_i = \frac{1}{N} \sum x_i^2 - \left( \frac{1}{N} \sum x_i \right)^2$$

I.e., with a single pass through the data we can accumulate $\sum x_i^2$ and $\sum x_i$, and then compute $\mu$ and $\sigma$ from that. 