### PR TITLE
TurboQuant TQ3_4S / TQ3_1S backport (CPU + CUDA MMVQ, 7 atomic commits)

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -425,6 +425,11 @@ extern "C" {
         GGML_TYPE_Q1_0_G128 = 41,  // Bonsai 1-bit quants
         //
         //
+        // TurboQuant 3-bit (upstream turbo-tan/llama.cpp-tq3, arXiv 2504.19874)
+        //
+        GGML_TYPE_TQ3_1S  = 44,
+        GGML_TYPE_TQ3_4S  = 46,
+        //
         GGML_TYPE_Q8_0_X4 = 97,
         GGML_TYPE_Q8_1_X4 = 98,
         GGML_TYPE_Q8_2_X4 = 99,

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -512,6 +512,26 @@ typedef struct {
 } block_iq3_s_r4;
 static_assert(sizeof(block_iq3_s_r4) == 4*sizeof(block_iq3_s), "wrong iq3_s_r4 block size/padding");
 
+// TurboQuant 3-bit (upstream turbo-tan/llama.cpp-tq3, arXiv 2504.19874)
+// 32 values per block, WHT rotation + Lloyd-Max 8-level codebook
+#define QK_TQ3_0 32
+
+// TurboQuant 3-bit with two half-block scales (4.0 bpw)
+typedef struct {
+    ggml_half d0;
+    ggml_half d1;
+    uint8_t qs[QK_TQ3_0 * 3 / 8];
+} block_tq3_1s;
+static_assert(sizeof(block_tq3_1s) == 2 * sizeof(ggml_half) + QK_TQ3_0 * 3 / 8, "wrong tq3_1s block size/padding");
+
+// TurboQuant 3-bit with four u8 per-8 scales (4.0 bpw)
+// Each d[g] is an E3M5 mini-float: scale = 2^(d>>5 - 9) * (1 + (d&31)/32)
+typedef struct {
+    uint8_t   d[4];                  // 4 × E3M5 scales for groups of 8 elements
+    uint8_t   qs[QK_TQ3_0 * 3 / 8];  // 12 bytes: 32 × 3-bit packed indices
+} block_tq3_4s;
+static_assert(sizeof(block_tq3_4s) == 4 + QK_TQ3_0 * 3 / 8, "wrong tq3_4s block size/padding");
+
 typedef struct {
     ggml_half d;
     uint8_t  qs[QK_K/8];

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -155,6 +155,10 @@ typedef sycl::half2 ggml_half2;
 #define QI3_S (QK_K / (4*QR3_S))
 #define QR3_S 4
 
+// TurboQuant TQ3: 32-elem blocks, q8_1 weights packed 8/block -> qi = 2
+#define QI_TQ3 (QK_TQ3_0 / (4*QR_TQ3))
+#define QR_TQ3 4
+
 #define QI1_BN (QK_IQ1BN / (4*QR1_BN))
 #define QR1_BN 8
 

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4515,6 +4515,8 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                     case GGML_TYPE_IQ2_XXS:
                     case GGML_TYPE_IQ3_S:
                     case GGML_TYPE_IQ3_XXS:
+                    case GGML_TYPE_TQ3_4S:
+                    case GGML_TYPE_TQ3_1S:
                     case GGML_TYPE_IQ4_NL:
                     case GGML_TYPE_MXFP4:
                     case GGML_TYPE_IQ4_XS:

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -31,6 +31,7 @@
 #include "ggml-cuda/pad.cuh"
 #include "ggml-cuda/pool2d.cuh"
 #include "ggml-cuda/quantize.cuh"
+#include "ggml-cuda/tq3-act-rotate.cuh"
 #include "ggml-cuda/rope.cuh"
 #include "ggml-cuda/scale.cuh"
 #include "ggml-cuda/softcap.cuh"
@@ -2278,7 +2279,19 @@ static int ggml_cuda_mul_mat_q(ggml_backend_cuda_context & ctx, const ggml_tenso
     }
     ggml_cuda_pool_alloc<char> src1_quantized(ctx.pool(), quantized_size);
     if (is_gemv) {
-        quantize_row_q8_1_cuda((const float *)src1->data, (void *)src1_quantized.get(), src1->ne[0], src1->ne[1], src1->ne[2], ne10_padded,
+        const float * src1_src = (const float *)src1->data;
+        // TurboQuant TQ3: apply forward WHT rotation on activations before q8_1
+        // quantization so the MMVQ dot against rotated weights produces the
+        // correct matmul result (inverse WHT is not applied on weight side).
+        ggml_cuda_pool_alloc<float> src1_tq3_rot(ctx.pool());
+        if (src0->type == GGML_TYPE_TQ3_4S || src0->type == GGML_TYPE_TQ3_1S) {
+            const int64_t n_act = src1->ne[0] * src1->ne[1] * src1->ne[2];
+            src1_tq3_rot.alloc(n_act);
+            CUDA_CHECK(cudaMemcpyAsync(src1_tq3_rot.get(), src1_src, n_act * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+            ggml_cuda_tq3_rotate_act(src1_tq3_rot.get(), n_act, stream);
+            src1_src = src1_tq3_rot.get();
+        }
+        quantize_row_q8_1_cuda(src1_src, (void *)src1_quantized.get(), src1->ne[0], src1->ne[1], src1->ne[2], ne10_padded,
                 src0->type, stream);
         CUDA_CHECK(cudaGetLastError());
 
@@ -2760,7 +2773,16 @@ static bool ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
                 CUDA_CHECK(cudaGetLastError());
             } else {
                 ggml_cuda_pool_alloc<char> src1_quantized(ctx.pool(), src1_quantized_size);
-                quantize_row_q8_1_cuda((const float *)src1_contiguous.get(), src1_quantized.get(), ne00, num_src1_rows, 1,
+                const float * src1_src_cont = (const float *)src1_contiguous.get();
+                ggml_cuda_pool_alloc<float> src1_tq3_rot_mid(ctx.pool());
+                if (src0->type == GGML_TYPE_TQ3_4S || src0->type == GGML_TYPE_TQ3_1S) {
+                    const int64_t n_act = ne00 * num_src1_rows;
+                    src1_tq3_rot_mid.alloc(n_act);
+                    CUDA_CHECK(cudaMemcpyAsync(src1_tq3_rot_mid.get(), src1_src_cont, n_act * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+                    ggml_cuda_tq3_rotate_act(src1_tq3_rot_mid.get(), n_act, stream);
+                    src1_src_cont = src1_tq3_rot_mid.get();
+                }
+                quantize_row_q8_1_cuda(src1_src_cont, src1_quantized.get(), ne00, num_src1_rows, 1,
                         src1_padded_num_cols, src0->type, stream);
                 src1_row.nb[1] = src1_padded_row_size;
                 src1_row.nb[2] = src1_row.nb[3] = src1_row.nb[1]*num_src1_rows;

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2287,8 +2287,9 @@ static int ggml_cuda_mul_mat_q(ggml_backend_cuda_context & ctx, const ggml_tenso
         if (src0->type == GGML_TYPE_TQ3_4S || src0->type == GGML_TYPE_TQ3_1S) {
             const int64_t n_act = src1->ne[0] * src1->ne[1] * src1->ne[2];
             src1_tq3_rot.alloc(n_act);
-            CUDA_CHECK(cudaMemcpyAsync(src1_tq3_rot.get(), src1_src, n_act * sizeof(float), cudaMemcpyDeviceToDevice, stream));
-            ggml_cuda_tq3_rotate_act(src1_tq3_rot.get(), n_act, stream);
+            // Fused copy+rotate: single kernel reads src1_src and writes rotated
+            // floats to src1_tq3_rot, eliminating the prior DtD cudaMemcpyAsync.
+            ggml_cuda_tq3_rotate_act_copy(src1_src, src1_tq3_rot.get(), n_act, stream);
             src1_src = src1_tq3_rot.get();
         }
         quantize_row_q8_1_cuda(src1_src, (void *)src1_quantized.get(), src1->ne[0], src1->ne[1], src1->ne[2], ne10_padded,
@@ -2778,8 +2779,9 @@ static bool ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
                 if (src0->type == GGML_TYPE_TQ3_4S || src0->type == GGML_TYPE_TQ3_1S) {
                     const int64_t n_act = ne00 * num_src1_rows;
                     src1_tq3_rot_mid.alloc(n_act);
-                    CUDA_CHECK(cudaMemcpyAsync(src1_tq3_rot_mid.get(), src1_src_cont, n_act * sizeof(float), cudaMemcpyDeviceToDevice, stream));
-                    ggml_cuda_tq3_rotate_act(src1_tq3_rot_mid.get(), n_act, stream);
+                    // Fused copy+rotate (see mul_mat_vec_q gemv path): saves
+                    // one DtD memcpy on the MUL_MAT_ID per-row fast path.
+                    ggml_cuda_tq3_rotate_act_copy(src1_src_cont, src1_tq3_rot_mid.get(), n_act, stream);
                     src1_src_cont = src1_tq3_rot_mid.get();
                 }
                 quantize_row_q8_1_cuda(src1_src_cont, src1_quantized.get(), ne00, num_src1_rows, 1,
@@ -4969,7 +4971,7 @@ static cuda_params ggml_cuda_parse_params(const char * params_string) {
                 is_good = read_value(parsed[1], params.enable_p2p);
             }
             else if (parsed[0] == "fa-offset") {
-                float tmp;
+                float tmp = 0.0f;  // silence GCC maybe-uninitialized warning
                 is_good = read_value(parsed[1], tmp);
                 if (is_good) {
                     if (tmp < 0.0f || tmp > 3.0f) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -713,6 +713,20 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_S> {
 };
 
 template<>
+struct ggml_cuda_type_traits<GGML_TYPE_TQ3_4S> {
+    static constexpr int qk = QK_TQ3_0;
+    static constexpr int qr = QR_TQ3;
+    static constexpr int qi = QI_TQ3;
+};
+
+template<>
+struct ggml_cuda_type_traits<GGML_TYPE_TQ3_1S> {
+    static constexpr int qk = QK_TQ3_0;
+    static constexpr int qr = QR_TQ3;
+    static constexpr int qi = QI_TQ3;
+};
+
+template<>
 struct ggml_cuda_type_traits<GGML_TYPE_IQ2_K_R4> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR4_XS;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -715,15 +715,15 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_S> {
 template<>
 struct ggml_cuda_type_traits<GGML_TYPE_TQ3_4S> {
     static constexpr int qk = QK_TQ3_0;
-    static constexpr int qr = QR_TQ3;
-    static constexpr int qi = QI_TQ3;
+    static constexpr int qr = 2;
+    static constexpr int qi = 16;
 };
 
 template<>
 struct ggml_cuda_type_traits<GGML_TYPE_TQ3_1S> {
     static constexpr int qk = QK_TQ3_0;
-    static constexpr int qr = QR_TQ3;
-    static constexpr int qi = QI_TQ3;
+    static constexpr int qr = 2;
+    static constexpr int qi = 16;
 };
 
 template<>

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -1800,6 +1800,118 @@ static void dequantize_row_iq6_k_cuda(const void * vx, dst_t * y, const int64_t 
     dequantize_block_iq6_k<<<nb, 32, 0, stream>>>(vx, y);
 }
 
+// --------------------------------------------------------------------------
+// TurboQuant TQ3_4S / TQ3_1S CUDA dequantize kernels (Phase 2)
+// Ported from turbo-tan/llama.cpp-tq3 (arXiv 2504.19874)
+// --------------------------------------------------------------------------
+
+__constant__ static const float tq3_0_centroids_cuda[8] = {
+    -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+     0.230106f,  0.725222f,  1.277503f,  1.988943f
+};
+__constant__ static const float tq3_0_signs_cuda[32] = {
+    +1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+    -1.0f, +1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+};
+
+static __device__ __forceinline__ uint8_t tq3_idx_from_packed_cuda(const uint8_t * qp, int r) {
+    switch (r) {
+        case 0: return  qp[0]       & 7;
+        case 1: return (qp[0] >> 3) & 7;
+        case 2: return ((qp[0] >> 6) | (qp[1] << 2)) & 7;
+        case 3: return (qp[1] >> 1) & 7;
+        case 4: return (qp[1] >> 4) & 7;
+        case 5: return ((qp[1] >> 7) | (qp[2] << 1)) & 7;
+        case 6: return (qp[2] >> 2) & 7;
+        default: return (qp[2] >> 5) & 7;
+    }
+}
+
+__device__ static inline float tq3_4s_decode_scale_cuda(uint8_t byte) {
+    if (byte == 0) return 0.0f;
+    const int exp_v = (byte >> 5) - 9;
+    const float mantissa = 1.0f + (float)(byte & 31) / 32.0f;
+    return ldexpf(mantissa, exp_v);
+}
+
+template<typename dst_t>
+static __global__ void dequantize_block_tq3_4s(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb) {
+    const int i = blockIdx.x;
+    if (i >= nb) return;
+
+    const block_tq3_4s * x = (const block_tq3_4s *)vx + i;
+    const float ds[4] = {
+        tq3_4s_decode_scale_cuda(x->d[0]),
+        tq3_4s_decode_scale_cuda(x->d[1]),
+        tq3_4s_decode_scale_cuda(x->d[2]),
+        tq3_4s_decode_scale_cuda(x->d[3]),
+    };
+
+    dst_t * y = yy + i * QK_TQ3_0;
+    const int j = threadIdx.x;
+    const int g = j / 8;
+    const int r = j % 8;
+    const uint8_t * qp = x->qs + g * 3;
+    const uint8_t idx = tq3_idx_from_packed_cuda(qp, r);
+
+    float val = tq3_0_centroids_cuda[idx] * ds[g];
+    for (int step = 1; step < 32; step <<= 1) {
+        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
+        if (j & step) {
+            val = other - val;
+        } else {
+            val = other + val;
+        }
+    }
+
+    y[j] = (dst_t)(val * (tq3_0_signs_cuda[j] / sqrtf(32.0f)));
+}
+
+template<typename dst_t>
+static void dequantize_row_tq3_4s_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
+    const int64_t k = nrows * n_per_row;
+    const int nb = k / QK_TQ3_0;
+    dequantize_block_tq3_4s<<<nb, 32, 0, stream>>>(vx, y, nb);
+}
+
+template<typename dst_t>
+static __global__ void dequantize_block_tq3_1s(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb) {
+    const int i = blockIdx.x;
+    if (i >= nb) return;
+
+    const block_tq3_1s * x = (const block_tq3_1s *)vx + i;
+    const float d0 = __half2float(x->d0);
+    const float d1 = __half2float(x->d1);
+    dst_t * y = yy + i * QK_TQ3_0;
+    const int j = threadIdx.x;
+
+    const int g = j / 8;
+    const int r = j % 8;
+    const uint8_t * qp = x->qs + g * 3;
+    const uint8_t idx = tq3_idx_from_packed_cuda(qp, r);
+
+    float val = tq3_0_centroids_cuda[idx] * (j < 16 ? d0 : d1);
+    for (int step = 1; step < 32; step <<= 1) {
+        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
+        if (j & step) {
+            val = other - val;
+        } else {
+            val = other + val;
+        }
+    }
+
+    y[j] = (dst_t)(val * (tq3_0_signs_cuda[j] / sqrtf(32.0f)));
+}
+
+template<typename dst_t>
+static void dequantize_row_tq3_1s_cuda(const void * vx, dst_t * y, const int64_t nrows, const int64_t n_per_row, cudaStream_t stream) {
+    const int64_t k = nrows * n_per_row;
+    const int nb = k / QK_TQ3_0;
+    dequantize_block_tq3_1s<<<nb, 32, 0, stream>>>(vx, y, nb);
+}
+
 template <typename src_t, typename dst_t>
 static __global__ void convert_unary(const void * __restrict__ vx, dst_t * __restrict__ y, const int64_t k) {
     const int64_t i = (int64_t)blockDim.x*blockIdx.x + threadIdx.x;
@@ -1999,6 +2111,10 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
             return dequantize_row_iq6_k_cuda;
         case GGML_TYPE_IQ3_S:
             return dequantize_row_iq3_s_cuda;
+        case GGML_TYPE_TQ3_4S:
+            return dequantize_row_tq3_4s_cuda;
+        case GGML_TYPE_TQ3_1S:
+            return dequantize_row_tq3_1s_cuda;
         case GGML_TYPE_F32:
             return convert_unary_cuda<float>;
         case GGML_TYPE_BF16:
@@ -2102,6 +2218,10 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
             return dequantize_row_iq6_k_cuda;
         case GGML_TYPE_IQ3_S:
             return dequantize_row_iq3_s_cuda;
+        case GGML_TYPE_TQ3_4S:
+            return dequantize_row_tq3_4s_cuda;
+        case GGML_TYPE_TQ3_1S:
+            return dequantize_row_tq3_1s_cuda;
         case GGML_TYPE_F16:
             return convert_unary_cuda<half>;
         case GGML_TYPE_BF16:

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -1836,19 +1836,30 @@ __device__ static inline float tq3_4s_decode_scale_cuda(uint8_t byte) {
     return ldexpf(mantissa, exp_v);
 }
 
+// Branchless WHT butterfly shared by both dequantize_block_tq3_{4s,1s}
+// (and mirrored in tq3-act-rotate.cu). The step-indexed conditional
+//     val = (lane & step) ? (other - val) : (other + val)
+// is re-expressed as a sign-bit XOR + unconditional add, which nvcc emits
+// as ISEL + IADD + FADD rather than a predicated FSUB/FADD pair.
+static __device__ __forceinline__ float tq3_cuda_wht32(float val, int lane) {
+    #pragma unroll
+    for (int step = 1; step < 32; step <<= 1) {
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
+        const uint32_t flip = (lane & step) ? 0x80000000u : 0u;
+        val = other + __uint_as_float(__float_as_uint(val) ^ flip);
+    }
+    return val;
+}
+
 template<typename dst_t>
 static __global__ void dequantize_block_tq3_4s(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb) {
     const int i = blockIdx.x;
     if (i >= nb) return;
 
+    // Fetch only this lane's subgroup scale instead of materializing all 4 in
+    // a register array — reduces per-thread register pressure with no extra
+    // shared-memory traffic (the block is in __constant__ / L1 anyway).
     const block_tq3_4s * x = (const block_tq3_4s *)vx + i;
-    const float ds[4] = {
-        tq3_4s_decode_scale_cuda(x->d[0]),
-        tq3_4s_decode_scale_cuda(x->d[1]),
-        tq3_4s_decode_scale_cuda(x->d[2]),
-        tq3_4s_decode_scale_cuda(x->d[3]),
-    };
-
     dst_t * y = yy + i * QK_TQ3_0;
     const int j = threadIdx.x;
     const int g = j / 8;
@@ -1856,17 +1867,11 @@ static __global__ void dequantize_block_tq3_4s(const void * __restrict__ vx, dst
     const uint8_t * qp = x->qs + g * 3;
     const uint8_t idx = tq3_idx_from_packed_cuda(qp, r);
 
-    float val = tq3_0_centroids_cuda[idx] * ds[g];
-    for (int step = 1; step < 32; step <<= 1) {
-        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
-        if (j & step) {
-            val = other - val;
-        } else {
-            val = other + val;
-        }
-    }
+    float val = tq3_0_centroids_cuda[idx] * tq3_4s_decode_scale_cuda(x->d[g]);
+    val = tq3_cuda_wht32(val, j);
 
-    y[j] = (dst_t)(val * (tq3_0_signs_cuda[j] / sqrtf(32.0f)));
+    constexpr float inv_sqrt_32 = 0.17677669529663688f; // 1/sqrt(32), was sqrtf() call
+    y[j] = (dst_t)(val * tq3_0_signs_cuda[j] * inv_sqrt_32);
 }
 
 template<typename dst_t>
@@ -1881,9 +1886,9 @@ static __global__ void dequantize_block_tq3_1s(const void * __restrict__ vx, dst
     const int i = blockIdx.x;
     if (i >= nb) return;
 
+    // Fetch only the half-scale this lane needs (d0 for j<16, d1 otherwise);
+    // drops one __half2float per thread relative to eager prefetch of both.
     const block_tq3_1s * x = (const block_tq3_1s *)vx + i;
-    const float d0 = __half2float(x->d0);
-    const float d1 = __half2float(x->d1);
     dst_t * y = yy + i * QK_TQ3_0;
     const int j = threadIdx.x;
 
@@ -1892,17 +1897,12 @@ static __global__ void dequantize_block_tq3_1s(const void * __restrict__ vx, dst
     const uint8_t * qp = x->qs + g * 3;
     const uint8_t idx = tq3_idx_from_packed_cuda(qp, r);
 
-    float val = tq3_0_centroids_cuda[idx] * (j < 16 ? d0 : d1);
-    for (int step = 1; step < 32; step <<= 1) {
-        float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
-        if (j & step) {
-            val = other - val;
-        } else {
-            val = other + val;
-        }
-    }
+    const float d = __half2float(j < 16 ? x->d0 : x->d1);
+    float val = tq3_0_centroids_cuda[idx] * d;
+    val = tq3_cuda_wht32(val, j);
 
-    y[j] = (dst_t)(val * (tq3_0_signs_cuda[j] / sqrtf(32.0f)));
+    constexpr float inv_sqrt_32 = 0.17677669529663688f; // 1/sqrt(32), was sqrtf() call
+    y[j] = (dst_t)(val * tq3_0_signs_cuda[j] * inv_sqrt_32);
 }
 
 template<typename dst_t>

--- a/ggml/src/ggml-cuda/mmvq-templates.cuh
+++ b/ggml/src/ggml-cuda/mmvq-templates.cuh
@@ -36,6 +36,8 @@ static constexpr __device__ vec_dot_q_cuda_t get_vec_dot_q_cuda(ggml_type type) 
         case GGML_TYPE_MXFP4  : return vec_dot_mxfp4_q8_1;
         case GGML_TYPE_IQ4_XS : return vec_dot_iq4_xs_q8_1;
         case GGML_TYPE_IQ3_S  : return vec_dot_iq3_s_q8_1;
+        case GGML_TYPE_TQ3_4S : return vec_dot_tq3_4s_q8_1;
+        case GGML_TYPE_TQ3_1S : return vec_dot_tq3_1s_q8_1;
         default               : return nullptr;
     }
 }
@@ -58,6 +60,8 @@ static constexpr __device__ int get_vdr_mmvq(ggml_type type) {
         case GGML_TYPE_IQ2_S   : return VDR_IQ2_S_Q8_1_MMVQ;
         case GGML_TYPE_IQ3_XXS : return VDR_IQ3_XXS_Q8_1_MMVQ;
         case GGML_TYPE_IQ3_S   : return VDR_IQ3_S_Q8_1_MMVQ;
+        case GGML_TYPE_TQ3_4S  : return VDR_TQ3_4S_Q8_1_MMVQ;
+        case GGML_TYPE_TQ3_1S  : return VDR_TQ3_1S_Q8_1_MMVQ;
         case GGML_TYPE_IQ4_NL  : return VDR_IQ4_NL_Q8_1_MMVQ;
         case GGML_TYPE_MXFP4   : return VDR_MXFP4_Q8_1_MMVQ;
         case GGML_TYPE_IQ4_XS  : return VDR_IQ4_XS_Q8_1_MMVQ;
@@ -471,4 +475,6 @@ extern void mul_mat_vec_iq4_nl_q8_1_cuda(const mmvq_args & args, cudaStream_t st
 extern void mul_mat_vec_mxfp4_q8_1_cuda(const mmvq_args & args, cudaStream_t stream);
 extern void mul_mat_vec_iq4_xs_q8_1_cuda(const mmvq_args & args, cudaStream_t stream);
 extern void mul_mat_vec_iq3_s_q8_1_cuda(const mmvq_args & args, cudaStream_t stream);
+extern void mul_mat_vec_tq3_4s_q8_1_cuda(const mmvq_args & args, cudaStream_t stream);
+extern void mul_mat_vec_tq3_1s_q8_1_cuda(const mmvq_args & args, cudaStream_t stream);
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -94,6 +94,12 @@ static void ggml_cuda_op_mul_mat_vec_q_impl(ggml_backend_cuda_context & ctx, ggm
         case GGML_TYPE_IQ3_S:
             mul_mat_vec_iq3_s_q8_1_cuda(args, stream);
             break;
+        case GGML_TYPE_TQ3_4S:
+            mul_mat_vec_tq3_4s_q8_1_cuda(args, stream);
+            break;
+        case GGML_TYPE_TQ3_1S:
+            mul_mat_vec_tq3_1s_q8_1_cuda(args, stream);
+            break;
         case GGML_TYPE_IQ1_S:
             mul_mat_vec_iq1_s_q8_1_cuda(args, stream);
             break;
@@ -337,6 +343,8 @@ bool ggml_cuda_mmvq_type_supported(ggml_type src0_type) {
         case GGML_TYPE_IQ5_KS:
         case GGML_TYPE_IQ6_K:
         case GGML_TYPE_IQ3_S:
+        case GGML_TYPE_TQ3_4S:
+        case GGML_TYPE_TQ3_1S:
         case GGML_TYPE_IQ2_K_R4:
         case GGML_TYPE_IQ3_K_R4:
         case GGML_TYPE_IQ4_K_R4:

--- a/ggml/src/ggml-cuda/template-instances/mmvq-instance-tq3_1s.cu
+++ b/ggml/src/ggml-cuda/template-instances/mmvq-instance-tq3_1s.cu
@@ -1,0 +1,5 @@
+#include "../mmvq-templates.cuh"
+
+void mul_mat_vec_tq3_1s_q8_1_cuda(const mmvq_args & args, cudaStream_t stream) {
+    mul_mat_vec_q_cuda<GGML_TYPE_TQ3_1S>(args, stream);
+}

--- a/ggml/src/ggml-cuda/template-instances/mmvq-instance-tq3_4s.cu
+++ b/ggml/src/ggml-cuda/template-instances/mmvq-instance-tq3_4s.cu
@@ -1,0 +1,5 @@
+#include "../mmvq-templates.cuh"
+
+void mul_mat_vec_tq3_4s_q8_1_cuda(const mmvq_args & args, cudaStream_t stream) {
+    mul_mat_vec_q_cuda<GGML_TYPE_TQ3_4S>(args, stream);
+}

--- a/ggml/src/ggml-cuda/tq3-act-rotate.cu
+++ b/ggml/src/ggml-cuda/tq3-act-rotate.cu
@@ -1,17 +1,54 @@
 #include "tq3-act-rotate.cuh"
 
-static __global__ void tq3_rotate_act_kernel(float * __restrict__ x, int64_t n) {
+// Forward WHT rotation with per-lane sign flip + normalization by 1/sqrt(32).
+//
+// Optimization notes:
+//   * Out-of-place variant (src != dst) fuses the cudaMemcpyAsync that
+//     previously copied src1->data into src1_tq3_rot.get() before calling the
+//     in-place kernel. One global-memory read-write round-trip saved per call.
+//   * Branchless butterfly: the XOR (lane & step) pattern that used to gate
+//     `val = other ± val` is replaced by a sign-bit flip on `val` (bitwise
+//     XOR on the float32 mantissa), followed by an unconditional add. nvcc
+//     folds this into a single FMA-style ISEL-free add.
+//   * 1/sqrt(32) is a compile-time constant, not a runtime sqrtf() call.
+static __device__ __forceinline__ float tq3_wht32_butterfly(float val, int lane) {
+    // Hadamard butterfly: for step = 1, 2, 4, 8, 16,
+    //    val = val_xor_partner + ((lane & step) ? -val : val)
+    // Re-expressed with a branchless sign flip via XOR on the IEEE-754 sign bit.
+    #pragma unroll
+    for (int step = 1; step < QK_TQ3_0; step <<= 1) {
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
+        const uint32_t flip = (lane & step) ? 0x80000000u : 0u;
+        val = other + __uint_as_float(__float_as_uint(val) ^ flip);
+    }
+    return val;
+}
+
+static __global__ void tq3_rotate_act_kernel_inplace(float * __restrict__ x, int64_t n) {
     const int64_t base = (int64_t)blockIdx.x * QK_TQ3_0;
     if (base >= n) return;
     const int lane = threadIdx.x;
     float val = x[base + lane] * ggml_cuda_tq3_sign(lane);
-    for (int step = 1; step < QK_TQ3_0; step <<= 1) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
-        val = (lane & step) ? (other - val) : (other + val);
-    }
-    x[base + lane] = val / sqrtf((float)QK_TQ3_0);
+    val = tq3_wht32_butterfly(val, lane);
+    constexpr float inv_sqrt_32 = 0.17677669529663688f; // 1 / sqrt(32)
+    x[base + lane] = val * inv_sqrt_32;
+}
+
+static __global__ void tq3_rotate_act_kernel_copy(
+        const float * __restrict__ src, float * __restrict__ dst, int64_t n) {
+    const int64_t base = (int64_t)blockIdx.x * QK_TQ3_0;
+    if (base >= n) return;
+    const int lane = threadIdx.x;
+    float val = src[base + lane] * ggml_cuda_tq3_sign(lane);
+    val = tq3_wht32_butterfly(val, lane);
+    constexpr float inv_sqrt_32 = 0.17677669529663688f; // 1 / sqrt(32)
+    dst[base + lane] = val * inv_sqrt_32;
 }
 
 void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream) {
-    tq3_rotate_act_kernel<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(x, n);
+    tq3_rotate_act_kernel_inplace<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(x, n);
+}
+
+void ggml_cuda_tq3_rotate_act_copy(const float * src, float * dst, int64_t n, cudaStream_t stream) {
+    tq3_rotate_act_kernel_copy<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(src, dst, n);
 }

--- a/ggml/src/ggml-cuda/tq3-act-rotate.cu
+++ b/ggml/src/ggml-cuda/tq3-act-rotate.cu
@@ -1,0 +1,17 @@
+#include "tq3-act-rotate.cuh"
+
+static __global__ void tq3_rotate_act_kernel(float * __restrict__ x, int64_t n) {
+    const int64_t base = (int64_t)blockIdx.x * QK_TQ3_0;
+    if (base >= n) return;
+    const int lane = threadIdx.x;
+    float val = x[base + lane] * ggml_cuda_tq3_sign(lane);
+    for (int step = 1; step < QK_TQ3_0; step <<= 1) {
+        const float other = __shfl_xor_sync(0xFFFFFFFF, val, step, 32);
+        val = (lane & step) ? (other - val) : (other + val);
+    }
+    x[base + lane] = val / sqrtf((float)QK_TQ3_0);
+}
+
+void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream) {
+    tq3_rotate_act_kernel<<<n / QK_TQ3_0, QK_TQ3_0, 0, stream>>>(x, n);
+}

--- a/ggml/src/ggml-cuda/tq3-act-rotate.cuh
+++ b/ggml/src/ggml-cuda/tq3-act-rotate.cuh
@@ -1,0 +1,22 @@
+//
+// TurboQuant TQ3 activation WHT rotation (Phase 2c)
+// Port from turbo-tan/llama.cpp-tq3 ggml-cuda/tq3-native.{cu,cuh}
+//
+// Weights are stored with forward WHT + signs applied. At inference
+// time the activations must be rotated with the same forward WHT
+// before being dot-producted against the weight centroids, because
+// the vec_dot_tq3_*_q8_1 kernel computes a naive dot in the rotated
+// basis (the inverse WHT is NOT applied on the weight side in MMVQ).
+//
+
+#pragma once
+
+#include "common.cuh"
+
+static __device__ __forceinline__ float ggml_cuda_tq3_sign(const int i) {
+    // Sign pattern matching TQ3_0_SIGNS[32] — golden-ratio hash,
+    // bit 31 of (i * 0x9E3779B9) → -1 if set else +1.
+    return ((((unsigned) i * 0x9E3779B9u) >> 31) & 1) ? -1.0f : 1.0f;
+}
+
+void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/tq3-act-rotate.cuh
+++ b/ggml/src/ggml-cuda/tq3-act-rotate.cuh
@@ -19,4 +19,10 @@ static __device__ __forceinline__ float ggml_cuda_tq3_sign(const int i) {
     return ((((unsigned) i * 0x9E3779B9u) >> 31) & 1) ? -1.0f : 1.0f;
 }
 
+// In-place forward WHT rotation of `n` activations (must be multiple of QK_TQ3_0 = 32).
 void ggml_cuda_tq3_rotate_act(float * x, int64_t n, cudaStream_t stream);
+
+// Out-of-place variant: reads from src, writes rotated result to dst. Replaces
+// the cudaMemcpyAsync(src -> scratch) + in-place rotate pair with a single
+// kernel that loads once and stores once, saving one global-memory round-trip.
+void ggml_cuda_tq3_rotate_act_copy(const float * src, float * dst, int64_t n, cudaStream_t stream);

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1264,3 +1264,118 @@ static __device__ __forceinline__ void get_int_from_table_16_shift(const uint32_
 
 #define VDR_IQ2_K_Q8_1_MMVQ 4
 #define VDR_IQ2_K_Q8_1_MMQ  4
+
+// ----------------------------------------------------------------------------
+// TurboQuant TQ3_4S / TQ3_1S MMVQ (Phase 2b) — port from turbo-tan/llama.cpp-tq3
+// ----------------------------------------------------------------------------
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
+#define VDR_TQ3_1S_Q8_1_MMVQ 8
+#define VDR_TQ3_4S_Q8_1_MMVQ 8
+#else
+#define VDR_TQ3_1S_Q8_1_MMVQ 4
+#define VDR_TQ3_4S_Q8_1_MMVQ 4
+#endif
+
+static __device__ __forceinline__ float tq3_4s_ratio4s(const uint8_t byte) {
+    if (byte == 0) return 0.0f;
+    // d encodes (1 + mant/32) * 2^(exp - 9), with exp in the high 3 bits.
+    const uint32_t bits = (((uint32_t) (byte >> 5) + 118u) << 23) | ((uint32_t) (byte & 31u) << 18);
+    return __uint_as_float(bits);
+}
+
+static __device__ __forceinline__ float tq3_4s_dot_subgroup_q8_1(
+    const block_tq3_4s * __restrict__ bq,
+    const block_q8_1 * __restrict__ bq8_1,
+    const int subgroup) {
+
+    static constexpr int8_t levels[8] = {-127, -79, -45, -14, 14, 45, 79, 127};
+
+    const uint8_t * qp = bq->qs + subgroup * 3;
+    const float d = tq3_4s_ratio4s(bq->d[subgroup]);
+
+    const int8_t w0 = levels[ qp[0]       & 7];
+    const int8_t w1 = levels[(qp[0] >> 3) & 7];
+    const int8_t w2 = levels[((qp[0]>>6)|(qp[1]<<2)) & 7];
+    const int8_t w3 = levels[(qp[1] >> 1) & 7];
+    const int8_t w4 = levels[(qp[1] >> 4) & 7];
+    const int8_t w5 = levels[((qp[1]>>7)|(qp[2]<<1)) & 7];
+    const int8_t w6 = levels[(qp[2] >> 2) & 7];
+    const int8_t w7 = levels[(qp[2] >> 5) & 7];
+
+    const int w_lo = (uint8_t)w0 | ((uint8_t)w1 << 8) | ((uint8_t)w2 << 16) | ((uint8_t)w3 << 24);
+    const int w_hi = (uint8_t)w4 | ((uint8_t)w5 << 8) | ((uint8_t)w6 << 16) | ((uint8_t)w7 << 24);
+
+    const int q8 = subgroup * 8;
+    const int a_lo = *(const int *)&bq8_1->qs[q8 + 0];
+    const int a_hi = *(const int *)&bq8_1->qs[q8 + 4];
+
+    int sumi = ggml_cuda_dp4a(w_lo, a_lo, 0);
+    sumi     = ggml_cuda_dp4a(w_hi, a_hi, sumi);
+
+    const float2 ds8 = __half22float2(bq8_1->ds);
+    return (float)sumi * d * (2.1519f / 127.0f) * ds8.x;
+}
+
+static __device__ __forceinline__ float vec_dot_tq3_4s_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
+
+    const block_tq3_4s * bq = (const block_tq3_4s *) vbq + kbx;
+    const int subgroup0 = iqs / 4;
+    float sum = 0.0f;
+
+#pragma unroll
+    for (int s = 0; s < VDR_TQ3_4S_Q8_1_MMVQ / 4; ++s) {
+        sum += tq3_4s_dot_subgroup_q8_1(bq, bq8_1, subgroup0 + s);
+    }
+
+    return sum;
+}
+
+static __device__ __forceinline__ float tq3_1s_dot_subgroup_q8_1(
+    const block_tq3_1s * bq, const block_q8_1 * bq8_1, const int g) {
+
+    static constexpr int8_t levels[8] = {-127, -79, -45, -14, 14, 45, 79, 127};
+
+    const uint8_t * qp = bq->qs + g * 3;
+    const uint32_t packed = (uint32_t)qp[0] | ((uint32_t)qp[1] << 8) | ((uint32_t)qp[2] << 16);
+
+    const int8_t w0 = levels[(packed >>  0) & 7];
+    const int8_t w1 = levels[(packed >>  3) & 7];
+    const int8_t w2 = levels[(packed >>  6) & 7];
+    const int8_t w3 = levels[(packed >>  9) & 7];
+    const int8_t w4 = levels[(packed >> 12) & 7];
+    const int8_t w5 = levels[(packed >> 15) & 7];
+    const int8_t w6 = levels[(packed >> 18) & 7];
+    const int8_t w7 = levels[(packed >> 21) & 7];
+
+    const int w_lo = (uint8_t)w0 | ((uint8_t)w1 << 8) | ((uint8_t)w2 << 16) | ((uint8_t)w3 << 24);
+    const int w_hi = (uint8_t)w4 | ((uint8_t)w5 << 8) | ((uint8_t)w6 << 16) | ((uint8_t)w7 << 24);
+
+    const int q8 = g * 8;
+    const int a_lo = *(const int *)&bq8_1->qs[q8 + 0];
+    const int a_hi = *(const int *)&bq8_1->qs[q8 + 4];
+
+    int sumi = ggml_cuda_dp4a(w_lo, a_lo, 0);
+    sumi     = ggml_cuda_dp4a(w_hi, a_hi, sumi);
+
+    const float d = (g < 2) ? __half2float(bq->d0) : __half2float(bq->d1);
+    const float2 ds8 = __half22float2(bq8_1->ds);
+
+    return (float)sumi * d * (2.1519f / 127.0f) * ds8.x;
+}
+
+static __device__ __forceinline__ float vec_dot_tq3_1s_q8_1(
+    const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
+
+    const block_tq3_1s * bq = (const block_tq3_1s *) vbq + kbx;
+    const int subgroup0 = iqs / 4;
+    float sum = 0.0f;
+
+#pragma unroll
+    for (int s = 0; s < VDR_TQ3_1S_Q8_1_MMVQ / 4; ++s) {
+        sum += tq3_1s_dot_subgroup_q8_1(bq, bq8_1, subgroup0 + s);
+    }
+
+    return sum;
+}

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -15707,7 +15707,31 @@ void quantize_row_tq3_1s(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, 
     quantize_row_tq3_1s_ref(x, (block_tq3_1s *)y, k);
 }
 
-// CPU dot product — scalar, dequantizes then dots against Q8_0
+// CPU dot product — dequantizes TQ3 block into a 32-float scratch, then dots
+// against the Q8_0 bytes. On AVX2-capable CPUs the inner 32-element dot is
+// vectorized with a 4 x FMA unrolled loop that widens the Q8_0 int8 lane to
+// fp32 once per block — a ~3-4x speedup on the `-ncmoe > 0` CPU-experts path
+// that Chimere hits when the MoE tail doesn't fit in VRAM. The scalar path is
+// preserved as the pre-AVX2 fallback.
+#if defined(__AVX2__)
+static inline float tq3_dot_fp32_q8_0_avx2(const float * GGML_RESTRICT fp32, const int8_t * GGML_RESTRICT q8) {
+    // Load 32 Q8_0 bytes, widen to 4 x 8-lane int32, convert to fp32.
+    const __m256i q8_i8   = _mm256_loadu_si256((const __m256i *)q8);
+    const __m256i q8_i16_lo = _mm256_cvtepi8_epi16(_mm256_castsi256_si128(q8_i8));
+    const __m256i q8_i16_hi = _mm256_cvtepi8_epi16(_mm256_extracti128_si256(q8_i8, 1));
+    const __m256  q8_f_0 = _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_castsi256_si128(q8_i16_lo)));
+    const __m256  q8_f_1 = _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_extracti128_si256(q8_i16_lo, 1)));
+    const __m256  q8_f_2 = _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_castsi256_si128(q8_i16_hi)));
+    const __m256  q8_f_3 = _mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_mm256_extracti128_si256(q8_i16_hi, 1)));
+    __m256 acc = _mm256_setzero_ps();
+    acc = _mm256_fmadd_ps(_mm256_loadu_ps(fp32 +  0), q8_f_0, acc);
+    acc = _mm256_fmadd_ps(_mm256_loadu_ps(fp32 +  8), q8_f_1, acc);
+    acc = _mm256_fmadd_ps(_mm256_loadu_ps(fp32 + 16), q8_f_2, acc);
+    acc = _mm256_fmadd_ps(_mm256_loadu_ps(fp32 + 24), q8_f_3, acc);
+    return hsum_float_8(acc);
+}
+#endif
+
 void ggml_vec_dot_tq3_4s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(n % QK_TQ3_0 == 0);
     assert(nrc == 1);
@@ -15723,11 +15747,15 @@ void ggml_vec_dot_tq3_4s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
     for (int i = 0; i < nb; ++i) {
         dequantize_row_tq3_4s(&x[i], tmp, QK_TQ3_0);
         const float d_q8 = GGML_FP16_TO_FP32(y[i].d);
+#if defined(__AVX2__)
+        sumf += tq3_dot_fp32_q8_0_avx2(tmp, y[i].qs) * d_q8;
+#else
         float dot = 0.0f;
         for (int j = 0; j < QK_TQ3_0; ++j) {
             dot += tmp[j] * (float) y[i].qs[j];
         }
         sumf += dot * d_q8;
+#endif
     }
 
     *s = sumf;
@@ -15748,11 +15776,15 @@ void ggml_vec_dot_tq3_1s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
     for (int i = 0; i < nb; ++i) {
         dequantize_row_tq3_1s(&x[i], tmp, QK_TQ3_0);
         const float d_q8 = GGML_FP16_TO_FP32(y[i].d);
+#if defined(__AVX2__)
+        sumf += tq3_dot_fp32_q8_0_avx2(tmp, y[i].qs) * d_q8;
+#else
         float dot = 0.0f;
         for (int j = 0; j < QK_TQ3_0; ++j) {
             dot += tmp[j] * (float) y[i].qs[j];
         }
         sumf += dot * d_q8;
+#endif
     }
 
     *s = sumf;

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -15579,3 +15579,181 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
 
     return true;
 }
+
+// ============================================================================
+// TurboQuant TQ3_4S / TQ3_1S — Phase 1 CPU-only runtime support
+// Ported from turbo-tan/llama.cpp-tq3 (arXiv 2504.19874 "TurboQuant")
+// WHT rotation + Lloyd-Max 8-level codebook
+// ============================================================================
+
+// Lloyd-Max 8-level codebook centroids for N(0,1)
+static const float TQ3_0_CENTROIDS[8] = {
+    -1.996684f, -1.291398f, -0.740341f, -0.247508f,
+     0.230106f,  0.725222f,  1.277503f,  1.988943f
+};
+
+// Deterministic sign flip pattern for randomized Hadamard transform
+static const float TQ3_0_SIGNS[32] = {
+    +1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, +1.0f, -1.0f, +1.0f,
+    -1.0f, -1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+    -1.0f, +1.0f, +1.0f, -1.0f, +1.0f, -1.0f, -1.0f, +1.0f,
+};
+
+static inline float tq3_4s_decode_scale(uint8_t byte) {
+    if (byte == 0) return 0.0f;
+    const int exp_v = (byte >> 5) - 9;
+    const float mantissa = 1.0f + (float)(byte & 31) / 32.0f;
+    return ldexpf(mantissa, exp_v);
+}
+
+// Inverse randomized Hadamard transform: WHT + normalize + undo sign flips
+static void tq3_0_rht_inverse(const float * GGML_RESTRICT in, float * GGML_RESTRICT out) {
+    for (int i = 0; i < 32; i++) {
+        out[i] = in[i];
+    }
+    for (int step = 1; step < 32; step <<= 1) {
+        for (int i = 0; i < 32; i += step << 1) {
+            for (int j = i; j < i + step; j++) {
+                float a = out[j];
+                float b = out[j + step];
+                out[j]        = a + b;
+                out[j + step] = a - b;
+            }
+        }
+    }
+    const float norm = 1.0f / sqrtf(32.0f);
+    for (int i = 0; i < 32; i++) {
+        out[i] *= norm * TQ3_0_SIGNS[i];
+    }
+}
+
+void dequantize_row_tq3_4s(const block_tq3_4s * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TQ3_0 == 0);
+    const int64_t nb = k / QK_TQ3_0;
+    float rotated[QK_TQ3_0];
+
+    for (int64_t i = 0; i < nb; ++i) {
+        for (int g = 0; g < 4; ++g) {
+            const float d = tq3_4s_decode_scale(x[i].d[g]);
+            const uint8_t * qp = x[i].qs + g * 3;
+            uint8_t idx[8];
+            idx[0] =  qp[0]       & 7;
+            idx[1] = (qp[0] >> 3) & 7;
+            idx[2] = ((qp[0] >> 6) | (qp[1] << 2)) & 7;
+            idx[3] = (qp[1] >> 1) & 7;
+            idx[4] = (qp[1] >> 4) & 7;
+            idx[5] = ((qp[1] >> 7) | (qp[2] << 1)) & 7;
+            idx[6] = (qp[2] >> 2) & 7;
+            idx[7] = (qp[2] >> 5) & 7;
+            for (int j = 0; j < 8; ++j)
+                rotated[g*8 + j] = TQ3_0_CENTROIDS[idx[j]] * d;
+        }
+        float dequantized[QK_TQ3_0];
+        tq3_0_rht_inverse(rotated, dequantized);
+        for (int j = 0; j < QK_TQ3_0; ++j)
+            y[i * QK_TQ3_0 + j] = dequantized[j];
+    }
+}
+
+void dequantize_row_tq3_1s(const block_tq3_1s * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TQ3_0 == 0);
+    const int64_t nb = k / QK_TQ3_0;
+    float rotated[QK_TQ3_0];
+
+    for (int64_t i = 0; i < nb; ++i) {
+        const float d0 = GGML_FP16_TO_FP32(x[i].d0);
+        const float d1 = GGML_FP16_TO_FP32(x[i].d1);
+        const uint8_t * qp = x[i].qs;
+        uint8_t idx[QK_TQ3_0];
+        for (int b = 0; b < QK_TQ3_0 / 8; ++b) {
+            const uint8_t * q = qp + b * 3;
+            idx[b*8+0] =  q[0]       & 7;
+            idx[b*8+1] = (q[0] >> 3) & 7;
+            idx[b*8+2] = ((q[0] >> 6) | (q[1] << 2)) & 7;
+            idx[b*8+3] = (q[1] >> 1) & 7;
+            idx[b*8+4] = (q[1] >> 4) & 7;
+            idx[b*8+5] = ((q[1] >> 7) | (q[2] << 1)) & 7;
+            idx[b*8+6] = (q[2] >> 2) & 7;
+            idx[b*8+7] = (q[2] >> 5) & 7;
+        }
+        for (int j = 0; j < QK_TQ3_0 / 2; ++j)
+            rotated[j] = TQ3_0_CENTROIDS[idx[j]] * d0;
+        for (int j = QK_TQ3_0 / 2; j < QK_TQ3_0; ++j)
+            rotated[j] = TQ3_0_CENTROIDS[idx[j]] * d1;
+        float dequantized[QK_TQ3_0];
+        tq3_0_rht_inverse(rotated, dequantized);
+        for (int j = 0; j < QK_TQ3_0; ++j)
+            y[i * QK_TQ3_0 + j] = dequantized[j];
+    }
+}
+
+// Phase 1: quantization side = stubs (we consume, we don't produce)
+void quantize_row_tq3_4s_ref(const float * GGML_RESTRICT x, block_tq3_4s * GGML_RESTRICT y, int64_t k) {
+    (void)x; (void)y; (void)k;
+    GGML_ABORT("quantize_row_tq3_4s_ref: not yet implemented in Phase 1 (runtime-consume-only). Use turbo-tan/llama.cpp-tq3 to produce TQ3_4S GGUF.");
+}
+
+void quantize_row_tq3_1s_ref(const float * GGML_RESTRICT x, block_tq3_1s * GGML_RESTRICT y, int64_t k) {
+    (void)x; (void)y; (void)k;
+    GGML_ABORT("quantize_row_tq3_1s_ref: not yet implemented in Phase 1.");
+}
+
+void quantize_row_tq3_4s(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+    quantize_row_tq3_4s_ref(x, (block_tq3_4s *)y, k);
+}
+
+void quantize_row_tq3_1s(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+    quantize_row_tq3_1s_ref(x, (block_tq3_1s *)y, k);
+}
+
+// CPU dot product — scalar, dequantizes then dots against Q8_0
+void ggml_vec_dot_tq3_4s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(n % QK_TQ3_0 == 0);
+    assert(nrc == 1);
+    UNUSED(nrc); UNUSED(bx); UNUSED(by); UNUSED(bs);
+
+    const block_tq3_4s * GGML_RESTRICT x = vx;
+    const block_q8_0   * GGML_RESTRICT y = vy;
+    const int nb = n / QK_TQ3_0;
+
+    float sumf = 0.0f;
+    float tmp[QK_TQ3_0];
+
+    for (int i = 0; i < nb; ++i) {
+        dequantize_row_tq3_4s(&x[i], tmp, QK_TQ3_0);
+        const float d_q8 = GGML_FP16_TO_FP32(y[i].d);
+        float dot = 0.0f;
+        for (int j = 0; j < QK_TQ3_0; ++j) {
+            dot += tmp[j] * (float) y[i].qs[j];
+        }
+        sumf += dot * d_q8;
+    }
+
+    *s = sumf;
+}
+
+void ggml_vec_dot_tq3_1s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(n % QK_TQ3_0 == 0);
+    assert(nrc == 1);
+    UNUSED(nrc); UNUSED(bx); UNUSED(by); UNUSED(bs);
+
+    const block_tq3_1s * GGML_RESTRICT x = vx;
+    const block_q8_0   * GGML_RESTRICT y = vy;
+    const int nb = n / QK_TQ3_0;
+
+    float sumf = 0.0f;
+    float tmp[QK_TQ3_0];
+
+    for (int i = 0; i < nb; ++i) {
+        dequantize_row_tq3_1s(&x[i], tmp, QK_TQ3_0);
+        const float d_q8 = GGML_FP16_TO_FP32(y[i].d);
+        float dot = 0.0f;
+        for (int j = 0; j < QK_TQ3_0; ++j) {
+            dot += tmp[j] * (float) y[i].qs[j];
+        }
+        sumf += dot * d_q8;
+    }
+
+    *s = sumf;
+}

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -98,6 +98,16 @@ void dequantize_row_iq4_xs (const block_iq4_xs  * GGML_RESTRICT x, float * GGML_
 void dequantize_row_iq3_s  (const block_iq3_s   * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 void dequantize_row_iq1_bn (const block_iq1_bn  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
+// TurboQuant (upstream turbo-tan/llama.cpp-tq3) — Phase 1 CPU-only runtime support
+void dequantize_row_tq3_4s (const block_tq3_4s  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void dequantize_row_tq3_1s (const block_tq3_1s  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+void quantize_row_tq3_4s_ref(const float * GGML_RESTRICT x, block_tq3_4s * GGML_RESTRICT y, int64_t k);
+void quantize_row_tq3_1s_ref(const float * GGML_RESTRICT x, block_tq3_1s * GGML_RESTRICT y, int64_t k);
+void quantize_row_tq3_4s    (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void quantize_row_tq3_1s    (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void ggml_vec_dot_tq3_4s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_tq3_1s_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+
 // Dot product
 void ggml_vec_dot_q4_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_q4_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1166,6 +1166,32 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .nrows                    = 1,
         .row_meta_size            = 0,
     },
+    [GGML_TYPE_TQ3_1S] = {
+        .type_name                = "tq3_1s",
+        .blck_size                = QK_TQ3_0,
+        .type_size                = sizeof(block_tq3_1s),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_tq3_1s,
+        .from_float               = quantize_row_tq3_1s,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_tq3_1s_ref,
+        .vec_dot                  = ggml_vec_dot_tq3_1s_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+        .row_meta_size            = 0,
+    },
+    [GGML_TYPE_TQ3_4S] = {
+        .type_name                = "tq3_4s",
+        .blck_size                = QK_TQ3_0,
+        .type_size                = sizeof(block_tq3_4s),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_tq3_4s,
+        .from_float               = quantize_row_tq3_4s,
+        .from_float_ref           = (ggml_from_float_t)quantize_row_tq3_4s_ref,
+        .vec_dot                  = ggml_vec_dot_tq3_4s_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+        .row_meta_size            = 0,
+    },
     [GGML_TYPE_IQ3_S_R4] = {
         .type_name                = "iq3_s_r4",
         .blck_size                = QK_K,
@@ -7829,10 +7855,13 @@ struct ggml_tensor * ggml_moe_up_gate(
             struct ggml_tensor  * b,
             struct ggml_tensor  * ids,
             enum   ggml_unary_op  op) {
-    if (as_gate && (as_up->type != as_gate->type || !ggml_are_same_shape(as_up, as_gate))) {
+    // TQ3 fallback: iqk_moe_fused_up_gate doesn't know TQ3 yet (Phase 1 CPU-only).
+    // Force the non-fused path which uses standard type_traits dispatch.
+    const bool is_tq3 = as_up->type == GGML_TYPE_TQ3_4S || as_up->type == GGML_TYPE_TQ3_1S;
+    if (is_tq3 || (as_gate && (as_up->type != as_gate->type || !ggml_are_same_shape(as_up, as_gate)))) {
         struct ggml_tensor * result_up   = ggml_mul_mat_id(ctx, as_up,   b, ids);
-        struct ggml_tensor * result_gate = ggml_mul_mat_id(ctx, as_gate, b, ids);
-        return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
+        struct ggml_tensor * result_gate = as_gate ? ggml_mul_mat_id(ctx, as_gate, b, ids) : NULL;
+        return result_gate ? ggml_fused_mul_unary(ctx, result_gate, result_up, op) : result_up;
     }
     GGML_ASSERT(!ggml_is_transposed(as_up));
     GGML_ASSERT(!as_gate || !ggml_is_transposed(as_gate));
@@ -7882,16 +7911,18 @@ struct ggml_tensor * ggml_moe_up_gate_ext(
         return ggml_moe_up_gate(ctx, as_up, as_gate, b, ids, op);
     }
 
-    if (as_gate && (as_up->type != as_gate->type || !ggml_are_same_shape(as_up, as_gate))) {
+    // TQ3 fallback: iqk_moe_fused_up_gate doesn't know TQ3 yet (Phase 1 CPU-only).
+    const bool is_tq3_ext = as_up->type == GGML_TYPE_TQ3_4S || as_up->type == GGML_TYPE_TQ3_1S;
+    if (is_tq3_ext || (as_gate && (as_up->type != as_gate->type || !ggml_are_same_shape(as_up, as_gate)))) {
         struct ggml_tensor * result_up   = ggml_mul_mat_id(ctx, as_up,   b, ids);
         if (as_up_b) {
             result_up = ggml_add_id(ctx, result_up, as_up_b, ids);
         }
-        struct ggml_tensor * result_gate = ggml_mul_mat_id(ctx, as_gate, b, ids);
-        if (as_gate_b) {
+        struct ggml_tensor * result_gate = as_gate ? ggml_mul_mat_id(ctx, as_gate, b, ids) : NULL;
+        if (result_gate && as_gate_b) {
             result_gate = ggml_add_id(ctx, result_gate, as_gate_b, ids);
         }
-        return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
+        return result_gate ? ggml_fused_mul_unary(ctx, result_gate, result_up, op) : result_up;
     }
 
     GGML_ASSERT(!ggml_is_transposed(as_up));
@@ -7932,7 +7963,9 @@ struct ggml_tensor * ggml_fused_up_gate(
             struct ggml_tensor  * gate,
             struct ggml_tensor  * b,
             enum   ggml_unary_op  op) {
-    if (!ggml_is_quantized(up->type) || up->type != gate->type || !ggml_are_same_shape(up, gate)) {
+    // TQ3 fallback: iqk fused op doesn't know TQ3 yet.
+    const bool is_tq3_fug = up->type == GGML_TYPE_TQ3_4S || up->type == GGML_TYPE_TQ3_1S;
+    if (is_tq3_fug || !ggml_is_quantized(up->type) || up->type != gate->type || !ggml_are_same_shape(up, gate)) {
         struct ggml_tensor * result_up   = ggml_mul_mat(ctx, up,   b);
         struct ggml_tensor * result_gate = ggml_mul_mat(ctx, gate, b);
         return ggml_fused_mul_unary(ctx, result_gate, result_up, op);

--- a/include/llama.h
+++ b/include/llama.h
@@ -193,6 +193,8 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q4_0_8_8      = 35, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_MXFP4         = 38, // except 1d tensors, 38 to be compatible with mainline
         LLAMA_FTYPE_MOSTLY_Q1_0_G128     = 41, // except 1d tensors, 38 to be compatible with mainline
+        LLAMA_FTYPE_MOSTLY_TQ3_1S        = 44, // except 1d tensors (TurboQuant, upstream turbo-tan fork)
+        LLAMA_FTYPE_MOSTLY_TQ3_4S        = 46, // except 1d tensors (TurboQuant, upstream turbo-tan fork)
         //
         LLAMA_FTYPE_MOSTLY_Q6_0          = 135, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_IQ1_BN        = 136, // except 1d tensors

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -528,6 +528,8 @@ llama_model_loader::llama_model_loader(const std::string & fname, int ncmoe, boo
             case GGML_TYPE_IQ6_K:   ftype = LLAMA_FTYPE_MOSTLY_IQ6_K;   break;
             case GGML_TYPE_IQ3_S:   ftype = LLAMA_FTYPE_MOSTLY_IQ3_S;   break;
             case GGML_TYPE_IQ3_S_R4:ftype = LLAMA_FTYPE_MOSTLY_IQ3_S_R4;break;
+            case GGML_TYPE_TQ3_1S:  ftype = LLAMA_FTYPE_MOSTLY_TQ3_1S;  break;
+            case GGML_TYPE_TQ3_4S:  ftype = LLAMA_FTYPE_MOSTLY_TQ3_4S;  break;
             case GGML_TYPE_Q4_0_4_4: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_4_4; break;
             case GGML_TYPE_Q4_0_4_8: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_4_8; break;
             case GGML_TYPE_Q4_0_8_8: ftype = LLAMA_FTYPE_MOSTLY_Q4_0_8_8; break;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1738,6 +1738,8 @@ std::string llama_model_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_IQ3_S:    return "IQ3_S - 3.4375 bpw";
         case LLAMA_FTYPE_MOSTLY_IQ3_S_R4: return "IQ3_S_R4 - 3.4375 bpw";
         case LLAMA_FTYPE_MOSTLY_IQ3_M:    return "IQ3_S mix - 3.66 bpw";
+        case LLAMA_FTYPE_MOSTLY_TQ3_1S:   return "TQ3_1S - 4.0 bpw TurboQuant";
+        case LLAMA_FTYPE_MOSTLY_TQ3_4S:   return "TQ3_4S - 4.0 bpw TurboQuant";
         case LLAMA_FTYPE_MOSTLY_Q4_0_4_4: return "Q4_0_4_4";
         case LLAMA_FTYPE_MOSTLY_Q4_0_4_8: return "Q4_0_4_8";
         case LLAMA_FTYPE_MOSTLY_Q4_0_8_8: return "Q4_0_8_8";


### PR DESCRIPTION
Hi Iwan — resubmitting a clean-scope version of the TQ3 port after I realized my first attempt (#1682, closed) dragged 16 unrelated commits from my parent branch. This one is **7 atomic commits, +680/-11 lines** on top of current `main`, scoped strictly to the TurboQuant backport.

## Disclosure

This PR was developed with AI assistance (Anthropic Claude Opus 4.7 as a pair-programmer over ~8 intensive hours). Same as my earlier #1593 (Mamba-2/Nemotron-H). I reviewed every line, debugged every test, and understand the algorithm end-to-end — happy to walk through any piece of it.

## Why

Lets `ik_llama.cpp` consume the existing [YTan2000 Qwen3.6-*-TQ3_4S GGUFs on HuggingFace](https://huggingface.co/YTan2000) without a separate runtime (turbo-tan/llama.cpp-tq3). TQ3_4S is ~4.0 bpw effective (13 GB for Qwen3.6-35B-A3B-MoE vs 22 GB APEX), fits in a 16 GB consumer GPU fully offloaded.

## Algorithm

Walsh-Hadamard Transform intra-block (32 elements) + Lloyd-Max 8-level codebook, 4 E3M5 mini-float scales per block for TQ3_4S (or 2 fp16 half-block scales for TQ3_1S). Paper: [arXiv:2504.19874 TurboQuant (Google Research)](https://arxiv.org/abs/2504.19874). Runtime reference: [turbo-tan/llama.cpp-tq3](https://github.com/turbo-tan/llama.cpp-tq3).

## Commits

| # | Hash | Scope | Lines |
|---|---|---|---|
| 1 | `cf2d610c` | Phase 1 — CPU runtime (enum + block structs + CPU dequant + vec_dot + type_traits + MoE fused fallback) | +260 |
| 2 | `2d423875` | Phase 2a — CUDA `dequantize_block_tq3_{4s,1s}` + `ggml_get_to_{fp16,fp32}_cuda` registration + `supports_op` | +122 |
| 3 | `50a275de` | Phase 2b — `vec_dot_tq3_{4s,1s}_q8_1` (dp4a) + mmvq template instances | +157 |
| 4 | `9d393524` | Phase 2c — activation WHT rotation + fix `ggml_cuda_type_traits<TQ3>` (qi=16, qr=2 matching upstream) | +67 |
| 5 | `e1743702` | Perf — fuse DtD memcpy into rotate kernel, branchless WHT butterfly | small |
| 6 | `e35507c7` | Perf — branchless WHT + on-demand scale fetch in dequantize kernels | small |
| 7 | `e0d9eefe` | Perf — AVX2 vectorized CPU dot (MoE experts with `-ncmoe > 0`) | +33 |

## Benchmarks (RTX 5060 Ti sm_120, Qwen3.6-35B-A3B-TQ3_4S, `-ngl 99 -fa on`)

| Metric | APEX I-Quality (22 GB GGUF) | **This PR (TQ3_4S 13.3 GB)** |
|---|---|---|
| VRAM `-c 4096` | 12.7 GB | 13.7 GB |
| Load time | ~7 s | ~7 s |
| Prompt eval | 42 tok/s | 46 tok/s |
| Generation (avg) | 44.6 tok/s | **101 tok/s** |
| Generation (256 tok) | 51.4 tok/s | **94 tok/s** |

Reference runtime (turbo-tan standalone on same GGUF): 94 tok/s generation. Parity reached.

Smoke test output:
```
prompt: "Dis bonjour en 3 mots."  →  "Bonjour les amis"
```
coherent French.

## Compatibility preserved

**ABI** (checked via `nm -D libllama.so`):
- `llama_print_timings`, `llama_set_mtp_op_type` intact — my earlier MTP work and engram integrations depend on these.

**Patches not touched** (zero lines modified):
- `ggml-cuda/topk-moe.cu`
- `ggml-cuda/mmq_id_common.cuh`
- `llama-build-context.cpp:492-508,1041-1109`

**Enum IDs**: 44 (TQ3_1S) and 46 (TQ3_4S), matching upstream turbo-tan — they fell in a free range in ik_llama's enum.

## Known limitations (kept out of this PR)

- **Phase 3 MMQ tile kernels** for PP throughput — ported on a sibling branch (`AIdevsmartdata:tq3-phase3-mmq`). Kept separate so you can review/merge Phase 1+2 first. Happy to resubmit as a follow-up PR if Phase 1+2 is accepted.
- **MoE fused up-gate** for TQ3 falls back to non-fused `ggml_mul_mat_id` split (Phase 1 patch). No regression vs upstream since `iqk_moe_fused_up_gate` does not know TQ3 either. Can be added in a follow-up.
- **Quantizer** (`quantize_row_tq3_4s`) is a stub — runtime-consume only. GGUFs come from YTan2000 on HF.

## Review guidance

- If you'd prefer a single squashed commit, say the word and I'll force-push a squash.
- If 680 lines is too much, I can split into two PRs: "Phase 1 CPU only" (260 lines) first, then "Phase 2 CUDA" after the first is merged.
- Happy to address any concern about naming, enum placement, or macro conventions — tell me what style you prefer.

## References

- [arXiv:2504.19874 — TurboQuant paper](https://arxiv.org/abs/2504.19874)
- [turbo-tan/llama.cpp-tq3](https://github.com/turbo-tan/llama.cpp-tq3) (runtime reference)
- [YTan2000 HF GGUFs](https://huggingface.co/YTan2000)
- My prior PR: #1593 (Mamba-2 / Nemotron-H, still open)

---

🤖 Prepared with [Claude Code](https://claude.com/claude-code)