### PR TITLE
Enable AVX-VNNI 256-bit path for Q8_K R8 matmul

### DIFF
--- a/ggml/src/iqk/iqk_gemm_kquants.cpp
+++ b/ggml/src/iqk/iqk_gemm_kquants.cpp
@@ -1795,7 +1795,7 @@ template <int nrc_y>
 static void mul_mat_q8_k_r8_q8_k(int n, const void * vx, size_t bx, const DataInfo& info, int nrc_x) {
     GGML_ASSERT(nrc_x%8 == 0);
     Q8<nrc_y, block_q8_K> q8(info);
-#ifndef HAVE_FANCY_SIMD
+#ifndef HAVE_VNNI256
     auto m1 = _mm256_set1_epi16(1);
 #endif
     int nbl = n / QK_K;
@@ -1811,25 +1811,18 @@ static void mul_mat_q8_k_r8_q8_k(int n, const void * vx, size_t bx, const DataIn
                 qx[1] = _mm256_loadu_si256((const __m256i *)iq8[ibl].qs+4*ib+1);
                 qx[2] = _mm256_loadu_si256((const __m256i *)iq8[ibl].qs+4*ib+2);
                 qx[3] = _mm256_loadu_si256((const __m256i *)iq8[ibl].qs+4*ib+3);
-#ifndef HAVE_FANCY_SIMD
                 auto s0 = _mm256_sign_epi8(qx[0], qx[0]);
                 auto s1 = _mm256_sign_epi8(qx[1], qx[1]);
                 auto s2 = _mm256_sign_epi8(qx[2], qx[2]);
                 auto s3 = _mm256_sign_epi8(qx[3], qx[3]);
-#else
-                qx[0] = _mm256_add_epi8(qx[0], _mm256_set1_epi8(127));
-                qx[1] = _mm256_add_epi8(qx[1], _mm256_set1_epi8(127));
-                qx[2] = _mm256_add_epi8(qx[2], _mm256_set1_epi8(127));
-                qx[3] = _mm256_add_epi8(qx[3], _mm256_set1_epi8(127));
-#endif
                 for (int iy = 0; iy < nrc_y; ++iy) {
                     auto y128 = _mm_loadu_si128((const __m128i*)q8.y[iy][ibl].qs+ib);
                     auto y = MM256_SET_M128I(y128, y128);
-#ifdef HAVE_FANCY_SIMD
-                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], qx[0], _mm256_shuffle_epi32(y, 0x00));
-                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], qx[1], _mm256_shuffle_epi32(y, 0x55));
-                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], qx[2], _mm256_shuffle_epi32(y, 0xaa));
-                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], qx[3], _mm256_shuffle_epi32(y, 0xff));
+#ifdef HAVE_VNNI256
+                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], s0, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x00), qx[0]));
+                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], s1, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x55), qx[1]));
+                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], s2, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xaa), qx[2]));
+                    isum[iy] = _mm256_dpbusd_epi32(isum[iy], s3, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0xff), qx[3]));
 #else
                     auto sumi1 = _mm256_madd_epi16(m1, _mm256_maddubs_epi16(s0, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x00), qx[0])));
                     auto sumi2 = _mm256_madd_epi16(m1, _mm256_maddubs_epi16(s1, _mm256_sign_epi8(_mm256_shuffle_epi32(y, 0x55), qx[1])));
@@ -1840,15 +1833,9 @@ static void mul_mat_q8_k_r8_q8_k(int n, const void * vx, size_t bx, const DataIn
 #endif
                 }
             }
-#ifdef HAVE_FANCY_SIMD
-            auto m4 = _mm256_mul_ps(d4, _mm256_set1_ps(-127.f));
-#endif
             for (int iy = 0; iy < nrc_y; ++iy) {
                 auto d4y = _mm256_mul_ps(d4, _mm256_set1_ps(q8.scale(iy, ibl)));
                 acc[iy] = _mm256_fmadd_ps(d4y, _mm256_cvtepi32_ps(isum[iy]), acc[iy]);
-#ifdef HAVE_FANCY_SIMD
-                acc[iy] = _mm256_fmadd_ps(m4, _mm256_set1_ps(q8.y[iy][ibl].sum), acc[iy]);
-#endif
                 isum[iy] = _mm256_setzero_si256();
             }
         }


### PR DESCRIPTION
Change 5 gates in mul_mat_q8_k_r8_q8_k from FANCY_SIMD to VNNI256. This unlocks dpbusd for AVX-VNNI here, greatly accelerating 2 and 3 bit quants. The other intrinsics in these blocks are AVX2, AVX, and FMA, all available on AVX-VNNI CPUs (details below).

<details>
<summary>Intrinsic analysis</summary>

| Intrinsic | Required ISA |
|---|---|
| `_mm256_dpbusd_epi32` | AVX-VNNI |
| `_mm256_add_epi8` | AVX2 |
| `_mm256_set1_epi8` | AVX |
| `_mm256_loadu_si256` | AVX |
| `_mm256_shuffle_epi32` | AVX2 |
| `_mm256_add_epi32` | AVX2 |
| `_mm256_setzero_si256` | AVX |
| `_mm256_mul_ps` | AVX |
| `_mm256_set1_ps` | AVX |
| `_mm256_fmadd_ps` | FMA |
| `_mm256_cvtepi32_ps` | AVX |

</details>

## Benchmarks

6 threads on Raptor Lake P-Cores

### Qwen3.5-2B, PP512

| Model | Baseline (median t/s) | PR (median t/s) | Change |
|---|---|---|---|
| Q2_K | 148.32 ± 1.65 | 242.01 ± 3.18 | **+63%** |
| IQ3_XS | 145.78 ± 1.38 | 237.13 ± 1.16 | **+63%** |
| IQ3_S | 145.45 ± 2.20 | 233.87 ± 1.23 | **+61%** |
| Q3_K_M | 148.40 ± 2.80 | 213.01 ± 0.89 | **+44%** |

### Qwen3.5-9B, PP512

| Model | Baseline (median t/s) | PR (median t/s) | Change |
|---|---|---|---|
| IQ2_S | 27.93 ± 0.23 | 55.27 ± 0.88 | **+98%** |
| Q2_K | 28.25 ± 0.31 | 52.97 ± 0.44 | **+88%** |
| IQ3_S | 29.25 ± 0.40 | 51.97 ± 0.41 | **+78%** |
| Q3_K_M | 30.07 ± 0.33 | 47.10 ± 1.55 | **+57%** |

### Control (different code path, should be unaffected)

| Model | Baseline (median t/s) | PR (median t/s) | Change |
|---|---|---|---|
| 2B-Q4_K_M (already optimized) | 152.71 ± 0.35 | 152.51 ± 0.70 | ~0% |