### PR TITLE
fix: use int8_t for GGUF bool array loading instead of platform-dependent bool

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -562,8 +562,8 @@ bool llama_model_loader::get_arr(const std::string & key, std::vector<T> & resul
 
     result.resize(arr_info.length);
     if (arr_info.gt == GGUF_TYPE_BOOL) {
-        std::transform((const bool *)arr_info.data, (const bool *)arr_info.data + arr_info.length, result.begin(),
-                [] (bool x) { return static_cast<T>(x); });
+        std::transform((const int8_t *)arr_info.data, (const int8_t *)arr_info.data + arr_info.length, result.begin(),
+                [] (int8_t x) { return static_cast<T>(x != 0); });
 
     } else {
         result.assign((const T*)arr_info.data, (const T *)arr_info.data + arr_info.length);
@@ -600,8 +600,8 @@ bool llama_model_loader::get_arr(const std::string & key, std::array<T, N_MAX> &
     }
 
     if (arr_info.gt == GGUF_TYPE_BOOL) {
-        std::transform((const bool *)arr_info.data, (const bool *)arr_info.data + arr_info.length, result.begin(),
-                [] (bool x) { return static_cast<T>(x); });
+        std::transform((const int8_t *)arr_info.data, (const int8_t *)arr_info.data + arr_info.length, result.begin(),
+                [] (int8_t x) { return static_cast<T>(x != 0); });
     } else {
         std::copy((const T*)arr_info.data, (const T *)arr_info.data + arr_info.length, result.begin());
     }


### PR DESCRIPTION
## Summary

GGUF stores boolean arrays as 1-byte `int8_t`, but `llama_model_loader::get_arr` was casting the underlying bytes through `const bool *`. The size of `bool` is implementation-defined in C++ — on most mainstream ABIs it's 1 byte, but the standard doesn't guarantee it. This fix replaces the cast with an explicit `int8_t *` cast and normalizes with `!= 0`, matching how the rest of the codebase handles boolean-valued bytes.

This mirrors the equivalent upstream fix in llama.cpp — see [ggerganov/llama.cpp#21428](https://github.com/ggerganov/llama.cpp/pull/21428).

## Changes

Two sites in `src/llama-model-loader.cpp` — both overloads of `get_arr` that handle `GGUF_TYPE_BOOL`:

```cpp
// Before:
std::transform((const bool *)arr_info.data, (const bool *)arr_info.data + arr_info.length, result.begin(),
        [] (bool x) { return static_cast<T>(x); });

// After:
std::transform((const int8_t *)arr_info.data, (const int8_t *)arr_info.data + arr_info.length, result.begin(),
        [] (int8_t x) { return static_cast<T>(x != 0); });
```

## Why it matters

On any platform where `sizeof(bool) != 1` the current code silently reads incorrect data or strides past the array end. Even on platforms where it happens to work, the cast is technically UB per the strict-aliasing rules — the GGUF spec is the source of truth here and it says `int8_t`.

## Testing

Verified on x86_64 Linux that models loading bool arrays (e.g. via GGUF metadata) continue to work correctly. The fix is behavior-preserving on platforms where `sizeof(bool) == 1`; it corrects behavior elsewhere.

## Review complexity

Low — 4-line change, localized to two adjacent template instantiations in a single file.