### PR TITLE
Add reuse property to ggml_cgraph

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -855,6 +855,7 @@ extern "C" {
         struct ggml_hash_set visited_hash_set;
 
         enum ggml_cgraph_eval_order order;
+        bool reused;
     };
 
     // scratch buffer

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2637,6 +2637,10 @@ enum ggml_status ggml_backend_sched_graph_compute_async(ggml_backend_sched_t sch
         }
     }
 
+    for (int i = 0; i < sched->n_splits; i++) {
+        sched->splits[i].graph.reused = graph->reused;
+    }
+
     return ggml_backend_sched_compute_splits(sched);
 }
 

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4231,6 +4231,10 @@ static bool is_cuda_graph_update_required(ggml_cuda_graph * graph, ggml_cgraph *
         graph->ggml_graph_properties.resize(cgraph->n_nodes);
     }
 
+    if (!cuda_graph_update_required && cgraph->reused) {
+        return false;
+    }
+
     // Loop over nodes in GGML graph to determine if CUDA graph update is required
     // and store properties to allow this comparison for the next token
     for (int i = 0; i < cgraph->n_nodes; i++) {

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -25909,6 +25909,7 @@ struct ggml_cgraph * ggml_new_graph_custom(struct ggml_context * ctx, size_t siz
         /*.leafs        =*/ leafs_ptr,
         /*.hash_table   =*/ { hash_size, hash_used, hash_keys_ptr },
         /*.order        =*/ GGML_CGRAPH_EVAL_ORDER_LEFT_TO_RIGHT,
+        /*.reused       =*/ false,
     };
 
     ggml_hash_set_reset(&cgraph->visited_hash_set);
@@ -25931,6 +25932,7 @@ struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph0, int i0, int i1)
         /*.leafs        =*/ NULL,
         /*.hash_table   =*/ { 0, NULL, NULL },
         /*.order        =*/ cgraph0->order,
+        /*.reused       =*/ cgraph0->reused,
     };
 
     return cgraph;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4006,6 +4006,7 @@ static int llama_decode_internal(
         } else {
             //printf("Reusing graph\n");
             gf = lctx.prev->graph;
+            gf->reused = true;
         }
 
         if (cparams.mtp_op_type != MTP_OP_NONE) {


### PR DESCRIPTION

Took the idea from PR 21764 in llama.cpp. Or rather, as the idea is obvious, the motivation to do it. The idea is that if a compute graph is reused, one can skip the checks if the graph properties have changed when using CUDA graphs. Up to  6% performance gains for TG are being claimed in the mainline PR, so that gave me the motivation to do it for `ik_llama.cpp`.

The outcome is rather disappointing - sub-1% gains (measured on a 2x3090 system).

Having noticed that the new tensor parallel option in `llama.cpp` (`-sm tensor`) has been merged ([PR 19378](https://github.com/ggml-org/llama.cpp/pull/19378)), I was curious to see how it does now, 2 months after the [PR was first submitted.  I made [some observations](https://github.com/ikawrakow/ik_llama.cpp/discussions/1247) about this effort back in February, so let's see what we get today.

A complete evaluation would be interesting, but here just a quick check with the Gemma4 models on a 2x3090 system. The results are below, and speak for themselves.

## Gemma4-26B-A4B-IQ4_XS

### llama.cpp

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.434 |  4716.75 |    1.080 |   118.49 |
|  2048 |    128 |   2048 |    0.458 |  4472.55 |    1.109 |   115.42 |
|  2048 |    128 |   4096 |    0.463 |  4425.22 |    1.126 |   113.63 |
|  2048 |    128 |   6144 |    0.472 |  4336.73 |    1.132 |   113.05 |
|  2048 |    128 |   8192 |    0.485 |  4226.80 |    1.139 |   112.41 |
|  2048 |    128 |  10240 |    0.491 |  4172.78 |    1.140 |   112.27 |
|  2048 |    128 |  12288 |    0.501 |  4087.37 |    1.137 |   112.62 |
|  2048 |    128 |  14336 |    0.513 |  3992.38 |    1.141 |   112.18 |
|  2048 |    128 |  16384 |    0.521 |  3933.51 |    1.145 |   111.79 |
|  2048 |    128 |  18432 |    0.530 |  3863.57 |    1.150 |   111.29 |
|  2048 |    128 |  20480 |    0.543 |  3770.79 |    1.153 |   111.02 |
|  2048 |    128 |  22528 |    0.550 |  3723.11 |    1.158 |   110.53 |
|  2048 |    128 |  24576 |    0.563 |  3639.96 |    1.162 |   110.19 |
|  2048 |    128 |  26624 |    0.573 |  3572.90 |    1.165 |   109.91 |
|  2048 |    128 |  28672 |    0.582 |  3519.25 |    1.169 |   109.50 |
|  2048 |    128 |  30720 |    0.591 |  3464.45 |    1.172 |   109.20 |

### ik_llama.cpp

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.327 |  6265.35 |    0.841 |   152.26 |
|  2048 |    128 |   2048 |    0.290 |  7057.27 |    0.866 |   147.84 |
|  2048 |    128 |   4096 |    0.301 |  6812.09 |    0.870 |   147.07 |
|  2048 |    128 |   6144 |    0.312 |  6555.22 |    0.877 |   146.00 |
|  2048 |    128 |   8192 |    0.324 |  6319.15 |    0.885 |   144.66 |
|  2048 |    128 |  10240 |    0.336 |  6092.81 |    0.890 |   143.81 |
|  2048 |    128 |  12288 |    0.348 |  5885.90 |    0.892 |   143.53 |
|  2048 |    128 |  14336 |    0.361 |  5677.94 |    0.901 |   142.06 |
|  2048 |    128 |  16384 |    0.374 |  5481.73 |    0.909 |   140.75 |
|  2048 |    128 |  18432 |    0.386 |  5308.63 |    0.927 |   138.12 |
|  2048 |    128 |  20480 |    0.397 |  5159.07 |    0.929 |   137.83 |
|  2048 |    128 |  22528 |    0.409 |  5009.88 |    0.930 |   137.60 |
|  2048 |    128 |  24576 |    0.418 |  4894.51 |    0.930 |   137.61 |
|  2048 |    128 |  26624 |    0.432 |  4744.07 |    0.938 |   136.53 |
|  2048 |    128 |  28672 |    0.444 |  4607.92 |    0.939 |   136.30 |
|  2048 |    128 |  30720 |    0.456 |  4487.35 |    0.949 |   134.95 |


