### PR TITLE
ggml-cuda: fix shared memory sizing in OpenAI argsort kernel

### DIFF
--- a/ggml/src/ggml-cuda/argsort.cu
+++ b/ggml/src/ggml-cuda/argsort.cu
@@ -407,7 +407,10 @@ static void argsort_openai_f32_f32_i32_cuda(const float * x, float * weights, in
 
     const dim3 block_dims(ncols_pad, 1, 1);
     const dim3 block_nums(nrows, 1, 1);
-    const size_t shared_mem = (ncols_pad + ncols_pad > WARP_SIZE ? WARP_SIZE : 0) * sizeof(int);
+    // k_openai_f32_f32_i32 always stores dst_row[ncols_pad] in dynamic shared memory.
+    // When blockDim > WARP_SIZE it also uses a per-warp float scratch segment (s_sum).
+    const int n_warps = (ncols_pad + WARP_SIZE - 1) / WARP_SIZE;
+    const size_t shared_mem = ncols_pad * sizeof(int) + (ncols_pad > WARP_SIZE ? n_warps * sizeof(float) : 0);
 
     // FIXME: this limit could be raised by ~2-4x on Ampere or newer
     GGML_ASSERT(shared_mem <= ggml_cuda_info().devices[ggml_cuda_get_device()].smpb);


### PR DESCRIPTION
### Summary
This fixes a CUDA shared-memory sizing bug in the OpenAI argsort path used during expert routing.

In `argsort_openai_f32_f32_i32_cuda()`, dynamic shared memory was under-allocated for kernel `k_openai_f32_f32_i32`.

- Kernel always writes `dst_row[ncols_pad]` in dynamic shared memory.
- For `blockDim.x > WARP_SIZE`, kernel also uses per-warp float scratch (`s_sum`).
- Previous launch allocation only reserved a tiny scratch segment and did not reserve `dst_row[ncols_pad]`.

This caused illegal memory access (CUDA error in `ggml-cuda.cu:132`) on GPT-OSS 120B fused routing path.

### Root Cause
File: `ggml/src/ggml-cuda/argsort.cu`

- `k_openai_f32_f32_i32` uses:
  - `extern __shared__ int dst_row[];`
  - `dst_row[col] = col;` for `col < ncols_pad`
  - optional float warp scratch via `(float *)(dst_row + ncols_pad)`
- Host launch-side `shared_mem` calculation was incorrect and under-sized.

### Fix
Update shared memory calculation to include both regions:

- `ncols_pad * sizeof(int)` for `dst_row`
- `n_warps * sizeof(float)` scratch only when `ncols_pad > WARP_SIZE`

where `n_warps = ceil(ncols_pad / WARP_SIZE)`.

### Validation
Reproduced and validated on RTX PRO 6000 Blackwell.

#### Before fix
Unsloth GPT-OSS 120B (`gpt-oss-120b-F16.gguf`) failed with CUDA error in fused path:
- prefill `rc = 134`
- gen `rc = 134`
- stderr: `.../ggml-cuda.cu:132: CUDA error`

#### After fix (fusion enabled, no workaround)
Using the same command line shape on Unsloth GPT-OSS 120B:

- prefill: `avg_ts = 5026.999257`, `rc = 0`
- gen: `avg_ts = 167.417082`, `rc = 0`

Additional check:
- `compute-sanitizer --tool memcheck` on GPT-OSS prefill now exits `rc=0` (no prior shared-memory OOB report).

Related quantized-model check:
- Unsloth GPT-OSS 20B quant (`gpt-oss-20b-Q2_K`) was also tested; this smaller quantized model did not reproduce the crash on either build.

### Why this is safe
- Change is isolated to launch-side dynamic shared-memory sizing for one kernel path.
- No algorithmic behavior changes to sorting, routing, or math.
- Only memory layout reservation is corrected to match kernel usage.

### Contributor Checklist
- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

## Maintainer Notes
If useful, I can split this into two commits:
1) fix only
2) follow-up regression test/guard (if there is a preferred CUDA test harness for this path)
