### PR TITLE
sweep-bench: add --minilog argument to reduce verbose logging

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2169,6 +2169,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         else { invalid_param = true; }
         return true;
     }
+    if (arg == "--minilog") {
+        params.minilog = true;
+        return true;
+    }
 
 #ifndef LOG_DISABLE_LOGS
     // Parse args for logging parameters

--- a/common/common.h
+++ b/common/common.h
@@ -471,6 +471,7 @@ struct gpt_params {
     std::string lora_outfile = "ggml-lora-merged-f16.gguf";
 
     bool sweep_bench_output_jsonl = false;
+    bool minilog = false;
 };
 
 

--- a/examples/sweep-bench/sweep-bench.cpp
+++ b/examples/sweep-bench/sweep-bench.cpp
@@ -14,8 +14,45 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
 #include <string>
 #include <vector>
+
+static void llama_selective_log_callback(ggml_log_level level, const char * text, void * user_data) {
+    (void) level;
+    (void) user_data;
+    const char * skip_patterns[] = {
+        "Setting default device in layer",
+        "llama_model_loader: Dumping metadata",
+        "llama_model_loader: - kv  ",
+        "llama_model_loader: - type ",
+        "validate_override:",
+        "load: printing all EOG",
+        "load:   - ",
+        "load: special tokens cache",
+        "load: token to piece cache",
+        "llm_load_print_meta:",
+        "print_info:",
+        "------------------- Layer sizes",
+        "Layer ",
+        "llm_load_tensors:",
+        "==========================",
+    };
+    for (const char * pat : skip_patterns) {
+        if (strstr(text, pat) != nullptr) {
+            return;
+        }
+    }
+    // Skip incomplete/continuation lines
+    int i = 0;
+    while (text[i] == ' ' || text[i] == '\t') {
+        i++;
+    }
+    if (text[i] == ',' || text[i] == '(' || text[i] == ')'|| (text[i] >= '0' && text[i] <= '9')) {
+        return;
+    }
+    LOG_TEE("%s", text);
+}
 
 static void print_usage(int, char ** argv) {
     LOG_TEE("\nexample usage:\n");
@@ -32,6 +69,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
     if (params.nrep < 1) params.nrep = 1;
+
+    if (params.minilog) {
+        llama_log_set(llama_selective_log_callback, nullptr);
+    }
 
     // init LLM
 


### PR DESCRIPTION
For the folks like me who don't have (yet) a proper workflow of benching, logging, graphing, PRing and so on, the logs of sweep-bench can be a bit verbose to one's taste.
Here's a --minilog option to trim a bit the bush of what's not always necessary for sweep-bench (to my taste).

It can be very easily amended to find a "consensus" so this can be merged.

More in details:

Purpose:
Add --minilog flag to llama-sweep-bench that filters log output to show only essential GPU/layer distribution information while suppressing verbose model metadata and per-layer device assignment messages.

Changes:
- Add llama_selective_log_callback with blacklist approach (sweep-bench.cpp)

Blacklisted patterns (hidden):
- Per-layer device assignments ('Setting default device in layer')
- KV metadata dump header and entries
- Tensor type counts
- Model validation messages
- EOG/special token cache info
- Metadata printout (llm_load_print_meta, print_info)
- Layer sizes table
- Tensor loading info (llm_load_tensors)
- Separator lines
- Most common cases of incomplete/continuation lines are also hidden

All other log output is shown, including:
- GPU VRAM info
- Split/buffer distribution per device
- Graph split estimates
- Final benchmark table and timings

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High