### PR TITLE
Log probabilities on token sampling crash

### DIFF
--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -738,7 +738,7 @@ llama_token llama_sample_token_with_rng_impl(struct llama_sampling * smpl, llama
         }
         out.flush();
         out.close();
-        LLAMA_LOG_ERROR("Data has been tored in probabilities.txt\n");
+        LLAMA_LOG_ERROR("Data has been stored in probabilities.txt\n");
         LLAMA_LOG_ERROR("Create an issue with full log and attach probabilities.txt to the issue\n");
         LLAMA_LOG_ERROR("\n\nCrashing now\n");
         GGML_ABORT("Fatal error");


### PR DESCRIPTION

There have been a few reports about a crash when sampling the next token. This PR adds code to create a log that contains all relevant information (how many candidate tokens, probabilities, logits, etc.) that can be attached to an issue about the crash.