### PR TITLE
Enable AVX-VNNI 256-bit path for Q8_1 R8 matmul

### DIFF
--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -1751,7 +1751,7 @@ static void mul_mat_q8_1_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
     auto dot = [&qx] (const int8_t * qy) {
         auto y128 = _mm_loadu_si128((const __m128i*)qy);
         auto y = MM256_SET_M128I(y128, y128);
-#ifdef HAVE_FANCY_SIMD
+#ifdef HAVE_VNNI256
         auto sumi = _mm256_setzero_si256();
         sumi = _mm256_dpbusd_epi32(sumi, qx[0], _mm256_shuffle_epi32(y, 0x00));
         sumi = _mm256_dpbusd_epi32(sumi, qx[1], _mm256_shuffle_epi32(y, 0x55));


### PR DESCRIPTION
Relax FANCY_SIMD to VNNI256 in `mul_mat_q8_1_r8_q8_2`. Single, small block of code here, just AVX, AVX2 and 256-bit VNNI.

<details>
<summary>intrinsics analysis</summary>

### VNNI256 path (formerly FANCY_SIMD)

| Intrinsic | ISA | Count |
|---|---|---|
| `_mm256_setzero_si256` | AVX | 1 |
| `_mm256_shuffle_epi32` | AVX2 | 4 |
| `_mm256_dpbusd_epi32` | AVX-VNNI / AVX-512 VNNI+VL | 4 |

### AVX2 fallback path

| Intrinsic | ISA | Count |
|---|---|---|
| `_mm256_shuffle_epi32` | AVX2 | 4 |
| `_mm256_maddubs_epi16` | AVX2 | 4 |
| `_mm256_add_epi16` | AVX2 | 2 |
| `_mm256_set1_epi16` | AVX | 2 |
| `_mm256_madd_epi16` | AVX2 | 2 |
| `_mm256_add_epi32` | AVX2 | 1 |
</details>

## Benchmark results

Qwen3.5-2B, pp512

| Quant | Baseline (t/s) | PR (t/s) | Speedup |
|---|---|---|---|
| Q4_K_S | 163.52 | 203.95 | **+24.7%** |
| Q4_K_M | 151.89 | 174.14 | **+14.7%** |
| Q5_K_S | 156.29 | 184.18 | **+17.8%** |
| Q5_K_M | 153.47 | 176.13 | **+14.8%** |

Q4_K_S sees the largest gain (~25%) consistent with perf showing 82% of time in `mul_mat_q8_1_r8_q8_2`.