### PR TITLE
Avoid disabling mmap w/NUMA

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -904,6 +904,7 @@ extern "C" {
 
     GGML_API void    ggml_numa_init(enum ggml_numa_strategy numa); // call once for better performance on NUMA systems
     GGML_API bool    ggml_is_numa(void); // true if init detected that system has >1 NUMA node
+    GGML_API enum ggml_numa_strategy ggml_get_numa_strategy(void);
 
     GGML_API void    ggml_print_object (const struct ggml_object * obj);
     GGML_API void    ggml_print_objects(const struct ggml_context * ctx);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4662,6 +4662,10 @@ bool ggml_is_numa(void) {
     return g_state.numa.n_nodes > 1;
 }
 
+enum ggml_numa_strategy ggml_get_numa_strategy(void) {
+    return g_state.numa.numa_strategy;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void ggml_print_object(const struct ggml_object * obj) {

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -3945,7 +3945,12 @@ bool create_tensors_helper::create_tensors() {
             throw std::runtime_error("unknown architecture");
     }
 
-    use_mmap_buffer &= !has_buft_overrides;
+    // NUMA distribute/numactl modes rely on mmap for page placement across nodes
+    bool numa_needs_mmap = (
+        ggml_get_numa_strategy() == GGML_NUMA_STRATEGY_DISTRIBUTE ||
+        ggml_get_numa_strategy() == GGML_NUMA_STRATEGY_NUMACTL
+    );
+    use_mmap_buffer &= !has_buft_overrides || numa_needs_mmap;
 
     if (model.split_mode == LLAMA_SPLIT_MODE_GRAPH || model.split_mode == LLAMA_SPLIT_MODE_ATTN) {
         const int n_layer = model.mtp ? model.layers.size()


### PR DESCRIPTION
...unless it's "isolate" which probably should do what the non-NUMA path would do.

Closes #1533 

This is guesswork as to how access to the numa param should be done from the tensor load context. Feel free to suggest something else.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
