### PR TITLE
server: fix ret=-3 on hybrid/recurrent prompt cache and clear sticky stop flag

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3075,11 +3075,14 @@ void  server_context::create_checkpoint_at_interval(server_slot & slot, const gp
 
 void server_context::apply_checkpoint(server_slot & slot) {
     llama_pos pos_next = slot.cache_tokens.pos_next(slot.n_past);
+    const bool has_recurrent = llama_model_has_recurrent(llama_get_model(slot.ctx));
+    // For hybrid/recurrent models, pos_min semantics don't apply: the recurrent state is a single
+    // snapshot, not a per-token window. Use pos_max against n_past to match whole-prefix checkpoints.
     const auto pos_min_thold = std::max(0, pos_next - 1);
     if (slot.n_past > 0 && slot.n_past < slot.cache_tokens.n_tokens()) {
         int32_t pos_min = llama_kv_cache_seq_pos_min(slot.ctx, slot.id);
 
-        if (pos_min > pos_min_thold) {
+        if (has_recurrent || pos_min > pos_min_thold) {
             SLT_WRN(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d\n", slot.n_past, (int)slot.cache_tokens.size(), slot.id, pos_min);
 
             // search for a context checkpoint
@@ -3088,6 +3091,11 @@ void server_context::apply_checkpoint(server_slot & slot) {
                 slot.server_cached_prompt.checkpoints.rend(),
                 [&](const auto & cur) {
                     // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
+                    if (has_recurrent) {
+                        // recurrent/hybrid: only whole-prefix checkpoints are valid; pick the latest one
+                        // that covers no more than the current n_past and still leaves tokens to decode.
+                        return cur.pos_max <= slot.n_past && cur.pos_max < pos_next;
+                    }
                     return cur.pos_min < pos_min_thold;
                 }
             );
@@ -3114,19 +3122,30 @@ void server_context::apply_checkpoint(server_slot & slot) {
             }
 
             if (do_reset) {
-                SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
-                    "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
-                slot.n_past = 0;
-                slot.n_past_prompt = 0;
+                if (has_recurrent) {
+                    // Hybrid/recurrent: do NOT zero n_past. The prompt prefix is already in cache_tokens
+                    // and update_slots() reprocesses from slot.n_past_prompt; dropping to 0 forces a full
+                    // recompute on every turn and — combined with cached state — trips llama_decode ret=-3.
+                    SLT_WRN(slot, "no usable hybrid/recurrent checkpoint; preserving slot state (n_past = %d, n_past_prompt = %d)\n",
+                        (int)slot.n_past, (int)slot.n_past_prompt);
+                } else {
+                    SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA, see %s)\n",
+                        "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
+                    slot.n_past = 0;
+                    slot.n_past_prompt = 0;
+                }
             }
         }
     }
 
     {
-        // erase any checkpoints with pos_min > pos_min_thold
+        // erase checkpoints that are no longer consistent with the current decode position.
+        // Transformer: anything with pos_min beyond the threshold is stale.
+        // Recurrent/hybrid: anything with pos_max past pos_next refers to future tokens we've rewound past.
         for (auto it = slot.server_cached_prompt.checkpoints.begin(); it != slot.server_cached_prompt.checkpoints.end();) {
             const auto & cur = *it;
-            if (cur.pos_min > pos_min_thold) {
+            const bool stale = has_recurrent ? (cur.pos_max > pos_next) : (cur.pos_min > pos_min_thold);
+            if (stale) {
                 SLT_WRN(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, (float)cur.data.size() / 1024 / 1024);
                 it = slot.server_cached_prompt.checkpoints.erase(it);
             } else {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7917,6 +7917,11 @@ int32_t llama_encode(
 int32_t llama_decode(
         struct llama_context * ctx,
           struct llama_batch   batch) {
+    // Clear any leftover stop signal from a previous (already-returned) decode. llama_decode_stop()
+    // is intended to interrupt the decode that is currently in flight; without this reset, a stop
+    // that arrived after the interrupted call returned would bleed into the next decode and cause
+    // an immediate ret=-3, which servers interpret as a fatal decode failure.
+    stop_internal_decode = false;
     const int ret = llama_decode_internal(*ctx, batch);
     if (ret < 0) {
         LLAMA_LOG_ERROR("%s: failed to decode, ret = %d\n", __func__, ret);


### PR DESCRIPTION
## Summary

Fixes two issues that together produce `llama_decode ret=-3` on hybrid / recurrent architectures (Qwen3.5 MoE, Qwen3.6 MoE, Qwen3-Next, Mamba), matching the symptom in #1576 and reproduced under our Qwen3.6 production workload.

1. **`server_context::apply_checkpoint()` is not hybrid-aware.** The selector was written for transformer KV semantics (per-token `pos_min` window). Hybrid/recurrent models use a single whole-prefix state snapshot, so the transformer selector can either pick a checkpoint whose `pos_max` is past the current `n_past` (restoring state ahead of the decode position) or miss entirely and fall through to `do_reset = true`, which zeros `slot.n_past` / `slot.n_past_prompt` while the recurrent state in the context is still populated. The next decode batch then disagrees with the live recurrent state → `ret=-3`.

2. **`stop_internal_decode` is a sticky file-static global.** `llama_decode_stop()` (called on client disconnect) sets it; the decode loop polls it and bails with `ret=-3`. It is only cleared on one conditional branch of `server_slot::release()`, so a stop signal that races past a decode that has already returned bleeds into the **next** `llama_decode()` call on the same context, producing an immediate `ret=-3` with zero work performed.

## Changes

**`examples/server/server-context.cpp`**

`apply_checkpoint` gates its logic on `llama_model_has_recurrent(llama_get_model(slot.ctx))` — the same helper already used in this file at line 115 and line 1471:

- Enter the checkpoint path whenever `has_recurrent` (not just on `pos_min > pos_min_thold`), so recurrent slots don't silently skip it.
- Selector (recurrent branch): match the latest checkpoint with `cur.pos_max <= slot.n_past && cur.pos_max < pos_next` — a whole-prefix snapshot that still leaves at least one token to decode (preserving [TAG_PROMPT_LOGITS]).
- On miss (recurrent branch): **do not zero `slot.n_past`**. `update_slots()` will continue from the valid `n_past_prompt` — this is the critical part; zeroing was the proximate trigger for the `ret=-3`.
- Erase loop (recurrent branch): drop checkpoints with `cur.pos_max > pos_next` — stale snapshots ahead of the current decode position.

Transformer behavior is byte-identical to before (`has_recurrent` is false → all branches fall to the existing logic).

**`src/llama.cpp`**

Public `llama_decode()` entry clears `stop_internal_decode` before calling `llama_decode_internal()`. This scopes the stop signal to the in-flight decode it was meant to interrupt. Concurrent `llama_decode_stop()` during the decode still takes effect on the next loop iteration as before.

## How to reproduce the bug (pre-fix)

Issue #1576 has the full reproduction. We hit it on Qwen3.6 (hybrid QWEN35MOE) via the prompt-cache path:
- warm a conversational prompt on the server (a checkpoint is recorded),
- send a follow-up prompt whose prefix matches the cached one partially,
- `apply_checkpoint` falls through to `do_reset = true`, zeros `n_past`,
- next `llama_decode()` returns `-3` and the slot wedges until restart.

The sticky-flag case reproduces with a client that cancels a streaming completion mid-prefill and then retries on the same context.

## Test plan

- [x] Builds clean with CUDA (sm_86): `cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 -DGGML_IQK_MUL_MAT=ON -DGGML_IQK_FLASH_ATTENTION=ON -DGGML_IQK_FA_ALL_QUANTS=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build --target llama-server`
- [x] No new public APIs; `llama_model_has_recurrent` is already declared in `include/llama.h:684` and defined in `src/llama-model.cpp:1872`
- [x] Transformer path is unchanged (reviewed each edit — `has_recurrent` defaults false for non-hybrid, non-recurrent architectures)
- [ ] Qwen3.6 validation on a live server (will follow this PR once maintainers weigh in on approach — happy to iterate)

Closes #1576