### PR TITLE
fix: FA vec kernels for D=256 quantized KV cache (e.g., Qwen3-Coder-Next)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f16.cuh
@@ -368,8 +368,8 @@ template <int Dk, int Dv, int cols_per_block, ggml_type type_K, ggml_type type_V
 void ggml_cuda_flash_attn_ext_vec_f16_case_impl(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     constexpr int nwarps = Dk/WARP_SIZE;
     fattn_kernel_t fattn_kernel = flash_attn_vec_ext_f16<Dk, Dv, cols_per_block, type_K, type_V, use_logit_softcap>;
-    constexpr bool need_f16_K = type_K == GGML_TYPE_F16;
-    constexpr bool need_f16_V = type_V == GGML_TYPE_F16;
+    constexpr bool need_f16_K = Dk != 128 && Dk != 192 && Dk != 256;
+    constexpr bool need_f16_V = Dv != 64 && Dv != 128 && Dv != 256;
     constexpr size_t nbytes_shared = 0;
     launch_fattn<Dv, cols_per_block, 1>(ctx, dst, fattn_kernel, nwarps, nbytes_shared, Dv, need_f16_K, need_f16_V);
 }

--- a/ggml/src/ggml-cuda/fattn-vec-f32.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f32.cuh
@@ -353,8 +353,8 @@ template <int Dk, int Dv, int cols_per_block, ggml_type type_K, ggml_type type_V
 void ggml_cuda_flash_attn_ext_vec_f32_case_impl(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     constexpr int nwarps = Dk/WARP_SIZE;
     fattn_kernel_t fattn_kernel = flash_attn_vec_ext_f32<Dk, Dv, cols_per_block, type_K, type_V, use_logit_softcap>;
-    constexpr bool need_f16_K = type_K == GGML_TYPE_F16;
-    constexpr bool need_f16_V = type_V == GGML_TYPE_F16;
+    constexpr bool need_f16_K = Dk != 128 && Dk != 256;
+    constexpr bool need_f16_V = Dv != 64 && Dv != 128 && Dv != 256;
     constexpr size_t nbytes_shared = 0;
     launch_fattn<Dv, cols_per_block, 1>(ctx, dst, fattn_kernel, nwarps, nbytes_shared, Dv, need_f16_K, need_f16_V);
 }


### PR DESCRIPTION
I ran into three issues in FA vec kernels with quantized KV cache at D=256:                                                                                                                                                        
                  
  - `need_f16_K/V` used dimension-based comparison (`Dk != 128`) that forced q8_0→f16 conversion at D=256. Changed to type-based checks (`type_K == GGML_TYPE_F16`).
  - `quantize_q8_1_to_shared` output pointers weren't advanced between loop iterations, so the second iteration overwrote the first half of Q data.
  - `Q_i32` array in vec_f32 kernel was mis-sized (`Dk >= expr` evaluates to boolean 1, not `expr`).
  - Also adds missing extern template declarations for `(256, Q8_0, Q8_0)`.
  
Tested on A100 (Ampere, CC 8.0) and GTX 1080 (Pascal, CC 6.1) for both vec_f16 and vec_f32 kernel paths with Qwen3-Coder-Next Q4_K_M with FA + f16 KV, FA + q8_0 KV.

Note: I did use AI to identify the issues and compare to mainline.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High