### PR TITLE
cuda: cap host MMQ tile size on Volta to match device kernels

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -121,12 +121,15 @@ struct tile_x_sizes {
 };
 
 static constexpr int get_mmq_x_max_host(const int cc) {
+    // On NVIDIA Volta the device-side MMQ kernels are only instantiated up to
+    // MMQ_DP4A_MAX_BATCH_SIZE when GGML_CUDA_FORCE_MMQ is defined (see
+    // get_mmq_x_max_device() below). If the host dispatch picks a larger tile,
+    // the kernel hits NO_DEVICE_CODE at runtime. Without GGML_CUDA_FORCE_MMQ
+    // the host already capped at MMQ_DP4A_MAX_BATCH_SIZE so cuBLAS handles
+    // larger batches. Either way the bound on Volta is the same, so collapse
+    // the two paths and document the constraint.
     return int8_mma_available(cc) ? 128 :
-#ifdef GGML_CUDA_FORCE_MMQ
-        cc >= CC_VOLTA && cc < CC_OFFSET_AMD ? 128                     : 64;
-#else
         cc >= CC_VOLTA && cc < CC_OFFSET_AMD ? MMQ_DP4A_MAX_BATCH_SIZE : 64;
-#endif // GGML_CUDA_FORCE_MMQ
 }
 
 static constexpr __device__ int get_mmq_x_max_device() {


### PR DESCRIPTION
## Problem

On NVIDIA Volta (sm_70, e.g. Tesla V100), building with `GGML_CUDA_FORCE_MMQ=ON` makes the host dispatcher pick MMQ tile sizes that the device kernels are not compiled for, triggering `NO_DEVICE_CODE` at runtime. The kernel returns without writing output, so prompt processing produces zero activations and the model emits garbage tokens. With `-sm none` / `-sm layer` and prompts longer than ~64 tokens, stderr fills with:

```
ggml/src/ggml-cuda/mmq.cuh:3941: ERROR: CUDA kernel mul_mat_q has no
device code compatible with CUDA arch 700. ggml-cuda.cu was compiled
for: 700
```

## Root cause

`get_mmq_x_max_host()` and `get_mmq_x_max_device()` disagree on Volta when `GGML_CUDA_FORCE_MMQ` is defined:

| build           | host returns      | device returns    |
| --------------- | ----------------- | ----------------- |
| no FORCE_MMQ    | 64 (`DP4A_MAX`)   | 128               |
| **FORCE_MMQ**   | **128**           | **64 (`DP4A_MAX`)** |

The host search loop in `mul_mat_q_case()` (`for (int mmq_x = 8; mmq_x <= mmq_x_max; mmq_x += 8)`) can pick `mmq_x ∈ {72, 80, …, 128}` and instantiate `launch_mul_mat_q<type, mmq_x>`, but the corresponding device template short-circuits via `NO_DEVICE_CODE` because `mmq_x > get_mmq_x_max_device()`.

## Fix

Cap the host bound at `MMQ_DP4A_MAX_BATCH_SIZE` on Volta independently of `GGML_CUDA_FORCE_MMQ`. This matches what the device side actually supports. `FORCE_MMQ` on Volta loses no usable functionality from this change because the wider device templates were never callable in the first place.

## Testing

Tesla V100-SXM2-32GB, CUDA 12.9, Qwen3.5-35B-A3B Q6_K.

Single-GPU (`llama-cli -ngl 99 -p "<~200 tokens>"`):

|              | PP (t/s)                     | TG (t/s) | output                  |
| ------------ | ---------------------------- | -------- | ----------------------- |
| before patch | broken (`NO_DEVICE_CODE`)    | 102      | corrupt for batch > 64  |
| after patch  | 630                          | 102      | coherent                |

Unchanged on Turing/Ampere/Hopper (gated by `int8_mma_available()`) and on AMD/HIP. No effect on `mmq_id_common.cuh` (MoE expert routing), where host and device already agree.

## Out of scope

`-sm graph` on Volta still produces garbage; this PR does not address that — the failure mode is different (no `NO_DEVICE_CODE`, runs at expected throughput) and likely lives in the graph-split inter-GPU exchange path.