### PR TITLE
Enable AVX-VNNI 256-bit path for Q8_0 R8 dot product

### DIFF
--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -1665,6 +1665,14 @@ static void mul_mat_q8_0_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
     auto dot = [&qx, &sx, &m1] (const int8_t * qy) {
         auto y128 = _mm_loadu_si128((const __m128i*)qy);
         auto y = MM256_SET_M128I(y128, y128);
+#ifdef HAVE_VNNI256
+        auto sumi = _mm256_setzero_si256();
+        sumi = _mm256_dpbusd_epi32(sumi, sx[0], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x00), qx[0]));
+        sumi = _mm256_dpbusd_epi32(sumi, sx[1], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x55), qx[1]));
+        sumi = _mm256_dpbusd_epi32(sumi, sx[2], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xaa), qx[2]));
+        sumi = _mm256_dpbusd_epi32(sumi, sx[3], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xff), qx[3]));
+        return sumi;
+#else
         auto sumi1 = _mm256_add_epi32(
                 _mm256_madd_epi16(m1, _mm256_maddubs_epi16(sx[0], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x00), qx[0]))),
                 _mm256_madd_epi16(m1, _mm256_maddubs_epi16(sx[1], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x55), qx[1])))
@@ -1674,6 +1682,7 @@ static void mul_mat_q8_0_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
                 _mm256_madd_epi16(m1, _mm256_maddubs_epi16(sx[3], _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xff), qx[3])))
         );
         return _mm256_add_epi32(sumi1, sumi2);
+#endif
     };
     for (int ix = 0; ix < nrc_x; ix += 8) {
         const block_q8_0_r8 * iq8 = (const block_q8_0_r8 *)((const char *)vx + ix*bx);


### PR DESCRIPTION
This PR adds a HAVE_VNNI256 path to the Q8_0 R8 matmul dot product in `mul_mat_q8_0_r8_q8_2`, replacing the `maddubs_epi16` + `madd_epi16` chain with `_mm256_dpbusd_epi32`.

Unlike my previous VNNI PRs, this one does not ungate existing FANCY_SIMD code, the AVX-512 approach is much different here. This PR is just a faster version of the existing non-FANCY path for AVX-VNNI hardware (vpdpbusd instruction).

## Benchmarks

Qwen3.5-0.8B prompt processing (pp512), 6 threads, 5 reps, median t/s:

| Quant | Baseline (t/s) | PR (t/s) | Speedup |
|-------|---------------|----------|---------|
| Q8_0 | 317.44 ± 0.98 | 403.36 ± 4.93 | **+27.1%** |
| Q6_K | 315.65 ± 2.02 | 393.23 ± 4.12 | **+24.6%** |
| Q5_K_M | 384.40 ± 3.21 | 429.63 ± 0.46 | **+11.8%** |
| Q4_K_M | 438.49 ± 2.95 | 452.55 ± 6.18 | **+3.2%** |

Improvement scales with Q8_0 layer proportion.

## Perplexity (Qwen3.5-0.8B-Q8_0, 580 chunks wikitext-2):
- Baseline: 18.6309 +/- 0.14984 (350 t/s)
- PR:       18.6309 +/- 0.14984 (436 t/s)

<details>

### How it works

The new VNNI path is a direct drop-in replacement for the existing AVX2 dot product. Both paths use the same operands and the same sign trick — the only difference is which instructions perform the multiply-accumulate:

**AVX2 (existing)** — 3 instructions per sub-block to go from u8×i8 to i32:
```cpp
// maddubs: u8×i8 → i16 pairs (adjacent bytes multiplied and added)
// madd(1, ...): widen i16 → i32 by adding adjacent pairs
// add_epi32: accumulate
madd_epi16(m1, maddubs_epi16(sx[k], sign_epi8(shuffle(y), qx[k])))
```

**VNNI (new)** — 1 instruction does the same thing:
```cpp
// dpbusd: u8×i8 → i32 directly
dpbusd_epi32(sumi, sx[k], sign_epi8(shuffle(y), qx[k]))
```

The operands are identical: `sx[k]` (unsigned, `abs(x)`) as the first argument, `sign_epi8(y, qx[k])` (y with signs flipped to match original x) as the second. The loop structure, accumulators, and scale handling are all unchanged.

### Comparison with Q8_1 R8

This follows the same `#ifdef` pattern already used for Q8_1 R8 (`mul_mat_q8_1_r8_q8_2`), which also has a `HAVE_VNNI256` path in its dot lambda. The only difference between Q8_0 and Q8_1 is the first operand to `dpbusd`:

- **Q8_1**: `dpbusd(qx[k], ...)` — Q8_1 stores quants as unsigned, so `qx` is used directly.
- **Q8_0**: `dpbusd(sx[k], ...)` — Q8_0 stores quants as signed, so the outer loop pre-computes `sx[k] = sign_epi8(qx[k], qx[k])` (i.e. `abs(x)`) to provide the unsigned operand.
</details>