### PR TITLE
ngram-mod: Reset i_last when low acceptance streak occurs

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -693,6 +693,7 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
 
                     mod.reset();
                     n_low = 0;
+                    i_last = 0;
                 }
             } else {
                 n_low = 0;


### PR DESCRIPTION
By resetting i_last to zero, we will include the current context when rebuilding the speculative map.

The existing behavior would skip the current context, thereby often losing the benefit of speculative decoding during later parts of the generation.

Port of my PR to mainline:
https://github.com/ggml-org/llama.cpp/pull/22168

Quick Benchmark on a 2x RTX 4000 Ada System with Qwen 3.6 35B-A3B:
`vllm bench serve --model Qwen/Qwen3.6-35B-A3B --host 127.0.0.1 --port 9876 --num-prompts 10 --dataset-name hf --dataset-path vdaita/edit_5k_char --backend openai-chat --endpoint '/v1/chat/completions' --max-concurrency 1`


Main without any spec decoding:
- Avg: 95.11 t/s 
- Peak: 102 t/s

Main with spec decoding (`--spec-type ngram-mod --spec-ngram-size-n 48 --draft-max 128 --draft-min 2`)
- Avg: 130.4 t/s
- Peak: 846 t/s

PR with spec decoding (same parameters):
- Avg: 142.82 t/s
- Peak: 926 t/s

At around 9% uplift the effect itself isn't exactly huge, but it helps especcially in cases where a low acceptance streak happens early on and then a bunch of repetition happens. 

---

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
