### PR TITLE
Print info when allocating large amounts of pinned host memory

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -1261,9 +1261,19 @@ static void * ggml_cuda_host_malloc(size_t size) {
     if (getenv("GGML_CUDA_NO_PINNED") != nullptr) {
         return nullptr;
     }
+    constexpr double k_warn_limit = 8.0;
 
     void * ptr = nullptr;
+    double size_GiB = size/(1024.*1024.*1024.);
+    auto tim1 = ggml_time_us();
+    if (size_GiB > k_warn_limit) {
+        GGML_CUDA_LOG_INFO("Allocating %.2f GiB of pinned host memory, this can take a while...\n", size_GiB);
+    }
     cudaError_t err = cudaMallocHost((void **) &ptr, size);
+    if (size_GiB > k_warn_limit) {
+        auto tim2 = ggml_time_us();
+        GGML_CUDA_LOG_INFO("    done allocating %.2f GiB in %.1f ms\n", size_GiB, 1e-3*(tim2-tim1));
+    }
     if (err != cudaSuccess) {
         // clear the error
         cudaGetLastError();


### PR DESCRIPTION

After restoring usage of pinned host memory in #1508 and #1510 I started wondering why model loading seems to be hanging for a while when loading very large models. Turns out what seems like hanging is caused by the large amount of pinned host memory being allocated via `cudaMallocHost`. This PR adds a message to standard output to inform about potentially long memory allocation times. For instance, loading Qwen-3.5-122B-A10B on a 2x3090 system we now see
```
Allocating 33.38 GiB of pinned host memory, this can take a while...
    done allocating 33.38 GiB in 7956.8 ms
```
 