### PR TITLE
Fix unknown tensor type warnings

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1861,6 +1861,9 @@ llm_tensor llm_tensor_type(llm_arch arch, const std::string & tensor_name, int i
         if (tensor_name.find(this_name) == 0) {
             return entry.first;
         }
+        if (tensor_name.find(base_name) == 0) {
+            return entry.first;
+        }
     }
     return LLM_TENSOR_UNKNOWN;
 }


### PR DESCRIPTION

Some tensor names do not have `.weight` or `.bias` extension (e.g., `blk.*.ssm_a` in Qwen-3.5 models), and this was causing unknown tensor type warnings. The PR fixes that.