### PR TITLE
CPU: allow all supported quantization types for FlashMLA

### DIFF
--- a/ggml/src/iqk/fa/iqk_fa_576_512.cpp
+++ b/ggml/src/iqk/fa/iqk_fa_576_512.cpp
@@ -81,6 +81,24 @@ inline bool iqk_deepseek_helper(ggml_type type_k,
         iqk_deepseek_helper<step_k>(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, scale, softcap, qkv, sinkf, M, S);
         return true;
     }
+    if (type_k == GGML_TYPE_Q4_0) {
+        HelperQ40 kh((const char *)k, stride_k);
+        HelperQ40 vh((const char *)v, stride_v);
+        iqk_deepseek_helper<step_k>(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, scale, softcap, qkv, sinkf, M, S);
+        return true;
+    }
+    if (type_k == GGML_TYPE_Q4_1) {
+        HelperQ41 kh((const char *)k, stride_k);
+        HelperQ41 vh((const char *)v, stride_v);
+        iqk_deepseek_helper<step_k>(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, scale, softcap, qkv, sinkf, M, S);
+        return true;
+    }
+    if (type_k == GGML_TYPE_IQ4_NL) {
+        HelperIQ4nl kh((const char *)k, stride_k);
+        HelperIQ4nl vh((const char *)v, stride_v);
+        iqk_deepseek_helper<step_k>(kh, vh, nq1, nk1, stride_q, stride_m, stride_qkv, q, mask, scale, softcap, qkv, sinkf, M, S);
+        return true;
+    }
 #endif
     if (type_k == GGML_TYPE_F16) {
         HelperF16 kh((const char *)k, stride_k);


### PR DESCRIPTION

For MLA models such as GLM-5, on the main branch the CPU backend only supports `f16, q8_0` and `q6_0` as KV cache quantization type (plus `bf16` if the CPU has native support for `bf16`). This leads to users reporting NaNs (e.g., #1616), and me not diagnosing the problem right away due to a short attention span.

It is not a good idea to use quantization types below `q8_0` for MLA models (no Hadamard is available), but unlike some other projects, I'm here to make the tools and not the rules.

This PR adds `Q4_0, Q4_1` and `IQ4_NL` KV cache support for MLA models.

Closes #1616  