### PR TITLE
Fix bug in CPU floash attention for bf16 KV cache

### DIFF
--- a/ggml/src/iqk/fa/iqk_fa_templates.h
+++ b/ggml/src/iqk/fa/iqk_fa_templates.h
@@ -2008,6 +2008,7 @@ struct FlashAttnBF16 {
             q    += q_step*stride_q;
             mask += q_step*stride_m;
             qkv  += q_step*stride_qkv;
+            if (M && S) { M += q_step; S += q_step; }
         }
         int n_left = nq1 - q_step*(nq1/q_step);
         if (n_left > 0) {


### PR DESCRIPTION

Closes #1520 

Bug is triggered for `bf16` KV cache and GQA different from 8, e.g., Qwen-3.5-27B (GQA = 6).