### PR TITLE
fix: build schema grammar in Qwen3-Coder XML template when no tools

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1936,23 +1936,55 @@ static common_chat_params common_chat_params_init_qwen3_coder_xml(const common_c
         data.preserved_tokens.insert(data.preserved_tokens.end(), { "<think>", "</think>" });
     }
 
-    // build grammar for tool call
-    static const xml_tool_call_format form = ([]() {
-        xml_tool_call_format form{};
-        form.scope_start = "";
-        form.tool_start = "\n<tool_call>\n<function=";
-        form.tool_sep = ">\n";
-        form.key_start = "<parameter=";
-        form.key_val_sep = ">\n";
-        form.val_end = "\n</parameter>\n";
-        form.tool_end = "</function>\n</tool_call>";
-        form.scope_end = "";
-        form.relax_arg = true;
-        return form;
+    // Build grammar. Three cases:
+    //   1) tools present -> XML tool-call grammar (existing behavior)
+    //   2) json_schema present, no tools -> schema grammar (respects optional
+    //      thinking prefix when the template supports it)
+    //   3) neither -> no grammar (free generation)
+    const bool has_tools = params.tools.is_array() && !params.tools.empty();
+    if (has_tools) {
+        static const xml_tool_call_format form = ([]() {
+            xml_tool_call_format form{};
+            form.scope_start = "";
+            form.tool_start = "\n<tool_call>\n<function=";
+            form.tool_sep = ">\n";
+            form.key_start = "<parameter=";
+            form.key_val_sep = ">\n";
+            form.val_end = "\n</parameter>\n";
+            form.tool_end = "</function>\n</tool_call>";
+            form.scope_end = "";
+            form.relax_arg = true;
+            return form;
         })();
         build_grammar_xml_tool_call(data, params.tools, form);
+    } else if (!params.json_schema.is_null()) {
+        if (!params.grammar.empty()) {
+            throw std::runtime_error("Either \"json_schema\" or \"grammar\" can be specified, but not both");
+        }
+        // Strict schema enforcement. If the template keeps <think>...</think>
+        // open, use a lazy grammar that triggers once thinking ends, captures
+        // the </think> tag, and prepends an optional "</think>" consumer to
+        // the root rule so the replayed tag is absorbed before the schema
+        // starts. Mirrors deepseek_r1, deepseek_v3_1, and kimi_k2 precedents.
+        // Otherwise enforce from the first token (grammar_lazy stays false
+        // from function entry when tools are absent).
+        if (data.thinking_forced_open) {
+            data.grammar_lazy = true;
+            data.grammar_triggers.push_back({
+                COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN_FULL,
+                "[\\s\\S]*?(</think>\\s*)",
+            });
+        }
+        data.grammar = build_grammar([&](const common_grammar_builder & builder) {
+            auto schema = params.json_schema;
+            builder.resolve_refs(schema);
+            builder.add_rule("root",
+                std::string(data.thinking_forced_open ? "( \"</think>\" space )? " : "") +
+                builder.add_schema("response", schema));
+        });
+    }
 
-        return data;
+    return data;
 }
 
 static common_chat_params common_chat_params_init_kimi_k2(const common_chat_template & tmpl, const struct templates_params & params) {


### PR DESCRIPTION
## Summary

`common_chat_params_init_qwen3_coder_xml` previously only built a grammar when `params.tools` was non-empty. Requests that sent `response_format.json_schema` (or top-level `json_schema`) with no tools reached the sampler with an empty grammar string, so output was completely unconstrained regardless of `strict=true`.

After the fix, three branches are explicit:

1. **Tools present** → XML tool-call grammar (existing behavior, unchanged).
2. **No tools, `json_schema` present** → strict GBNF built from the schema. If the template kept `<think>...</think>` open (Step-3.5-Flash / Nemotron 3 Nano), the grammar is lazy with a `</think>` pattern trigger, mirroring the `deepseek_r1` / `deepseek_v3_1` / `kimi_k2` thinking-enforced paths. Otherwise enforcement starts at token 0.
3. **Neither** → no grammar, free generation.

Also adds a throw when both `json_schema` and `grammar` are passed, matching the `common_chat_params_init_mistral_nemo` precedent (`"Either \"json_schema\" or \"grammar\" can be specified, but not both"`). Previously the initializer would silently overwrite user-supplied grammar.

## Why at the initializer level

The Qwen3-Coder XML dispatcher still routes Qwen3-Coder, Step-3.5-Flash, and Nemotron-3 Nano here when `inputs.use_peg=false`. Those users currently lose schema enforcement entirely. The autoparser refactor in #1376 centralizes this concern, at which point this fix dissolves into the new architecture; until it lands, the initializer-level fix is the minimal correct change.

## Testing

Validated on Terra (RTX 3080 Ti, Qwen3.5-35B-A3B Q4_K_M, turbo K4V3 KV, `-ger -ser 3,0 -c 512 -fa 1`):
- `/v1/chat/completions` with `response_format={type: "json_schema", ...}` and no `tools` now produces strictly schema-conformant JSON.
- Previous behavior (no constraint) reproduced on the parent commit.
- Tool-call path (`tools=[...]`) unchanged — XML tool-call grammar still built and triggered.
- Passing both `json_schema` and `grammar` now raises `runtime_error` instead of silently dropping the caller's grammar.

Note on test coverage: `tests/test-chat.cpp` is currently commented out of the default build (unrelated pre-existing compile errors in legacy scaffolding, `common_chat_parser_params` symbol renamed to `common_chat_syntax`). Happy to add cases inside `test_template_output_parsers` in a follow-up if the maintainer wants test-chat revived as part of this change.