### PR TITLE
Enable all CPU-backend FA supported quants by default

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -139,7 +139,7 @@ set   (GGML_CUDA_COMPRESSION_MODE "size" CACHE STRING
 set_property(CACHE GGML_CUDA_COMPRESSION_MODE PROPERTY STRINGS "none;speed;balance;size")
 
 option(GGML_IQK_FLASH_ATTENTION             "ggml: enable the IQK FlashAttention CPU kernels" ON)
-option(GGML_IQK_FA_ALL_QUANTS               "ggml: compile all quants for IQK FlashAttention" OFF)
+option(GGML_IQK_FA_ALL_QUANTS               "ggml: compile all quants for IQK FlashAttention" ON)
 
 option(GGML_CURL                            "ggml: use libcurl to download model from an URL" OFF)
 option(GGML_HIPBLAS                         "ggml: use hipBLAS"                               OFF)


### PR DESCRIPTION

I observe many people trying to use quantization lower than `Q6_0` on the CPU backend without having enabled all CPU-backend supported quantization types. This leads to NaNs and issues/PRs being submitted.

Hence, enabling all supported quants by default. On the CPU backend these are
* `Q8_0`
* `Q6_0`
* `Q4_1`
* `IQ4_NL`
* `Q4_0`

I guess, I should also guard against usage of the not supported `Q5_0` and `Q5_1`, but I'll do that in another PR.

If you feel bothered by the now longer build time, use `-DGGML_IQK_FA_ALL_QUANTS=OFF` to go back to the previous default, and then remember to only use `Q8_0` and `Q6_0` quantization for the KV cache when running on the CPU.