### PR TITLE
perplexity : fix large-vocab logit offset overflow

### DIFF
--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -207,7 +207,9 @@ static void process_logits(std::ostream& out, int n_vocab, const float * logits,
                 break;
             }
             lock.unlock();
-            const double v = log_softmax(n_vocab, logits + i*n_vocab, log_probs.data() + int64_t(i)*nv, tokens[i+1]);
+            const size_t logits_offset = size_t(i)*size_t(n_vocab);
+            const size_t probs_offset  = size_t(i)*size_t(nv);
+            const double v = log_softmax(n_vocab, logits + logits_offset, log_probs.data() + probs_offset, tokens[i+1]);
             local_nll += v;
             local_nll2 += v*v;
         }
@@ -453,9 +455,11 @@ static results_perplexity perplexity_v2(llama_context * ctx, const gpt_params & 
         for (int j = n_ctx - params.ppl_stride - 1; j < n_ctx - 1; ++j) {
 
             // Calculate probability of next token, given the previous ones.
+            const size_t offset = size_t(j)*size_t(n_vocab);
+            const float * tok_logits_begin = logits.data() + offset;
             const std::vector<float> tok_logits(
-                logits.begin() + (j + 0) * n_vocab,
-                logits.begin() + (j + 1) * n_vocab);
+                tok_logits_begin,
+                tok_logits_begin + n_vocab);
 
             const float prob = softmax(tok_logits)[tokens[start + j + 1]];
             logit_history[start + j + 1] = tok_logits[tokens[start + j + 1]];


### PR DESCRIPTION
# perplexity : fix large-vocab logit offset overflow

## Summary

This fixes integer overflow in `llama-perplexity` when computing logit offsets for large-context, large-vocabulary models.

In `perplexity_v2()`, expressions such as `j * n_vocab` and `i * n_vocab` were evaluated with `int` operands. For models with very large vocabularies, these products can exceed the signed 32-bit integer range at larger context sizes. When that happens, the offset can wrap before it is used to index into the logits buffer, producing an invalid iterator and potentially crashing while constructing `tok_logits`.

The fix performs the offset arithmetic as `size_t` before applying the offset to the logits buffer.

## Details

One reproduced failure used Qwen3.5-122B-A10B GGUF with the following runtime values:

```text
n_ctx       = 12544
ppl_stride  = 512
n_vocab     = 248320
logits.size = 3114926080
```

For the first affected loop iteration:

```text
j = n_ctx - ppl_stride - 1 = 12031
```

The expected offset is:

```text
12031 * 248320 = 2987537920
```

This value does not fit in a signed 32-bit `int`. If the multiplication is evaluated as `int`, the result can overflow before being used to slice the logits vector.

The patch changes the affected offset calculations to use explicit `size_t` multiplication, then uses those offsets for pointer arithmetic.

No new assertions or extra control flow are added, keeping the change minimal and localized.

## Checklist

* [x] I have read the [[contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
* Self-reported review complexity:

  * [x] Low
  * [ ] Medium
  * [ ] High