### PR TITLE
fix: Kimi-K2 parser ignores enable_thinking=false, response goes to reasoning_content

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1356,7 +1356,7 @@ static common_chat_params common_chat_params_init_kimi_k2(const common_chat_temp
     };
 
     auto has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
-    auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+    auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && inputs.enable_thinking;
     auto include_grammar   = has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE;
 
     const std::string SECTION_BEGIN = "<|tool_calls_section_begin|>";


### PR DESCRIPTION
Fixes #1685

## Problem

When calling with `"chat_template_kwargs": {"thinking": false}` (instant mode), the Kimi-K2 parser still routes all output to `reasoning_content` instead of `content`.

**Root cause:** In `common_chat_params_init_kimi_k2`, `extract_reasoning` only checks `reasoning_format` but ignores `enable_thinking`:

```cpp
// Before (bug)
auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
```

## Fix

Add the `enable_thinking` check, consistent with how other thinking models (Qwen3, etc.) handle it:

```cpp
// After
auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && inputs.enable_thinking;
```

## Change

One line in `common/chat.cpp` inside `common_chat_params_init_kimi_k2`.