### PR TITLE
Fix jinja

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -22,6 +22,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <fstream>
 
 using json = nlohmann::ordered_json;
 
@@ -550,6 +551,8 @@ std::string common_chat_format_single(
     std::string fmt_past_msg;
     if (!past_msg.empty()) {
         inputs.messages = past_msg;
+        auto & extra = inputs.messages.emplace_back();
+        extra.role = new_msg.role;
         inputs.add_generation_prompt = false;
         fmt_past_msg = common_chat_templates_apply(tmpls, inputs).prompt;
     }
@@ -557,11 +560,21 @@ std::string common_chat_format_single(
     // if the past_msg ends with a newline, we must preserve it in the formatted version
     if (add_ass && !fmt_past_msg.empty() && fmt_past_msg.back() == '\n') {
         ss << "\n";
-    };
+    }
+    if (inputs.messages.empty()) {
+        inputs.messages.push_back(new_msg);
+    } else {
+        inputs.messages.back() = new_msg;
+    }
     // format chat with new_msg
-    inputs.messages.push_back(new_msg);
     inputs.add_generation_prompt = add_ass;
     auto fmt_new_msg = common_chat_templates_apply(tmpls, inputs).prompt;
+    if (fmt_new_msg.size() < fmt_past_msg.size()) {
+        LOG_ERR("============================================ Oops: new message is of length %zu, past message is %zu\n", fmt_new_msg.size(), fmt_past_msg.size());
+        LOG_ERR("=== past message: <%s>\n", fmt_past_msg.c_str());
+        LOG_ERR("=== new  message: <%s>\n", fmt_new_msg.c_str());
+        throw std::runtime_error("Failed to apply chat template");
+    }
     // get the diff part
     ss << fmt_new_msg.substr(fmt_past_msg.size(), fmt_new_msg.size() - fmt_past_msg.size());
     return ss.str();


### PR DESCRIPTION

Closes #1514 

Running `llama-cli` with GLM-4.5-AIR and jinja enabled, I can consistently reproduce a crash by first saying
```
Hi there
```
and then
```
Give me an extended summary of the history of Bulgaria
```

The crash happens here: https://github.com/ikawrakow/ik_llama.cpp/blob/c06067fa14186e705356db3f0fb7d8603a9ca914/common/chat.cpp#L566

It happens because `fmt_new_msg` is shorter than `fmt_past_msg`, so `fmt_new_msg.size() - fmt_past_msg.size()` is negative, so becomes a huge value because `size()` is unsigned.

Looking closer, I observe that the content between `<think>` and `</think>` has not been removed in `fmt_past_msg`, but it has been removed in `fmt_new_msg`, and that's why `fmt_new_msg` is shorter than `fmt_past_msg`.

The PR works around this by adding a fake empty message to the past messages before applying the jinja template, then replacing the fake message with the actual new message and applying the jinja template.

As I know nothing about jinja, so have no idea what is actually supposed to happen, I need someone more knowledgable to verify that the fix makes sense. I did try the PR on a few models and it seemed to work fine, but nevertheless.