### PR TITLE
Fix NaNs in Q4_K/Q5_K quantized MiniMax-2.7 models on CUDA

### DIFF
--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -129,7 +129,7 @@ static __global__ void quantize_mmq_q8_1(
         }
     }
 
-    const float d = amax/127.f;
+    float d = amax/127.f;
     const float d_inv = d > 0 ? 1/d : 0.f;
     char4 q;
     q.x = roundf(xi.x*d_inv);
@@ -162,6 +162,8 @@ static __global__ void quantize_mmq_q8_1(
     }
 
     if (ds_layout == MMQ_Q8_1_DS_LAYOUT_DS4) {
+        d = max(-65504.0f, min(65504.f, d));
+        sum = max(-65504.0f, min(65504.f, sum));
         y[ib].ds4[iqs/32] = make_half2(d, sum);
     } else {
         y[ib].d4[iqs/32]  = d;

--- a/ggml/src/ggml-cuda/quantize_id.cu
+++ b/ggml/src/ggml-cuda/quantize_id.cu
@@ -91,9 +91,11 @@ static __global__ void quantize_mmq_q8_1(
         return;
     }
 
-    const float d = 1.0f / d_inv;
+    float d = 1.0f / d_inv;
 
     if (ds_layout == MMQ_Q8_1_DS_LAYOUT_DS4) {
+        d = max(-65504.0f, min(65504.f, d));
+        sum = max(-65504.0f, min(65504.f, sum));
         y[ib].ds4[iqs/32] = make_half2(d, sum);
     } else {
         y[ib].d4[iqs/32]  = d;


### PR DESCRIPTION

See #1656

The issue is that the quant block sum stored as `fp16` can overflow when quantizing activations as `Q8_1`. The block sum is used in the MMQ matrix multiplication kernels of `Q4_1, Q5_1, Q4_K, Q5_K` and `IQ1_S`.

This PR is a quick and dirty hack - it simply clamps the block scale and sum to the maximum value representable by `fp16` (65504).

A more principled approach would be to implement for CUDA what was done for the CPU backend in #292: use `bf16` for the block scale and store the block quant sum as `int16_t` (which cannot overflow as we only have 32 values in `-127...127`). 

Closes #1656   
