### PR TITLE
Fix bug when splitting merged ffn_up/gate_exps tensors

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -3548,7 +3548,7 @@ static void prepare_up_gate_split(ggml_tensor * t, llama_split_tensor & split) {
         if (!extra->splits[is]) continue;
         auto & ranges = split.ranges[is];
         ranges.resize(2);
-        int nrows_is = extra->splits[idim]->ne[1]/2;
+        int nrows_is = extra->splits[is]->ne[idim]/2;
         ranges[0] = {ntot,         nrows_is};
         ranges[1] = {ntot + nrows, nrows_is};
         ntot += nrows_is;


### PR DESCRIPTION

Closes #1478 

The bug shows up when the merged tensors are not split evenly between the GPUs (because this is not possible as it is the case for Qwen-3.5-122B-A10B with split model graph using 3 GPUs).

