### PR TITLE
Be able to use imatrix computed with merged ffn_gate_up_exps

### DIFF
--- a/src/llama-quantize.cpp
+++ b/src/llama-quantize.cpp
@@ -1453,6 +1453,13 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
                         auto pos = pos1 != std::string::npos ? pos1 : pos2;
                         auto merged_name = name.substr(0, pos) + "ffn_gate_up_exps.weight";
                         it = imatrix_data->find(merged_name);
+                        if (it == imatrix_data->end()) {
+                            auto up_name = name.substr(0, pos) + "ffn_up_exps.weight";
+                            it = imatrix_data->find(up_name);
+                        }
+                    } else if (auto pos = name.find("ffn_gate_up_exps.weight"); pos != std::string::npos) {
+                        auto not_merged_name = name.substr(0, pos) + "ffn_up_exps.weight";
+                        it = imatrix_data->find(not_merged_name);
                     } else {
                         // MLA hack: most imatrix files floating around the Internet have been computed with standard attention.
                         //           This means that the imatrix file does not contain data for the *.attn_k_b.weight and *.attn_v_b.weight


### PR DESCRIPTION

This PR is a sibling of #1418.

If one has an imatrix available that has been computed using a model with merged `ffn_gate_up_exps` tensors, but one has a model where `ffn_up_exps` and `ffn_gate_exps` are separate, the PR allow the imatrix to be still used to quantize this model. Basically, the `ffn_up_exps`, `ffn_gate_exps`, and `ffn_gate_up_exps`  tensors "see" exactly the same activations, so one can use the imatrix data for `ffn_gate_up_exps` also for `ffn_up_exps` and `ffn_gate_exps`.  Correspondingly, also the reverse case is now supported. I.e., one has an imatrix computed with separate `ffn_up_exps` and `ffn_gate_exps` tensors, but now one wants to use it to quantize a model with merged `ffn_gate_up_exps` tensors. This will also work with this PR.