### PR TITLE
mul_mat_q8_0_r8_q8_2: combine dot products before float conversion

### DIFF
--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -1706,21 +1706,20 @@ static void mul_mat_q8_0_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
             }
             for (int k = 0; k < 4; ++k) {
                 auto scales = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq8[4*ib4+k].d));
+                __m256i sumi_first[nrc_y];
                 for (int j = 0; j < 4; ++j) {
                     qx[j] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+j);
                     sx[j] = _mm256_sign_epi8(qx[j], qx[j]);
                 }
                 for (int iy = 0; iy < nrc_y; ++iy) {
-                    auto sumi = dot(q8.y[iy][ib4].qs+32*k);
-                    auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(d8[4*iy+k]));
-                    acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
+                    sumi_first[iy] = dot(q8.y[iy][ib4].qs+32*k);
                 }
                 for (int j = 0; j < 4; ++j) {
                     qx[j] = _mm256_loadu_si256((const __m256i *)iq8[4*ib4+k].qs+4+j);
                     sx[j] = _mm256_sign_epi8(qx[j], qx[j]);
                 }
                 for (int iy = 0; iy < nrc_y; ++iy) {
-                    auto sumi = dot(q8.y[iy][ib4].qs+32*k+16);
+                    auto sumi = _mm256_add_epi32(sumi_first[iy], dot(q8.y[iy][ib4].qs+32*k+16));
                     auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(d8[4*iy+k]));
                     acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
                 }
@@ -1728,15 +1727,14 @@ static void mul_mat_q8_0_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
         }
         for (int ib = 4*(nb/4); ib < nb; ++ib) {
             auto scales = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)iq8[ib].d));
+            __m256i sumi_first[nrc_y];
             for (int j = 0; j < 4; ++j) {
                 qx[j] = _mm256_loadu_si256((const __m256i *)iq8[ib].qs+j);
                 sx[j] = _mm256_sign_epi8(qx[j], qx[j]);
             }
             for (int iy = 0; iy < nrc_y; ++iy) {
                 auto qy = (const block_q8_2 *)q8.y[iy];
-                auto sumi = dot(qy[ib].qs);
-                auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_BF16_TO_FP32(ggml_bf16_t{qy[ib].d})));
-                acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
+                sumi_first[iy] = dot(qy[ib].qs);
             }
             for (int j = 0; j < 4; ++j) {
                 qx[j] = _mm256_loadu_si256((const __m256i *)iq8[ib].qs+4+j);
@@ -1744,7 +1742,7 @@ static void mul_mat_q8_0_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
             }
             for (int iy = 0; iy < nrc_y; ++iy) {
                 auto qy = (const block_q8_2 *)q8.y[iy];
-                auto sumi = dot(qy[ib].qs+16);
+                auto sumi = _mm256_add_epi32(sumi_first[iy], dot(qy[ib].qs+16));
                 auto d4d8 = _mm256_mul_ps(scales, _mm256_set1_ps(GGML_BF16_TO_FP32(ggml_bf16_t{qy[ib].d})));
                 acc[iy] = _mm256_fmadd_ps(d4d8, _mm256_cvtepi32_ps(sumi), acc[iy]);
             }


### PR DESCRIPTION
Both halves of a k sub-block in `mul_mat_q8_0_r8_q8_2` share the same scale factor (`scales * d8[4*iy+k]`). Previously each half did its own `vcvtdq2ps` + `vmulps` + `vfmadd` to accumulate into the float result. This patch adds the two integer dot products with `vpaddd` first, then does a single float conversion and accumulate.

In simpler terms:

Original: acc += scale × float(A) + scale × float(B)
New: acc += scale × float(A + B)

Text generation was identical in my testing but perplexity was .0025 lower. By avoiding one floating-point rounding, it may actually be slightly more precise?

## Testing

### Benchmarks

Test Model: Qwen3.5 0.8B

6x Raptor Cove @ 3.5GHz

<img width="1275" height="1049" alt="results" src="https://github.com/user-attachments/assets/0ad21249-ba33-46a6-b3fd-2a3dfa87e229" />

IQ3_KT, IQ4_KT, Q4_0, Q6_K and others go through this kernel.

IQ4_XS does not and is a control.

### QA

Test Model: Qwen3.5 0.8B IQ3_KT

Text generation on 4/4 prompts identical.

Perplexity nearly identical:

Baseline: 20.5825 +/- 0.16742
PR: 20.5800 +/- 0.16739