### PR TITLE
Fix hybrid graph parallel + muge

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4666,7 +4666,9 @@ static void llama_repack_up_gate_exps(llama_context & lctx) {
     auto & model = lctx.model;
     bool needs_repack = false;
     for (auto & l : model.layers) {
-        if (l.ffn_up_gate_exps && l.ffn_up_exps && l.ffn_gate_exps) {
+        if (l.ffn_up_gate_exps && l.ffn_up_exps && l.ffn_gate_exps &&
+            ggml_backend_buffer_is_host(l.ffn_up_gate_exps->buffer) &&
+            ggml_backend_buffer_is_host(l.ffn_up_exps->buffer) && ggml_backend_buffer_is_host(l.ffn_gate_exps->buffer)) {
             needs_repack = true; break;
         }
     }
@@ -4675,7 +4677,9 @@ static void llama_repack_up_gate_exps(llama_context & lctx) {
     std::vector<char> aux_buffer_up, aux_buffer_gate, aux_buffer_up_gate;
     for (int il = 0; il < int(model.layers.size()); ++il) {
         auto & l = model.layers[il];
-        if (l.ffn_up_gate_exps && l.ffn_up_exps && l.ffn_gate_exps) {
+        if (l.ffn_up_gate_exps && l.ffn_up_exps && l.ffn_gate_exps &&
+            ggml_backend_buffer_is_host(l.ffn_up_gate_exps->buffer) &&
+            ggml_backend_buffer_is_host(l.ffn_up_exps->buffer) && ggml_backend_buffer_is_host(l.ffn_gate_exps->buffer)) {
             GGML_ASSERT(l.ffn_up_gate_exps->type  == l.ffn_up_exps->type  && l.ffn_up_gate_exps->type  == l.ffn_gate_exps->type);
             GGML_ASSERT(l.ffn_up_gate_exps->ne[0] == l.ffn_up_exps->ne[0] && l.ffn_up_gate_exps->ne[0] == l.ffn_gate_exps->ne[0]);
             GGML_ASSERT(l.ffn_up_gate_exps->ne[2] == l.ffn_up_exps->ne[2] && l.ffn_up_gate_exps->ne[2] == l.ffn_gate_exps->ne[2]);
@@ -5209,9 +5213,7 @@ struct llama_context * llama_init_from_model(
                 LLAMA_LOG_INFO("%s: pipeline parallelism enabled (n_copies=%d)\n", __func__, ggml_backend_sched_get_n_copies(ctx->sched));
             }
 
-            if (ctx->model.split_mode != LLAMA_SPLIT_MODE_GRAPH) {
-                llama_repack_up_gate_exps(*ctx);
-            }
+            llama_repack_up_gate_exps(*ctx);
 
             // build worst-case graph
             int n_past = cparams.n_ctx - n_tokens;


### PR DESCRIPTION

I had not noticed that there is an issue when using partial offload with split mode `graph` and on-the-fly merged `ffn_up/gate_exps` (`-sm graph -muge`).

This PR fixes it.

There is a small PP performance gain from `-muge` that depends on what fraction of the MoE tensors have been left on the CPU. Here is an example `sweep-bench` for `Qwen-3.5-35B-A3B` on 2x3090 with `--n-cpu-moe 16`

### -sm graph --n-cpu-moe 16 -muge

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.776 |  2637.71 |    1.252 |   102.21 |
|  2048 |    128 |   2048 |    0.731 |  2800.30 |    1.262 |   101.47 |
|  2048 |    128 |   4096 |    0.724 |  2829.35 |    1.269 |   100.88 |
|  2048 |    128 |   6144 |    0.731 |  2803.40 |    1.275 |   100.42 |
|  2048 |    128 |   8192 |    0.739 |  2769.74 |    1.281 |    99.89 |
|  2048 |    128 |  10240 |    0.743 |  2755.68 |    1.291 |    99.12 |
|  2048 |    128 |  12288 |    0.750 |  2729.36 |    1.296 |    98.77 |
|  2048 |    128 |  14336 |    0.752 |  2722.51 |    1.304 |    98.17 |
|  2048 |    128 |  16384 |    0.765 |  2677.96 |    1.312 |    97.59 |
|  2048 |    128 |  18432 |    0.768 |  2668.24 |    1.321 |    96.93 |
|  2048 |    128 |  20480 |    0.774 |  2646.97 |    1.328 |    96.37 |
|  2048 |    128 |  22528 |    0.777 |  2635.63 |    1.346 |    95.08 |
|  2048 |    128 |  24576 |    0.783 |  2614.14 |    1.345 |    95.14 |
|  2048 |    128 |  26624 |    0.793 |  2583.69 |    1.351 |    94.75 |
|  2048 |    128 |  28672 |    0.800 |  2559.75 |    1.357 |    94.35 |
|  2048 |    128 |  30720 |    0.801 |  2557.36 |    1.360 |    94.10 |
|  2048 |    128 |  32768 |    0.812 |  2522.93 |    1.362 |    93.97 |
|  2048 |    128 |  34816 |    0.819 |  2499.45 |    1.360 |    94.08 |
|  2048 |    128 |  36864 |    0.821 |  2493.73 |    1.364 |    93.82 |
|  2048 |    128 |  38912 |    0.827 |  2475.37 |    1.370 |    93.41 |
|  2048 |    128 |  40960 |    0.834 |  2455.84 |    1.373 |    93.26 |
|  2048 |    128 |  43008 |    0.842 |  2431.89 |    1.397 |    91.65 |
|  2048 |    128 |  45056 |    0.846 |  2420.47 |    1.453 |    88.11 |
|  2048 |    128 |  47104 |    0.855 |  2396.71 |    1.394 |    91.82 |
|  2048 |    128 |  49152 |    0.855 |  2395.57 |    1.395 |    91.73 |
|  2048 |    128 |  51200 |    0.869 |  2356.76 |    1.404 |    91.20 |
|  2048 |    128 |  53248 |    0.870 |  2352.88 |    1.402 |    91.28 |
|  2048 |    128 |  55296 |    0.876 |  2339.03 |    1.407 |    90.99 |
|  2048 |    128 |  57344 |    0.884 |  2316.08 |    1.412 |    90.65 |
|  2048 |    128 |  59392 |    0.892 |  2296.26 |    1.417 |    90.30 |
|  2048 |    128 |  61440 |    0.892 |  2295.84 |    1.419 |    90.19 |
|  2048 |    128 |  63488 |    0.902 |  2269.73 |    1.429 |    89.57 |
 
### -sm graph --n-cpu-moe 16

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.813 |  2520.09 |    1.254 |   102.05 |
|  2048 |    128 |   2048 |    0.763 |  2683.58 |    1.268 |   100.94 |
|  2048 |    128 |   4096 |    0.757 |  2703.87 |    1.273 |   100.56 |
|  2048 |    128 |   6144 |    0.764 |  2679.30 |    1.279 |   100.07 |
|  2048 |    128 |   8192 |    0.774 |  2647.32 |    1.286 |    99.56 |
|  2048 |    128 |  10240 |    0.776 |  2639.26 |    1.297 |    98.70 |
|  2048 |    128 |  12288 |    0.782 |  2619.33 |    1.300 |    98.43 |
|  2048 |    128 |  14336 |    0.787 |  2603.06 |    1.316 |    97.29 |
|  2048 |    128 |  16384 |    0.799 |  2561.74 |    1.353 |    94.61 |
|  2048 |    128 |  18432 |    0.802 |  2552.61 |    1.369 |    93.51 |
|  2048 |    128 |  20480 |    0.807 |  2536.52 |    1.345 |    95.19 |
|  2048 |    128 |  22528 |    0.810 |  2528.06 |    1.362 |    93.99 |
|  2048 |    128 |  24576 |    0.817 |  2506.20 |    1.363 |    93.93 |
|  2048 |    128 |  26624 |    0.824 |  2485.21 |    1.369 |    93.53 |
|  2048 |    128 |  28672 |    0.836 |  2448.54 |    1.372 |    93.32 |
|  2048 |    128 |  30720 |    0.837 |  2446.23 |    1.383 |    92.56 |
|  2048 |    128 |  32768 |    0.849 |  2412.19 |    1.381 |    92.71 |
|  2048 |    128 |  34816 |    0.849 |  2411.89 |    1.382 |    92.65 |
|  2048 |    128 |  36864 |    0.852 |  2403.94 |    1.387 |    92.29 |
|  2048 |    128 |  38912 |    0.859 |  2383.17 |    1.391 |    92.00 |
|  2048 |    128 |  40960 |    0.867 |  2362.57 |    1.394 |    91.79 |
|  2048 |    128 |  43008 |    0.869 |  2357.59 |    1.413 |    90.62 |
|  2048 |    128 |  45056 |    0.873 |  2344.64 |    1.413 |    90.59 |
|  2048 |    128 |  47104 |    0.884 |  2316.53 |    1.418 |    90.29 |
|  2048 |    128 |  49152 |    0.888 |  2306.13 |    1.421 |    90.11 |
|  2048 |    128 |  51200 |    0.905 |  2264.03 |    1.452 |    88.16 |
|  2048 |    128 |  53248 |    0.907 |  2258.96 |    1.426 |    89.74 |
|  2048 |    128 |  55296 |    0.906 |  2259.31 |    1.431 |    89.45 |
|  2048 |    128 |  57344 |    0.916 |  2236.68 |    1.434 |    89.23 |
|  2048 |    128 |  59392 |    0.921 |  2224.56 |    1.437 |    89.09 |
|  2048 |    128 |  61440 |    0.927 |  2210.24 |    1.460 |    87.67 |
|  2048 |    128 |  63488 |    0.933 |  2194.97 |    1.451 |    88.19 |


@abc-nix If you had entered an issue instead of silently suffering, it could have been fixed earlier.

