### PR TITLE
Add ffn_gate_up_exps to --cpu-moe and --n-cpu-moe overrides

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1482,7 +1482,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "--cpu-moe" || arg == "-cmoe") {
-        params.tensor_buft_overrides.push_back({strdup("\\.ffn_(up|down|gate)_exps\\.weight"), ggml_backend_cpu_buffer_type()});
+        params.tensor_buft_overrides.push_back({strdup("\\.ffn_(up|down|gate|gate_up)_exps\\.weight"), ggml_backend_cpu_buffer_type()});
         return true;
     }
     if (arg == "--n-cpu-moe" || arg == "-ncmoe") {
@@ -1494,7 +1494,7 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
             return true;
         }
         for (int32_t l = 0; l < n_layers; ++l) {
-            std::string pattern = "blk\\." + std::to_string(l) + "\\.(ffn_(up|down|gate)_exps\\.weight)";
+            std::string pattern = "blk\\." + std::to_string(l) + "\\.(ffn_(up|down|gate|gate_up)_exps\\.weight)";
             params.tensor_buft_overrides.push_back({strdup(pattern.c_str()), ggml_backend_cpu_buffer_type()});
         }
         return true;


### PR DESCRIPTION

Haha, lots of little details around the merged `ffn_gate_up_exps` tensors imposed on the world by `llama.cpp` maintainers.

This PR adds tensor overrides for these tensors when using `--cpu-moe` or `--n-cpu-moe`.

Thanks to @ubergarm for reminding me with [this comment](https://github.com/ikawrakow/ik_llama.cpp/pull/1413#issuecomment-4056289318).