### PR TITLE
fix: propagate CPPHTTPLIB_OPENSSL_SUPPORT to cpp-httplib target when …

### DIFF
--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -84,6 +84,8 @@ if (LLAMA_SERVER_SSL)
     find_package(OpenSSL REQUIRED)
     target_link_libraries(${TARGET} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
     target_compile_definitions(${TARGET} PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+    target_compile_definitions(cpp-httplib PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+    target_link_libraries(cpp-httplib PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 endif()
 
 if (LLAMA_SERVER_SQLITE3)


### PR DESCRIPTION
---
**Problem:** Building with `-DLLAMA_SERVER_SSL=ON` fails at link time with:
```
undefined reference to `httplib::SSLServer::SSLServer(...)'
Root cause: CPPHTTPLIB_OPENSSL_SUPPORT was only defined for the llama-server target, but cpp-httplib is compiled as a separate static library target. That library was compiled without SSL support, so SSLServer simply didn't exist in the archive.
Fix: Propagate the compile definition and OpenSSL link libraries to the cpp-httplib target as well.
Closes #1449


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
