### PR TITLE
Fix long max. context bottleneck

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1182,6 +1182,18 @@ static uint32_t llama_kv_cache_cell_max(const struct llama_kv_cache & cache) {
     return 0;
 }
 
+static uint32_t llama_kv_cache_cell_max(const struct llama_kv_cache & cache, uint32_t pad) {
+    for (uint32_t i = cache.size; i > 0; i -= pad) {
+        const llama_kv_cell & cell = cache.cells[i - 1];
+
+        if (cell.pos >= 0 && !cell.is_empty()) {
+            return i;
+        }
+    }
+
+    return 0;
+}
+
 static void llama_kv_cache_clear(struct llama_kv_cache & cache) {
     for (int32_t i = 0; i < (int32_t) cache.size; ++i) {
         cache.cells[i].pos = -1;
@@ -3398,8 +3410,8 @@ static int llama_decode_internal(
                 // after enough generations, the benefit from this heuristic disappears
                 // if we start defragmenting the cache, the benefit from this will be more important
                 const uint32_t pad = llama_kv_cache_get_padding(cparams);
-                kv_self.n = std::min(kv_self.size, std::max(pad, GGML_PAD(llama_kv_cache_cell_max(kv_self), pad)));
-                //kv_self.n = llama_kv_cache_cell_max(kv_self);
+                auto max_cell = llama_kv_cache_cell_max(kv_self, pad);
+                kv_self.n = std::min(kv_self.size, std::max(pad, GGML_PAD(max_cell, pad)));
             }
         }
         if (stop_internal_decode) {


### PR DESCRIPTION

Haha, for any piece of `ggml/llama.cpp` code that I haven't touched yet, expect the worst.

In this particular case, it was issue #1416 that made me look into the performance degradation with large `--ctx-size`. I had noticed a slight degradation of TG performance with increasing `--ctx-size`, but I basically never go beyond 64k tokens, so the degradation wasn't so bad, so I didn't take it seriously. But with `--ctx-size 1048576` as used in #1416, the performance degradation becomes massive.

So, what is it this time? 

It is the `llama_kv_cache_cell_max()` function. It searches for the last used KV cache cell by scanning backwards (i.e., from the last KV cache cell towards the first). This linear scan becomes very slow with a long maximum context length, leading to the observed TG performance degradation (impact on PP is negligible as the time to compute the batch is much longer, so this overhead does not move the needle).

As I'm seeing many people using `--ctx-size 262144` with the Qwen-3.5 models, the PR will have a non-negligible positive impact on TG performance with full GPU offload. Here example `sweep-bench` results for Qwen-3.5-35B-A3B using split mode graph on a 2x3090 system for `--ctx-size 262144`

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.361 |  5678.20 |    0.917 |   139.62 |
|  2048 |    128 |   2048 |    0.321 |  6377.50 |    0.918 |   139.38 |
|  2048 |    128 |   4096 |    0.310 |  6604.19 |    0.924 |   138.57 |
|  2048 |    128 |   6144 |    0.316 |  6484.28 |    0.929 |   137.71 |
|  2048 |    128 |   8192 |    0.323 |  6347.81 |    0.936 |   136.79 |
|  2048 |    128 |  10240 |    0.328 |  6246.38 |    0.946 |   135.25 |
|  2048 |    128 |  12288 |    0.333 |  6141.00 |    0.954 |   134.22 |
|  2048 |    128 |  14336 |    0.340 |  6026.06 |    0.961 |   133.17 |
|  2048 |    128 |  16384 |    0.345 |  5928.67 |    0.969 |   132.05 |

### PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.362 |  5660.12 |    0.839 |   152.52 |
|  2048 |    128 |   2048 |    0.328 |  6236.35 |    0.863 |   148.32 |
|  2048 |    128 |   4096 |    0.309 |  6618.84 |    0.843 |   151.78 |
|  2048 |    128 |   6144 |    0.314 |  6513.52 |    0.846 |   151.30 |
|  2048 |    128 |   8192 |    0.320 |  6390.27 |    0.850 |   150.54 |
|  2048 |    128 |  10240 |    0.328 |  6251.83 |    0.855 |   149.64 |
|  2048 |    128 |  12288 |    0.332 |  6162.25 |    0.861 |   148.66 |
|  2048 |    128 |  14336 |    0.341 |  6008.10 |    0.868 |   147.42 |
|  2048 |    128 |  16384 |    0.345 |  5933.19 |    0.878 |   145.79 |
 
  
Closes #1416
