### PR TITLE
Enable multiple graphs/schedulers for speculative decoder

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1330,7 +1330,15 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
     }
     if (arg == "-gr" || arg == "--graph-reuse") {
         CHECK_ARG
-        params.n_graph_reuse = std::stoi(argv[i]);
+        std::string val = argv[i];
+        auto comma = val.find(',');
+        if (comma != std::string::npos) {
+            params.n_graph_reuse_main  = std::stoi(val.substr(0, comma));
+            params.n_graph_reuse_draft = std::stoi(val.substr(comma + 1));
+            params.n_graph_reuse = params.n_graph_reuse_main + params.n_graph_reuse_draft;
+        } else {
+            params.n_graph_reuse = std::stoi(val);
+        }
         return true;
     }
     if (arg == "-no-gr" || arg == "--no-graph-reuse") {
@@ -2313,7 +2321,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-no-fug, --no-fused-up-gate",   "disable fused up-gate (default: %s)", params.fused_up_gate ? "enabled" : "disabled" });
     options.push_back({ "*",           "-no-mmad, --no-fused-mul-multiadd", "disable fused mul-multi_add (default: %s)", params.fused_mmad? "enabled" : "disabled" });
     //options.push_back({ "*",           "-rcache, --rope-cache",         "enable RoPE cache (default: %s)", params.rope_cache ? "enabled" : "disabled" });
-    options.push_back({ "*",           "-gr,  --graph-reuse",           "number of cached graphs for reuse (default: %d, 0 = disabled)", params.n_graph_reuse });
+    options.push_back({ "*",           "-gr,  --graph-reuse",           "graph reuse slots: N (auto split) or M,D (main,draft) (default: %d)", params.n_graph_reuse });
     options.push_back({ "*",           "-no-gr, --no-graph-reuse",      "disable graph reuse (same as -gr 0)" });
     options.push_back({ "*",         "-ser,  --smart-expert-reduction", "experts reduction (default: %d,%g)", params.min_experts, params.thresh_experts});
     options.push_back({ "*",         "-mqkv,  --merge-qkv,",            "merge Q,K,V (default: %d)", params.merge_qkv});
@@ -3427,7 +3435,9 @@ struct llama_context_params common_context_params_to_llama(const gpt_params & pa
     cparams.fused_up_gate     = params.fused_up_gate;
     cparams.fused_mmad        = params.fused_mmad;
     cparams.rope_cache        = params.rope_cache;
-    cparams.n_graph_reuse    = params.n_graph_reuse;
+    cparams.n_graph_reuse       = params.n_graph_reuse;
+    cparams.n_graph_reuse_main  = params.n_graph_reuse_main;
+    cparams.n_graph_reuse_draft = params.n_graph_reuse_draft;
     cparams.k_cache_hadamard  = params.k_cache_hadamard;
     cparams.v_cache_hadamard  = params.v_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1329,11 +1329,12 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "-gr" || arg == "--graph-reuse") {
-        params.graph_reuse = true;
+        CHECK_ARG
+        params.n_graph_reuse = std::stoi(argv[i]);
         return true;
     }
     if (arg == "-no-gr" || arg == "--no-graph-reuse") {
-        params.graph_reuse = false;
+        params.n_graph_reuse = 0;
         return true;
     }
     if (arg == "-ser" || arg == "--smart-expert-reduction") {
@@ -2312,8 +2313,8 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-no-fug, --no-fused-up-gate",   "disable fused up-gate (default: %s)", params.fused_up_gate ? "enabled" : "disabled" });
     options.push_back({ "*",           "-no-mmad, --no-fused-mul-multiadd", "disable fused mul-multi_add (default: %s)", params.fused_mmad? "enabled" : "disabled" });
     //options.push_back({ "*",           "-rcache, --rope-cache",         "enable RoPE cache (default: %s)", params.rope_cache ? "enabled" : "disabled" });
-    options.push_back({ "*",           "-gr, --graph-reuse",            "enable graph reuse (default: %s)", params.graph_reuse ? "enabled" : "disabled" });
-    options.push_back({ "*",           "-no-gr, --no-graph-reuse",      "disable graph reuse (default: %s)", !params.graph_reuse ? "enabled" : "disabled" });
+    options.push_back({ "*",           "-gr,  --graph-reuse",           "number of cached graphs for reuse (default: %d, 0 = disabled)", params.n_graph_reuse });
+    options.push_back({ "*",           "-no-gr, --no-graph-reuse",      "disable graph reuse (same as -gr 0)" });
     options.push_back({ "*",         "-ser,  --smart-expert-reduction", "experts reduction (default: %d,%g)", params.min_experts, params.thresh_experts});
     options.push_back({ "*",         "-mqkv,  --merge-qkv,",            "merge Q,K,V (default: %d)", params.merge_qkv});
     options.push_back({ "*",         "-muge,  --merge-up-gate-experts,","merge ffn_up/gate_exps (default: %d)", params.merge_up_gate_exps});
@@ -3426,7 +3427,7 @@ struct llama_context_params common_context_params_to_llama(const gpt_params & pa
     cparams.fused_up_gate     = params.fused_up_gate;
     cparams.fused_mmad        = params.fused_mmad;
     cparams.rope_cache        = params.rope_cache;
-    cparams.graph_reuse       = params.graph_reuse;
+    cparams.n_graph_reuse    = params.n_graph_reuse;
     cparams.k_cache_hadamard  = params.k_cache_hadamard;
     cparams.v_cache_hadamard  = params.v_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
@@ -4442,7 +4443,7 @@ void yaml_dump_non_result_info(FILE * stream, const gpt_params & params, const l
     fprintf(stream, "fused_up_gate: %s # default: true\n", params.fused_up_gate ? "true" : "false");
     fprintf(stream, "fused_mmad: %s # default: true\n", params.fused_mmad ? "true" : "false");
     fprintf(stream, "rope_cache: %s # default: false\n", params.rope_cache ? "true" : "false");
-    fprintf(stream, "graph_reuse: %s # default: false\n", params.graph_reuse ? "true" : "false");
+    fprintf(stream, "n_graph_reuse: %d\n", params.n_graph_reuse);
     fprintf(stream, "k_cache_hadamard: %s # default: false\n", params.k_cache_hadamard ? "true" : "false");
     fprintf(stream, "v_cache_hadamard: %s # default: false\n", params.v_cache_hadamard ? "true" : "false");
     fprintf(stream, "split_mode_graph_scheduling: %s # default: false\n", params.split_mode_graph_scheduling ? "true" : "false");

--- a/common/common.h
+++ b/common/common.h
@@ -334,7 +334,9 @@ struct gpt_params {
     bool fused_mmad        = true;  // fused mul+multi_add op
     bool grouped_expert_routing = false; // if to use grouped expert routing (BailingMoeV2 arch)
     bool rope_cache        = false; // if to use RoPE cache (for supported models)
-    int  n_graph_reuse     = 1;     // number of graphs to cache for reuse (0=disable, 1=default, >1=multi-graph)
+    int  n_graph_reuse       = 1;   // total graph reuse slots (backward compat, 0=disable)
+    int  n_graph_reuse_main  = -1;  // main scheduler slots (-1 = auto from n_graph_reuse)
+    int  n_graph_reuse_draft = -1;  // draft/MTP scheduler slots (-1 = auto from n_graph_reuse)
     int  min_experts       = -1;
     float thresh_experts   = 0;
 

--- a/common/common.h
+++ b/common/common.h
@@ -334,7 +334,7 @@ struct gpt_params {
     bool fused_mmad        = true;  // fused mul+multi_add op
     bool grouped_expert_routing = false; // if to use grouped expert routing (BailingMoeV2 arch)
     bool rope_cache        = false; // if to use RoPE cache (for supported models)
-    bool graph_reuse       = true;  // if to reuse compute graphs
+    int  n_graph_reuse     = 1;     // number of graphs to cache for reuse (0=disable, 1=default, >1=multi-graph)
     int  min_experts       = -1;
     float thresh_experts   = 0;
 

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1018,7 +1018,7 @@ struct cmd_params_instance {
         cparams.flash_attn = flash_attn;
         cparams.mla_attn = mla_attn;
         cparams.attn_max_batch = attn_max_batch;
-        cparams.graph_reuse = reuse;
+        cparams.n_graph_reuse = reuse ? 1 : 0;
         cparams.fused_moe_up_gate = fmoe;
         cparams.grouped_expert_routing = ger;
         cparams.rope_cache = rcache;

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -2107,6 +2107,8 @@ void server_context::process_single_task(server_task&& task) {
         res.id_multi = task.id_multi;
         res.stop = true;
         res.error = false;
+
+        const auto gr = llama_get_graph_reuse_stats(ctx);
         res.data = {
             { "idle",                            n_idle_slots       },
             { "processing",                      n_processing_slots },
@@ -2125,6 +2127,18 @@ void server_context::process_single_task(server_task&& task) {
 
             { "kv_cache_tokens_count",           llama_get_kv_cache_token_count(ctx)},
             { "kv_cache_used_cells",             llama_get_kv_cache_used_cells(ctx)},
+
+            { "graph_reuse", {
+                { "n_reuse_main",   gr.n_graph_reuse_main },
+                { "n_new_main",     gr.n_graph_new_main },
+                { "n_reuse_mtp",    gr.n_graph_reuse_mtp },
+                { "n_new_mtp",      gr.n_graph_new_mtp },
+                { "n_reuse_cross",  gr.n_graph_reuse_cross },
+                { "n_sched_swap",   gr.n_sched_swap },
+                { "t_reuse_us",     gr.t_graph_reuse_us },
+                { "t_build_us",     gr.t_graph_build_us },
+                { "t_sched_reset_us", gr.t_sched_reset_us },
+            }},
 
             { "slots",                           slots_data },
         };

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -857,6 +857,34 @@ int main(int argc, char ** argv) {
             }}}
         };
 
+        if (data.contains("graph_reuse")) {
+            const auto & gr = data.at("graph_reuse");
+            const int32_t reuse_main = gr.at("n_reuse_main");
+            const int32_t new_main   = gr.at("n_new_main");
+            const int32_t reuse_mtp  = gr.at("n_reuse_mtp");
+            const int32_t new_mtp    = gr.at("n_new_mtp");
+            const int32_t total_all  = reuse_main + new_main + reuse_mtp + new_mtp;
+            const int32_t reuse_all  = reuse_main + reuse_mtp;
+
+            auto & counters = all_metrics_def["counter"];
+            counters.push_back({{"name", "graph_reuse_total"},       {"help", "Total graph reuse hits."},         {"value", (uint64_t)reuse_all}});
+            counters.push_back({{"name", "graph_new_total"},         {"help", "Total new graph builds."},         {"value", (uint64_t)(new_main + new_mtp)}});
+            counters.push_back({{"name", "graph_reuse_main"},        {"help", "Graph reuse hits (main model)."},  {"value", (uint64_t)reuse_main}});
+            counters.push_back({{"name", "graph_new_main"},          {"help", "New graph builds (main model)."},  {"value", (uint64_t)new_main}});
+            counters.push_back({{"name", "graph_reuse_mtp"},         {"help", "Graph reuse hits (MTP/draft)."},   {"value", (uint64_t)reuse_mtp}});
+            counters.push_back({{"name", "graph_new_mtp"},           {"help", "New graph builds (MTP/draft)."},   {"value", (uint64_t)new_mtp}});
+            counters.push_back({{"name", "graph_reuse_cross_slot"},  {"help", "Cross-slot graph reuses."},        {"value", (uint64_t)(int32_t)gr.at("n_reuse_cross")}});
+            counters.push_back({{"name", "sched_swaps_total"},       {"help", "Scheduler main/draft swaps."},     {"value", (uint64_t)(int32_t)gr.at("n_sched_swap")}});
+
+            auto & gauges = all_metrics_def["gauge"];
+            gauges.push_back({{"name", "graph_reuse_rate"},          {"help", "Graph reuse hit rate (0-1)."},     {"value", total_all > 0 ? 1.0 * reuse_all / total_all : 0.0}});
+            gauges.push_back({{"name", "graph_reuse_rate_main"},     {"help", "Graph reuse rate main model."},    {"value", (reuse_main + new_main) > 0 ? 1.0 * reuse_main / (reuse_main + new_main) : 0.0}});
+            gauges.push_back({{"name", "graph_reuse_rate_mtp"},      {"help", "Graph reuse rate MTP/draft."},     {"value", (reuse_mtp + new_mtp) > 0 ? 1.0 * reuse_mtp / (reuse_mtp + new_mtp) : 0.0}});
+            gauges.push_back({{"name", "graph_reuse_seconds"},       {"help", "Time in graph reuse path (s)."},   {"value", (int64_t)gr.at("t_reuse_us") / 1.e6}});
+            gauges.push_back({{"name", "graph_build_seconds"},       {"help", "Time building new graphs (s)."},   {"value", (int64_t)gr.at("t_build_us") / 1.e6}});
+            gauges.push_back({{"name", "sched_reset_seconds"},       {"help", "Time in scheduler reset (s)."},    {"value", (int64_t)gr.at("t_sched_reset_us") / 1.e6}});
+        }
+
         std::stringstream prometheus;
 
         for (const auto & el : all_metrics_def.items()) {
@@ -879,6 +907,65 @@ int main(int argc, char ** argv) {
 
         res.set_content(prometheus.str(), "text/plain; version=0.0.4");
         res.status = 200; // HTTP OK
+    };
+
+    const auto handle_graph_reuse_stats = [&ctx_server](const httplib::Request &, httplib::Response & res) {
+        server_task task;
+        task.id = ctx_server.queue_tasks.get_new_id();
+        task.id_multi  = -1;
+        task.id_target = -1;
+        task.type = SERVER_TASK_TYPE_METRICS;
+
+        ctx_server.queue_results.add_waiting_task_id(task.id);
+        ctx_server.queue_tasks.post(std::move(task));
+
+        server_task_result result = ctx_server.queue_results.recv(task.id);
+        ctx_server.queue_results.remove_waiting_task_id(task.id);
+
+        json data = result.data;
+        json response;
+
+        if (data.contains("graph_reuse")) {
+            const auto & gr = data.at("graph_reuse");
+            const int32_t reuse_main = gr.at("n_reuse_main");
+            const int32_t new_main   = gr.at("n_new_main");
+            const int32_t reuse_mtp  = gr.at("n_reuse_mtp");
+            const int32_t new_mtp    = gr.at("n_new_mtp");
+            const int32_t total_main = reuse_main + new_main;
+            const int32_t total_mtp  = reuse_mtp + new_mtp;
+            const int32_t total_all  = total_main + total_mtp;
+            const int32_t reuse_all  = reuse_main + reuse_mtp;
+            const int64_t t_reuse    = gr.at("t_reuse_us");
+            const int64_t t_build    = gr.at("t_build_us");
+            const int64_t t_reset    = gr.at("t_sched_reset_us");
+
+            response = {
+                {"reuse_rate",      total_all  > 0 ? 1.0 * reuse_all / total_all : 0.0},
+                {"reuse_rate_main", total_main > 0 ? 1.0 * reuse_main / total_main : 0.0},
+                {"reuse_rate_mtp",  total_mtp  > 0 ? 1.0 * reuse_mtp / total_mtp : 0.0},
+                {"counts", {
+                    {"reuse_main",   reuse_main},
+                    {"new_main",     new_main},
+                    {"reuse_mtp",    reuse_mtp},
+                    {"new_mtp",      new_mtp},
+                    {"reuse_cross",  (int32_t)gr.at("n_reuse_cross")},
+                    {"sched_swaps",  (int32_t)gr.at("n_sched_swap")},
+                }},
+                {"time_ms", {
+                    {"reuse",        t_reuse / 1000.0},
+                    {"build",        t_build / 1000.0},
+                    {"sched_reset",  t_reset / 1000.0},
+                    {"saved_by_reuse", t_build > 0 && reuse_all > 0
+                        ? (t_build / (double)(new_main + new_mtp)) * reuse_all / 1000.0
+                        : 0.0},
+                }},
+            };
+        } else {
+            response = {{"error", "graph reuse not active"}};
+        }
+
+        res.set_content(response.dump(2), MIMETYPE_JSON);
+        res.status = 200;
     };
 
     const auto handle_slots_save = [&ctx_server, &params](const httplib::Request & req, httplib::Response & res, int id_slot) {
@@ -2041,6 +2128,7 @@ int main(int argc, char ** argv) {
     // register API routes
     svr->Get ("/health",              handle_health);
     svr->Get ("/metrics",             handle_metrics);
+    svr->Get ("/graph-reuse-stats",   handle_graph_reuse_stats);
     svr->Get ("/props",               handle_props);
     svr->Get("/v1/props",             handle_props_simple);
     svr->Get ("/v1/models",           handle_models);

--- a/include/llama.h
+++ b/include/llama.h
@@ -460,7 +460,9 @@ extern "C" {
         bool fused_up_gate;     // whether to use fused up/gate op [EXPERIMENTAL]
         bool fused_mmad;        // whether to use fused mul+multi_add op [EXPERIMENTAL]
         bool rope_cache;        // whether to use RoPE cache [EXPERIMENTAL]
-        int  n_graph_reuse;     // number of graphs to cache for reuse (0=disable, 1=default, >1=multi-graph) [EXPERIMENTAL]
+        int  n_graph_reuse;       // total graph reuse slots (backward compat, 0=disable) [EXPERIMENTAL]
+        int  n_graph_reuse_main;  // main scheduler graph slots (-1 = auto) [EXPERIMENTAL]
+        int  n_graph_reuse_draft; // draft/MTP scheduler graph slots (-1 = auto) [EXPERIMENTAL]
         int  min_experts;
         float thresh_experts;
         bool only_active_experts;

--- a/include/llama.h
+++ b/include/llama.h
@@ -530,6 +530,21 @@ extern "C" {
         int32_t n_eval;
     };
 
+    struct llama_graph_reuse_stats {
+        // Reuse rates (graph_reuse / (graph_reuse + graph_new) = hit rate)
+        int32_t n_graph_reuse_main;
+        int32_t n_graph_new_main;     // new graph builds for main model
+        int32_t n_graph_reuse_mtp;    // graphs reused for MTP/draft operations
+        int32_t n_graph_new_mtp;      // new graph builds for MTP/draft
+        int32_t n_graph_reuse_cross;  // cross-slot reuses
+        int32_t n_sched_swap;         // scheduler swaps (sched <-> sched_draft)
+
+        // Time accounting
+        int64_t t_graph_reuse_us;     // total time in graph reuse path
+        int64_t t_graph_build_us;     // total time in new graph build + alloc path
+        int64_t t_sched_reset_us;     // time spent in reset_scheduler
+    };
+
     // used in chat template
     typedef struct llama_chat_message {
         const char * role;
@@ -1492,6 +1507,10 @@ LLAMA_API struct llama_grammar* llama_sampler_init_grammar_lazy_patterns(
 
     LLAMA_API void llama_print_timings(struct llama_context * ctx);
     LLAMA_API void llama_reset_timings(struct llama_context * ctx);
+
+    // Graph reuse metrics
+    LLAMA_API struct llama_graph_reuse_stats llama_get_graph_reuse_stats(struct llama_context * ctx);
+    LLAMA_API void llama_reset_graph_reuse_stats(struct llama_context * ctx);
 
     // Print system information
     LLAMA_API const char * llama_print_system_info(void);

--- a/include/llama.h
+++ b/include/llama.h
@@ -460,7 +460,7 @@ extern "C" {
         bool fused_up_gate;     // whether to use fused up/gate op [EXPERIMENTAL]
         bool fused_mmad;        // whether to use fused mul+multi_add op [EXPERIMENTAL]
         bool rope_cache;        // whether to use RoPE cache [EXPERIMENTAL]
-        bool graph_reuse;       // whether to reuse graphs when possible [EXPERIMENTAL]
+        int  n_graph_reuse;     // number of graphs to cache for reuse (0=disable, 1=default, >1=multi-graph) [EXPERIMENTAL]
         int  min_experts;
         float thresh_experts;
         bool only_active_experts;

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -95,6 +95,11 @@ void llm_build_context::init() {
 
     ctx0 = ggml_init(params);
 
+    // clear cache_copies to avoid stale entries from previous builds.
+    for (auto & cc : lctx.cache_copies) {
+        cc.cpy = nullptr;
+    }
+
     lctx.inp_tokens      = nullptr;
     lctx.inp_embd        = nullptr;
     lctx.inp_pos         = nullptr;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -190,6 +190,7 @@ struct llama_context {
 
     // memory buffers used to evaluate the model
     std::vector<uint8_t> buf_compute_meta;
+    std::vector<uint8_t> buf_compute_meta_draft;
     ggml_backend_sched_t sched = nullptr;
     ggml_backend_sched_t sched_draft = nullptr; // dedicated scheduler for speculative graphs
 
@@ -225,6 +226,7 @@ struct llama_context {
         size_t        step = 0;
     };
     std::vector<CacheCopy> cache_copies;
+    std::vector<CacheCopy> cache_copies_draft;
 
     // --- Speculative graph reuse ---
     // Caches up to n_graph_reuse compute graphs to avoid rebuilding them on every decode.
@@ -267,6 +269,7 @@ struct llama_context {
     };
 
     std::vector<GraphSlot> graph_slots;
+    std::vector<GraphSlot> graph_slots_draft;
     int      active_graph_slot = -1;
     int      active_graph_slot_draft = -1;
     uint64_t graph_slot_counter = 0;   // monotonic counter for LRU

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -233,9 +233,10 @@ struct llama_context {
         bool     valid = false;
         uint64_t last_used = 0;     // LRU counter
         int               all_seq_id = 0;
+        int               n_tokens   = 0;
         int               n_outputs  = 0;
         int               n_kv       = 0;
-        int               n_splits   = 0; // scheduler splits; cross-slot reuse safe when <= 1
+        int               n_splits   = 0;
         llama_mtp_op_type mtp_op_type = MTP_OP_NONE;
         ggml_cgraph *     graph = nullptr;
 
@@ -275,6 +276,7 @@ struct llama_context {
     bool  can_reuse_graph(const llama_batch & u_batch);
     bool  update_cache_copies();
     bool  update_cache_copies_for_slot(int slot_idx);
+    bool  rebuild_cache_copies_for_slot(int slot_idx);
     void  save_graph_original_srcs(ggml_cgraph * gf);
     void  restore_graph_original_srcs(GraphSlot & slot);
     void  store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -275,6 +275,19 @@ struct llama_context {
     uint64_t graph_slot_counter = 0;   // monotonic counter for LRU
     std::vector<ggml_tensor *> graph_srcs_pending;
 
+    // Graph reuse performance counters
+    struct {
+        int32_t n_graph_reuse_main  = 0;
+        int32_t n_graph_new_main    = 0;
+        int32_t n_graph_reuse_mtp   = 0;
+        int32_t n_graph_new_mtp     = 0;
+        int32_t n_graph_reuse_cross = 0;
+        int32_t n_sched_swap        = 0;
+        int64_t t_graph_reuse_us    = 0;
+        int64_t t_graph_build_us    = 0;
+        int64_t t_sched_reset_us    = 0;
+    } gr_stats;
+
     void  reset_scheduler();
     int   find_reusable_graph(const llama_batch & u_batch);
     bool  can_reuse_graph(const llama_batch & u_batch);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -191,6 +191,7 @@ struct llama_context {
     // memory buffers used to evaluate the model
     std::vector<uint8_t> buf_compute_meta;
     ggml_backend_sched_t sched = nullptr;
+    ggml_backend_sched_t sched_mtp = nullptr; // dedicated scheduler for MTP graphs
 
     ggml_abort_callback abort_callback      = nullptr;
     void *              abort_callback_data = nullptr;
@@ -234,12 +235,14 @@ struct llama_context {
         int               all_seq_id = 0;
         int               n_outputs  = 0;
         int               n_kv       = 0;
+        int               n_splits   = 0; // scheduler splits; cross-slot reuse safe when <= 1
         llama_mtp_op_type mtp_op_type = MTP_OP_NONE;
         ggml_cgraph *     graph = nullptr;
 
         // For n_graph_reuse > 1: per-slot copies of buf_compute_meta, cache_copies, and input tensor ptrs.
         std::vector<uint8_t>   buf_compute_meta;
         std::vector<CacheCopy> cache_copies;
+        std::vector<ggml_tensor *> original_srcs; // [node * GGML_MAX_SRC + src_idx]
         // Input tensor pointers
         ggml_tensor * inp_tokens      = nullptr;
         ggml_tensor * inp_embd        = nullptr;
@@ -263,13 +266,17 @@ struct llama_context {
 
     std::vector<GraphSlot> graph_slots;
     int      active_graph_slot = -1;
+    int      active_graph_slot_mtp = -1;
     uint64_t graph_slot_counter = 0;   // monotonic counter for LRU
+    std::vector<ggml_tensor *> graph_srcs_pending;
 
     void  reset_scheduler();
     int   find_reusable_graph(const llama_batch & u_batch);
     bool  can_reuse_graph(const llama_batch & u_batch);
     bool  update_cache_copies();
     bool  update_cache_copies_for_slot(int slot_idx);
+    void  save_graph_original_srcs(ggml_cgraph * gf);
+    void  restore_graph_original_srcs(GraphSlot & slot);
     void  store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf);
     void  activate_graph_slot(int slot_idx);
     void  save_input_tensors_to_slot(GraphSlot & slot);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -219,19 +219,62 @@ struct llama_context {
 
     ggml_backend_t ggml_backend_by_name(const char * name);
 
-    struct Prev;
-    std::unique_ptr<Prev> prev;
-
-    void reset_scheduler();
-    bool can_reuse_graph(const llama_batch & u_batch);
-
     struct CacheCopy {
         ggml_tensor * cpy = nullptr;
         size_t        step = 0;
     };
     std::vector<CacheCopy> cache_copies;
 
-    bool update_cache_copies();
+    // --- Multi-graph reuse ---
+    static constexpr int GRAPH_SLOTS_MAX = 8;
+
+    struct GraphSlot {
+        bool     valid = false;
+        uint64_t last_used = 0;     // LRU counter
+        int               all_seq_id = 0;
+        int               n_outputs  = 0;
+        int               n_kv       = 0;
+        llama_mtp_op_type mtp_op_type = MTP_OP_NONE;
+        ggml_cgraph *     graph = nullptr;
+
+        // For n_graph_reuse > 1: per-slot copies of buf_compute_meta, cache_copies, and input tensor ptrs.
+        std::vector<uint8_t>   buf_compute_meta;
+        std::vector<CacheCopy> cache_copies;
+        // Input tensor pointers
+        ggml_tensor * inp_tokens      = nullptr;
+        ggml_tensor * inp_embd        = nullptr;
+        ggml_tensor * inp_pos         = nullptr;
+        ggml_tensor * inp_out_ids     = nullptr;
+        ggml_tensor * inp_KQ_mask     = nullptr;
+        ggml_tensor * inp_KQ_mask_swa = nullptr;
+        ggml_tensor * inp_K_shift     = nullptr;
+        ggml_tensor * inp_mean        = nullptr;
+        ggml_tensor * inp_cls         = nullptr;
+        ggml_tensor * inp_s_copy      = nullptr;
+        ggml_tensor * inp_s_mask      = nullptr;
+        ggml_tensor * inp_s_seq       = nullptr;
+        ggml_tensor * inp_s_seq_qnext = nullptr;
+        ggml_tensor * inp_pos_bucket  = nullptr;
+        ggml_tensor * inp_embd_enc    = nullptr;
+        ggml_tensor * inp_KQ_mask_cross = nullptr;
+        ggml_tensor * inp_scale       = nullptr;
+        ggml_tensor * inp_mtp_states  = nullptr;
+    };
+
+    std::vector<GraphSlot> graph_slots;
+    int      active_graph_slot = -1;
+    uint64_t graph_slot_counter = 0;   // monotonic counter for LRU
+
+    void  reset_scheduler();
+    int   find_reusable_graph(const llama_batch & u_batch);
+    bool  can_reuse_graph(const llama_batch & u_batch);
+    bool  update_cache_copies();
+    bool  update_cache_copies_for_slot(int slot_idx);
+    void  store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf);
+    void  activate_graph_slot(int slot_idx);
+    void  save_input_tensors_to_slot(GraphSlot & slot);
+    void  restore_input_tensors_from_slot(GraphSlot & slot);
+    void  invalidate_graph_slots();
 
     bool prepare_mtp_graph_inputs(
         struct llama_context & lctx);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -191,7 +191,7 @@ struct llama_context {
     // memory buffers used to evaluate the model
     std::vector<uint8_t> buf_compute_meta;
     ggml_backend_sched_t sched = nullptr;
-    ggml_backend_sched_t sched_mtp = nullptr; // dedicated scheduler for MTP graphs
+    ggml_backend_sched_t sched_draft = nullptr; // dedicated scheduler for speculative graphs
 
     ggml_abort_callback abort_callback      = nullptr;
     void *              abort_callback_data = nullptr;
@@ -226,12 +226,13 @@ struct llama_context {
     };
     std::vector<CacheCopy> cache_copies;
 
-    // --- Multi-graph reuse ---
+    // --- Speculative graph reuse ---
+    // Caches up to n_graph_reuse compute graphs to avoid rebuilding them on every decode.
     static constexpr int GRAPH_SLOTS_MAX = 8;
 
     struct GraphSlot {
         bool     valid = false;
-        uint64_t last_used = 0;     // LRU counter
+        uint64_t last_used = 0;     // monotonic LRU counter (higher = more recent)
         int               all_seq_id = 0;
         int               n_tokens   = 0;
         int               n_outputs  = 0;
@@ -240,7 +241,7 @@ struct llama_context {
         llama_mtp_op_type mtp_op_type = MTP_OP_NONE;
         ggml_cgraph *     graph = nullptr;
 
-        // For n_graph_reuse > 1: per-slot copies of buf_compute_meta, cache_copies, and input tensor ptrs.
+        // For n_graph_reuse > 1: per-slot snapshot of build context for cross-slot restoration.
         std::vector<uint8_t>   buf_compute_meta;
         std::vector<CacheCopy> cache_copies;
         std::vector<ggml_tensor *> original_srcs; // [node * GGML_MAX_SRC + src_idx]
@@ -267,7 +268,7 @@ struct llama_context {
 
     std::vector<GraphSlot> graph_slots;
     int      active_graph_slot = -1;
-    int      active_graph_slot_mtp = -1;
+    int      active_graph_slot_draft = -1;
     uint64_t graph_slot_counter = 0;   // monotonic counter for LRU
     std::vector<ggml_tensor *> graph_srcs_pending;
 
@@ -276,7 +277,6 @@ struct llama_context {
     bool  can_reuse_graph(const llama_batch & u_batch);
     bool  update_cache_copies();
     bool  update_cache_copies_for_slot(int slot_idx);
-    bool  rebuild_cache_copies_for_slot(int slot_idx);
     void  save_graph_original_srcs(ggml_cgraph * gf);
     void  restore_graph_original_srcs(GraphSlot & slot);
     void  store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf);

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -39,6 +39,8 @@ struct llama_cparams {
     bool fused_mmad;
     bool rope_cache;
     int  n_graph_reuse;
+    int  n_graph_reuse_main;
+    int  n_graph_reuse_draft;
     bool k_cache_hadamard;
     bool v_cache_hadamard;
     bool split_mode_graph_scheduling;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -38,7 +38,7 @@ struct llama_cparams {
     bool fused_up_gate;
     bool fused_mmad;
     bool rope_cache;
-    bool graph_reuse;
+    int  n_graph_reuse;
     bool k_cache_hadamard;
     bool v_cache_hadamard;
     bool split_mode_graph_scheduling;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4222,17 +4222,23 @@ static int llama_decode_internal(
 #endif
         ggml_cgraph * gf = nullptr;
         int reuse_slot = lctx.find_reusable_graph(u_batch);
+        const bool is_mtp_op = (cparams.mtp_op_type != MTP_OP_NONE);
+        const int64_t t_gr_start = ggml_time_us();
 
         if (reuse_slot >= 0) {
             bool was_cross = (reuse_slot != lctx.active_graph_slot);
             lctx.activate_graph_slot(reuse_slot);
             if (lctx.active_graph_slot >= 0) {
                 gf = lctx.graph_slots[reuse_slot].graph;
+                const int64_t t_gr_end = ggml_time_us();
+                lctx.gr_stats.t_graph_reuse_us += (t_gr_end - t_gr_start);
+                if (is_mtp_op) { lctx.gr_stats.n_graph_reuse_mtp++; }
+                else           { lctx.gr_stats.n_graph_reuse_main++; }
+                if (was_cross) { lctx.gr_stats.n_graph_reuse_cross++; }
 #if IK_PRINT_TIMING
-                tim2 = ggml_time_us();
                 printf("graph_reuse(slot=%d, %s, spec_op=%d, ntok=%d): %d us\n",
                        reuse_slot, was_cross ? "cross" : "same", (int)cparams.mtp_op_type,
-                       (int)n_tokens, int(tim2-tim1));
+                       (int)n_tokens, int(t_gr_end - t_gr_start));
 #endif
             } else {
                 reuse_slot = -1;
@@ -4248,11 +4254,12 @@ static int llama_decode_internal(
                        (int)cparams.mtp_op_type, (int)n_tokens, reason, lctx.active_graph_slot);
             }
 #endif
+            const int64_t t_reset_start = ggml_time_us();
             lctx.reset_scheduler();
             ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
+            lctx.gr_stats.t_sched_reset_us += (ggml_time_us() - t_reset_start);
 #if IK_PRINT_TIMING
-            tim2 = ggml_time_us();
-            printf("sched_reset(...): %d us\n", int(tim2-tim1));
+            printf("sched_reset(...): %d us\n", int(ggml_time_us() - t_reset_start));
 #endif
 
 #if IK_PRINT_TIMING
@@ -4264,7 +4271,8 @@ static int llama_decode_internal(
             printf("build_graph(...): %d us\n", int(tim2-tim1));
 #endif
             const bool will_store = (u_batch.embd == nullptr
-                                     && lctx.cparams.n_graph_reuse > 1);
+                                     && !lctx.graph_slots.empty()
+                                     && (lctx.cparams.n_graph_reuse > 1 || lctx.sched_draft));
             if (will_store) {
                 lctx.save_graph_original_srcs(gf);
             }
@@ -4280,12 +4288,19 @@ static int llama_decode_internal(
             if (u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
                 lctx.store_graph_slot(u_batch, gf);
 #if IK_PRINT_TIMING
+                if (lctx.active_graph_slot >= 0) {
                 printf("graph_store(slot=%d, spec_op=%d, ntok=%d, splits=%d)\n",
                        lctx.active_graph_slot, (int)cparams.mtp_op_type,
                        (int)n_tokens,
                        lctx.graph_slots[lctx.active_graph_slot].n_splits);
+                }
 #endif
             }
+
+            const int64_t t_build_end = ggml_time_us();
+            lctx.gr_stats.t_graph_build_us += (t_build_end - t_gr_start);
+            if (is_mtp_op) { lctx.gr_stats.n_graph_new_mtp++; }
+            else           { lctx.gr_stats.n_graph_new_main++; }
         }
 
         if (cparams.mtp_op_type != MTP_OP_NONE) {
@@ -9379,6 +9394,25 @@ void llama_reset_timings(struct llama_context * ctx) {
     ctx->t_p_eval_us = ctx->n_p_eval = 0;
 
     ctx->sampling.reset_timings();
+}
+
+struct llama_graph_reuse_stats llama_get_graph_reuse_stats(struct llama_context * ctx) {
+    auto & s = ctx->gr_stats;
+    return {
+        s.n_graph_reuse_main,
+        s.n_graph_new_main,
+        s.n_graph_reuse_mtp,
+        s.n_graph_new_mtp,
+        s.n_graph_reuse_cross,
+        s.n_sched_swap,
+        s.t_graph_reuse_us,
+        s.t_graph_build_us,
+        s.t_sched_reset_us,
+    };
+}
+
+void llama_reset_graph_reuse_stats(struct llama_context * ctx) {
+    ctx->gr_stats = {};
 }
 
 const char * llama_print_system_info(void) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -29,7 +29,7 @@
 #include "iqk/iqk_quantize.h"
 #include "iqk/iqk_cpu_ops.h"
 
-#define IK_PRINT_TIMING 2
+#define IK_PRINT_TIMING 0
 
 #ifdef GGML_USE_RPC
 #  include "ggml-rpc.h"
@@ -585,7 +585,8 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
             if (i == active_graph_slot) {
                 return i;
             }
-            if (slot.n_splits > 4 && !slot.original_srcs.empty() && cross_slot_candidate < 0) {
+            // Avoiding Cross-slot for high-split graphs as its causes logit corruption.
+            if (slot.n_splits <= 4 && !slot.original_srcs.empty() && cross_slot_candidate < 0) {
                 cross_slot_candidate = i;
             }
         }
@@ -4269,8 +4270,7 @@ static int llama_decode_internal(
             printf("build_graph(...): %d us\n", int(tim2-tim1));
 #endif
             const bool will_store = (u_batch.embd == nullptr
-                                     && lctx.cparams.n_graph_reuse > 1
-                                     && cparams.mtp_op_type == MTP_OP_NONE);
+                                     && lctx.cparams.n_graph_reuse > 1);
             if (will_store) {
                 lctx.save_graph_original_srcs(gf);
             }
@@ -4283,8 +4283,7 @@ static int llama_decode_internal(
             tim2 = ggml_time_us();
             printf("sched_alloc_graph(...): %d us\n", int(tim2-tim1));
 #endif
-            if (u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0
-                && cparams.mtp_op_type == MTP_OP_NONE) {
+            if (u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
                 lctx.store_graph_slot(u_batch, gf);
 #if IK_PRINT_TIMING
                 printf("graph_store(slot=%d, mtp=%d, ntok=%d, splits=%d)\n",

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -29,7 +29,7 @@
 #include "iqk/iqk_quantize.h"
 #include "iqk/iqk_cpu_ops.h"
 
-#define IK_PRINT_TIMING 0
+#define IK_PRINT_TIMING 2
 
 #ifdef GGML_USE_RPC
 #  include "ggml-rpc.h"
@@ -563,7 +563,6 @@ void llama_context::invalidate_graph_slots() {
 }
 
 int llama_context::find_reusable_graph(const llama_batch & u_batch) {
-    if (u_batch.n_tokens > 1) return -1;
     if (u_batch.embd)         return -1;
     if (cparams.n_graph_reuse <= 0) return -1;
 
@@ -573,6 +572,7 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
         auto & slot = graph_slots[i];
         if (!slot.valid || !slot.graph) continue;
         if (slot.mtp_op_type != cparams.mtp_op_type) continue;
+        if (slot.n_tokens != (int)u_batch.n_tokens)  continue;
         if (u_batch.all_seq_id != slot.all_seq_id)   continue;
         if (kv_self.head == 0)                        continue;
         if ((int)kv_self.n != slot.n_kv)              continue;
@@ -585,7 +585,7 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
             if (i == active_graph_slot) {
                 return i;
             }
-            if (slot.n_splits <= 4 && !slot.original_srcs.empty() && cross_slot_candidate < 0) {
+            if (slot.n_splits > 4 && !slot.original_srcs.empty() && cross_slot_candidate < 0) {
                 cross_slot_candidate = i;
             }
         }
@@ -794,12 +794,14 @@ void llama_context::restore_graph_original_srcs(GraphSlot & slot) {
 
 void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf) {
     const int n_slots = (int)graph_slots.size();
+    const int n_tok = (int)u_batch.n_tokens;
 
-    // Find an existing slot for a graph
+    // Find the best slot for this graph.
     int target = -1;
-
     for (int i = 0; i < n_slots; ++i) {
-        if (graph_slots[i].valid && graph_slots[i].mtp_op_type == cparams.mtp_op_type) {
+        if (graph_slots[i].valid &&
+            graph_slots[i].mtp_op_type == cparams.mtp_op_type &&
+            graph_slots[i].n_tokens == n_tok) {
             target = i;
             break;
         }
@@ -831,6 +833,7 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
     slot.valid       = true;
     slot.last_used   = ++graph_slot_counter;
     slot.all_seq_id  = (int)u_batch.all_seq_id;
+    slot.n_tokens    = (int)u_batch.n_tokens;
     slot.n_outputs   = (int)n_outputs;
     slot.n_kv        = (int)kv_self.n;
     slot.n_splits    = ggml_backend_sched_get_n_splits(sched);
@@ -879,7 +882,12 @@ void llama_context::activate_graph_slot(int slot_idx) {
             restore_input_tensors_from_slot(slot);
 
             ggml_backend_sched_reset(sched);
-            ggml_backend_sched_alloc_graph(sched, slot.graph);
+            if (!ggml_backend_sched_alloc_graph(sched, slot.graph)) {
+                std::swap(buf_compute_meta, slot.buf_compute_meta);
+                slot.valid = false;
+                active_graph_slot = -1;
+                return;
+            }
 
             std::swap(buf_compute_meta, slot.buf_compute_meta);
 
@@ -889,6 +897,8 @@ void llama_context::activate_graph_slot(int slot_idx) {
                 return;
             }
         } else {
+            restore_input_tensors_from_slot(slot);
+
             if (!update_cache_copies_for_slot(slot_idx)) {
                 slot.valid = false;
                 active_graph_slot = -1;
@@ -4238,8 +4248,7 @@ static int llama_decode_internal(
 #if IK_PRINT_TIMING
             {
                 const char * reason = "no_match";
-                if (n_tokens > 1) reason = "multi_tok";
-                else if (lctx.cparams.n_graph_reuse <= 0) reason = "disabled";
+                if (lctx.cparams.n_graph_reuse <= 0) reason = "disabled";
                 printf("graph_new(mtp=%d, ntok=%d, reason=%s, active=%d)\n",
                        (int)cparams.mtp_op_type, (int)n_tokens, reason, lctx.active_graph_slot);
             }
@@ -4259,8 +4268,9 @@ static int llama_decode_internal(
             tim2 = ggml_time_us();
             printf("build_graph(...): %d us\n", int(tim2-tim1));
 #endif
-            const bool will_store = (u_batch.n_tokens == 1 && u_batch.embd == nullptr
-                                     && lctx.cparams.n_graph_reuse > 1);
+            const bool will_store = (u_batch.embd == nullptr
+                                     && lctx.cparams.n_graph_reuse > 1
+                                     && cparams.mtp_op_type == MTP_OP_NONE);
             if (will_store) {
                 lctx.save_graph_original_srcs(gf);
             }
@@ -4273,11 +4283,13 @@ static int llama_decode_internal(
             tim2 = ggml_time_us();
             printf("sched_alloc_graph(...): %d us\n", int(tim2-tim1));
 #endif
-            if (u_batch.n_tokens == 1 && u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
+            if (u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0
+                && cparams.mtp_op_type == MTP_OP_NONE) {
                 lctx.store_graph_slot(u_batch, gf);
 #if IK_PRINT_TIMING
-                printf("graph_store(slot=%d, mtp=%d, splits=%d)\n",
+                printf("graph_store(slot=%d, mtp=%d, ntok=%d, splits=%d)\n",
                        lctx.active_graph_slot, (int)cparams.mtp_op_type,
+                       (int)n_tokens,
                        lctx.graph_slots[lctx.active_graph_slot].n_splits);
 #endif
             }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -544,35 +544,119 @@ static size_t llama_get_device_memory(const llama_model & model, int device) {
     GGML_UNUSED(device);
 }
 
-struct llama_context::Prev {
-    int all_seq_id;
-    int n_outputs;
-    int n_kv;
-    llama_mtp_op_type mtp_op_type;
-    ggml_cgraph * graph;
-};
-
 void llama_context::reset_scheduler() {
     ggml_backend_sched_reset(sched);
-    prev.reset();
+    invalidate_graph_slots();
+}
+
+void llama_context::invalidate_graph_slots() {
+    for (auto & slot : graph_slots) {
+        slot.valid = false;
+    }
+    active_graph_slot = -1;
+}
+
+int llama_context::find_reusable_graph(const llama_batch & u_batch) {
+    if (u_batch.n_tokens > 1) return -1;
+    if (u_batch.embd)         return -1;
+    if (cparams.n_graph_reuse <= 0) return -1;
+
+    for (int i = 0; i < (int)graph_slots.size(); ++i) {
+        auto & slot = graph_slots[i];
+        if (!slot.valid || !slot.graph) continue;
+        if (slot.mtp_op_type != cparams.mtp_op_type) continue;
+        if (u_batch.all_seq_id != slot.all_seq_id)   continue;
+        if (kv_self.head == 0)                        continue;
+        if ((int)kv_self.n != slot.n_kv)              continue;
+        if (n_outputs != slot.n_outputs)              continue;
+        if (cparams.n_graph_reuse == 1) {
+            if (update_cache_copies()) {
+                return i;
+            }
+        } else {
+            if (update_cache_copies_for_slot(i)) {
+                return i;
+            }
+        }
+    }
+    return -1;
 }
 
 bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
-    if (!prev || !prev->graph) return false;
-    if (u_batch.n_tokens > 1) return false;
-    if (u_batch.embd) return false;
-    if (!cparams.graph_reuse) return false;
-    return u_batch.all_seq_id == prev->all_seq_id &&
-           kv_self.head > 0 &&
-           kv_self.n == prev->n_kv &&
-           n_outputs == prev->n_outputs &&
-           cparams.mtp_op_type == prev->mtp_op_type &&
-           update_cache_copies();
+    return find_reusable_graph(u_batch) >= 0;
+}
+
+bool llama_context::update_cache_copies_for_slot(int slot_idx) {
+    auto & cc = graph_slots[slot_idx].cache_copies;
+    const int n_layer = model.mtp ? model.hparams.n_layer
+                                  : model.hparams.n_layer - model.hparams.nextn_predict_layers;
+    auto layer_has_attention_kv = [&](int il) {
+        return !model.hparams.is_recurrent(il);
+    };
+    if ((int)kv_self.k_l.size() != n_layer) return false;
+    if (!(kv_self.v_l.empty() || (int)kv_self.v_l.size() == n_layer)) return false;
+    for (int il = 0; il < n_layer; ++il) {
+        if (!layer_has_attention_kv(il) || kv_self.k_l[il] == nullptr) {
+            continue;
+        }
+        auto kl = (ggml_split_tensor_t *)kv_self.k_l[il]->extra;
+        if (kl) {
+            GGML_ASSERT(model.split_mode == LLAMA_SPLIT_MODE_GRAPH || model.split_mode == LLAMA_SPLIT_MODE_ATTN);
+            GGML_ASSERT(model.splits.size() > 1);
+            auto vl = !kv_self.v_l.empty() && kv_self.v_l[il] ? (ggml_split_tensor_t *)kv_self.v_l[il]->extra : nullptr;
+            GGML_ASSERT(kl && (!kv_self.v_l[il] || vl));
+            if (vl) {
+                GGML_ASSERT(kl->n_device == vl->n_device);
+            }
+            for (int id = 0; id < kl->n_device; ++id) {
+                if (!kl->splits[id]) continue;
+                auto& c = cc[2*model.splits.size()*il + 2*id + 0];
+                if (!c.cpy) continue;
+                if (c.cpy->op != GGML_OP_CPY || c.cpy->view_src != kl->splits[id]) return false;
+                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->src[1]->data = (char *)kl->splits[id]->data + c.cpy->view_offs;
+                c.cpy->data = c.cpy->src[1]->data;
+            }
+            if (!vl) continue;
+            for (int id = 0; id < vl->n_device; ++id) {
+                if (!vl->splits[id]) continue;
+                auto& c = cc[2*model.splits.size()*il + 2*id + 1];
+                if (!c.cpy) continue;
+                if (c.cpy->op != GGML_OP_CPY || c.cpy->view_src != vl->splits[id]) return false;
+                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->src[1]->data = (char *)vl->splits[id]->data + c.cpy->view_offs;
+                c.cpy->data = c.cpy->src[1]->data;
+            }
+        } else {
+            for (int jl = 0; jl < n_layer; ++jl) {
+                if (!layer_has_attention_kv(jl) || kv_self.k_l[jl] == nullptr) continue;
+                if (kv_self.k_l[jl]->extra) continue;
+                auto& c = cc[2*jl+0];
+                if (!c.cpy) continue;
+                if (c.cpy->op != GGML_OP_CPY || c.cpy->view_src != kv_self.k_l[jl]) return false;
+                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->src[1]->data = (char *)kv_self.k_l[jl]->data + c.cpy->view_offs;
+                c.cpy->data = c.cpy->src[1]->data;
+            }
+            if (kv_self.v_l.empty()) return true;
+            for (int jl = 0; jl < n_layer; ++jl) {
+                if (!layer_has_attention_kv(jl) || kv_self.v_l[jl] == nullptr) continue;
+                if (kv_self.v_l[jl]->extra) continue;
+                auto& c = cc[2*jl+1];
+                if (!c.cpy) continue;
+                if (c.cpy->op != GGML_OP_CPY || c.cpy->view_src != kv_self.v_l[jl]) return false;
+                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->src[1]->data = (char *)kv_self.v_l[jl]->data + c.cpy->view_offs;
+                c.cpy->data = c.cpy->src[1]->data;
+            }
+        }
+    }
+    return true;
 }
 
 bool llama_context::update_cache_copies() {
     const int n_layer = model.mtp ? model.hparams.n_layer
-                                  : model.hparams.n_layer - model.hparams.nextn_predict_layers; //cache_copies.size()/2;
+                                  : model.hparams.n_layer - model.hparams.nextn_predict_layers;
     auto layer_has_attention_kv = [&](int il) {
         return !model.hparams.is_recurrent(il);
     };
@@ -633,6 +717,122 @@ bool llama_context::update_cache_copies() {
         }
     }
     return true;
+}
+
+void llama_context::save_input_tensors_to_slot(GraphSlot & slot) {
+    slot.inp_tokens      = inp_tokens;
+    slot.inp_embd        = inp_embd;
+    slot.inp_pos         = inp_pos;
+    slot.inp_out_ids     = inp_out_ids;
+    slot.inp_KQ_mask     = inp_KQ_mask;
+    slot.inp_KQ_mask_swa = inp_KQ_mask_swa;
+    slot.inp_K_shift     = inp_K_shift;
+    slot.inp_mean        = inp_mean;
+    slot.inp_cls         = inp_cls;
+    slot.inp_s_copy      = inp_s_copy;
+    slot.inp_s_mask      = inp_s_mask;
+    slot.inp_s_seq       = inp_s_seq;
+    slot.inp_s_seq_qnext = inp_s_seq_qnext;
+    slot.inp_pos_bucket  = inp_pos_bucket;
+    slot.inp_embd_enc    = inp_embd_enc;
+    slot.inp_KQ_mask_cross = inp_KQ_mask_cross;
+    slot.inp_scale       = inp_scale;
+    slot.inp_mtp_states  = inp_mtp_states;
+}
+
+void llama_context::restore_input_tensors_from_slot(GraphSlot & slot) {
+    inp_tokens      = slot.inp_tokens;
+    inp_embd        = slot.inp_embd;
+    inp_pos         = slot.inp_pos;
+    inp_out_ids     = slot.inp_out_ids;
+    inp_KQ_mask     = slot.inp_KQ_mask;
+    inp_KQ_mask_swa = slot.inp_KQ_mask_swa;
+    inp_K_shift     = slot.inp_K_shift;
+    inp_mean        = slot.inp_mean;
+    inp_cls         = slot.inp_cls;
+    inp_s_copy      = slot.inp_s_copy;
+    inp_s_mask      = slot.inp_s_mask;
+    inp_s_seq       = slot.inp_s_seq;
+    inp_s_seq_qnext = slot.inp_s_seq_qnext;
+    inp_pos_bucket  = slot.inp_pos_bucket;
+    inp_embd_enc    = slot.inp_embd_enc;
+    inp_KQ_mask_cross = slot.inp_KQ_mask_cross;
+    inp_scale       = slot.inp_scale;
+    inp_mtp_states  = slot.inp_mtp_states;
+}
+
+void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf) {
+    const int n_slots = (int)graph_slots.size();
+
+    // Find an existing slot for a graph
+    int target = -1;
+
+    for (int i = 0; i < n_slots; ++i) {
+        if (graph_slots[i].valid && graph_slots[i].mtp_op_type == cparams.mtp_op_type) {
+            target = i;
+            break;
+        }
+    }
+
+    if (target < 0) {
+        for (int i = 0; i < n_slots; ++i) {
+            if (!graph_slots[i].valid) {
+                target = i;
+                break;
+            }
+        }
+    }
+
+    if (target < 0) {
+        uint64_t min_used = UINT64_MAX;
+        for (int i = 0; i < n_slots; ++i) {
+            if (graph_slots[i].last_used < min_used) {
+                min_used = graph_slots[i].last_used;
+                target = i;
+            }
+        }
+    }
+
+    GGML_ASSERT(target >= 0);
+    auto & slot = graph_slots[target];
+    slot.valid       = true;
+    slot.last_used   = ++graph_slot_counter;
+    slot.all_seq_id  = (int)u_batch.all_seq_id;
+    slot.n_outputs   = (int)n_outputs;
+    slot.n_kv        = (int)kv_self.n;
+    slot.mtp_op_type = cparams.mtp_op_type;
+    slot.graph       = gf;
+
+    if (cparams.n_graph_reuse > 1) {
+        std::swap(buf_compute_meta, slot.buf_compute_meta);
+        std::swap(cache_copies, slot.cache_copies);
+        save_input_tensors_to_slot(slot);
+
+        if (buf_compute_meta.size() < slot.buf_compute_meta.size()) {
+            buf_compute_meta.resize(slot.buf_compute_meta.size());
+        }
+    }
+
+    active_graph_slot = target;
+}
+
+void llama_context::activate_graph_slot(int slot_idx) {
+    GGML_ASSERT(slot_idx >= 0 && slot_idx < (int)graph_slots.size());
+    auto & slot = graph_slots[slot_idx];
+    GGML_ASSERT(slot.valid && slot.graph);
+
+    slot.last_used = ++graph_slot_counter;
+
+    if (cparams.n_graph_reuse > 1 && slot_idx != active_graph_slot) {
+        std::swap(buf_compute_meta, slot.buf_compute_meta);
+        std::swap(cache_copies, slot.cache_copies);
+        restore_input_tensors_from_slot(slot);
+
+        ggml_backend_sched_reset(sched);
+        ggml_backend_sched_alloc_graph(sched, slot.graph);
+    }
+
+    active_graph_slot = slot_idx;
 }
 
 llama_context::llama_context(const llama_model & model)
@@ -3919,7 +4119,8 @@ static int llama_decode_internal(
         tim1 = ggml_time_us();
 #endif
         ggml_cgraph * gf = nullptr;
-        if (!lctx.can_reuse_graph(u_batch)) {
+        int reuse_slot = lctx.find_reusable_graph(u_batch);
+        if (reuse_slot < 0) {
             lctx.reset_scheduler();
             ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
 #if IK_PRINT_TIMING
@@ -3944,14 +4145,12 @@ static int llama_decode_internal(
             tim2 = ggml_time_us();
             printf("sched_alloc_graph(...): %d us\n", int(tim2-tim1));
 #endif
-            if (u_batch.n_tokens == 1 && u_batch.embd == nullptr && lctx.cparams.graph_reuse) {
-                lctx.prev = std::make_unique<llama_context::Prev>(llama_context::Prev{
-                        (int)u_batch.all_seq_id, (int)lctx.n_outputs, (int)lctx.kv_self.n,
-                        cparams.mtp_op_type, gf});
+            if (u_batch.n_tokens == 1 && u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
+                lctx.store_graph_slot(u_batch, gf);
             }
         } else {
-            //printf("Reusing graph\n");
-            gf = lctx.prev->graph;
+            lctx.activate_graph_slot(reuse_slot);
+            gf = lctx.graph_slots[reuse_slot].graph;
         }
 
         if (cparams.mtp_op_type != MTP_OP_NONE) {
@@ -4126,7 +4325,7 @@ static int llama_decode_internal(
             // We need to discard this graph. Otherwise, iwith CUDA graphs enabled, the graph will get resused and this will reset the
             // recurrent state for each new token. This is probably not very relevant in practice because we basically never run TG with
             // empty context, but for the sake of correctness let's just do it.
-            lctx.prev.reset();
+            lctx.invalidate_graph_slots();
         }
     }
 
@@ -4153,7 +4352,7 @@ static int llama_decode_internal(
 #if IK_PRINT_TIMING
     auto tim1 = ggml_time_us();
 #endif
-    if (!lctx.prev) {
+    if (lctx.active_graph_slot < 0) {
         lctx.reset_scheduler();
     }
 #if IK_PRINT_TIMING
@@ -4957,7 +5156,7 @@ struct llama_context_params llama_context_default_params() {
         /*.fused_up_gate               =*/ true,
         /*.fused_mmad                  =*/ true,
         /*.rope_cache                  =*/ false,
-        /*.graph_reuse                 =*/ true,
+        /*.n_graph_reuse               =*/ 1,
         /*.min_experts                 =*/ -1,
         /*.thtesh_experts              =*/ 0.0f,
         /*.only_active_experts         =*/ false,
@@ -5340,7 +5539,7 @@ struct llama_context * llama_init_from_model(
     cparams.fused_up_gate    = params.fused_up_gate;
     cparams.fused_mmad       = params.fused_mmad;
     cparams.rope_cache       = params.rope_cache;
-    cparams.graph_reuse      = params.graph_reuse;
+    cparams.n_graph_reuse   = params.n_graph_reuse;
     cparams.k_cache_hadamard = params.k_cache_hadamard;
     cparams.v_cache_hadamard = params.v_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
@@ -5446,7 +5645,11 @@ struct llama_context * llama_init_from_model(
     LLAMA_LOG_INFO("%s: fused_up_gate = %d\n",     __func__, cparams.fused_up_gate);
     LLAMA_LOG_INFO("%s: fused_mmad    = %d\n",     __func__, cparams.fused_mmad);
     LLAMA_LOG_INFO("%s: rope_cache    = %d\n",     __func__, cparams.rope_cache);
-    LLAMA_LOG_INFO("%s: graph_reuse   = %d\n",     __func__, cparams.graph_reuse);
+    LLAMA_LOG_INFO("%s: n_graph_reuse = %d\n",     __func__, cparams.n_graph_reuse);
+    if (cparams.n_graph_reuse > 0) {
+        const int n_slots = std::min(cparams.n_graph_reuse, (int)llama_context::GRAPH_SLOTS_MAX);
+        ctx->graph_slots.resize(n_slots);
+    }
     LLAMA_LOG_INFO("%s: k_cache_hadam = %d\n",     __func__, cparams.k_cache_hadamard);
     LLAMA_LOG_INFO("%s: v_cache_hadam = %d\n",     __func__, cparams.v_cache_hadamard);
     LLAMA_LOG_INFO("%s: split_mode_graph_scheduling = %d\n",   __func__, cparams.split_mode_graph_scheduling);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -546,16 +546,19 @@ static size_t llama_get_device_memory(const llama_model & model, int device) {
 
 void llama_context::reset_scheduler() {
     ggml_backend_sched_reset(sched);
-    if (cparams.n_graph_reuse <= 1) {
-        invalidate_graph_slots();
-    } else {
+    if (sched_draft || cparams.n_graph_reuse > 1) {
         active_graph_slot = -1;
+    } else {
+        invalidate_graph_slots();
     }
 }
 
 void llama_context::invalidate_graph_slots() {
-    LLAMA_LOG_DEBUG("%s: invalidating all %d graph slots\n", __func__, (int)graph_slots.size());
+    LLAMA_LOG_DEBUG("%s: invalidating all %d + %d graph slots\n", __func__, (int)graph_slots.size(), (int)graph_slots_draft.size());
     for (auto & slot : graph_slots) {
+        slot.valid = false;
+    }
+    for (auto & slot : graph_slots_draft) {
         slot.valid = false;
     }
     active_graph_slot = -1;
@@ -565,6 +568,7 @@ void llama_context::invalidate_graph_slots() {
 int llama_context::find_reusable_graph(const llama_batch & u_batch) {
     if (u_batch.embd)         return -1;
     if (cparams.n_graph_reuse <= 0) return -1;
+    if (graph_slots.empty())  return -1;
 
     int cross_slot_candidate = -1;
 
@@ -577,7 +581,7 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
         if (kv_self.head == 0)                        continue;
         if ((int)kv_self.n != slot.n_kv)              continue;
         if (n_outputs != slot.n_outputs)              continue;
-        if (cparams.n_graph_reuse == 1) {
+        if (cparams.n_graph_reuse == 1 && !sched_draft) {
             if (update_cache_copies()) {
                 return i;
             }
@@ -794,6 +798,7 @@ void llama_context::restore_graph_original_srcs(GraphSlot & slot) {
 }
 
 void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf) {
+    if (graph_slots.empty()) return;
     const int n_slots = (int)graph_slots.size();
     const int n_tok = (int)u_batch.n_tokens;
 
@@ -842,7 +847,7 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
     slot.mtp_op_type = cparams.mtp_op_type;
     slot.graph       = gf;
 
-    if (cparams.n_graph_reuse > 1) {
+    if (cparams.n_graph_reuse > 1 || sched_draft) {
         std::swap(buf_compute_meta, slot.buf_compute_meta);
         std::swap(cache_copies, slot.cache_copies);
         std::swap(graph_srcs_pending, slot.original_srcs);
@@ -873,7 +878,7 @@ void llama_context::activate_graph_slot(int slot_idx) {
                     __func__, slot_idx, (int)slot.mtp_op_type, slot.n_kv, graph_slot_counter + 1);
     slot.last_used = ++graph_slot_counter;
 
-    if (cparams.n_graph_reuse > 1) {
+    if (cparams.n_graph_reuse > 1 || sched_draft) {
         const bool cross_slot = (slot_idx != active_graph_slot);
 
         if (cross_slot) {
@@ -932,9 +937,17 @@ void llama_context::set_mtp_op_type(llama_mtp_op_type value) {
         if (is_mtp && !was_mtp) {
             std::swap(sched, sched_draft);
             std::swap(active_graph_slot, active_graph_slot_draft);
+            std::swap(graph_slots, graph_slots_draft);
+            std::swap(buf_compute_meta, buf_compute_meta_draft);
+            std::swap(cache_copies, cache_copies_draft);
+            gr_stats.n_sched_swap++;
         } else if (!is_mtp && was_mtp) {
             std::swap(sched, sched_draft);
             std::swap(active_graph_slot, active_graph_slot_draft);
+            std::swap(graph_slots, graph_slots_draft);
+            std::swap(buf_compute_meta, buf_compute_meta_draft);
+            std::swap(cache_copies, cache_copies_draft);
+            gr_stats.n_sched_swap++;
         }
     }
 
@@ -5770,7 +5783,17 @@ struct llama_context * llama_init_from_model(
     LLAMA_LOG_INFO("%s: n_graph_reuse = %d\n",     __func__, cparams.n_graph_reuse);
     if (cparams.n_graph_reuse > 0) {
         const int n_slots = std::min(cparams.n_graph_reuse, (int)llama_context::GRAPH_SLOTS_MAX);
-        ctx->graph_slots.resize(n_slots);
+        const bool has_mtp = model->hparams.nextn_predict_layers > 0 && cparams.mtp;
+        if (has_mtp && n_slots >= 1) {
+            const int main_slots  = 1;
+            const int draft_slots = n_slots - 1;
+            ctx->graph_slots.resize(main_slots);
+            ctx->graph_slots_draft.resize(draft_slots);
+            LLAMA_LOG_INFO("%s: graph slots   = %d main + %d draft\n", __func__, main_slots, draft_slots);
+        } else {
+            ctx->graph_slots.resize(n_slots);
+            LLAMA_LOG_INFO("%s: graph slots   = %d\n", __func__, n_slots);
+        }
     }
     LLAMA_LOG_INFO("%s: k_cache_hadam = %d\n",     __func__, cparams.k_cache_hadamard);
     LLAMA_LOG_INFO("%s: v_cache_hadam = %d\n",     __func__, cparams.v_cache_hadamard);
@@ -6109,7 +6132,7 @@ struct llama_context * llama_init_from_model(
             LLAMA_LOG_INFO("%s: graph splits = %d\n", __func__, n_splits);
 
             // Create a dedicated scheduler for speculative graphs.
-            if (model->hparams.nextn_predict_layers > 0 && ctx->cparams.mtp) {
+            if (cparams.n_graph_reuse >= 1 && model->hparams.nextn_predict_layers > 0 && ctx->cparams.mtp) {
                 ctx->sched_draft = ggml_backend_sched_new(
                     ctx->backends.data(), backend_buft.data(),
                     ctx->backends.size(), max_nodes, false);
@@ -6119,12 +6142,18 @@ struct llama_context * llama_init_from_model(
 
                 std::vector<uint8_t> buf_draft_meta(ggml_tensor_overhead() * max_nodes + ggml_graph_overhead_custom(max_nodes, false));
                 std::swap(ctx->buf_compute_meta, buf_draft_meta);
+                auto saved_cache_copies = std::move(ctx->cache_copies);
+                ctx->cache_copies.resize(saved_cache_copies.size());
 
                 ggml_cgraph * gf_draft = llm_build_context::llama_build_graph(
                     *ctx, llama_batch_get_one(&token, 1, n_past, 0), true);
 
                 std::swap(ctx->buf_compute_meta, buf_draft_meta);
                 ctx->cparams.mtp_op_type = saved_mtp_op;
+
+                ctx->buf_compute_meta_draft = std::move(buf_draft_meta);
+                ctx->cache_copies_draft = std::move(ctx->cache_copies);
+                ctx->cache_copies = std::move(saved_cache_copies);
 
                 if (!ggml_backend_sched_reserve(ctx->sched_draft, gf_draft)) {
                     LLAMA_LOG_WARN("%s: failed to reserve draft scheduler, falling back to shared scheduler\n", __func__);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -559,12 +559,15 @@ void llama_context::invalidate_graph_slots() {
         slot.valid = false;
     }
     active_graph_slot = -1;
+    active_graph_slot_mtp = -1;
 }
 
 int llama_context::find_reusable_graph(const llama_batch & u_batch) {
     if (u_batch.n_tokens > 1) return -1;
     if (u_batch.embd)         return -1;
     if (cparams.n_graph_reuse <= 0) return -1;
+
+    int cross_slot_candidate = -1;
 
     for (int i = 0; i < (int)graph_slots.size(); ++i) {
         auto & slot = graph_slots[i];
@@ -579,10 +582,15 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
                 return i;
             }
         } else {
-            return i;
+            if (i == active_graph_slot) {
+                return i;
+            }
+            if (slot.n_splits <= 4 && !slot.original_srcs.empty() && cross_slot_candidate < 0) {
+                cross_slot_candidate = i;
+            }
         }
     }
-    return -1;
+    return cross_slot_candidate;
 }
 
 bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
@@ -764,6 +772,26 @@ void llama_context::restore_input_tensors_from_slot(GraphSlot & slot) {
     inp_mtp_states  = slot.inp_mtp_states;
 }
 
+void llama_context::save_graph_original_srcs(ggml_cgraph * gf) {
+    const int n = gf->n_nodes;
+    graph_srcs_pending.resize(n * GGML_MAX_SRC);
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < GGML_MAX_SRC; j++) {
+            graph_srcs_pending[i * GGML_MAX_SRC + j] = gf->nodes[i]->src[j];
+        }
+    }
+}
+
+void llama_context::restore_graph_original_srcs(GraphSlot & slot) {
+    ggml_cgraph * gf = slot.graph;
+    GGML_ASSERT((int)slot.original_srcs.size() == gf->n_nodes * GGML_MAX_SRC);
+    for (int i = 0; i < gf->n_nodes; i++) {
+        for (int j = 0; j < GGML_MAX_SRC; j++) {
+            gf->nodes[i]->src[j] = slot.original_srcs[i * GGML_MAX_SRC + j];
+        }
+    }
+}
+
 void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * gf) {
     const int n_slots = (int)graph_slots.size();
 
@@ -805,12 +833,14 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
     slot.all_seq_id  = (int)u_batch.all_seq_id;
     slot.n_outputs   = (int)n_outputs;
     slot.n_kv        = (int)kv_self.n;
+    slot.n_splits    = ggml_backend_sched_get_n_splits(sched);
     slot.mtp_op_type = cparams.mtp_op_type;
     slot.graph       = gf;
 
     if (cparams.n_graph_reuse > 1) {
         std::swap(buf_compute_meta, slot.buf_compute_meta);
         std::swap(cache_copies, slot.cache_copies);
+        std::swap(graph_srcs_pending, slot.original_srcs);
         save_input_tensors_to_slot(slot);
 
         if (buf_compute_meta.size() < slot.buf_compute_meta.size()) {
@@ -834,21 +864,36 @@ void llama_context::activate_graph_slot(int slot_idx) {
     auto & slot = graph_slots[slot_idx];
     GGML_ASSERT(slot.valid && slot.graph);
 
-    LLAMA_LOG_DEBUG("%s: reusing slot %d (mtp_op=%d, n_kv=%d, lru=%" PRIu64 ", cross_slot=%s)\n",
-                    __func__, slot_idx, (int)slot.mtp_op_type, slot.n_kv, graph_slot_counter + 1,
-                    (cparams.n_graph_reuse > 1 && slot_idx != active_graph_slot) ? "yes" : "no");
+    LLAMA_LOG_DEBUG("%s: reusing slot %d (mtp_op=%d, n_kv=%d, lru=%" PRIu64 ")\n",
+                    __func__, slot_idx, (int)slot.mtp_op_type, slot.n_kv, graph_slot_counter + 1);
     slot.last_used = ++graph_slot_counter;
 
-    if (cparams.n_graph_reuse > 1 && slot_idx != active_graph_slot) {
-        restore_input_tensors_from_slot(slot);
+    if (cparams.n_graph_reuse > 1) {
+        const bool cross_slot = (slot_idx != active_graph_slot);
 
-        ggml_backend_sched_reset(sched);
-        ggml_backend_sched_alloc_graph(sched, slot.graph);
+        if (cross_slot) {
+            GGML_ASSERT(!slot.original_srcs.empty());
+            restore_graph_original_srcs(slot);
 
-        if (!update_cache_copies_for_slot(slot_idx)) {
-            slot.valid = false;
-            active_graph_slot = -1;
-            return;
+            std::swap(buf_compute_meta, slot.buf_compute_meta);
+            restore_input_tensors_from_slot(slot);
+
+            ggml_backend_sched_reset(sched);
+            ggml_backend_sched_alloc_graph(sched, slot.graph);
+
+            std::swap(buf_compute_meta, slot.buf_compute_meta);
+
+            if (!update_cache_copies_for_slot(slot_idx)) {
+                slot.valid = false;
+                active_graph_slot = -1;
+                return;
+            }
+        } else {
+            if (!update_cache_copies_for_slot(slot_idx)) {
+                slot.valid = false;
+                active_graph_slot = -1;
+                return;
+            }
         }
     }
 
@@ -868,11 +913,25 @@ llama_context::llama_context(const llama_model & model)
 void llama_context::set_mtp_op_type(llama_mtp_op_type value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
+    // swap to/from the dedicated MTP scheduler.
+    if (sched_mtp) {
+        const bool was_mtp = (cparams.mtp_op_type != MTP_OP_NONE);
+        const bool is_mtp  = (value != MTP_OP_NONE);
+        if (is_mtp && !was_mtp) {
+            std::swap(sched, sched_mtp);
+            std::swap(active_graph_slot, active_graph_slot_mtp);
+        } else if (!is_mtp && was_mtp) {
+            std::swap(sched, sched_mtp);
+            std::swap(active_graph_slot, active_graph_slot_mtp);
+        }
+    }
+
     cparams.mtp_op_type = value;
 }
 
 llama_context::~llama_context() {
     ggml_backend_sched_free(sched);
+    ggml_backend_sched_free(sched_mtp);
 
     for (ggml_backend_t backend : backends) {
         ggml_backend_free(backend);
@@ -3862,7 +3921,25 @@ static void llama_graph_compute(
 
     ggml_backend_sched_graph_compute_async(lctx.sched, gf);
 
-    // fprintf(stderr, "splits: %d\n", ggml_backend_sched_get_n_splits(lctx.sched));
+#ifndef NDEBUG
+    {
+        static int log_count = 0;
+        if (log_count < 50) {
+            const char * mtp_name = "UNKNOWN";
+            switch (lctx.cparams.mtp_op_type) {
+                case MTP_OP_NONE:      mtp_name = "NONE"; break;
+                case MTP_OP_WARMUP:    mtp_name = "WARMUP"; break;
+                case MTP_OP_DRAFT_GEN: mtp_name = "DRAFT_GEN"; break;
+            }
+            fprintf(stderr, "[DIAG] splits: %d, copies: %d, nodes: %d, mtp_op: %s\n",
+                ggml_backend_sched_get_n_splits(lctx.sched),
+                ggml_backend_sched_get_n_copies(lctx.sched),
+                gf->n_nodes,
+                mtp_name);
+            ++log_count;
+        }
+    }
+#endif
 }
 
 static bool prepare_mtp_graph_inputs(struct llama_context & lctx) {
@@ -4142,15 +4219,31 @@ static int llama_decode_internal(
         int reuse_slot = lctx.find_reusable_graph(u_batch);
 
         if (reuse_slot >= 0) {
+            bool was_cross = (reuse_slot != lctx.active_graph_slot);
             lctx.activate_graph_slot(reuse_slot);
             if (lctx.active_graph_slot >= 0) {
                 gf = lctx.graph_slots[reuse_slot].graph;
+#if IK_PRINT_TIMING
+                tim2 = ggml_time_us();
+                printf("graph_reuse(slot=%d, %s, mtp=%d, ntok=%d): %d us\n",
+                       reuse_slot, was_cross ? "cross" : "same", (int)cparams.mtp_op_type,
+                       (int)n_tokens, int(tim2-tim1));
+#endif
             } else {
                 reuse_slot = -1;
             }
         }
 
         if (reuse_slot < 0) {
+#if IK_PRINT_TIMING
+            {
+                const char * reason = "no_match";
+                if (n_tokens > 1) reason = "multi_tok";
+                else if (lctx.cparams.n_graph_reuse <= 0) reason = "disabled";
+                printf("graph_new(mtp=%d, ntok=%d, reason=%s, active=%d)\n",
+                       (int)cparams.mtp_op_type, (int)n_tokens, reason, lctx.active_graph_slot);
+            }
+#endif
             lctx.reset_scheduler();
             ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
 #if IK_PRINT_TIMING
@@ -4166,6 +4259,11 @@ static int llama_decode_internal(
             tim2 = ggml_time_us();
             printf("build_graph(...): %d us\n", int(tim2-tim1));
 #endif
+            const bool will_store = (u_batch.n_tokens == 1 && u_batch.embd == nullptr
+                                     && lctx.cparams.n_graph_reuse > 1);
+            if (will_store) {
+                lctx.save_graph_original_srcs(gf);
+            }
 
 #if IK_PRINT_TIMING
             tim1 = ggml_time_us();
@@ -4177,6 +4275,11 @@ static int llama_decode_internal(
 #endif
             if (u_batch.n_tokens == 1 && u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
                 lctx.store_graph_slot(u_batch, gf);
+#if IK_PRINT_TIMING
+                printf("graph_store(slot=%d, mtp=%d, splits=%d)\n",
+                       lctx.active_graph_slot, (int)cparams.mtp_op_type,
+                       lctx.graph_slots[lctx.active_graph_slot].n_splits);
+#endif
             }
         }
 
@@ -6012,6 +6115,45 @@ struct llama_context * llama_init_from_model(
             int n_splits = ggml_backend_sched_get_n_splits(ctx->sched);
             LLAMA_LOG_INFO("%s: graph nodes  = %d\n", __func__, gf->n_nodes);
             LLAMA_LOG_INFO("%s: graph splits = %d\n", __func__, n_splits);
+
+            // create dedicated MTP scheduler if MTP is available
+            if (model->hparams.nextn_predict_layers > 0 && ctx->cparams.mtp) {
+                ctx->sched_mtp = ggml_backend_sched_new(
+                    ctx->backends.data(), backend_buft.data(),
+                    ctx->backends.size(), max_nodes, false);
+
+                auto saved_mtp_op = ctx->cparams.mtp_op_type;
+                ctx->cparams.mtp_op_type = MTP_OP_DRAFT_GEN;
+
+                std::vector<uint8_t> buf_mtp_meta(ggml_tensor_overhead() * max_nodes + ggml_graph_overhead_custom(max_nodes, false));
+                std::swap(ctx->buf_compute_meta, buf_mtp_meta);
+
+                ggml_cgraph * gf_mtp = llm_build_context::llama_build_graph(
+                    *ctx, llama_batch_get_one(&token, 1, n_past, 0), true);
+
+                std::swap(ctx->buf_compute_meta, buf_mtp_meta);
+                ctx->cparams.mtp_op_type = saved_mtp_op;
+
+                if (!ggml_backend_sched_reserve(ctx->sched_mtp, gf_mtp)) {
+                    LLAMA_LOG_WARN("%s: failed to reserve MTP scheduler, falling back to shared scheduler\n", __func__);
+                    ggml_backend_sched_free(ctx->sched_mtp);
+                    ctx->sched_mtp = nullptr;
+                } else {
+                    int n_splits_mtp = ggml_backend_sched_get_n_splits(ctx->sched_mtp);
+                    LLAMA_LOG_INFO("%s: MTP graph nodes  = %d\n", __func__, gf_mtp->n_nodes);
+                    LLAMA_LOG_INFO("%s: MTP graph splits = %d\n", __func__, n_splits_mtp);
+                    for (size_t i = 0; i < ctx->backends.size(); i++) {
+                        ggml_backend_t backend = ctx->backends[i];
+                        ggml_backend_buffer_type_t buft_i = backend_buft[i];
+                        size_t size = ggml_backend_sched_get_buffer_size(ctx->sched_mtp, backend);
+                        if (size > 1) {
+                            LLAMA_LOG_INFO("%s: %10s MTP compute buffer size = %8.2f MiB\n", __func__,
+                                    ggml_backend_buft_name(buft_i),
+                                    size / 1024.0 / 1024.0);
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -6025,12 +6167,18 @@ struct llama_context * llama_init_from_model(
                         ggml_op_name(ggml_op(op)), on_off ? "ON" : "OFF");
             }
             ggml_backend_sched_set_op_offload(ctx->sched, ggml_op(op), on_off);
+            if (ctx->sched_mtp) {
+                ggml_backend_sched_set_op_offload(ctx->sched_mtp, ggml_op(op), on_off);
+            }
         }
     }
 
     if (params.only_active_experts) {
         LLAMA_LOG_INFO("%s: enabling only_active_experts scheduling\n", __func__);
         ggml_backend_sched_set_only_active_experts(ctx->sched, true);
+        if (ctx->sched_mtp) {
+            ggml_backend_sched_set_only_active_experts(ctx->sched_mtp, true);
+        }
     }
     if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH && (!model->has_tensor_overrides() || cparams.split_mode_graph_scheduling)) {
         ggml_backend_sched_set_split_mode_graph(ctx->sched, true, cparams.scheduler_async);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -559,7 +559,7 @@ void llama_context::invalidate_graph_slots() {
         slot.valid = false;
     }
     active_graph_slot = -1;
-    active_graph_slot_mtp = -1;
+    active_graph_slot_draft = -1;
 }
 
 int llama_context::find_reusable_graph(const llama_batch & u_batch) {
@@ -585,7 +585,7 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
             if (i == active_graph_slot) {
                 return i;
             }
-            // Avoiding Cross-slot for high-split graphs as its causes logit corruption.
+            // Avoid Cross-slot for high-split graphs as its causes logit corruption.
             if (slot.n_splits <= 4 && !slot.original_srcs.empty() && cross_slot_candidate < 0) {
                 cross_slot_candidate = i;
             }
@@ -797,7 +797,8 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
     const int n_slots = (int)graph_slots.size();
     const int n_tok = (int)u_batch.n_tokens;
 
-    // Find the best slot for this graph.
+    // Slot selection strategy: 1) reuse existing slot with same (op_type, n_tokens),
+    // 2) use an empty slot, 3) evict the least-recently-used slot.
     int target = -1;
     for (int i = 0; i < n_slots; ++i) {
         if (graph_slots[i].valid &&
@@ -829,7 +830,7 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
 
     GGML_ASSERT(target >= 0);
     auto & slot = graph_slots[target];
-    LLAMA_LOG_DEBUG("%s: storing graph in slot %d (mtp_op=%d, n_kv=%d, n_out=%d, lru=%" PRIu64 ")\n",
+    LLAMA_LOG_DEBUG("%s: storing graph in slot %d (spec_op=%d, n_kv=%d, n_out=%d, lru=%" PRIu64 ")\n",
                     __func__, target, (int)cparams.mtp_op_type, (int)kv_self.n, (int)n_outputs, graph_slot_counter + 1);
     slot.valid       = true;
     slot.last_used   = ++graph_slot_counter;
@@ -868,7 +869,7 @@ void llama_context::activate_graph_slot(int slot_idx) {
     auto & slot = graph_slots[slot_idx];
     GGML_ASSERT(slot.valid && slot.graph);
 
-    LLAMA_LOG_DEBUG("%s: reusing slot %d (mtp_op=%d, n_kv=%d, lru=%" PRIu64 ")\n",
+    LLAMA_LOG_DEBUG("%s: reusing slot %d (spec_op=%d, n_kv=%d, lru=%" PRIu64 ")\n",
                     __func__, slot_idx, (int)slot.mtp_op_type, slot.n_kv, graph_slot_counter + 1);
     slot.last_used = ++graph_slot_counter;
 
@@ -925,15 +926,15 @@ void llama_context::set_mtp_op_type(llama_mtp_op_type value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
     // swap to/from the dedicated MTP scheduler.
-    if (sched_mtp) {
+    if (sched_draft) {
         const bool was_mtp = (cparams.mtp_op_type != MTP_OP_NONE);
         const bool is_mtp  = (value != MTP_OP_NONE);
         if (is_mtp && !was_mtp) {
-            std::swap(sched, sched_mtp);
-            std::swap(active_graph_slot, active_graph_slot_mtp);
+            std::swap(sched, sched_draft);
+            std::swap(active_graph_slot, active_graph_slot_draft);
         } else if (!is_mtp && was_mtp) {
-            std::swap(sched, sched_mtp);
-            std::swap(active_graph_slot, active_graph_slot_mtp);
+            std::swap(sched, sched_draft);
+            std::swap(active_graph_slot, active_graph_slot_draft);
         }
     }
 
@@ -942,7 +943,7 @@ void llama_context::set_mtp_op_type(llama_mtp_op_type value) {
 
 llama_context::~llama_context() {
     ggml_backend_sched_free(sched);
-    ggml_backend_sched_free(sched_mtp);
+    ggml_backend_sched_free(sched_draft);
 
     for (ggml_backend_t backend : backends) {
         ggml_backend_free(backend);
@@ -3931,26 +3932,6 @@ static void llama_graph_compute(
 #endif
 
     ggml_backend_sched_graph_compute_async(lctx.sched, gf);
-
-#ifndef NDEBUG
-    {
-        static int log_count = 0;
-        if (log_count < 50) {
-            const char * mtp_name = "UNKNOWN";
-            switch (lctx.cparams.mtp_op_type) {
-                case MTP_OP_NONE:      mtp_name = "NONE"; break;
-                case MTP_OP_WARMUP:    mtp_name = "WARMUP"; break;
-                case MTP_OP_DRAFT_GEN: mtp_name = "DRAFT_GEN"; break;
-            }
-            fprintf(stderr, "[DIAG] splits: %d, copies: %d, nodes: %d, mtp_op: %s\n",
-                ggml_backend_sched_get_n_splits(lctx.sched),
-                ggml_backend_sched_get_n_copies(lctx.sched),
-                gf->n_nodes,
-                mtp_name);
-            ++log_count;
-        }
-    }
-#endif
 }
 
 static bool prepare_mtp_graph_inputs(struct llama_context & lctx) {
@@ -4236,7 +4217,7 @@ static int llama_decode_internal(
                 gf = lctx.graph_slots[reuse_slot].graph;
 #if IK_PRINT_TIMING
                 tim2 = ggml_time_us();
-                printf("graph_reuse(slot=%d, %s, mtp=%d, ntok=%d): %d us\n",
+                printf("graph_reuse(slot=%d, %s, spec_op=%d, ntok=%d): %d us\n",
                        reuse_slot, was_cross ? "cross" : "same", (int)cparams.mtp_op_type,
                        (int)n_tokens, int(tim2-tim1));
 #endif
@@ -4250,7 +4231,7 @@ static int llama_decode_internal(
             {
                 const char * reason = "no_match";
                 if (lctx.cparams.n_graph_reuse <= 0) reason = "disabled";
-                printf("graph_new(mtp=%d, ntok=%d, reason=%s, active=%d)\n",
+                printf("graph_new(spec_op=%d, ntok=%d, reason=%s, active=%d)\n",
                        (int)cparams.mtp_op_type, (int)n_tokens, reason, lctx.active_graph_slot);
             }
 #endif
@@ -4286,7 +4267,7 @@ static int llama_decode_internal(
             if (u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
                 lctx.store_graph_slot(u_batch, gf);
 #if IK_PRINT_TIMING
-                printf("graph_store(slot=%d, mtp=%d, ntok=%d, splits=%d)\n",
+                printf("graph_store(slot=%d, spec_op=%d, ntok=%d, splits=%d)\n",
                        lctx.active_graph_slot, (int)cparams.mtp_op_type,
                        (int)n_tokens,
                        lctx.graph_slots[lctx.active_graph_slot].n_splits);
@@ -6127,38 +6108,38 @@ struct llama_context * llama_init_from_model(
             LLAMA_LOG_INFO("%s: graph nodes  = %d\n", __func__, gf->n_nodes);
             LLAMA_LOG_INFO("%s: graph splits = %d\n", __func__, n_splits);
 
-            // create dedicated MTP scheduler if MTP is available
+            // Create a dedicated scheduler for speculative graphs.
             if (model->hparams.nextn_predict_layers > 0 && ctx->cparams.mtp) {
-                ctx->sched_mtp = ggml_backend_sched_new(
+                ctx->sched_draft = ggml_backend_sched_new(
                     ctx->backends.data(), backend_buft.data(),
                     ctx->backends.size(), max_nodes, false);
 
                 auto saved_mtp_op = ctx->cparams.mtp_op_type;
                 ctx->cparams.mtp_op_type = MTP_OP_DRAFT_GEN;
 
-                std::vector<uint8_t> buf_mtp_meta(ggml_tensor_overhead() * max_nodes + ggml_graph_overhead_custom(max_nodes, false));
-                std::swap(ctx->buf_compute_meta, buf_mtp_meta);
+                std::vector<uint8_t> buf_draft_meta(ggml_tensor_overhead() * max_nodes + ggml_graph_overhead_custom(max_nodes, false));
+                std::swap(ctx->buf_compute_meta, buf_draft_meta);
 
-                ggml_cgraph * gf_mtp = llm_build_context::llama_build_graph(
+                ggml_cgraph * gf_draft = llm_build_context::llama_build_graph(
                     *ctx, llama_batch_get_one(&token, 1, n_past, 0), true);
 
-                std::swap(ctx->buf_compute_meta, buf_mtp_meta);
+                std::swap(ctx->buf_compute_meta, buf_draft_meta);
                 ctx->cparams.mtp_op_type = saved_mtp_op;
 
-                if (!ggml_backend_sched_reserve(ctx->sched_mtp, gf_mtp)) {
-                    LLAMA_LOG_WARN("%s: failed to reserve MTP scheduler, falling back to shared scheduler\n", __func__);
-                    ggml_backend_sched_free(ctx->sched_mtp);
-                    ctx->sched_mtp = nullptr;
+                if (!ggml_backend_sched_reserve(ctx->sched_draft, gf_draft)) {
+                    LLAMA_LOG_WARN("%s: failed to reserve draft scheduler, falling back to shared scheduler\n", __func__);
+                    ggml_backend_sched_free(ctx->sched_draft);
+                    ctx->sched_draft = nullptr;
                 } else {
-                    int n_splits_mtp = ggml_backend_sched_get_n_splits(ctx->sched_mtp);
-                    LLAMA_LOG_INFO("%s: MTP graph nodes  = %d\n", __func__, gf_mtp->n_nodes);
-                    LLAMA_LOG_INFO("%s: MTP graph splits = %d\n", __func__, n_splits_mtp);
+                    int n_splits_draft = ggml_backend_sched_get_n_splits(ctx->sched_draft);
+                    LLAMA_LOG_INFO("%s: draft graph nodes  = %d\n", __func__, gf_draft->n_nodes);
+                    LLAMA_LOG_INFO("%s: draft graph splits = %d\n", __func__, n_splits_draft);
                     for (size_t i = 0; i < ctx->backends.size(); i++) {
                         ggml_backend_t backend = ctx->backends[i];
                         ggml_backend_buffer_type_t buft_i = backend_buft[i];
-                        size_t size = ggml_backend_sched_get_buffer_size(ctx->sched_mtp, backend);
+                        size_t size = ggml_backend_sched_get_buffer_size(ctx->sched_draft, backend);
                         if (size > 1) {
-                            LLAMA_LOG_INFO("%s: %10s MTP compute buffer size = %8.2f MiB\n", __func__,
+                            LLAMA_LOG_INFO("%s: %10s draft compute buffer size = %8.2f MiB\n", __func__,
                                     ggml_backend_buft_name(buft_i),
                                     size / 1024.0 / 1024.0);
                         }
@@ -6178,8 +6159,8 @@ struct llama_context * llama_init_from_model(
                         ggml_op_name(ggml_op(op)), on_off ? "ON" : "OFF");
             }
             ggml_backend_sched_set_op_offload(ctx->sched, ggml_op(op), on_off);
-            if (ctx->sched_mtp) {
-                ggml_backend_sched_set_op_offload(ctx->sched_mtp, ggml_op(op), on_off);
+            if (ctx->sched_draft) {
+                ggml_backend_sched_set_op_offload(ctx->sched_draft, ggml_op(op), on_off);
             }
         }
     }
@@ -6187,8 +6168,8 @@ struct llama_context * llama_init_from_model(
     if (params.only_active_experts) {
         LLAMA_LOG_INFO("%s: enabling only_active_experts scheduling\n", __func__);
         ggml_backend_sched_set_only_active_experts(ctx->sched, true);
-        if (ctx->sched_mtp) {
-            ggml_backend_sched_set_only_active_experts(ctx->sched_mtp, true);
+        if (ctx->sched_draft) {
+            ggml_backend_sched_set_only_active_experts(ctx->sched_draft, true);
         }
     }
     if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH && (!model->has_tensor_overrides() || cparams.split_mode_graph_scheduling)) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -546,10 +546,15 @@ static size_t llama_get_device_memory(const llama_model & model, int device) {
 
 void llama_context::reset_scheduler() {
     ggml_backend_sched_reset(sched);
-    invalidate_graph_slots();
+    if (cparams.n_graph_reuse <= 1) {
+        invalidate_graph_slots();
+    } else {
+        active_graph_slot = -1;
+    }
 }
 
 void llama_context::invalidate_graph_slots() {
+    LLAMA_LOG_DEBUG("%s: invalidating all %d graph slots\n", __func__, (int)graph_slots.size());
     for (auto & slot : graph_slots) {
         slot.valid = false;
     }
@@ -574,9 +579,7 @@ int llama_context::find_reusable_graph(const llama_batch & u_batch) {
                 return i;
             }
         } else {
-            if (update_cache_copies_for_slot(i)) {
-                return i;
-            }
+            return i;
         }
     }
     return -1;
@@ -795,6 +798,8 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
 
     GGML_ASSERT(target >= 0);
     auto & slot = graph_slots[target];
+    LLAMA_LOG_DEBUG("%s: storing graph in slot %d (mtp_op=%d, n_kv=%d, n_out=%d, lru=%" PRIu64 ")\n",
+                    __func__, target, (int)cparams.mtp_op_type, (int)kv_self.n, (int)n_outputs, graph_slot_counter + 1);
     slot.valid       = true;
     slot.last_used   = ++graph_slot_counter;
     slot.all_seq_id  = (int)u_batch.all_seq_id;
@@ -811,6 +816,14 @@ void llama_context::store_graph_slot(const llama_batch & u_batch, ggml_cgraph * 
         if (buf_compute_meta.size() < slot.buf_compute_meta.size()) {
             buf_compute_meta.resize(slot.buf_compute_meta.size());
         }
+        const auto & hparams = model.hparams;
+        size_t needed = ((model.split_mode == LLAMA_SPLIT_MODE_GRAPH || model.split_mode == LLAMA_SPLIT_MODE_ATTN)
+                         && model.splits.size() > 1)
+                        ? 2 * model.splits.size() * hparams.n_layer
+                        : 2 * hparams.n_layer;
+        if (cache_copies.size() < needed) {
+            cache_copies.resize(needed);
+        }
     }
 
     active_graph_slot = target;
@@ -821,15 +834,22 @@ void llama_context::activate_graph_slot(int slot_idx) {
     auto & slot = graph_slots[slot_idx];
     GGML_ASSERT(slot.valid && slot.graph);
 
+    LLAMA_LOG_DEBUG("%s: reusing slot %d (mtp_op=%d, n_kv=%d, lru=%" PRIu64 ", cross_slot=%s)\n",
+                    __func__, slot_idx, (int)slot.mtp_op_type, slot.n_kv, graph_slot_counter + 1,
+                    (cparams.n_graph_reuse > 1 && slot_idx != active_graph_slot) ? "yes" : "no");
     slot.last_used = ++graph_slot_counter;
 
     if (cparams.n_graph_reuse > 1 && slot_idx != active_graph_slot) {
-        std::swap(buf_compute_meta, slot.buf_compute_meta);
-        std::swap(cache_copies, slot.cache_copies);
         restore_input_tensors_from_slot(slot);
 
         ggml_backend_sched_reset(sched);
         ggml_backend_sched_alloc_graph(sched, slot.graph);
+
+        if (!update_cache_copies_for_slot(slot_idx)) {
+            slot.valid = false;
+            active_graph_slot = -1;
+            return;
+        }
     }
 
     active_graph_slot = slot_idx;
@@ -4120,6 +4140,16 @@ static int llama_decode_internal(
 #endif
         ggml_cgraph * gf = nullptr;
         int reuse_slot = lctx.find_reusable_graph(u_batch);
+
+        if (reuse_slot >= 0) {
+            lctx.activate_graph_slot(reuse_slot);
+            if (lctx.active_graph_slot >= 0) {
+                gf = lctx.graph_slots[reuse_slot].graph;
+            } else {
+                reuse_slot = -1;
+            }
+        }
+
         if (reuse_slot < 0) {
             lctx.reset_scheduler();
             ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
@@ -4148,9 +4178,6 @@ static int llama_decode_internal(
             if (u_batch.n_tokens == 1 && u_batch.embd == nullptr && lctx.cparams.n_graph_reuse > 0) {
                 lctx.store_graph_slot(u_batch, gf);
             }
-        } else {
-            lctx.activate_graph_slot(reuse_slot);
-            gf = lctx.graph_slots[reuse_slot].graph;
         }
 
         if (cparams.mtp_op_type != MTP_OP_NONE) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5307,6 +5307,8 @@ struct llama_context_params llama_context_default_params() {
         /*.fused_mmad                  =*/ true,
         /*.rope_cache                  =*/ false,
         /*.n_graph_reuse               =*/ 1,
+        /*.n_graph_reuse_main          =*/ -1,
+        /*.n_graph_reuse_draft         =*/ -1,
         /*.min_experts                 =*/ -1,
         /*.thtesh_experts              =*/ 0.0f,
         /*.only_active_experts         =*/ false,
@@ -5689,7 +5691,9 @@ struct llama_context * llama_init_from_model(
     cparams.fused_up_gate    = params.fused_up_gate;
     cparams.fused_mmad       = params.fused_mmad;
     cparams.rope_cache       = params.rope_cache;
-    cparams.n_graph_reuse   = params.n_graph_reuse;
+    cparams.n_graph_reuse       = params.n_graph_reuse;
+    cparams.n_graph_reuse_main  = params.n_graph_reuse_main;
+    cparams.n_graph_reuse_draft = params.n_graph_reuse_draft;
     cparams.k_cache_hadamard = params.k_cache_hadamard;
     cparams.v_cache_hadamard = params.v_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
@@ -5797,17 +5801,32 @@ struct llama_context * llama_init_from_model(
     LLAMA_LOG_INFO("%s: rope_cache    = %d\n",     __func__, cparams.rope_cache);
     LLAMA_LOG_INFO("%s: n_graph_reuse = %d\n",     __func__, cparams.n_graph_reuse);
     if (cparams.n_graph_reuse > 0) {
-        const int n_slots = std::min(cparams.n_graph_reuse, (int)llama_context::GRAPH_SLOTS_MAX);
         const bool has_mtp = model->hparams.nextn_predict_layers > 0 && cparams.mtp;
-        if (has_mtp && n_slots >= 1) {
-            const int main_slots  = 1;
-            const int draft_slots = n_slots - 1;
+        int main_slots, draft_slots;
+        if (cparams.n_graph_reuse_main >= 0 && cparams.n_graph_reuse_draft >= 0) {
+            main_slots  = std::min(cparams.n_graph_reuse_main,  (int)llama_context::GRAPH_SLOTS_MAX);
+            draft_slots = has_mtp ? std::min(cparams.n_graph_reuse_draft, (int)llama_context::GRAPH_SLOTS_MAX) : 0;
+        } else {
+            // TODO: Deactivate backwards logic
+            const int n_slots = std::min(cparams.n_graph_reuse, (int)llama_context::GRAPH_SLOTS_MAX);
+            if (has_mtp && n_slots >= 1) {
+                main_slots  = 1;
+                draft_slots = n_slots - 1;
+            } else {
+                main_slots  = n_slots;
+                draft_slots = 0;
+            }
+        }
+        if (main_slots > 0) {
             ctx->graph_slots.resize(main_slots);
+        }
+        if (draft_slots > 0) {
             ctx->graph_slots_draft.resize(draft_slots);
+        }
+        if (draft_slots > 0 || (has_mtp && main_slots > 0)) {
             LLAMA_LOG_INFO("%s: graph slots   = %d main + %d draft\n", __func__, main_slots, draft_slots);
         } else {
-            ctx->graph_slots.resize(n_slots);
-            LLAMA_LOG_INFO("%s: graph slots   = %d\n", __func__, n_slots);
+            LLAMA_LOG_INFO("%s: graph slots   = %d\n", __func__, main_slots);
         }
     }
     LLAMA_LOG_INFO("%s: k_cache_hadam = %d\n",     __func__, cparams.k_cache_hadamard);


### PR DESCRIPTION
I'm opening this PR for discussion and have taken @ikawrakow suggestion to [work on the graph reuse logic](https://github.com/ikawrakow/ik_llama.cpp/discussions/1228#discussioncomment-15691778) in order to improve the speed of speculative decoding (right now I'm focusing solely on MTP).

Based on my tests, the theoretical impact that both graph reuse and the scheduler could generate is approximately 8%. To mitigate this, I enabled the option to choose how many graphs you want to create; however, a lot of data would still be lost in the scheduler that saves information from the previous graph, so I created two schedulers, with the second one dedicated exclusively to speculative decoding.

My rationale is to segment these operations for each one, so that if I want to use `--draft-max 3`, I could use `-gr 3,3`, which would create 3 graphs for each scheduler to use. Here is an example (Tested as part of PR #1531):

## GLM 4.7-smol IQ2_KS (93 layers, 179 main splits, 2-3 MTP splits)

| Config | Main Reuse | MTP Reuse | Sched Overhead | Speed |
|--------|-----------|------------|--------------|-------|
| **gr1** (1 main + 0 draft) | 50.0% | 0.0% | 262.5ms | 12.73 t/s |
| **gr1,1** (1 main + 1 draft) | 49.9% | 16.0% | 265.8ms | 12.80 t/s |
| **gr1,2** (1 main + 2 draft) | 50.0% | 66.3% | 282.2ms | 13.25 t/s |

## Comparison with GLM 4.5 Air (47 layers, 55 main splits, 2 MTP splits)

| Config | Main Reuse | MTP Reuse | Sched Overhead | Speed |
|--------|-----------|-----------|----------------|-------|
| **gr1** | 55.8% | 0.0% | 33.9ms | 16.18 t/s |
| **gr1,1** | 55.8% | 10.5% | 33.0ms | 16.05 t/s |
| **gr1,2** | 55.8% | 77.2% | 44.0ms | 16.06 t/s |

One of the problems I identified is that the adopted approach does not necessarily provide benefits; for example, in GLM 4.5 Air, where operations are already fast, I may experience negative returns when reusing a graph. Furthermore, in both tested models, I observed similar performance regardless of whether I used `-gr` or not.

This led me to consider whether something in `ggml-backend.cpp`, such as `ggml_backend_sched_graph_compute_async`, was not being reused effectively, but I did not identify any issues here.

With that in mind, I’d like to keep the PR open for discussions about improvements to performance and architecture.