### PR TITLE
Enable AVX-VNNI 256-bit path for Q3_K R4 matmul

### DIFF
--- a/ggml/src/iqk/iqk_gemm_kquants.cpp
+++ b/ggml/src/iqk/iqk_gemm_kquants.cpp
@@ -1364,7 +1364,7 @@ static void mul_mat_q3_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
     auto shuff = _mm256_loadu_si256((const __m256i *)k_shuff);
 #ifdef HAVE_FANCY_SIMD
     __m256i isum[nrc_y];
-#else
+#elif !defined(HAVE_VNNI256)
     auto m1 = _mm256_set1_epi16(1);
 #endif
     int nbl = n / QK_K;
@@ -1415,6 +1415,16 @@ static void mul_mat_q3_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
                     sumi = _mm256_dpwssd_epi32(sumi, s3, _mm256_shuffle_epi32(bsums, 0xaa));
                     sumi = _mm256_dpwssd_epi32(sumi, s4, _mm256_shuffle_epi32(bsums, 0xff));
                     isum[iy] = sumi;
+#elif defined(HAVE_VNNI256)
+                    sumi = _mm256_dpwssd_epi32(sumi, s1, _mm256_shuffle_epi32(bsums, 0x00));
+                    sumi = _mm256_dpwssd_epi32(sumi, s2, _mm256_shuffle_epi32(bsums, 0x55));
+                    sumi = _mm256_dpwssd_epi32(sumi, s3, _mm256_shuffle_epi32(bsums, 0xaa));
+                    sumi = _mm256_dpwssd_epi32(sumi, s4, _mm256_shuffle_epi32(bsums, 0xff));
+                    if constexpr (nrc_y == 1) {
+                        acc[iy] = _mm256_fmadd_ps(min, _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    } else {
+                        acc[iy] = _mm256_fmadd_ps(_mm256_mul_ps(min, _mm256_set1_ps(q8.scale(iy, ibl))), _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    }
 #else
                     sumi = _mm256_add_epi32(sumi, _mm256_madd_epi16(s1, _mm256_shuffle_epi32(bsums, 0x00)));
                     sumi = _mm256_add_epi32(sumi, _mm256_madd_epi16(s2, _mm256_shuffle_epi32(bsums, 0x55)));
@@ -1449,6 +1459,17 @@ static void mul_mat_q3_k_r4_q8_k(int n, const void * vx, size_t bx, const DataIn
                     sumi = _mm256_dpbusd_epi32(sumi, qx[2], _mm256_shuffle_epi32(y, 0xaa));
                     sumi = _mm256_dpbusd_epi32(sumi, qx[3], _mm256_shuffle_epi32(y, 0xff));
                     isum[iy] = _mm256_add_epi32(isum[iy], _mm256_mullo_epi32(iscales, sumi));
+#elif defined(HAVE_VNNI256)
+                    auto sumi = _mm256_setzero_si256();
+                    sumi = _mm256_dpbusd_epi32(sumi, qx[0], _mm256_shuffle_epi32(y, 0x00));
+                    sumi = _mm256_dpbusd_epi32(sumi, qx[1], _mm256_shuffle_epi32(y, 0x55));
+                    sumi = _mm256_dpbusd_epi32(sumi, qx[2], _mm256_shuffle_epi32(y, 0xaa));
+                    sumi = _mm256_dpbusd_epi32(sumi, qx[3], _mm256_shuffle_epi32(y, 0xff));
+                    if constexpr (nrc_y == 1) {
+                        acc[iy] = _mm256_fmadd_ps(scales, _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    } else {
+                        acc[iy] = _mm256_fmadd_ps(_mm256_mul_ps(scales, _mm256_set1_ps(q8.scale(iy, ibl))), _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    }
 #else
                     auto sumi1 = _mm256_add_epi16(_mm256_maddubs_epi16(qx[0], _mm256_shuffle_epi32(y, 0x00)),
                                                   _mm256_maddubs_epi16(qx[1], _mm256_shuffle_epi32(y, 0x55)));


### PR DESCRIPTION
Enable VNNI (`vpdpbusd` and `vpdpwssd`) for 256-bit VNNI in `mul_mat_q3_k_r4_q8_k`. This relaxes FANCY_SIMD to HAVE_VNNI256 and refactors it to use a method between the old FANCY and fallback modes.

Why not just ungate the existing FANCY_SIMD code? In performance profiling of token generation, this just moved the compute bottleneck to `vpmulld`. Token generation isnt compute limited, but the PR approach is more efficient and performance profiling shows it is now even more dominated by `vmovdqu` (memory loads/stores). Its important to note this also changes how AVX-512 platforms run this kernel - its possible the original code is better on AVX-512 CPUs and this PR will cause a regression. I am willing to do AVX-512 testing if needed.

Prompt processing naturally benefits from this PR due to the now familiar change to use VNNI fused instructions in place of the AVX2 alternatives.

## Performance

Qwen3.5-2B, Q3_K_M, -rtr 1

<img width="2100" height="750" alt="q3km_sweep_comparison" src="https://github.com/user-attachments/assets/14ca7aad-0612-4a7b-b09a-0f1e8431d929" />

## QA

Qwen3.5-2B, Q3_K_M, --run-time-repack

Text generations on general knowledge questions were bit identical. Perplexity testing was identical on a full run (13.8283 +/- 0.10343).

## Details

More details below the fold (details section co-written with an agent)

<details>

## Approach

A naive port of the `HAVE_FANCY_SIMD` path introduced a `vpmulld` bottleneck. The original AVX-512 path deferred float conversion and accumulated integer results using `_mm256_mullo_epi32(iscales, sumi)`. On Raptor Lake P-cores, `vpmulld` consumed ~15% of the function's cycles, replacing the memory-move stall as the dominant bottleneck.

The hybrid approach taken here uses VNNI for the dot products only, while keeping the baseline's per-sub-block float accumulation strategy:

- `_mm256_maddubs_epi16` + `_mm256_add_epi16` + `_mm256_madd_epi16` (3 instructions) replaced by `_mm256_dpbusd_epi32` (1 instruction)
- `_mm256_madd_epi16` + `_mm256_add_epi32` replaced by `_mm256_dpwssd_epi32` for bsums correction
- No `isum` integer accumulator, no `vpmulld`, no deferred float conversion

### PP perf profile (pp512, 6 threads)

| Metric | Baseline | Hybrid (VNNI256) | Delta |
|--------|----------|-------------------|-------|
| Throughput | 295 t/s | 319 t/s | +8.1% |
| Instructions | 658.9B | 610.2B | −7.4% |
| Cycles | 220.0B | 202.9B | −7.8% |
| IPC | 3.00 | 3.01 | ~same |

The speedup comes entirely from executing fewer instructions at the same IPC. The VNNI path replaces a 3-instruction dot product chain with a 2-instruction chain:

| Instruction | Baseline | Hybrid |
|-------------|----------|--------|
| vpmaddubsw | 32 | -- |
| vpaddw | 24 | -- |
| vpmaddwd | 40 | -- |
| vpdpbusd | -- | 32 |
| vpdpwssd | -- | 32 |
| **Dot product total** | **96** | **64** |

96 → 64 dot product instructions (−33%). Total function instructions: 820 → 779 (−5%). The float accumulation path (vcvtdq2ps, vfmadd*) is unchanged at 33 instructions each.

### Instruction profile, prompt processing (mul_mat_q3_k_r4_q8_k, top instructions)

| Instruction     | Baseline | Hybrid  |
|-----------------|----------|---------|
| vpdpbusd        | --       | ~20%    |
| vpshufd         | ~14%     | ~16%    |
| vpmaddubsw      | ~14%     | --      |
| vpaddw          | ~11%     | --      |
| vfmadd213ps     | ~9%      | ~6%     |
| vmovdqu (move)  | ~5%      | ~8%     |
| vcvtdq2ps       | ~6%      | ~7%     |
| vpmaddwd        | ~6%      | --      |
| vpsrlw          | ~5%      | ~6%     |
| vmovaps         | ~5%      | ~4%     |
| vpdpwssd        | --       | ~3%     |
| vmulps          | ~3%      | ~3%     |
| vfmadd231ps     | ~3%      | ~2%     |

In PP, `vmovdqu` is only ~5-8% of cycles (vs ~31-36% in TG), confirming the workload is compute-bound. The dot product chain (`vpmaddubsw` + `vpaddw` + `vpmaddwd` = ~31%) is replaced by `vpdpbusd` + `vpdpwssd` (~23%), directly reducing compute pressure.

### Instruction profile, token generation (mul_mat_q3_k_r4_q8_k, top instructions)

| Instruction     | Baseline | Hybrid  |
|-----------------|----------|---------|
| vmovdqu (move)  | ~31%     | ~36%    |
| vpmaddubsw      | ~10%     | --      |
| vpmaddwd        | ~10%     | --      |
| vpdpbusd        | --       | ~11%    |
| vpmulld         | --       | --      |

The hybrid path eliminates `vpmaddubsw` + `vpmaddwd` in favor of `vpdpbusd`, with no `vpmulld` bottleneck. The memory move (`vmovdqu`) is now more dominant, confirming the workload is cleanly memory-bound.

### Why not a naive port of HAVE_FANCY_SIMD?

A direct `HAVE_FANCY_SIMD` -> `HAVE_VNNI256` substitution was tested first. That path defers float conversion and uses`_mm256_mullo_epi32(iscales, sumi)` to accumulate integer results. On Raptor Lake P-cores, `vpmulld` consumed ~15% of the function's cycles — becoming the second hottest instruction after the memory move and replacing the memory stall as the compute bottleneck. On E-cores (Gracemont here) the problem was worse: `vpmulld` hit ~13% and the overall throughput regressed by ~5% (20.96 vs 22.04 t/s).
</details>