### PR TITLE
Alternative graph parallel for MiniMax-M2

### DIFF
--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -365,6 +365,30 @@ static __global__ void fused_rms_norm_f32(const src_t * x, const float * y, floa
 }
 
 template <int block_size, typename src_t>
+static __global__ void fused_rms_norm_f32(const src_t * x, const float * y, const float * sum, float * dst, const int ncols, float eps) {
+    const int row = blockIdx.x*blockDim.y + threadIdx.y;
+    const int tid = threadIdx.x;
+
+    const float mean = sum[row] / ncols;
+    const float scale = rsqrtf(mean + eps);
+
+    if constexpr (std::is_same_v<src_t, block_q8_0>) {
+        auto xr = x + (row*ncols)/QK8_0;
+        for (int col = tid; col < ncols; col += block_size) {
+            dst[row*ncols + col] = scale * y[col] * (float)xr[col / QK8_0].d * xr[col / QK8_0].qs[col % QK8_0];
+        }
+    } else if constexpr (std::is_same_v<src_t, nv_bfloat16>) {
+        for (int col = tid; col < ncols; col += block_size) {
+            dst[row*ncols + col] = scale * y[col] * __bfloat162float(x[row*ncols + col]);
+        }
+    } else {
+        for (int col = tid; col < ncols; col += block_size) {
+            dst[row*ncols + col] = scale * y[col] * (float)x[row*ncols + col];
+        }
+    }
+}
+
+template <int block_size, typename src_t>
 static __global__ void fused_rms_norm_f32_nc(
         const src_t * x, const float * y, float * dst, const int ncols, const int64_t stride_row, const int64_t stride_channel,
         const int64_t stride_sample, const float eps) {
@@ -534,6 +558,31 @@ static void fused_rms_norm_f32_cuda(const src_t * x, const float * y, float * ds
 }
 
 template <typename src_t>
+static void fused_rms_norm_f32_cuda(const src_t * x, const float * y, const float * sum, float * dst,
+        const int ncols, const int nrows, float eps, cudaStream_t stream) {
+    constexpr int kBlockSize = 256;
+    GGML_ASSERT(ncols % WARP_SIZE == 0);
+    if (ncols < kBlockSize) {
+        switch (ncols) {
+            case  32: fused_rms_norm_f32< 32><<<nrows,  32, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            case  64: fused_rms_norm_f32< 64><<<nrows,  64, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            case  96: fused_rms_norm_f32< 96><<<nrows,  96, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            case 128: fused_rms_norm_f32<128><<<nrows, 128, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            case 160: fused_rms_norm_f32<160><<<nrows, 160, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            case 192: fused_rms_norm_f32<192><<<nrows, 192, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            default : fused_rms_norm_f32<224><<<nrows, 224, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+        }
+    }
+    else if (ncols < 1024) {
+        const dim3 block_dims(kBlockSize, 1, 1);
+        fused_rms_norm_f32<kBlockSize><<<nrows, block_dims, 0, stream>>>(x, y, sum, dst, ncols, eps);
+    } else {
+        const dim3 block_dims(1024, 1, 1);
+        fused_rms_norm_f32<1024><<<nrows, block_dims, 0, stream>>>(x, y, sum, dst, ncols, eps);
+    }
+}
+
+template <typename src_t>
 static void fused_rms_norm_f32_nc_cuda(
         const src_t * x, const float * y, float * dst, const int ncols, const int nrows, const int nchannels, const int nsamples,
         const int64_t stride_row, const int64_t stride_channel, const int64_t stride_sample, const float eps, cudaStream_t stream) {
@@ -660,6 +709,7 @@ void ggml_cuda_op_fused_rms_norm(ggml_backend_cuda_context & ctx, ggml_tensor * 
     }
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
+    const ggml_tensor * src2 = dst->src[2];
     const float * src0_d = (const float *)src0->data;
     const float * src1_d = (const float *)src1->data;
     float * dst_d = (float *)dst->data;
@@ -676,6 +726,16 @@ void ggml_cuda_op_fused_rms_norm(ggml_backend_cuda_context & ctx, ggml_tensor * 
     memcpy(&eps, dst->op_params, sizeof(float));
 
     const int64_t ne00 = src0->ne[0];
+
+    if (src2) {
+        GGML_ASSERT(src0->type == GGML_TYPE_F32);
+        GGML_ASSERT(src2->type == GGML_TYPE_F32);
+        GGML_ASSERT(ggml_is_contiguous(src0));
+        const int64_t nrows = ggml_nrows(src0);
+        GGML_ASSERT(src2->ne[0] == nrows);
+        fused_rms_norm_f32_cuda(src0_d, src1_d, (const float *)src2->data, dst_d, ne00, nrows, eps, stream);
+        return;
+    }
 
     if (ggml_is_contiguous(src0)) {
         const int64_t nrows = ggml_nrows(src0);

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -365,11 +365,11 @@ static __global__ void fused_rms_norm_f32(const src_t * x, const float * y, floa
 }
 
 template <int block_size, typename src_t>
-static __global__ void fused_rms_norm_f32(const src_t * x, const float * y, const float * sum, float * dst, const int ncols, float eps) {
+static __global__ void fused_rms_norm_f32(const src_t * x, const float * y, const float * sum, float * dst, const int ncols, float eps, float norm) {
     const int row = blockIdx.x*blockDim.y + threadIdx.y;
     const int tid = threadIdx.x;
 
-    const float mean = sum[row] / ncols;
+    const float mean = sum[row] * norm;
     const float scale = rsqrtf(mean + eps);
 
     if constexpr (std::is_same_v<src_t, block_q8_0>) {
@@ -559,26 +559,26 @@ static void fused_rms_norm_f32_cuda(const src_t * x, const float * y, float * ds
 
 template <typename src_t>
 static void fused_rms_norm_f32_cuda(const src_t * x, const float * y, const float * sum, float * dst,
-        const int ncols, const int nrows, float eps, cudaStream_t stream) {
+        const int ncols, const int nrows, float eps, float norm, cudaStream_t stream) {
     constexpr int kBlockSize = 256;
     GGML_ASSERT(ncols % WARP_SIZE == 0);
     if (ncols < kBlockSize) {
         switch (ncols) {
-            case  32: fused_rms_norm_f32< 32><<<nrows,  32, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
-            case  64: fused_rms_norm_f32< 64><<<nrows,  64, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
-            case  96: fused_rms_norm_f32< 96><<<nrows,  96, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
-            case 128: fused_rms_norm_f32<128><<<nrows, 128, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
-            case 160: fused_rms_norm_f32<160><<<nrows, 160, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
-            case 192: fused_rms_norm_f32<192><<<nrows, 192, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
-            default : fused_rms_norm_f32<224><<<nrows, 224, 0, stream>>>(x, y, sum, dst, ncols, eps); break;
+            case  32: fused_rms_norm_f32< 32><<<nrows,  32, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
+            case  64: fused_rms_norm_f32< 64><<<nrows,  64, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
+            case  96: fused_rms_norm_f32< 96><<<nrows,  96, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
+            case 128: fused_rms_norm_f32<128><<<nrows, 128, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
+            case 160: fused_rms_norm_f32<160><<<nrows, 160, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
+            case 192: fused_rms_norm_f32<192><<<nrows, 192, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
+            default : fused_rms_norm_f32<224><<<nrows, 224, 0, stream>>>(x, y, sum, dst, ncols, eps, norm); break;
         }
     }
     else if (ncols < 1024) {
         const dim3 block_dims(kBlockSize, 1, 1);
-        fused_rms_norm_f32<kBlockSize><<<nrows, block_dims, 0, stream>>>(x, y, sum, dst, ncols, eps);
+        fused_rms_norm_f32<kBlockSize><<<nrows, block_dims, 0, stream>>>(x, y, sum, dst, ncols, eps, norm);
     } else {
         const dim3 block_dims(1024, 1, 1);
-        fused_rms_norm_f32<1024><<<nrows, block_dims, 0, stream>>>(x, y, sum, dst, ncols, eps);
+        fused_rms_norm_f32<1024><<<nrows, block_dims, 0, stream>>>(x, y, sum, dst, ncols, eps, norm);
     }
 }
 
@@ -731,9 +731,12 @@ void ggml_cuda_op_fused_rms_norm(ggml_backend_cuda_context & ctx, ggml_tensor * 
         GGML_ASSERT(src0->type == GGML_TYPE_F32);
         GGML_ASSERT(src2->type == GGML_TYPE_F32);
         GGML_ASSERT(ggml_is_contiguous(src0));
+        int ntot_cols = dst->op_params[1];
+        GGML_ASSERT(ntot_cols > 0);
+        float norm = 1.f/ntot_cols;
         const int64_t nrows = ggml_nrows(src0);
         GGML_ASSERT(src2->ne[0] == nrows);
-        fused_rms_norm_f32_cuda(src0_d, src1_d, (const float *)src2->data, dst_d, ne00, nrows, eps, stream);
+        fused_rms_norm_f32_cuda(src0_d, src1_d, (const float *)src2->data, dst_d, ne00, nrows, eps, norm, stream);
         return;
     }
 

--- a/ggml/src/ggml-cuda/reduce.cu
+++ b/ggml/src/ggml-cuda/reduce.cu
@@ -164,7 +164,6 @@ void ggml_cuda_op_reduce([[maybe_unused]] ggml_backend_cuda_context & ctx, ggml_
         return;
     }
 #endif
-    printf("Not using NCCL\n");
     GGML_ASSERT(dst->data == dst->src[ctx.device]->data);
     auto nbytes = ggml_nbytes(dst);
     int idx[GGML_CUDA_MAX_DEVICES];
@@ -436,7 +435,7 @@ void ggml_cuda_op_reduce([[maybe_unused]] ggml_backend_cuda_context & ctx, ggml_
         }
         return;
     }
-    if (dst->ne[1] < 32 && ctx.p2p_enabled) {
+    if (dst->ne[1] < 32 && ctx.p2p_enabled && ggml_nelements(dst) >= 8*nhave) {
         GGML_ASSERT(dst->type != GGML_TYPE_Q8_0);
         for (int ii = 0; ii < nhave; ++ii) {
             int i = idx[ii];

--- a/ggml/src/ggml-cuda/reduce.cu
+++ b/ggml/src/ggml-cuda/reduce.cu
@@ -164,6 +164,7 @@ void ggml_cuda_op_reduce([[maybe_unused]] ggml_backend_cuda_context & ctx, ggml_
         return;
     }
 #endif
+    printf("Not using NCCL\n");
     GGML_ASSERT(dst->data == dst->src[ctx.device]->data);
     auto nbytes = ggml_nbytes(dst);
     int idx[GGML_CUDA_MAX_DEVICES];

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -9911,8 +9911,7 @@ ggml_cgraph* llm_build_context::build_minimaxm2() {
             int head_count    = 0;
             int head_count_kv = 0;
             int n_device = wq->n_device;
-            std::vector<ggml_tensor *> attn(n_device, nullptr);
-            bool input_added = false;
+            std::vector<ggml_tensor *> q_all(n_device, nullptr), k_all(n_device, nullptr), v_all(n_device, nullptr), q_k_all(n_device, nullptr);
             for (int id = 0; id < n_device; ++id) {
                 if (!wq->splits[id]) continue;
                 int il_id = 1000*il + id;
@@ -9928,28 +9927,68 @@ ggml_cgraph* llm_build_context::build_minimaxm2() {
                 auto Vcur = llm_build_lora_mm(lctx, ctx0, wv->splits[id], cur);
                 cb(Vcur, "Vcur", il_id);
 
-                // Do this here so Q, K, V matrix multiplications may be fused
-                ggml_build_forward_expand(gf, Qcur);
-                ggml_build_forward_expand(gf, Kcur);
-                ggml_build_forward_expand(gf, Vcur);
+                q_all[id] = Qcur;
+                q_all[id] = Kcur;
+                v_all[id] = Vcur;
 
-                Qcur = llm_build_norm(ctx0, Qcur, hparams, q_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+                auto Qsqr = ggml_mul(ctx0, Qcur, Qcur);
+                auto Qsum = ggml_sum_rows(ctx0, Qsqr);
+                Qsum = ggml_reshape_1d(ctx0, Qsum, Qsum->ne[1]);
+
+                auto Ksqr = ggml_mul(ctx0, Kcur, Kcur);
+                auto Ksum = ggml_sum_rows(ctx0, Ksqr);
+                Ksum = ggml_reshape_1d(ctx0, Ksum, Ksum->ne[1]);
+
+                q_k_all[id] = ggml_concat(ctx0, Qsum, Ksum, 0);
+            }
+            auto kq_sum = ggml_reduce(ctx0, q_k_all.data(), n_device, GGML_OP_ADD);
+
+            std::vector<ggml_tensor *> attn(n_device, nullptr);
+            bool input_added = false;
+            for (int id = 0; id < n_device; ++id) {
+                if (!wq->splits[id]) continue;
+                int il_id = 1000*il + id;
+                auto kq = get_input_tensor_sm_graph(ctx0, kq_sum, id);
+                auto qsum = ggml_view_1d(ctx0, kq, n_tokens, 0);
+                auto ksum = ggml_view_1d(ctx0, kq, n_tokens, n_tokens*ggml_element_size(kq));
+                auto input = get_input_tensor_sm_graph(ctx0, inpL, id);
+                //cur = llm_build_norm(ctx0, input, hparams, attn_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+
+                //auto Qcur = llm_build_lora_mm(lctx, ctx0, wq->splits[id], cur);
+                //cb(Qcur, "Qcur", il_id);
+
+                //auto Kcur = llm_build_lora_mm(lctx, ctx0, wk->splits[id], cur);
+                //cb(Kcur, "Kcur", il_id);
+
+                //auto Vcur = llm_build_lora_mm(lctx, ctx0, wv->splits[id], cur);
+                //cb(Vcur, "Vcur", il_id);
+
+                //// Do this here so Q, K, V matrix multiplications may be fused
+                //ggml_build_forward_expand(gf, Qcur);
+                //ggml_build_forward_expand(gf, Kcur);
+                //ggml_build_forward_expand(gf, Vcur);
+
+                auto Qcur = llm_build_norm(ctx0, q_all[id], hparams, q_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+                Qcur->src[2] = qsum;
                 cb(Qcur, "Qcur_normed", il_id);
 
-                Kcur = llm_build_norm(ctx0, Kcur, hparams, k_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+                auto Kcur = llm_build_norm(ctx0, k_all[id], hparams, k_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+                Kcur->src[2] = ksum;
                 cb(Kcur, "Kcur_normed", il_id);
 
-                // reshape for multi-head
-                Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
-                Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+                auto Vcur = v_all[id];
 
                 int gqa_ratio   = n_head / n_head_kv;
                 int nhead_kv_id = Vcur->ne[0] / n_embd_head_v;
                 int nhead_id    = nhead_kv_id * gqa_ratio;
                 GGML_ASSERT(nhead_kv_id > 0 && nhead_kv_id <= n_head_kv);
 
-                Qcur = ggml_view_3d(ctx0, Qcur, n_embd_head_k, nhead_id,    n_tokens, Qcur->nb[1], Qcur->nb[2], head_count*Qcur->nb[1]);
-                Kcur = ggml_view_3d(ctx0, Kcur, n_embd_head_k, nhead_kv_id, n_tokens, Kcur->nb[1], Kcur->nb[2], head_count_kv*Kcur->nb[1]);
+                // reshape for multi-head
+                Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head_k, nhead_id,    n_tokens);
+                Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head_k, nhead_kv_id, n_tokens);
+
+                //Qcur = ggml_view_3d(ctx0, Qcur, n_embd_head_k, nhead_id,    n_tokens, Qcur->nb[1], Qcur->nb[2], head_count*Qcur->nb[1]);
+                //Kcur = ggml_view_3d(ctx0, Kcur, n_embd_head_k, nhead_kv_id, n_tokens, Kcur->nb[1], Kcur->nb[2], head_count_kv*Kcur->nb[1]);
                 head_count    += nhead_id;
                 head_count_kv += nhead_kv_id;
 

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -1980,21 +1980,61 @@ std::tuple<ggml_tensor*, ggml_tensor*, ggml_tensor*> llm_build_context::llm_buil
     }
 
     auto [Q, K, V] = llm_build_mul_mat_qkv(gf, cur, wq, bq, wk, bk, wv, bv, attention_scale, il, add_graph_split);
-    auto Qcur = ggml_reshape_3d(ctx0, Q, n_embd_head_k, Q->ne[0]/n_embd_head_k, n_tokens);
-    // Command-R/R+ uses LayerNorm (not RMSNorm) for per-head Q/K normalisation
-    const auto qk_norm_type = (model.arch == LLM_ARCH_COMMAND_R) ? LLM_NORM : LLM_NORM_RMS;
+
+    auto qk_norm_type = (model.arch == LLM_ARCH_COMMAND_R) ? LLM_NORM : LLM_NORM_RMS;
     if (q_norm) {
-        Qcur = llm_build_norm(ctx0, Qcur, hparams, q_norm, NULL, qk_norm_type, cb, il);
-        cb(Qcur, "Qcur_normed", il);
+        if (q_norm->ne[0] == n_embd_head_k) {
+            Q = ggml_reshape_3d(ctx0, Q, n_embd_head_k, Q->ne[0]/n_embd_head_k, n_tokens);
+            Q = llm_build_norm(ctx0, Q, hparams, q_norm, NULL, qk_norm_type, cb, il);
+            cb(Q, "Q_normed", il);
+        }
+        else if (q_norm->ne[0] == Q->ne[0]) {
+            Q = llm_build_norm(ctx0, Q, hparams, q_norm, NULL, qk_norm_type, cb, il);
+            Q = ggml_reshape_3d(ctx0, Q, n_embd_head_k, Q->ne[0]/n_embd_head_k, n_tokens);
+            cb(Q, "Q_normed", il);
+        }
+        else {
+            LLAMA_LOG_ERROR("Unexpected q_norm size %ld. Q is %ld x %ld x %ld x %ld\n", q_norm->ne[0], Q->ne[0], Q->ne[1], Q->ne[2], Q->ne[3]);
+            GGML_ABORT("Fatal error");
+        }
+    } else {
+        Q = ggml_reshape_3d(ctx0, Q, n_embd_head_k, Q->ne[0]/n_embd_head_k, n_tokens);
     }
 
-    auto Kcur = ggml_reshape_3d(ctx0, K, n_embd_head_k, K->ne[0]/n_embd_head_k, n_tokens);
     if (k_norm) {
-        Kcur = llm_build_norm(ctx0, Kcur, hparams, k_norm, NULL, qk_norm_type, cb, il);
-        cb(Kcur, "Kcur_normed", il);
+        if (k_norm->ne[0] == n_embd_head_k) {
+            K = ggml_reshape_3d(ctx0, K, n_embd_head_k, K->ne[0]/n_embd_head_k, n_tokens);
+            K = llm_build_norm(ctx0, K, hparams, q_norm, NULL, qk_norm_type, cb, il);
+            cb(K, "K_normed", il);
+        }
+        else if (k_norm->ne[0] == K->ne[0]) {
+            K = llm_build_norm(ctx0, K, hparams, q_norm, NULL, qk_norm_type, cb, il);
+            K = ggml_reshape_3d(ctx0, K, n_embd_head_k, K->ne[0]/n_embd_head_k, n_tokens);
+            cb(K, "K_normed", il);
+        }
+        else {
+            LLAMA_LOG_ERROR("Unexpected k_norm size %ld. K is %ld x %ld x %ld x %ld\n", k_norm->ne[0], K->ne[0], K->ne[1], K->ne[2], K->ne[3]);
+            GGML_ABORT("Fatal error");
+        }
+    } else {
+        K = ggml_reshape_3d(ctx0, K, n_embd_head_k, K->ne[0]/n_embd_head_k, n_tokens);
     }
-    auto Vcur = V;
-    return {Qcur, Kcur, Vcur};
+    return {Q, K, V};
+
+    //auto Qcur = ggml_reshape_3d(ctx0, Q, n_embd_head_k, Q->ne[0]/n_embd_head_k, n_tokens);
+    //// Command-R/R+ uses LayerNorm (not RMSNorm) for per-head Q/K normalisation
+    //if (q_norm) {
+    //    Qcur = llm_build_norm(ctx0, Qcur, hparams, q_norm, NULL, qk_norm_type, cb, il);
+    //    cb(Qcur, "Qcur_normed", il);
+    //}
+
+    //auto Kcur = ggml_reshape_3d(ctx0, K, n_embd_head_k, K->ne[0]/n_embd_head_k, n_tokens);
+    //if (k_norm) {
+    //    Kcur = llm_build_norm(ctx0, Kcur, hparams, k_norm, NULL, qk_norm_type, cb, il);
+    //    cb(Kcur, "Kcur_normed", il);
+    //}
+    //auto Vcur = V;
+    //return {Qcur, Kcur, Vcur};
 }
 
 static ggml_tensor * build_output(llama_context & lctx, ggml_context * ctx, ggml_tensor * cur, ggml_tensor * output, const llm_build_cb & cb) {
@@ -9928,7 +9968,7 @@ ggml_cgraph* llm_build_context::build_minimaxm2() {
                 cb(Vcur, "Vcur", il_id);
 
                 q_all[id] = Qcur;
-                q_all[id] = Kcur;
+                k_all[id] = Kcur;
                 v_all[id] = Vcur;
 
                 auto Qsqr = ggml_mul(ctx0, Qcur, Qcur);
@@ -9942,6 +9982,8 @@ ggml_cgraph* llm_build_context::build_minimaxm2() {
                 q_k_all[id] = ggml_concat(ctx0, Qsum, Ksum, 0);
             }
             auto kq_sum = ggml_reduce(ctx0, q_k_all.data(), n_device, GGML_OP_ADD);
+            cb(kq_sum, "kq_sum", il);
+            ggml_build_forward_expand(gf, kq_sum);
 
             std::vector<ggml_tensor *> attn(n_device, nullptr);
             bool input_added = false;
@@ -9968,11 +10010,15 @@ ggml_cgraph* llm_build_context::build_minimaxm2() {
                 //ggml_build_forward_expand(gf, Kcur);
                 //ggml_build_forward_expand(gf, Vcur);
 
-                auto Qcur = llm_build_norm(ctx0, q_all[id], hparams, q_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+                auto Qcur = q_all[id];
+                //printf("Qcur: %ld x %ld x %ld x %ld, q_norm: %ld x %ld x %ld x %ld\n", Qcur->ne[0], Qcur->ne[1], Qcur->ne[2], Qcur->ne[3], q_norm->splits[id]->ne[0], q_norm->splits[id]->ne[1], q_norm->splits[id]->ne[2], q_norm->splits[id]->ne[3]);
+                Qcur = llm_build_norm(ctx0, Qcur, hparams, q_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
                 Qcur->src[2] = qsum;
                 cb(Qcur, "Qcur_normed", il_id);
 
-                auto Kcur = llm_build_norm(ctx0, k_all[id], hparams, k_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
+                auto Kcur = k_all[id];
+                //printf("Kcur: %ld x %ld x %ld x %ld, k_norm: %ld x %ld x %ld x %ld\n", Kcur->ne[0], Kcur->ne[1], Kcur->ne[2], Kcur->ne[3], k_norm->splits[id]->ne[0], k_norm->splits[id]->ne[1], k_norm->splits[id]->ne[2], k_norm->splits[id]->ne[3]);
+                Kcur = llm_build_norm(ctx0, Kcur, hparams, k_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
                 Kcur->src[2] = ksum;
                 cb(Kcur, "Kcur_normed", il_id);
 

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -10014,12 +10014,14 @@ ggml_cgraph* llm_build_context::build_minimaxm2() {
                 //printf("Qcur: %ld x %ld x %ld x %ld, q_norm: %ld x %ld x %ld x %ld\n", Qcur->ne[0], Qcur->ne[1], Qcur->ne[2], Qcur->ne[3], q_norm->splits[id]->ne[0], q_norm->splits[id]->ne[1], q_norm->splits[id]->ne[2], q_norm->splits[id]->ne[3]);
                 Qcur = llm_build_norm(ctx0, Qcur, hparams, q_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
                 Qcur->src[2] = qsum;
+                Qcur->op_params[1] = model.layers[il].wq->ne[1];
                 cb(Qcur, "Qcur_normed", il_id);
 
                 auto Kcur = k_all[id];
                 //printf("Kcur: %ld x %ld x %ld x %ld, k_norm: %ld x %ld x %ld x %ld\n", Kcur->ne[0], Kcur->ne[1], Kcur->ne[2], Kcur->ne[3], k_norm->splits[id]->ne[0], k_norm->splits[id]->ne[1], k_norm->splits[id]->ne[2], k_norm->splits[id]->ne[3]);
                 Kcur = llm_build_norm(ctx0, Kcur, hparams, k_norm->splits[id], nullptr, LLM_NORM_RMS, cb, il_id);
                 Kcur->src[2] = ksum;
+                Kcur->op_params[1] = model.layers[il].wk->ne[1];
                 cb(Kcur, "Kcur_normed", il_id);
 
                 auto Vcur = v_all[id];

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -4163,39 +4163,24 @@ bool create_tensors_helper::create_tensors() {
                 LLAMA_LOG_DEBUG("  split_kq:"); for ([[maybe_unused]] auto s : split_kq) LLAMA_LOG_DEBUG(" %d", s);
                 LLAMA_LOG_DEBUG("\n");
 
-                //if (layer.attn_q_norm && layer.attn_q_norm->ne[0] == wq_ne1) {
-                //    // If RMS norm is not applied per attention head, as it is usually the case, but is applied to the
-                //    // entire Q tensor (e.g., MiniMax-2), we need to have a copy of the entire wq and attn_q_norm tensors
-                //    // on each participating GPU.
-                //    prepare_split_tensors(-1, ctx_split, layer.wq, layer.split_wq, split_vo, mem_used);
-                //    prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_vo, mem_used);
-                //    if (layer.bq) {
-                //        prepare_split_tensors(-1, ctx_split, layer.bq, layer.split_bq, split_vo, mem_used);
-                //    }
-                //    LLAMA_LOG_DEBUG("Not splitting wq, attn_q_norm in layer layer %d because of RMS norm\n", il);
-                //} else {
-                    prepare_split_tensors(1, ctx_split, layer.wq, layer.split_wq, split_kq, mem_used);
-                    if (layer.attn_q_norm) {
-                        printf("attn_q_norm: %ld x %ld, wq_ne1 = %d\n", layer.attn_q_norm->ne[0], layer.attn_q_norm->ne[1], wq_ne1);
-                        if (layer.attn_q_norm->ne[1] > 1) {
-                            // 2D per-head norm (e.g., Command-R+): split along the Q-head dimension
-                            auto split_q_heads = split_kq;
-                            for (auto & s : split_q_heads) s /= hparams.n_embd_head_k(il);
-                            prepare_split_tensors(1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_q_heads, mem_used);
-                        }
-                        else if (layer.attn_q_norm->ne[0] == wq_ne1) {
-                            printf("Splitting q_norm on dim 0\n");
-                            // MiniMax-M2
-                            prepare_split_tensors( 0, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
-                        } else {
-                            printf("Mirroring q_norm\n");
-                            prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
-                        }
+                prepare_split_tensors(1, ctx_split, layer.wq, layer.split_wq, split_kq, mem_used);
+                if (layer.attn_q_norm) {
+                    if (layer.attn_q_norm->ne[1] > 1) {
+                        // 2D per-head norm (e.g., Command-R+): split along the Q-head dimension
+                        auto split_q_heads = split_kq;
+                        for (auto & s : split_q_heads) s /= hparams.n_embd_head_k(il);
+                        prepare_split_tensors(1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_q_heads, mem_used);
                     }
-                    if (layer.bq) {
-                        prepare_split_tensors(0, ctx_split, layer.bq, layer.split_bq, split_kq, mem_used);
+                    else if (layer.attn_q_norm->ne[0] == wq_ne1) {
+                        // MiniMax-M2
+                        prepare_split_tensors( 0, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
+                    } else {
+                        prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
                     }
-                //}
+                }
+                if (layer.bq) {
+                    prepare_split_tensors(0, ctx_split, layer.bq, layer.split_bq, split_kq, mem_used);
+                }
                 prepare_split_tensors(0, ctx_split, layer.wo, layer.split_wo, split_vo, mem_used);
                 if (layer.bo) {
                     prepare_split_tensors(-1, ctx_split, layer.bo, layer.split_bo, split_vo, mem_used);
@@ -4223,41 +4208,26 @@ bool create_tensors_helper::create_tensors() {
                     for (auto & s : split_kq) s /= gqa_ratio;
                 }
                 for (auto & s : split_vo) s /= gqa_ratio;
-                //if (layer.attn_k_norm && layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
-                //    // If RMS norm is not applied per attention head, as it is usually the case, but is applied to the
-                //    // entire K tensor (e.g., MiniMax-2), we need to have a copy of the entire wk and attn_k_norm tensors
-                //    // on each participating GPU.
-                //    prepare_split_tensors(-1, ctx_split, layer.wk, layer.split_wk, split_vo, mem_used);
-                //    prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_vo, mem_used);
-                //    if (layer.bk) {
-                //        prepare_split_tensors(-1, ctx_split, layer.bk, layer.split_bk, split_vo, mem_used);
-                //    }
-                //    LLAMA_LOG_DEBUG("Not splitting wk, attn_k_norm in layer layer %d because of RMS norm\n", il);
-                //} else {
-                    prepare_split_tensors(1, ctx_split, layer.wk, layer.split_wk, split_kq, mem_used);
-                    if (layer.bk) {
-                        prepare_split_tensors(0, ctx_split, layer.bk, layer.split_bk, split_kq, mem_used);
+                prepare_split_tensors(1, ctx_split, layer.wk, layer.split_wk, split_kq, mem_used);
+                if (layer.bk) {
+                    prepare_split_tensors(0, ctx_split, layer.bk, layer.split_bk, split_kq, mem_used);
+                }
+                if (layer.attn_k_norm) {
+                    if (layer.attn_k_norm->ne[1] > 1) {
+                        // 2D per-head norm (e.g., Command-R+): split along the KV-head dimension
+                        // split_kq has already been divided by gqa_ratio, so values are in
+                        // (n_embd_head_k * n_head_kv) units; divide again to get head units
+                        auto split_k_heads = split_kq;
+                        for (auto & s : split_k_heads) s /= hparams.n_embd_head_k(il);
+                        prepare_split_tensors(1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_k_heads, mem_used);
                     }
-                    if (layer.attn_k_norm) {
-                        printf("attn_k_norm: %ld x %ld, wq_ne1 = %d\n", layer.attn_k_norm->ne[0], layer.attn_q_norm->ne[1], wq_ne1);
-                        if (layer.attn_k_norm->ne[1] > 1) {
-                            // 2D per-head norm (e.g., Command-R+): split along the KV-head dimension
-                            // split_kq has already been divided by gqa_ratio, so values are in
-                            // (n_embd_head_k * n_head_kv) units; divide again to get head units
-                            auto split_k_heads = split_kq;
-                            for (auto & s : split_k_heads) s /= hparams.n_embd_head_k(il);
-                            prepare_split_tensors(1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_k_heads, mem_used);
-                        }
-                        else if (layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
-                            printf("Splitting k_norm on dim 0\n");
-                            // MiniMax-M2
-                            prepare_split_tensors( 0, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
-                        } else {
-                            printf("Mirroring k_norm\n");
-                            prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
-                        }
+                    else if (layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
+                        // MiniMax-M2
+                        prepare_split_tensors( 0, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
+                    } else {
+                        prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
                     }
-                //}
+                }
                 if (layer.wv) {
                     prepare_split_tensors(1, ctx_split, layer.wv, layer.split_wv, split_vo, mem_used);
                     if (layer.bv) {

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -4176,6 +4176,7 @@ bool create_tensors_helper::create_tensors() {
                 //} else {
                     prepare_split_tensors(1, ctx_split, layer.wq, layer.split_wq, split_kq, mem_used);
                     if (layer.attn_q_norm) {
+                        printf("attn_q_norm: %ld x %ld, wq_ne1 = %d\n", layer.attn_q_norm->ne[0], layer.attn_q_norm->ne[1], wq_ne1);
                         if (layer.attn_q_norm->ne[1] > 1) {
                             // 2D per-head norm (e.g., Command-R+): split along the Q-head dimension
                             auto split_q_heads = split_kq;
@@ -4183,9 +4184,11 @@ bool create_tensors_helper::create_tensors() {
                             prepare_split_tensors(1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_q_heads, mem_used);
                         }
                         else if (layer.attn_q_norm->ne[0] == wq_ne1) {
+                            printf("Splitting q_norm on dim 0\n");
                             // MiniMax-M2
                             prepare_split_tensors( 0, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
                         } else {
+                            printf("Mirroring q_norm\n");
                             prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
                         }
                     }
@@ -4236,6 +4239,7 @@ bool create_tensors_helper::create_tensors() {
                         prepare_split_tensors(0, ctx_split, layer.bk, layer.split_bk, split_kq, mem_used);
                     }
                     if (layer.attn_k_norm) {
+                        printf("attn_k_norm: %ld x %ld, wq_ne1 = %d\n", layer.attn_k_norm->ne[0], layer.attn_q_norm->ne[1], wq_ne1);
                         if (layer.attn_k_norm->ne[1] > 1) {
                             // 2D per-head norm (e.g., Command-R+): split along the KV-head dimension
                             // split_kq has already been divided by gqa_ratio, so values are in
@@ -4245,9 +4249,11 @@ bool create_tensors_helper::create_tensors() {
                             prepare_split_tensors(1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_k_heads, mem_used);
                         }
                         else if (layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
+                            printf("Splitting k_norm on dim 0\n");
                             // MiniMax-M2
                             prepare_split_tensors( 0, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
                         } else {
+                            printf("Mirroring k_norm\n");
                             prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
                         }
                     }

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -4163,17 +4163,17 @@ bool create_tensors_helper::create_tensors() {
                 LLAMA_LOG_DEBUG("  split_kq:"); for ([[maybe_unused]] auto s : split_kq) LLAMA_LOG_DEBUG(" %d", s);
                 LLAMA_LOG_DEBUG("\n");
 
-                if (layer.attn_q_norm && layer.attn_q_norm->ne[0] == wq_ne1) {
-                    // If RMS norm is not applied per attention head, as it is usually the case, but is applied to the
-                    // entire Q tensor (e.g., MiniMax-2), we need to have a copy of the entire wq and attn_q_norm tensors
-                    // on each participating GPU.
-                    prepare_split_tensors(-1, ctx_split, layer.wq, layer.split_wq, split_vo, mem_used);
-                    prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_vo, mem_used);
-                    if (layer.bq) {
-                        prepare_split_tensors(-1, ctx_split, layer.bq, layer.split_bq, split_vo, mem_used);
-                    }
-                    LLAMA_LOG_DEBUG("Not splitting wq, attn_q_norm in layer layer %d because of RMS norm\n", il);
-                } else {
+                //if (layer.attn_q_norm && layer.attn_q_norm->ne[0] == wq_ne1) {
+                //    // If RMS norm is not applied per attention head, as it is usually the case, but is applied to the
+                //    // entire Q tensor (e.g., MiniMax-2), we need to have a copy of the entire wq and attn_q_norm tensors
+                //    // on each participating GPU.
+                //    prepare_split_tensors(-1, ctx_split, layer.wq, layer.split_wq, split_vo, mem_used);
+                //    prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_vo, mem_used);
+                //    if (layer.bq) {
+                //        prepare_split_tensors(-1, ctx_split, layer.bq, layer.split_bq, split_vo, mem_used);
+                //    }
+                //    LLAMA_LOG_DEBUG("Not splitting wq, attn_q_norm in layer layer %d because of RMS norm\n", il);
+                //} else {
                     prepare_split_tensors(1, ctx_split, layer.wq, layer.split_wq, split_kq, mem_used);
                     if (layer.attn_q_norm) {
                         if (layer.attn_q_norm->ne[1] > 1) {
@@ -4181,6 +4181,10 @@ bool create_tensors_helper::create_tensors() {
                             auto split_q_heads = split_kq;
                             for (auto & s : split_q_heads) s /= hparams.n_embd_head_k(il);
                             prepare_split_tensors(1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_q_heads, mem_used);
+                        }
+                        else if (layer.attn_q_norm->ne[0] == wq_ne1) {
+                            // MiniMax-M2
+                            prepare_split_tensors( 0, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
                         } else {
                             prepare_split_tensors(-1, ctx_split, layer.attn_q_norm, layer.split_q_norm, split_kq, mem_used);
                         }
@@ -4188,7 +4192,7 @@ bool create_tensors_helper::create_tensors() {
                     if (layer.bq) {
                         prepare_split_tensors(0, ctx_split, layer.bq, layer.split_bq, split_kq, mem_used);
                     }
-                }
+                //}
                 prepare_split_tensors(0, ctx_split, layer.wo, layer.split_wo, split_vo, mem_used);
                 if (layer.bo) {
                     prepare_split_tensors(-1, ctx_split, layer.bo, layer.split_bo, split_vo, mem_used);
@@ -4216,17 +4220,17 @@ bool create_tensors_helper::create_tensors() {
                     for (auto & s : split_kq) s /= gqa_ratio;
                 }
                 for (auto & s : split_vo) s /= gqa_ratio;
-                if (layer.attn_k_norm && layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
-                    // If RMS norm is not applied per attention head, as it is usually the case, but is applied to the
-                    // entire K tensor (e.g., MiniMax-2), we need to have a copy of the entire wk and attn_k_norm tensors
-                    // on each participating GPU.
-                    prepare_split_tensors(-1, ctx_split, layer.wk, layer.split_wk, split_vo, mem_used);
-                    prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_vo, mem_used);
-                    if (layer.bk) {
-                        prepare_split_tensors(-1, ctx_split, layer.bk, layer.split_bk, split_vo, mem_used);
-                    }
-                    LLAMA_LOG_DEBUG("Not splitting wk, attn_k_norm in layer layer %d because of RMS norm\n", il);
-                } else {
+                //if (layer.attn_k_norm && layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
+                //    // If RMS norm is not applied per attention head, as it is usually the case, but is applied to the
+                //    // entire K tensor (e.g., MiniMax-2), we need to have a copy of the entire wk and attn_k_norm tensors
+                //    // on each participating GPU.
+                //    prepare_split_tensors(-1, ctx_split, layer.wk, layer.split_wk, split_vo, mem_used);
+                //    prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_vo, mem_used);
+                //    if (layer.bk) {
+                //        prepare_split_tensors(-1, ctx_split, layer.bk, layer.split_bk, split_vo, mem_used);
+                //    }
+                //    LLAMA_LOG_DEBUG("Not splitting wk, attn_k_norm in layer layer %d because of RMS norm\n", il);
+                //} else {
                     prepare_split_tensors(1, ctx_split, layer.wk, layer.split_wk, split_kq, mem_used);
                     if (layer.bk) {
                         prepare_split_tensors(0, ctx_split, layer.bk, layer.split_bk, split_kq, mem_used);
@@ -4239,11 +4243,15 @@ bool create_tensors_helper::create_tensors() {
                             auto split_k_heads = split_kq;
                             for (auto & s : split_k_heads) s /= hparams.n_embd_head_k(il);
                             prepare_split_tensors(1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_k_heads, mem_used);
+                        }
+                        else if (layer.attn_k_norm->ne[0] == layer.wk->ne[1]) {
+                            // MiniMax-M2
+                            prepare_split_tensors( 0, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
                         } else {
                             prepare_split_tensors(-1, ctx_split, layer.attn_k_norm, layer.split_k_norm, split_kq, mem_used);
                         }
                     }
-                }
+                //}
                 if (layer.wv) {
                     prepare_split_tensors(1, ctx_split, layer.wv, layer.split_wv, split_vo, mem_used);
                     if (layer.bv) {


### PR DESCRIPTION

The MiniMax-M2 model use `rms_norm(Q)` and `rms_norm(K)` on all attention heads instead of the more common per head `rms_norm`.

On the main branch we deal with that by duplicating the `attn_q` and `attn_k` tensors on all GPUs, and performing the same `Q` and `K` matrix multiplications and `rms_norm` ops on each GPU. After this is complete, each GPU picks the appropriate portion of the resulting `Q` and `K` tensors to compute the remaining self-attention operations.

In this PR we split the `attn_q` and `attn_k` tensors per GPU, but add an additional synchronization point after the `Q` and `K` matrix multiplications that obtains the row squared sums for the entire `Q` and `K ` tensors needed later for the `rms_norm` operations.

The outcome is a mixed bag in terms of performance:
* We make significant gains for PP with full offload and also with hybrid CPU/GPU inference
* TG is better with hybrid inference (tested with `--cpu-moe` and `--n-cpu-moe 34` on a 2x3090)
* TG is ~5-10% lower with full GPU offload (tested with `IQ2_KL` model on a 4x3090 system)

So, not sure with to do with this PR. If I knew that most people run hybrid inference with MuiniMax-M2 models, than the PR is a clear winner. But if that's is not the case, and most people using MiniMax-M2 belong to the fortunate few VRAM-rich, then the decision depends on the predominant usage pattern (PP vs TG heavy).

   