### PR TITLE
speculative: keep MTP draft hidden state alive across steps

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1374,6 +1374,8 @@ std::vector<llama_token> mtp_speculative_gen_draft(
 
     llama_token current_input_id = id_last;
     int32_t current_n_past = n_past;
+    const int n_embd = llama_model_n_embd(llama_get_model(ctx));
+    std::vector<float> draft_hidden_state(n_embd);
 
     for (int i = 0; i < n_draft; ++i) {
         mtp_batch.n_tokens = 0;
@@ -1389,9 +1391,13 @@ std::vector<llama_token> mtp_speculative_gen_draft(
         drafts.push_back(id_next);
 
         const float * emb = llama_get_embeddings_ith(ctx, 0);
-        if (emb) {
-            llama_set_draft_input_hidden_state(ctx, emb);
+        if (!emb) {
+            break;
         }
+        
+        // Keep a stable copy because later decode steps reuse ctx->embd storage.
+        memcpy(draft_hidden_state.data(), emb, n_embd * sizeof(float));
+        llama_set_draft_input_hidden_state(ctx, draft_hidden_state.data());
 
         current_input_id = id_next;
         current_n_past++;


### PR DESCRIPTION
This PR fixes hidden-state lifetime in MTP speculative decoding.

During multi-step drafting, the code passed a pointer into `ctx->embd` back into the next draft step. That storage can be reused by later decode calls, so later draft tokens could be generated from stale/overwritten hidden states. This patch copies the hidden state into stable storage before feeding it back into MTP.

I observe a performance and acceptance uplift for `--draft-max > 1`, where later draft steps consume the previous draft hidden state. `--draft-max 1` is basically unchanged.

For the table below, I used the prompts and model from #1698.

Command:
```
GGML_CUDA_NO_PINNED=1 ./llama-server \
    -m ~/.../Qwen3.6-27B-MTP-Q8_0.gguf \
    -c 4096 -ngl 12 \ 
    --temp 0.0 \
    -mtp --draft-max N --draft-p-min 0.0
```

| Task | No MTP | main d=1 | this PR d=1 | main d=2 | this PR d=2 |
|---|---:|---:|---:|---:|---:|
| Code (t=0) | 2.71 t/s | 3.90 t/s @ 93% | 3.93 t/s @ 93% | 2.67 t/s @ 61% | 4.45 t/s @ 85% |
| Extract (t=0) | 2.89 t/s | 4.50 t/s @ 97% | 4.39 t/s @ 97% | 2.84 t/s @ 60% | 6.14 t/s @ 98% |

`--draft-max 2` uplift vs main:

| Task | Throughput uplift | Acceptance uplift |
|---|---:|---:|
| Code (t=0) | x1.67 | +24 pp |
| Extract (t=0) | x2.16 | +38 pp |

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
