### PR TITLE
server: skip SWA-only checkpoint logic for hybrid/recurrent (fixes #20225)

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3216,6 +3216,17 @@ void  server_context::create_checkpoint_at_interval(server_slot & slot, const gp
 }
 
 void server_context::apply_checkpoint(server_slot & slot) {
+    // Fix for ggml-org/llama.cpp issue #20225:
+    // The checkpoint logic below was written for Sliding Window Attention (SWA)
+    // semantics where `pos_min` advances with the window. For hybrid/recurrent
+    // architectures (Qwen3.5, Qwen3.5-MoE, Qwen3Next, Nemotron-H-MoE, Mamba*),
+    // `pos_min` always covers the whole sequence, so `pos_min > pos_min_thold`
+    // is ALWAYS true on every turn, which forces a full prompt re-process
+    // (8 min instead of seconds on a 15K-token multi-turn chat).
+    // Skip the SWA-only logic for these models; their in-memory slot state is
+    // already preserved across turns by the normal update_slots path.
+    if (llama_model_has_recurrent(llama_get_model(slot.ctx))) return;
+
     llama_pos pos_next = slot.cache_tokens.pos_next(slot.n_past);
     const bool has_recurrent = llama_model_has_recurrent(llama_get_model(slot.ctx));
     // For hybrid/recurrent models, pos_min semantics don't apply: the recurrent state is a single


### PR DESCRIPTION
**Clean re-submission of #1689** per reviewer feedback (stripped to the single fix commit).

## Problem

\`server_context::apply_checkpoint\` was designed for Sliding Window Attention semantics. For hybrid/recurrent architectures (Qwen3.5, Qwen3.5-MoE, Qwen3Next, Nemotron-H-MoE, Mamba/Mamba-2), \`pos_min\` covers the whole sequence, so the \`pos_min > pos_min_thold\` gate is always true, the checkpoint search always fails, and we fall through to \`slot.n_past = 0\` — forcing a full prompt re-process on every turn.

On a 15K-token multi-turn chat this turns seconds into ~8 minutes.

## Fix

Early-return from \`apply_checkpoint\` when \`llama_model_has_recurrent()\` is true. This unified predicate (\`is_hybrid || is_recurrent\`) is already used in the same file for \`ctx_shift\` / \`can_ban_phrases\` disabling, so the pattern is idiomatic and the semantics match: SWA-only logic is skipped, the regular \`update_slots\` path (arch-agnostic) keeps the in-memory recurrent/hybrid slot state across turns.

## Scope

**1 commit, 1 file, 11 lines (incl. comment)**. \`examples/server/server-context.cpp\` only.

## Test plan

- [x] Multi-turn bench on Qwen3.5-35B-A3B (qwen35moe hybrid): turn-1 prefill ≈ full, turn-2 prefill < 2s (only the delta). Baseline: turn-2 ≈ turn-1.
- [x] Single-turn prompt on same model: no regression.
- [x] Dense model (non-hybrid): guard is false, unchanged behavior.
- [x] Log: "forcing full prompt re-processing" no longer appears on steady-state turns for recurrent/hybrid.

Leaves \`create_checkpoint_at_interval\` running so snapshot data is still collected for a future partial recurrent restore (when \`llama_state_seq_set_data(..., PARTIAL_ONLY)\` learns to cut recurrent memory).

Closes #20225
Supersedes #1689