### PR TITLE
Turn off CPU ssm_conv and silu fusion

### DIFF
--- a/ggml/src/iqk/iqk_cpu_ops.cpp
+++ b/ggml/src/iqk/iqk_cpu_ops.cpp
@@ -555,6 +555,7 @@ bool iqk_ssm_conv4(int nr, int nc, int nt,
         uint64_t nb01, uint64_t nb10, uint64_t nb11, uint64_t nb21,
         const float * x0_in, const float * s0_in, const float * c_in,
         float * dst, float * dst_silu, int ith, int nth) {
+    return false;
 #if defined __AVX2__
     if (nt <= 32 || nc != 4 || nr%16 != 0) {
         return false;


### PR DESCRIPTION

I'm finding that #1421 is breaking things. Which is strange as I tested quite a bit and was confident that it works.

Turning this fusion off for now until I figure out what goes wrong.