### PR TITLE
Fix BF16 mmproj on the CPU

### DIFF
--- a/ggml/src/iqk/iqk_gemm_floats.cpp
+++ b/ggml/src/iqk/iqk_gemm_floats.cpp
@@ -519,7 +519,7 @@ void set_mul_mat_bf16_r16(std::array<mul_mat_t, IQK_MAX_NY>& funcs) {
 bool iqk_set_kernels_float(int ne00, int typeA, int typeB, std::array<mul_mat_t, IQK_MAX_NY>& kernels) {
 
     if (typeA == GGML_TYPE_BF16) {
-        if (ne00 % 32) return false;
+        if (ne00 % 16) return false;
         switch (typeB) {
 #ifdef __AVX512BF16__
             case GGML_TYPE_BF16: set_mul_mat_bf16(kernels); break;


### PR DESCRIPTION

Now `bf16` mmproj files can be used for Qwen3vl/Qwen3.5 with running CPU-only or when using `--no-mmproj-offload`.

The issue was that the `IQK` GEMM implementation was asking the row size to be a multiple of 32, but the `ffn_down` tensors in the vision encoder are only divisible by 16. The implementation does handle it correctly, so not sure why I had the 32 divisibility check.

Closes #1406.
