### PR TITLE
Even better Q4_0 KV cache

### DIFF
--- a/ggml/src/ggml-cuda/cpy-utils.cuh
+++ b/ggml/src/ggml-cuda/cpy-utils.cuh
@@ -39,15 +39,27 @@ static __device__ void quantize_f32_q4_0_block(const float * __restrict__ x, blo
 
     y->d = d;
 
+    float sumqx = 0, sumq2 = 0;
     for (int j = 0; j < QK4_0/2; ++j) {
-        const float x0 = x[0       + j]*id;
-        const float x1 = x[QK4_0/2 + j]*id;
+        const float v0 = x[0       + j];
+        const float v1 = x[QK4_0/2 + j];
+        const float x0 = v0*id;
+        const float x1 = v1*id;
 
         const uint8_t xi0 = min(15, (int8_t)(x0 + 8.5f));
         const uint8_t xi1 = min(15, (int8_t)(x1 + 8.5f));
+        float q0 = xi0 - 8;
+        float q1 = xi1 - 8;
+        float w0 = v0*v0;
+        float w1 = v1*v1;
+        sumqx += w0*q0*v0 + w1*q1*v1;
+        sumq2 += w0*q0*q0 + w1*q1*q1;
 
         y->qs[j]  = xi0;
         y->qs[j] |= xi1 << 4;
+    }
+    if (sumq2 > 0) {
+        y->d = sumqx/sumq2;
     }
 }
 


### PR DESCRIPTION

Even a low-key project such as `ik_llama.cpp` is being bombarded with TurboQuant hype.

OK, then, let us raise the bar even higher. The bar has been high in `ik_llama.cpp` since Hadamard transforms were added for the K-cache in PRs #1033 and #1034 a while ago. Hadamard transform for V-cache was added more recently in PR #1527  (but that has a much smaller impact than using Hadamard transforms for the K-cache). 

This PR adds a scale adjustment for `Q4_0` quantized KV cache, for a computationally cheap but noticeable improvement as measured by perplexity.

I'm noticing that `IQ4_NL` KV cache, while much better than `Q4_0` without the Hadamard transform, with Hadamard either becomes worst than `Q4_0`, or the gap to `Q4_0` is much reduced. I'm still looking into that, so for now just `Q4_0`  stuff. The same method used in this PR is already used for `Q6_0` KV cache, and could also be added for `Q5_0`.

Here are some examples. The importance of KV cache quantization errors increases with increasing context length. Hence, instead of using a context of 512 customary in llama-land, the data in the table below is for a context of 8192 tokens. I did not go beyond 8192 tokens as the test corpus is `wiki.test.raw`, where very few articles exceed a context of 8k tokens. I did not add a comparison to a TurboQuant implementation to avoid discussions about how there was still a lot that could be improved in the TurboQuant implementations floating around the Internet.

|  Model  | PPL (f16) | PPL (q4_0, main) | PPL (q4_0, PR) | Delta (%, main) | Delta (%, PR) |
| ---: | ---: | ---: | ---: | ---: | ---: |
| LlaMA-3.1-8B, Q4_0 | 6.4258 | 6.5036 | 6.5025 |  +1.21 |  +1.19 |
| LlaMA-3.1-70B, Q4_0 | 3.5332 | 3.6129 | 3.5721 | +2.26 | +1.10 |
| Qwen3-8B-Base, bf16 | 6.0185 | 6.1448 | 6.1347 | +2.10 | +1.93 |
| Gemma3-12B, bf16 | 7.2896 | 7.3427 | 7.3406 |  +0.73 | +0.70 |
| GLM-4.5-AIR, IQ4_KSS | 5.5990 | 5.6471 | 5.5826 | +0.86 | -0.29 |
| Qwen3.5-35B-A3B, IQ4_XS | 5.8992 | 5.9241 | 5.9211 | +0.42 | +0.37 |
| Qwen3.5-27B, Q4_K_S | 7.1535 | 7.1939 | 7.1493 | +0.56 | -0.06 |