### PR TITLE
Auto-fit for dense models

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -2375,10 +2375,14 @@ static bool llm_load_tensors(
                     if (loaded_sum + layer_sizes[il] <= split_size) {
                         model.default_layer_device[il] = id;
                         loaded_sum += layer_sizes[il];
-                        LLAMA_LOG_INFO("Setting default device in layer %2d to %d\n", il, id);
+                        if (required_mem <= available_mem) {
+                            LLAMA_LOG_INFO("Setting default device in layer %2d to %d\n", il, id);
+                        }
                     } else {
                         if (loaded_sum + layer_sizes[il] - split_size < split_size - loaded_sum) {
-                            LLAMA_LOG_INFO("Setting default device in layer %2d to %d\n", il, id);
+                            if (required_mem <= available_mem) {
+                                LLAMA_LOG_INFO("Setting default device in layer %2d to %d\n", il, id);
+                            }
                             model.default_layer_device[il] = id;
                             loaded_sum += layer_sizes[il++];
                         }
@@ -2514,7 +2518,7 @@ static bool llm_load_tensors(
                     if (device_mem[id] >= layer_sizes[il]) {
                         device_mem[id] -= layer_sizes[il];
                         model.default_layer_device[il] = id;
-                        printf("Setting layer %d to device %d\n", il, id);
+                        LLAMA_LOG_INFO("Setting layer %d to device %d\n", il, id);
                     } else {
                         --id;
                         if (id >= 0) {


### PR DESCRIPTION

Cont #1501 

Closes #1186 

Strictly speaking, the request in #1186 was to port the `-fit` approach from mainline. This PR and PR #1501 are not a port of the llama.cpp `-fit` feature, but a completely independent and original `ik_llama.cpp` implementation. But as they achieve the same goal, #1186 can be closed. 
