### PR TITLE
Fix the fix

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4679,8 +4679,7 @@ static void llama_repack_up_gate_exps(llama_context & lctx) {
     bool needs_repack = false;
     for (auto & l : model.layers) {
         if (l.ffn_up_gate_exps && l.ffn_up_exps && l.ffn_gate_exps &&
-            ggml_backend_buffer_is_host(l.ffn_up_gate_exps->buffer) &&
-            ggml_backend_buffer_is_host(l.ffn_up_exps->buffer) && ggml_backend_buffer_is_host(l.ffn_gate_exps->buffer)) {
+           !l.ffn_up_gate_exps->extra) {
             needs_repack = true; break;
         }
     }
@@ -4690,8 +4689,7 @@ static void llama_repack_up_gate_exps(llama_context & lctx) {
     for (int il = 0; il < int(model.layers.size()); ++il) {
         auto & l = model.layers[il];
         if (l.ffn_up_gate_exps && l.ffn_up_exps && l.ffn_gate_exps &&
-            ggml_backend_buffer_is_host(l.ffn_up_gate_exps->buffer) &&
-            ggml_backend_buffer_is_host(l.ffn_up_exps->buffer) && ggml_backend_buffer_is_host(l.ffn_gate_exps->buffer)) {
+           !l.ffn_up_gate_exps->extra) {
             GGML_ASSERT(l.ffn_up_gate_exps->type  == l.ffn_up_exps->type  && l.ffn_up_gate_exps->type  == l.ffn_gate_exps->type);
             GGML_ASSERT(l.ffn_up_gate_exps->ne[0] == l.ffn_up_exps->ne[0] && l.ffn_up_gate_exps->ne[0] == l.ffn_gate_exps->ne[0]);
             GGML_ASSERT(l.ffn_up_gate_exps->ne[2] == l.ffn_up_exps->ne[2] && l.ffn_up_gate_exps->ne[2] == l.ffn_gate_exps->ne[2]);


### PR DESCRIPTION

Closes #1432 

Basically, merged `ffn_up/gate_exps` tensors that participate in split mode `graph` are handled differently from those that do not. Hence, one needs a way to identify the split vs no-split tensors. In my previous fix in PR #1426 I used as identification whether the merged tensor is stored in RAM. But that does not work for the case when the merged tensor is offloaded to the GPU via tensor overrides, and is excluded from split mode `graph` because of that (but is still in VRAM, not in RAM).

This PR is the correct way to do it. One identifies tensors participating in split mode `graph` via the `extra` data field not being null.  