### PR TITLE
Prevent adding system message that starts with 'x-anthropic-'.

### DIFF
--- a/examples/server/server-common.cpp
+++ b/examples/server/server-common.cpp
@@ -1202,8 +1202,11 @@ json anthropic_params_from_json(
         }
         else if (system_param.is_array()) {
             for (const auto& block : system_param) {
-                if (json_value(block, "type", std::string()) == "text") {
-                    system_content += json_value(block, "text", std::string());
+                 if (json_value(block, "type", std::string()) == "text") {
+                    std::string content_block = json_value(block, "text", std::string());
+                    if (!string_starts_with(content_block, "x-anthropic-")) {
+                        system_content += content_block;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Claude code send messages like this now:

```
{
  "system": [
    {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.37.0d9; cc_entrypoint=cli; cch=fa690;"},
    {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."},
    {"type": "text", "text": "...full system prompt..."}
  ],
  "messages": [{"role": "user", "content": "hey"}]
}
```

In the first system message, `cch` change for every request.

This PR will significantly increase the prompt cache hit rate and speed up claude-code.

~~However, so far I haven’t been able to get claude-code to actually work. The tool call parser still seems to have bugs, causing the claude-code instance to stop after the first tool call. The model does generate the tool call, but the parser fails to convert it into a native tool call message.~~

Edit2: The tool call issue has been fixed by PR #1437. I tested ik_llama.cpp with claude-code, and the request/response loop for each tool call has been reduced from 20+ seconds to about 1–2 seconds.

~~The mainline llama.cpp seems to exhibit the same behavior, so we may need to wait for a fix. I’m planning to open a PR for the mainline llama.cpp once the issue is resolved.~~

Edit: latest mainline llama.cpp seems fix the issue, I'll open a PR there.



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
