### PR TITLE
Better barrier

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -846,6 +846,7 @@ extern "C" {
         int size;
         int n_nodes;
         int n_leafs;
+        int n_batch;
 
         struct ggml_tensor ** nodes;
         struct ggml_tensor ** grads;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -2783,6 +2783,7 @@ struct ggml_compute_state_shared {
     const struct ggml_cplan * cplan;
 
     int n_threads;
+    int n_batch;
 
     // synchronization primitives
     atomic_int n_barrier;
@@ -4497,16 +4498,7 @@ inline static void ggml_critical_section_start(void) {
     }
 }
 
-#ifdef GGML_USE_OPENMP
-static void ggml_barrier(struct ggml_compute_state_shared * shared) {
-    if (shared->n_threads == 1) {
-        return;
-    }
-
-    #pragma omp barrier
-}
-#else
-static void ggml_barrier(struct ggml_compute_state_shared * shared) {
+static inline void ggml_barrier_impl(struct ggml_compute_state_shared * shared) {
     if (shared->n_threads == 1) {
         return;
     }
@@ -4538,6 +4530,22 @@ static void ggml_barrier(struct ggml_compute_state_shared * shared) {
             sched_yield();
         }
     }
+}
+
+#ifdef GGML_USE_OPENMP
+static void ggml_barrier(struct ggml_compute_state_shared * shared) {
+    if (shared->n_threads == 1) {
+        return;
+    }
+    if (shared && shared->n_batch > 32) {
+        ggml_barrier_impl(shared);
+        return;
+    }
+    #pragma omp barrier
+}
+#else
+static void ggml_barrier(struct ggml_compute_state_shared * shared) {
+    ggml_barrier_impl(shared);
 }
 #endif
 
@@ -25878,6 +25886,7 @@ struct ggml_cgraph * ggml_new_graph_custom(struct ggml_context * ctx, size_t siz
         /*.size         =*/ size,
         /*.n_nodes      =*/ 0,
         /*.n_leafs      =*/ 0,
+        /*.n_batch      =*/ 0,
         /*.nodes        =*/ nodes_ptr,
         /*.grads        =*/ grads_ptr,
         /*.leafs        =*/ leafs_ptr,
@@ -25899,6 +25908,7 @@ struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph0, int i0, int i1)
         /*.size         =*/ 0,
         /*.n_nodes      =*/ i1 - i0,
         /*.n_leafs      =*/ 0,
+        /*.n_batch      =*/ cgraph0->n_batch,
         /*.nodes        =*/ cgraph0->nodes + i0,
         /*.grads        =*/ cgraph0->grads ? cgraph0->grads + i0 : NULL,
         /*.leafs        =*/ NULL,
@@ -26638,6 +26648,7 @@ enum ggml_status ggml_graph_compute(struct ggml_cgraph * cgraph, struct ggml_cpl
         /*.cgraph                  =*/ cgraph,
         /*.cgraph_plan             =*/ cplan,
         /*.n_threads               =*/ n_threads,
+        /*.n_batch                 =*/ cgraph->n_batch,
         /*.n_barrier               =*/ 0,
         /*.n_barrier_passed        =*/ 0,
         /*.abort_callback          =*/ NULL,

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -9988,8 +9988,10 @@ ggml_cgraph * llm_build_context::llama_build_graph(
             GGML_ABORT("fatal error");
     }
 
+    result->n_batch = llm.n_tokens;
+
     // add on pooling layer
-    if (lctx.cparams.mtp_op_type == MTP_OP_NONE && (lctx.cparams.embeddings || 
+    if (lctx.cparams.mtp_op_type == MTP_OP_NONE && (lctx.cparams.embeddings ||
         (lctx.model.hparams.nextn_predict_layers > 0 || lctx.model.mtp))) {
         result = llm.append_pooling(result);
     }


### PR DESCRIPTION

Lately I have been mostly working on a system with a 64-core Ryzen-3995WX CPU, and I have noticed that, unexpectedly, PP performance steadily decreases with u-batch size for u-batch >= 512. From past experience on a 16-core Ryzen-7950X CPU, the expectation is that PP performance, depending on model, will peak somewhere in [512, 2048]. Looking more closely, I'm finding that the fraction of time spent on barriers (calls to `ggml_barrier`) also increases with u-batch size, reaching more than 30% for u-batch = 2048. I looked into various hypothesis for this strange behavior such as
* Tensors for MoE models are not very large, so perhaps the strategy for dividing the work between threads is not good when there are many threads. This lead to a minor improvement (2-3%) in PR #1447, but nowhere near the observed 30+% barrier penalty
* False sharing. When each thread has to compute less than 16 rows per model tensor in a matrix multiplication, the results between two consecutive threads get written to the same cache line. One can work around that by storing matrix multiplication results in thread-local temporary buffers and only copying into the final destination at the end. This too did not  lead to noticeable improvement (and I did not commit the changes because there was no real improvement while the code became much uglier).

In all of this I have been using OpenMP for thread management, and the thread synchronization barrier in that case is simply
```c++
#pragma omp barrier
```
Eventually I decided to disable OpenMP and see what happens then. In that case, `ggml_barrier` uses its own buil-in implementation. Boom, PP performance for large batch sizes became much better! But TG performance suffered significantly (~30% drop), which is not surprising as the OpenMP barrier is normally one of the best (unless something goes wrong, that is).

And this is how we arrive at this PR. I have added a new data field to the `ggml_cgraph` struct that contains the number of tokens in the u-batch. It is populated when building the compute graph. Then, during compute graph evaluation on the CPU, `ik_llama.cpp` now uses either the OpenMP barrier (u-batch size <= 32) or the build-in `ggml_barrier` (u-batch > 32).

The PR will have no effect of OpenMP is not used (e.g., most Windows users), and is likely to not have an effect for systems with not too many cores.

> [!IMPORTANT]
> I would appreciate benchmark results from other people as this is a fairly significant change in the guts of CPU inference.

Here are some `sweep-bench` results for the main branch and this PR on a Ryzen-3995WX. The model is `IQ2_XSS` quantized Mistral-4. All runs are with `-rtr -ctk q8_0 -t 64` I have used the same range for the y-axis (tokens per second) so that one can easily see the performance differences for the different u-batch sizes.

### u-batch = 4096 

<img width="792" height="612" alt="pp_4096" src="https://github.com/user-attachments/assets/224fb936-0961-4a01-b1c3-bef54c8a36cf" />

### u-batch = 2048

<img width="792" height="612" alt="pp_2048" src="https://github.com/user-attachments/assets/72075578-ac79-4cbe-82b9-d83a51db5d5d" />

### u-batch = 1024

<img width="792" height="612" alt="pp_1024" src="https://github.com/user-attachments/assets/b529eee6-1734-4acd-a553-cc69c6473f13" />

### u-batch = 512

<img width="792" height="612" alt="pp_512" src="https://github.com/user-attachments/assets/90116def-23a1-49c8-8208-02fd6411e9b9" />


