### PR TITLE
Enable CUDA graphs for AllReduce ops when possible

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4092,7 +4092,7 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_cuda_graph 
 
         if (ggml_is_noop(node)) continue;
 
-        if (node->op == GGML_OP_REDUCE) {
+        if (node->op == GGML_OP_REDUCE && !reduce_can_use_cuda_graphs(node)) {
             use_cuda_graph = false;
             break;
         }
@@ -4354,6 +4354,10 @@ GGML_CALL static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t
     // or previous graph capture failure.
     // Also disable for multi-gpu for now. TO DO investigate
     bool use_cuda_graph = !disable_cuda_graphs_due_to_env && cuda_ctx->use_cuda_graph;
+
+    if (use_cuda_graph && cgraph->n_nodes == 1 && cgraph->nodes[0]->op == GGML_OP_REDUCE) {
+        use_cuda_graph &= reduce_can_use_cuda_graphs(cgraph->nodes[0]);
+    }
 
     ggml_cuda_graph * graph = nullptr;
     if (use_cuda_graph) {

--- a/ggml/src/ggml-cuda/reduce.cu
+++ b/ggml/src/ggml-cuda/reduce.cu
@@ -117,6 +117,24 @@ static void copy_missing_tensors(ggml_backend_cuda_context & ctx, ggml_tensor * 
     ggml_cuda_set_device(ctx.device);
 }
 
+bool reduce_can_use_cuda_graphs([[maybe_unused]] ggml_tensor * dst) {
+#ifdef GGML_USE_NCCL
+#if __CUDA_ARCH__ >= CC_AMPERE
+    constexpr bool bf16_supported = true;
+#else
+    constexpr bool bf16_supported = false;
+#endif
+    int nreduce = dst->op_params[1];
+    int nhave   = dst->op_params[2];
+    auto & info = ggml_cuda_info();
+    if (info.have_nccl && dst->type != GGML_TYPE_Q8_0 && nhave == nreduce && (nhave == 2 || dst->ne[1] < 32) &&
+       (dst->type != GGML_TYPE_BF16 || bf16_supported) && info.device_count == nreduce) {
+        return true;
+    }
+#endif
+    return false;
+}
+
 void ggml_cuda_op_reduce([[maybe_unused]] ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     auto op = (ggml_op)dst->op_params[0];

--- a/ggml/src/ggml-cuda/reduce.cuh
+++ b/ggml/src/ggml-cuda/reduce.cuh
@@ -5,3 +5,5 @@
 void ggml_cuda_op_reduce(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_fake_cpy(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+bool reduce_can_use_cuda_graphs(ggml_tensor * dst);


### PR DESCRIPTION

On the main branch use of CUDA graphs gets disabled if the compute graph contains AllReduce ops (i.e., when using `-sm graph` and processing graph splits that contain AllReduce ops). I don't recall the details, but my guess is that I did that because we cannot use CUDA graphs without using NCCL.

This PR enables CUDA graphs use in the presence of AllReduce ops when possible. In the current state this is possible when
* `ik_llama.cpp` has been built with NCCL support
* Always when there are just 2 GPUs
* For 3+ GPUs when all GPUs participate in the AllReduce ops **and** the batch size is less than 32. Disabling the NCCL path for 3+ GPUs and batch sizes > 32 is based on the observation that the `ik_llama.cpp` own implementation is faster in that case.

We get non-negligible performance gains. Here some `sweep-bench` examples on a 2x3090 system

## Qwen-3.6-27B-Q8_0

### PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.745 |  2747.69 |    2.457 |    52.11 |
|  2048 |    128 |   2048 |    0.740 |  2768.13 |    2.457 |    52.10 |
|  2048 |    128 |   4096 |    0.739 |  2770.72 |    2.479 |    51.62 |
|  2048 |    128 |   6144 |    0.761 |  2690.14 |    2.493 |    51.35 |
|  2048 |    128 |   8192 |    0.818 |  2503.51 |    2.504 |    51.12 |
|  2048 |    128 |  10240 |    0.830 |  2468.95 |    2.520 |    50.79 |
|  2048 |    128 |  12288 |    0.843 |  2429.27 |    2.535 |    50.50 |
|  2048 |    128 |  14336 |    0.855 |  2395.84 |    2.550 |    50.19 |
|  2048 |    128 |  16384 |    0.867 |  2363.48 |    2.586 |    49.49 |
|  2048 |    128 |  18432 |    0.879 |  2328.79 |    2.591 |    49.39 |
|  2048 |    128 |  20480 |    0.893 |  2293.78 |    2.608 |    49.08 |
|  2048 |    128 |  22528 |    0.905 |  2262.75 |    2.617 |    48.91 |
|  2048 |    128 |  24576 |    0.920 |  2226.75 |    2.623 |    48.80 |
|  2048 |    128 |  26624 |    0.930 |  2201.74 |    2.633 |    48.62 |
|  2048 |    128 |  28672 |    0.944 |  2170.51 |    2.641 |    48.47 |
|  2048 |    128 |  30720 |    0.955 |  2144.34 |    2.651 |    48.28 |
|  2048 |    128 |  32768 |    0.966 |  2120.62 |    2.682 |    47.73 |
|  2048 |    128 |  34816 |    0.980 |  2090.18 |    2.689 |    47.60 |
|  2048 |    128 |  36864 |    0.992 |  2064.23 |    2.706 |    47.31 |
|  2048 |    128 |  38912 |    1.008 |  2032.04 |    2.714 |    47.16 |
|  2048 |    128 |  40960 |    1.016 |  2015.79 |    2.720 |    47.06 |
|  2048 |    128 |  43008 |    1.031 |  1987.11 |    2.730 |    46.89 |
|  2048 |    128 |  45056 |    1.045 |  1960.42 |    2.740 |    46.71 |
|  2048 |    128 |  47104 |    1.058 |  1936.09 |    2.750 |    46.54 |
|  2048 |    128 |  49152 |    1.069 |  1916.67 |    2.786 |    45.94 |
|  2048 |    128 |  51200 |    1.085 |  1887.96 |    2.789 |    45.90 |
|  2048 |    128 |  53248 |    1.101 |  1860.19 |    2.806 |    45.61 |
|  2048 |    128 |  55296 |    1.112 |  1842.35 |    2.816 |    45.45 |
|  2048 |    128 |  57344 |    1.128 |  1816.12 |    2.824 |    45.33 |
|  2048 |    128 |  59392 |    1.141 |  1794.78 |    2.831 |    45.22 |
|  2048 |    128 |  61440 |    1.158 |  1768.41 |    2.846 |    44.97 |
|  2048 |    128 |  63488 |    1.167 |  1755.43 |    2.857 |    44.81 |

### Main branch 

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.840 |  2437.01 |    2.670 |    47.94 |
|  2048 |    128 |   2048 |    0.844 |  2425.68 |    2.664 |    48.06 |
|  2048 |    128 |   4096 |    0.832 |  2460.49 |    2.687 |    47.63 |
|  2048 |    128 |   6144 |    0.845 |  2422.91 |    2.703 |    47.35 |
|  2048 |    128 |   8192 |    0.859 |  2382.94 |    2.713 |    47.17 |
|  2048 |    128 |  10240 |    0.871 |  2352.22 |    2.728 |    46.92 |
|  2048 |    128 |  12288 |    0.884 |  2317.99 |    2.742 |    46.68 |
|  2048 |    128 |  14336 |    0.897 |  2284.16 |    2.757 |    46.43 |
|  2048 |    128 |  16384 |    0.909 |  2252.89 |    2.793 |    45.82 |
|  2048 |    128 |  18432 |    0.921 |  2223.50 |    2.800 |    45.71 |
|  2048 |    128 |  20480 |    0.934 |  2192.76 |    2.816 |    45.46 |
|  2048 |    128 |  22528 |    0.945 |  2167.65 |    2.824 |    45.32 |
|  2048 |    128 |  24576 |    0.961 |  2130.70 |    2.830 |    45.22 |
|  2048 |    128 |  26624 |    0.975 |  2101.09 |    2.842 |    45.03 |
|  2048 |    128 |  28672 |    0.987 |  2074.47 |    2.850 |    44.92 |
|  2048 |    128 |  30720 |    1.000 |  2048.62 |    2.861 |    44.74 |
|  2048 |    128 |  32768 |    1.013 |  2022.52 |    2.890 |    44.29 |
|  2048 |    128 |  34816 |    1.026 |  1996.40 |    2.898 |    44.16 |
|  2048 |    128 |  36864 |    1.038 |  1972.83 |    2.917 |    43.88 |
|  2048 |    128 |  38912 |    1.050 |  1949.75 |    2.923 |    43.80 |
|  2048 |    128 |  40960 |    1.063 |  1926.07 |    2.928 |    43.71 |
|  2048 |    128 |  43008 |    1.077 |  1901.43 |    2.938 |    43.56 |
|  2048 |    128 |  45056 |    1.089 |  1880.09 |    2.948 |    43.42 |
|  2048 |    128 |  47104 |    1.103 |  1857.17 |    2.957 |    43.28 |
|  2048 |    128 |  49152 |    1.116 |  1834.52 |    2.995 |    42.74 |
|  2048 |    128 |  51200 |    1.128 |  1815.02 |    3.000 |    42.67 |
|  2048 |    128 |  53248 |    1.143 |  1791.92 |    3.017 |    42.43 |
|  2048 |    128 |  55296 |    1.158 |  1767.99 |    3.028 |    42.27 |
|  2048 |    128 |  57344 |    1.172 |  1748.01 |    3.040 |    42.11 |
|  2048 |    128 |  59392 |    1.186 |  1727.07 |    3.051 |    41.95 |
|  2048 |    128 |  61440 |    1.200 |  1706.81 |    3.064 |    41.77 |
|  2048 |    128 |  63488 |    1.214 |  1687.52 |    3.075 |    41.62 |


## Qwen3.5-35B-A3B IQ4_XS

### PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.318 |  6444.67 |    0.727 |   175.98 |
|  2048 |    128 |   2048 |    0.274 |  7486.31 |    0.720 |   177.81 |
|  2048 |    128 |   4096 |    0.265 |  7725.68 |    0.724 |   176.72 |
|  2048 |    128 |   6144 |    0.280 |  7325.72 |    0.725 |   176.46 |
|  2048 |    128 |   8192 |    0.294 |  6969.42 |    0.730 |   175.23 |
|  2048 |    128 |  10240 |    0.299 |  6838.25 |    0.736 |   173.99 |
|  2048 |    128 |  12288 |    0.305 |  6718.54 |    0.741 |   172.77 |
|  2048 |    128 |  14336 |    0.311 |  6583.54 |    0.749 |   170.97 |
|  2048 |    128 |  16384 |    0.317 |  6463.61 |    0.756 |   169.42 |
|  2048 |    128 |  18432 |    0.324 |  6329.80 |    0.764 |   167.57 |
|  2048 |    128 |  20480 |    0.329 |  6233.17 |    0.772 |   165.87 |
|  2048 |    128 |  22528 |    0.335 |  6118.89 |    0.788 |   162.40 |
|  2048 |    128 |  24576 |    0.340 |  6020.15 |    0.791 |   161.87 |
|  2048 |    128 |  26624 |    0.346 |  5921.95 |    0.793 |   161.35 |
|  2048 |    128 |  28672 |    0.352 |  5821.65 |    0.797 |   160.59 |
|  2048 |    128 |  30720 |    0.359 |  5700.61 |    0.802 |   159.58 |
|  2048 |    128 |  32768 |    0.365 |  5611.79 |    0.807 |   158.55 |
|  2048 |    128 |  34816 |    0.371 |  5519.32 |    0.811 |   157.82 |
|  2048 |    128 |  36864 |    0.377 |  5436.01 |    0.816 |   156.85 |
|  2048 |    128 |  38912 |    0.383 |  5353.76 |    0.821 |   155.90 |
|  2048 |    128 |  40960 |    0.389 |  5271.54 |    0.826 |   154.87 |
|  2048 |    128 |  43008 |    0.395 |  5186.77 |    0.844 |   151.68 |
|  2048 |    128 |  45056 |    0.401 |  5107.95 |    0.848 |   150.97 |
|  2048 |    128 |  47104 |    0.407 |  5033.23 |    0.852 |   150.20 |
|  2048 |    128 |  49152 |    0.413 |  4964.35 |    0.855 |   149.63 |
|  2048 |    128 |  51200 |    0.420 |  4878.51 |    0.860 |   148.83 |
|  2048 |    128 |  53248 |    0.425 |  4816.43 |    0.864 |   148.07 |
|  2048 |    128 |  55296 |    0.432 |  4737.56 |    0.870 |   147.05 |
|  2048 |    128 |  57344 |    0.435 |  4704.66 |    0.875 |   146.29 |
|  2048 |    128 |  59392 |    0.442 |  4631.21 |    0.880 |   145.46 |
|  2048 |    128 |  61440 |    0.450 |  4553.16 |    0.886 |   144.42 |
|  2048 |    128 |  63488 |    0.455 |  4502.31 |    0.904 |   141.58 |

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.366 |  5601.98 |    0.834 |   153.49 |
|  2048 |    128 |   2048 |    0.320 |  6390.29 |    0.833 |   153.60 |
|  2048 |    128 |   4096 |    0.311 |  6594.26 |    0.840 |   152.43 |
|  2048 |    128 |   6144 |    0.316 |  6481.73 |    0.842 |   152.01 |
|  2048 |    128 |   8192 |    0.322 |  6351.79 |    0.847 |   151.17 |
|  2048 |    128 |  10240 |    0.328 |  6243.12 |    0.852 |   150.26 |
|  2048 |    128 |  12288 |    0.333 |  6142.77 |    0.858 |   149.21 |
|  2048 |    128 |  14336 |    0.340 |  6029.97 |    0.865 |   147.92 |
|  2048 |    128 |  16384 |    0.346 |  5926.44 |    0.872 |   146.72 |
|  2048 |    128 |  18432 |    0.352 |  5825.05 |    0.880 |   145.49 |
|  2048 |    128 |  20480 |    0.357 |  5732.50 |    0.887 |   144.29 |
|  2048 |    128 |  22528 |    0.363 |  5643.27 |    0.904 |   141.60 |
|  2048 |    128 |  24576 |    0.368 |  5558.48 |    0.906 |   141.25 |
|  2048 |    128 |  26624 |    0.375 |  5465.15 |    0.909 |   140.84 |
|  2048 |    128 |  28672 |    0.382 |  5363.08 |    0.912 |   140.40 |
|  2048 |    128 |  30720 |    0.388 |  5282.04 |    0.916 |   139.76 |
|  2048 |    128 |  32768 |    0.393 |  5207.18 |    0.921 |   138.99 |
|  2048 |    128 |  34816 |    0.400 |  5122.59 |    0.923 |   138.61 |
|  2048 |    128 |  36864 |    0.405 |  5056.81 |    0.929 |   137.75 |
|  2048 |    128 |  38912 |    0.412 |  4966.49 |    0.940 |   136.14 |
|  2048 |    128 |  40960 |    0.420 |  4881.15 |    0.942 |   135.92 |
|  2048 |    128 |  43008 |    0.426 |  4807.64 |    0.963 |   132.99 |
|  2048 |    128 |  45056 |    0.428 |  4790.34 |    0.963 |   132.88 |
|  2048 |    128 |  47104 |    0.435 |  4703.95 |    0.965 |   132.59 |
|  2048 |    128 |  49152 |    0.442 |  4631.93 |    0.968 |   132.25 |
|  2048 |    128 |  51200 |    0.448 |  4566.52 |    0.973 |   131.57 |
|  2048 |    128 |  53248 |    0.454 |  4508.33 |    0.977 |   131.06 |
|  2048 |    128 |  55296 |    0.462 |  4431.92 |    0.984 |   130.11 |
|  2048 |    128 |  57344 |    0.469 |  4367.18 |    0.994 |   128.83 |
|  2048 |    128 |  59392 |    0.474 |  4318.42 |    0.996 |   128.55 |
|  2048 |    128 |  61440 |    0.481 |  4253.52 |    1.001 |   127.93 |
|  2048 |    128 |  63488 |    0.489 |  4191.61 |    1.019 |   125.59 |

## GPT-OSS-20B MXFP4

### PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.217 |  9433.48 |    0.429 |   298.07 |
|  2048 |    128 |   2048 |    0.174 | 11801.86 |    0.443 |   288.71 |
|  2048 |    128 |   4096 |    0.181 | 11334.52 |    0.450 |   284.54 |
|  2048 |    128 |   6144 |    0.232 |  8831.05 |    0.462 |   276.77 |
|  2048 |    128 |   8192 |    0.228 |  8980.88 |    0.465 |   275.39 |
|  2048 |    128 |  10240 |    0.236 |  8690.97 |    0.472 |   271.25 |
|  2048 |    128 |  12288 |    0.244 |  8398.74 |    0.481 |   265.85 |
|  2048 |    128 |  14336 |    0.251 |  8153.77 |    0.484 |   264.46 |
|  2048 |    128 |  16384 |    0.257 |  7958.00 |    0.493 |   259.41 |
|  2048 |    128 |  18432 |    0.260 |  7884.87 |    0.495 |   258.60 |
|  2048 |    128 |  20480 |    0.266 |  7685.35 |    0.497 |   257.45 |
|  2048 |    128 |  22528 |    0.274 |  7476.04 |    0.510 |   251.07 |
|  2048 |    128 |  24576 |    0.281 |  7285.56 |    0.513 |   249.57 |
|  2048 |    128 |  26624 |    0.291 |  7027.42 |    0.522 |   245.14 |
|  2048 |    128 |  28672 |    0.298 |  6877.31 |    0.531 |   240.96 |
|  2048 |    128 |  30720 |    0.305 |  6724.39 |    0.534 |   239.73 |
|  2048 |    128 |  32768 |    0.306 |  6695.02 |    0.543 |   235.89 |
|  2048 |    128 |  34816 |    0.319 |  6418.33 |    0.545 |   234.69 |
|  2048 |    128 |  36864 |    0.325 |  6295.40 |    0.560 |   228.42 |
|  2048 |    128 |  38912 |    0.331 |  6186.84 |    0.565 |   226.40 |
|  2048 |    128 |  40960 |    0.338 |  6059.40 |    0.569 |   225.04 |
|  2048 |    128 |  43008 |    0.345 |  5941.62 |    0.581 |   220.18 |
|  2048 |    128 |  45056 |    0.350 |  5847.80 |    0.586 |   218.60 |
|  2048 |    128 |  47104 |    0.356 |  5754.30 |    0.591 |   216.50 |
|  2048 |    128 |  49152 |    0.362 |  5653.52 |    0.596 |   214.63 |
|  2048 |    128 |  51200 |    0.372 |  5504.83 |    0.608 |   210.64 |
|  2048 |    128 |  53248 |    0.379 |  5410.13 |    0.620 |   206.49 |
|  2048 |    128 |  55296 |    0.382 |  5367.82 |    0.625 |   204.96 |
|  2048 |    128 |  57344 |    0.388 |  5280.26 |    0.625 |   204.68 |
|  2048 |    128 |  59392 |    0.395 |  5187.32 |    0.637 |   200.92 |
|  2048 |    128 |  61440 |    0.406 |  5048.96 |    0.641 |   199.59 |
|  2048 |    128 |  63488 |    0.415 |  4930.13 |    0.661 |   193.63 |

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.291 |  7048.53 |    0.499 |   256.28 |
|  2048 |    128 |   2048 |    0.233 |  8785.33 |    0.518 |   246.94 |
|  2048 |    128 |   4096 |    0.238 |  8618.69 |    0.521 |   245.46 |
|  2048 |    128 |   6144 |    0.241 |  8512.30 |    0.534 |   239.68 |
|  2048 |    128 |   8192 |    0.246 |  8329.84 |    0.534 |   239.76 |
|  2048 |    128 |  10240 |    0.258 |  7946.76 |    0.542 |   235.97 |
|  2048 |    128 |  12288 |    0.265 |  7730.61 |    0.556 |   230.28 |
|  2048 |    128 |  14336 |    0.270 |  7587.55 |    0.558 |   229.33 |
|  2048 |    128 |  16384 |    0.273 |  7498.54 |    0.566 |   226.34 |
|  2048 |    128 |  18432 |    0.280 |  7323.65 |    0.568 |   225.38 |
|  2048 |    128 |  20480 |    0.286 |  7156.76 |    0.572 |   223.95 |
|  2048 |    128 |  22528 |    0.293 |  6996.61 |    0.584 |   219.33 |
|  2048 |    128 |  24576 |    0.299 |  6845.56 |    0.587 |   218.07 |
|  2048 |    128 |  26624 |    0.306 |  6695.57 |    0.597 |   214.44 |
|  2048 |    128 |  28672 |    0.312 |  6566.90 |    0.601 |   213.10 |
|  2048 |    128 |  30720 |    0.318 |  6441.18 |    0.603 |   212.12 |
|  2048 |    128 |  32768 |    0.324 |  6315.55 |    0.616 |   207.80 |
|  2048 |    128 |  34816 |    0.331 |  6181.20 |    0.620 |   206.45 |
|  2048 |    128 |  36864 |    0.338 |  6058.35 |    0.630 |   203.30 |
|  2048 |    128 |  38912 |    0.349 |  5871.83 |    0.635 |   201.51 |
|  2048 |    128 |  40960 |    0.356 |  5747.13 |    0.646 |   198.00 |
|  2048 |    128 |  43008 |    0.363 |  5642.81 |    0.658 |   194.60 |
|  2048 |    128 |  45056 |    0.369 |  5555.34 |    0.659 |   194.11 |
|  2048 |    128 |  47104 |    0.376 |  5439.62 |    0.670 |   191.10 |
|  2048 |    128 |  49152 |    0.382 |  5359.97 |    0.678 |   188.67 |
|  2048 |    128 |  51200 |    0.389 |  5258.58 |    0.684 |   187.22 |
|  2048 |    128 |  53248 |    0.397 |  5156.44 |    0.693 |   184.74 |
|  2048 |    128 |  55296 |    0.405 |  5062.56 |    0.701 |   182.49 |
|  2048 |    128 |  57344 |    0.405 |  5054.06 |    0.706 |   181.39 |
|  2048 |    128 |  59392 |    0.417 |  4915.22 |    0.713 |   179.61 |
|  2048 |    128 |  61440 |    0.425 |  4819.61 |    0.724 |   176.87 |
|  2048 |    128 |  63488 |    0.437 |  4681.58 |    0.737 |   173.77 |
