### PR TITLE
CUDA: restore pinned memory usage for tensor overrides

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1482,7 +1482,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "--cpu-moe" || arg == "-cmoe") {
-        params.tensor_buft_overrides.push_back({strdup("\\.ffn_(up|down|gate|gate_up)_exps\\.weight"), ggml_backend_cpu_buffer_type()});
+        params.ncmoe = 999;
+        //params.tensor_buft_overrides.push_back({strdup("\\.ffn_(up|down|gate|gate_up)_exps\\.weight"), ggml_backend_cpu_buffer_type()});
         return true;
     }
     if (arg == "--n-cpu-moe" || arg == "-ncmoe") {

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -217,12 +217,14 @@ create_tensors_helper::create_tensors_helper(llama_model_loader & _ml, llama_mod
 
     if (ml.tensor_buft_overrides) {
         for (const auto * o = ml.tensor_buft_overrides; o->pattern != nullptr; ++o) {
-            overrides.emplace_back(std::make_pair(std::regex(o->pattern), o->buft));
+            auto buft = o->buft;
+            if (ggml_backend_buft_is_host(buft)) buft = llama_default_buffer_type_cpu(true);
+            overrides.emplace_back(std::make_pair(std::regex(o->pattern), buft));
         }
     }
 
     if (ml.ncmoe > 0) {
-        auto buft = ggml_backend_cpu_buffer_type();
+        auto buft = llama_default_buffer_type_cpu(true);
         if (model.split_mode == LLAMA_SPLIT_MODE_ATTN || model.split_mode == LLAMA_SPLIT_MODE_GRAPH || ml.ncmoe >= n_layer || model.devices.size() < 2) {
             int nmax = std::min(ml.ncmoe, n_layer);
             for (int i = 0; i < nmax; ++i) {


### PR DESCRIPTION

Using pinned memory buffers for tensors kept in RAM via tensor overrides (or `--cpu-moe, --n-cpu-moe`) got lost somewhere along the way. 

This PR restores pinned buffers for the `--no-mmap` case. I'll look into doing the same when `mmap` is used.

We get massive PP performance improvement for hybrid inference.

Here example `sweep-bench` results for Qwen-3.5-122B-A10B with all MoE tensors left on the CPU via `--cpu-moe`. GPU is 3090, CPU is Ryzen-3995WX, using `-sm graph` (but with all MoE tensors left in RAM the difference to `-sm layer` is small)

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |    4.005 |   511.37 |    1.952 |    32.79 |
|  2048 |     64 |   2048 |    3.957 |   517.50 |    1.986 |    32.22 |
|  2048 |     64 |   4096 |    3.992 |   513.02 |    1.936 |    33.05 |
|  2048 |     64 |   6144 |    3.956 |   517.67 |    1.930 |    33.16 |
|  2048 |     64 |   8192 |    3.967 |   516.20 |    1.935 |    33.08 |
|  2048 |     64 |  10240 |    3.995 |   512.61 |    1.935 |    33.08 |
|  2048 |     64 |  12288 |    3.994 |   512.75 |    1.946 |    32.89 |
|  2048 |     64 |  14336 |    4.007 |   511.09 |    1.937 |    33.04 |
|  2048 |     64 |  16384 |    4.051 |   505.53 |    1.933 |    33.11 |
|  2048 |     64 |  18432 |    4.033 |   507.79 |    1.958 |    32.69 |
|  2048 |     64 |  20480 |    4.047 |   506.09 |    1.997 |    32.05 |
|  2048 |     64 |  22528 |    4.095 |   500.13 |    1.957 |    32.70 |
|  2048 |     64 |  24576 |    4.049 |   505.77 |    1.956 |    32.71 |
|  2048 |     64 |  26624 |    4.071 |   503.13 |    1.981 |    32.31 |
|  2048 |     64 |  28672 |    4.097 |   499.94 |    1.962 |    32.62 |
|  2048 |     64 |  30720 |    4.051 |   505.58 |    1.965 |    32.58 |
|  2048 |     64 |  32768 |    4.110 |   498.28 |    1.975 |    32.41 |

### PR 

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |    3.141 |   652.00 |    1.933 |    33.11 |
|  2048 |     64 |   2048 |    3.104 |   659.89 |    1.935 |    33.08 |
|  2048 |     64 |   4096 |    3.108 |   659.00 |    1.936 |    33.05 |
|  2048 |     64 |   6144 |    3.131 |   654.00 |    1.939 |    33.01 |
|  2048 |     64 |   8192 |    3.140 |   652.30 |    1.944 |    32.92 |
|  2048 |     64 |  10240 |    3.134 |   653.43 |    1.950 |    32.83 |
|  2048 |     64 |  12288 |    3.166 |   646.84 |    1.995 |    32.08 |
|  2048 |     64 |  14336 |    3.175 |   645.05 |    1.959 |    32.67 |
|  2048 |     64 |  16384 |    3.195 |   640.90 |    1.965 |    32.57 |
|  2048 |     64 |  18432 |    3.201 |   639.83 |    1.969 |    32.50 |
|  2048 |     64 |  20480 |    3.207 |   638.63 |    1.965 |    32.58 |
|  2048 |     64 |  22528 |    3.198 |   640.48 |    1.987 |    32.22 |
|  2048 |     64 |  24576 |    3.217 |   636.62 |    1.968 |    32.52 |
|  2048 |     64 |  26624 |    3.236 |   632.88 |    2.000 |    32.01 |
|  2048 |     64 |  28672 |    3.259 |   628.43 |    2.008 |    31.87 |
|  2048 |     64 |  30720 |    3.227 |   634.74 |    2.077 |    30.81 |
|  2048 |     64 |  32768 |    3.269 |   626.40 |    1.984 |    32.27 |
