### PR TITLE
Fix misleading quantize error message

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -586,7 +586,7 @@ int main(int argc, char ** argv) {
             return 1;
         }
         if (!try_parse_ftype(argv[arg_idx], params.ftype, ftype_str)) {
-            fprintf(stderr, "%s: invalid ftype '%s'\n", __func__, argv[3]);
+            fprintf(stderr, "%s: invalid ftype '%s'\n", __func__, argv[arg_idx]);
             return 1;
         }
         if (ftype_str == "COPY") {


### PR DESCRIPTION

When one makes a mistake with the `llama-quantize` command line arguments and one has used non-positional arguments (`--imatrix, --output-tensor-type`, etc.), one gets a misleading error message. This has been annoying me forever, and finally today I decided that it is time to fix it.