### PR TITLE
llama : fix KV cache quantization for hybrid Mamba/attention models

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5308,6 +5308,30 @@ struct llama_context * llama_init_from_model(
         params.v_cache_hadamard = false;
     }
 
+    // Hybrid Mamba/attention models (Qwen3.5, Qwen3-Next) require q8_0 minimum for KV cache
+    // Lower-bit quantization causes NaN accumulation in SSM state or attention-recurrent interaction
+    if (llm_arch_is_hybrid(model->arch)) {
+        bool need_upgrade_k = ggml_is_quantized(params.type_k) &&
+                              params.type_k != GGML_TYPE_Q8_0 &&
+                              params.type_k != GGML_TYPE_Q8_1 &&
+                              params.type_k != GGML_TYPE_Q8_KV;
+        bool need_upgrade_v = ggml_is_quantized(params.type_v) &&
+                              params.type_v != GGML_TYPE_Q8_0 &&
+                              params.type_v != GGML_TYPE_Q8_1 &&
+                              params.type_v != GGML_TYPE_Q8_KV;
+
+        if (need_upgrade_k) {
+            LLAMA_LOG_WARN("%s: hybrid Mamba/attention models require q8_0 minimum for K cache (requested: %s). Upgrading to q8_0\n",
+                __func__, ggml_type_name(params.type_k));
+            params.type_k = GGML_TYPE_Q8_0;
+        }
+        if (need_upgrade_v) {
+            LLAMA_LOG_WARN("%s: hybrid Mamba/attention models require q8_0 minimum for V cache (requested: %s). Upgrading to q8_0\n",
+                __func__, ggml_type_name(params.type_v));
+            params.type_v = GGML_TYPE_Q8_0;
+        }
+    }
+
     llama_context * ctx = new llama_context(*model);
 
     // add devices to ctx->cparams from model


### PR DESCRIPTION
Hybrid Mamba/attention models such as Qwen3.5 and Qwen3-Next crash with NaN logits when using KV cache quantization below `q8_0` on the CPU backend. The failure is immediate and catastrophic -- `Failed to sample token` followed by abort, not a gradual perplexity degradation.

The root cause is that 4/5/6-bit quantization of the KV cache in the attention layers introduces errors that accumulate through the interleaved SSM layers. In Qwen3.5-35B-A3B (40 layers: 10 attention + 30 SSM, `full_attention_interval=4`), the SSM recurrent state is always F32, but it consumes attention outputs that went through quantized KV cache -- and those errors compound across the attention/SSM cycle.

I initially tried porting the `sumqx/sumq2` scale adjustment from PR #1547 to the CPU `quantize_row_q4_0_ref()` path, hoping better scale selection would be sufficient. It was not - NaN still occurs. PR #1547's scale adjustment is CUDA-only (`cpy-utils.cuh`) and even the same technique on CPU does not prevent the catastrophic precision loss in hybrid architectures.

This PR auto-upgrades sub-`q8_0` quantized KV cache types to `q8_0` for hybrid models, with a warning. Non-quantized types (`f16`, `bf16`, `f32`) and `q8_0`/`q8_1`/`q8_kv` pass through unchanged.

### Reproducing

```
llama-cli -m Qwen3.5-35B-A3B-Q4_K_M.gguf -np 1 -fa on -t 16 -ctk q4_0 -ctv q4_0 -khad -vhad -p "Hello world" -n 64
```

| Configuration | KV cache | Result |
| ---: | ---: | :--- |
| main, no fix | q4_0 | `Failed to sample token` / NaN crash |
| scale adjustment only (PR #1547 technique on CPU) | q4_0 | `Failed to sample token` / NaN crash |
| this PR | q4_0 requested, q8_0 actual | coherent output, warning printed |
| main, no fix | q8_0 | coherent output |
| main, no fix | f16 | coherent output |

Tested on Qwen3.5-35B-A3B (Q4_K_M, 40 layers, 10 attention + 30 SSM, `full_attention_interval=4`), CPU-only build, AVX2. The `q8_0` KV cache works correctly including with Hadamard transforms (`-khad -vhad`).

### Note on scope

The guard applies to all backends, not just CPU. On CUDA, `q4_0` KV cache may work for short contexts (PR #1547 shows acceptable PPL at 8k tokens), but NaN is a tail event that PPL averages can mask, and it is likely to surface at longer contexts. Since `llama_init_from_model()` sets the cache type globally (not per-backend), there is no clean way to scope this to CPU-only without refactoring the KV cache initialization to support per-layer or per-backend type selection.


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
