### PR TITLE
sweep-bench: print timings!

### DIFF
--- a/examples/sweep-bench/sweep-bench.cpp
+++ b/examples/sweep-bench/sweep-bench.cpp
@@ -136,6 +136,8 @@ int main(int argc, char ** argv) {
     common_batch_clear(batch);
     llama_kv_cache_clear(ctx);
 
+    llama_reset_timings(ctx);
+
     int i_loop = 0;
 
     for (unsigned int n_kv = 0; n_kv < n_kv_max; n_kv += params.n_ubatch) {
@@ -210,6 +212,8 @@ int main(int argc, char ** argv) {
 
         ++i_loop;
     }
+
+    llama_print_timings(ctx);
 
     llama_batch_free(batch);
 


### PR DESCRIPTION
It's practical, I think!

Example :

```
main: n_kv_max = 67584, n_batch = 2048, n_ubatch = 2048, flash_attn = 1, n_gpu_layers = 150, n_threads = 1, n_threads_batch = 1

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.551 |  3714.16 |    1.221 |   104.83 |
|  2048 |    128 |   2048 |    0.561 |  3651.98 |    1.233 |   103.79 |
|  2048 |    128 |   4096 |    0.573 |  3576.25 |    1.242 |   103.02 |
|  2048 |    128 |   6144 |    0.586 |  3494.69 |    1.251 |   102.34 |
|  2048 |    128 |   8192 |    0.599 |  3419.95 |    1.266 |   101.10 |
|  2048 |    128 |  10240 |    0.615 |  3330.09 |    1.282 |    99.84 |
|  2048 |    128 |  12288 |    0.629 |  3256.43 |    1.300 |    98.46 |
|  2048 |    128 |  14336 |    0.641 |  3196.34 |    1.308 |    97.83 |
|  2048 |    128 |  16384 |    0.655 |  3128.76 |    1.315 |    97.33 |
|  2048 |    128 |  18432 |    0.669 |  3061.54 |    1.324 |    96.66 |
|  2048 |    128 |  20480 |    0.681 |  3006.30 |    1.334 |    95.99 |
|  2048 |    128 |  22528 |    0.693 |  2953.41 |    1.353 |    94.58 |
|  2048 |    128 |  24576 |    0.710 |  2886.18 |    1.359 |    94.16 |
|  2048 |    128 |  26624 |    0.725 |  2824.73 |    1.367 |    93.63 |
|  2048 |    128 |  28672 |    0.740 |  2767.91 |    1.375 |    93.07 |
|  2048 |    128 |  30720 |    0.754 |  2717.75 |    1.385 |    92.43 |
|  2048 |    128 |  32768 |    0.769 |  2663.19 |    1.407 |    91.00 |
|  2048 |    128 |  34816 |    0.787 |  2602.43 |    1.413 |    90.61 |
|  2048 |    128 |  36864 |    0.797 |  2569.50 |    1.420 |    90.14 |
|  2048 |    128 |  38912 |    0.818 |  2502.75 |    1.432 |    89.42 |
|  2048 |    128 |  40960 |    0.836 |  2450.28 |    1.442 |    88.74 |
|  2048 |    128 |  43008 |    0.849 |  2411.72 |    1.467 |    87.28 |
|  2048 |    128 |  45056 |    0.868 |  2360.73 |    1.473 |    86.87 |
|  2048 |    128 |  47104 |    0.879 |  2330.31 |    1.480 |    86.50 |
|  2048 |    128 |  49152 |    0.902 |  2270.92 |    1.489 |    85.95 |
|  2048 |    128 |  51200 |    0.913 |  2243.27 |    1.499 |    85.36 |
|  2048 |    128 |  53248 |    0.934 |  2192.01 |    1.521 |    84.16 |
|  2048 |    128 |  55296 |    0.956 |  2142.90 |    1.535 |    83.37 |
|  2048 |    128 |  57344 |    0.966 |  2119.11 |    1.536 |    83.36 |
|  2048 |    128 |  59392 |    0.990 |  2069.08 |    1.545 |    82.86 |
|  2048 |    128 |  61440 |    1.013 |  2021.43 |    1.558 |    82.13 |
|  2048 |    128 |  63488 |    1.039 |  1971.58 |    1.580 |    81.03 |
|  2048 |    128 |  65536 |    1.052 |  1947.10 |    1.593 |    80.37 |

llama_print_timings:        load time =    8604.80 ms
llama_print_timings:      sample time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings: prompt eval time =   25741.96 ms / 67584 tokens (    0.38 ms per token,  2625.44 tokens per second)
llama_print_timings:        eval time =   46297.05 ms /  4224 runs   (   10.96 ms per token,    91.24 tokens per second)
llama_print_timings:       total time =   72059.79 ms / 71808 tokens
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High