### PR TITLE
server : catch sampler/grammar exceptions to avoid process abort (#1725)

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3830,7 +3830,22 @@ void server_context::speculative_decoding_accept() {
         apply_server_biases(slot);
 
         // the accepted tokens from the speculation
-        const auto ids = common_sampler_sample_and_accept_n(slot.ctx_sampling, ctx, slot.i_batch_dft, slot.drafted);
+        std::vector<llama_token> ids;
+        try {
+            ids = common_sampler_sample_and_accept_n(slot.ctx_sampling, ctx, slot.i_batch_dft, slot.drafted);
+        } catch (const std::exception & e) {
+            LOG_ERROR("speculative sampling failed, releasing slot", {
+                {"id_slot", slot.id},
+                {"id_task", slot.id_task},
+                {"error", e.what()},
+            });
+            send_error(slot, std::string("sampling error: ") + e.what(), ERROR_TYPE_SERVER);
+            slot.release();
+            slot.i_batch = -1;
+            slot.i_batch_dft.clear();
+            slot.drafted.clear();
+            continue;
+        }
 
         int32_t mtp_n_past_base = 0;
         std::vector<float> mtp_hidden_state_pre;
@@ -4340,9 +4355,21 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
 
             apply_server_biases(slot);
 
-            const llama_token id = common_sampler_sample(slot.ctx_sampling, ctx, tok_idx);
-
-            common_sampler_accept(slot.ctx_sampling, ctx, id, true);
+            llama_token id;
+            try {
+                id = common_sampler_sample(slot.ctx_sampling, ctx, tok_idx);
+                common_sampler_accept(slot.ctx_sampling, ctx, id, true);
+            } catch (const std::exception & e) {
+                LOG_ERROR("sampling failed, releasing slot", {
+                    {"id_slot", slot.id},
+                    {"id_task", slot.id_task},
+                    {"error", e.what()},
+                });
+                send_error(slot, std::string("sampling error: ") + e.what(), ERROR_TYPE_SERVER);
+                slot.release();
+                slot.i_batch = -1;
+                continue;
+            }
 
             slot.n_decoded += 1;
             const int64_t t_current = ggml_time_us();


### PR DESCRIPTION
Closes #1725.

## Summary

When `llama_grammar_accept_token` throws (`src/llama-grammar.cpp:1508`,
`Unexpected empty grammar stack after accepting piece: …`) during
generation, the exception unwinds out of
`server_context::process_batch_tokens` /
`speculative_decoding_accept` → `update_slots` →
`server_queue::start_loop` → `main`, hits `std::terminate`, and aborts
the entire `llama-server` process. This drops every in-flight request
and forces a manual restart.

This PR wraps the two slot-level sample/accept call sites that can hit
grammar acceptance in `try/catch (std::exception)`. On exception we
log the failure, `send_error` to the requesting task, release the
slot, and continue serving. The pattern matches the existing
`try/catch` around `common_sampler_init`
(`examples/server/server-context.cpp:1659-1670`) in the same file.

This does **not** attempt to fix the underlying cause of the empty
grammar stack (suspected: post-`kv_cache_seq_add` logits collapsing on
quantized KV + flash-attn, or a JSON-schema dead-end where every
candidate is masked to `-INF` and EOG is also blocked). That is left
for a follow-up; see the discussion in #1725. The PR's only goal is
to keep the server alive when the grammar layer asserts.

## Trigger

- Gemma 4 (`<pad>` at id 0, not in EOG list) + strict
  `response_format=json_schema` + `cache_type_k=q8_0` + flash-attn +
  ctx_shift firing during generation. See #1725 for the journal trace
  and the configuration that reproduced the abort.
- The bug is non-deterministic: in a 10-conversation Engram bakeoff
  it hit on the third conversation; in a separate 10-conversation
  smoke three `[context_shift]` events fired cleanly without the
  throw.

## What changed

`examples/server/server-context.cpp` (+31 / -4):

- Wrap the main-path `common_sampler_sample` /
  `common_sampler_accept` call in `process_batch_tokens` (around line
  4358) in a try/catch. On `std::exception`: `LOG_ERROR`,
  `send_error(slot, …, ERROR_TYPE_SERVER)`, `slot.release()`,
  `slot.i_batch = -1`, `continue` to the next slot.
- Same pattern around `common_sampler_sample_and_accept_n` in
  `speculative_decoding_accept` (around line 3833), additionally
  clearing `slot.i_batch_dft` / `slot.drafted` so the slot can
  re-enter cleanly.

No new dependencies, no new headers, no new files. Indentation and
brace style match surrounding code.

## Validation

- Clean build of `llama-server` against `4447 a8aecbf1` with the
  patch applied.
- **Pre-patch behavior**: documented `terminate called after throwing
  std::runtime_error … what(): Unexpected empty grammar stack after
  accepting piece: <pad> (0)` from a real Engram Phase 2 run on the
  configuration described in #1725. Process aborted, in-flight
  requests dropped.
- **Post-patch happy-path validation**: same launch profile,
  10-conversation smoke. Three `[context_shift]` events across two
  tasks; all three released cleanly with `truncated=true` and
  `status=200 method="POST" path="/v1/chat/completions"`. Server
  PID stable across the run. Confirms the patch does not regress the
  normal ctx_shift path.
- **Post-patch catch-path**: not yet exercised — the throw is
  content-/state-dependent and did not fire in the smoke. The fix is
  justified independent of that exercise: the throw is reachable per
  the journal trace, the catch is conservative, and the same
  try/catch shape is already in use a few hundred lines above. Happy
  to leave it open for a longer soak if a maintainer wants stronger
  evidence before merging.

## Risk

Low. The catch is scoped narrowly to the sample/accept call. The only
behavior change on the happy path is one extra try-frame; on the
unhappy path we now release the slot and emit an HTTP error instead
of calling `std::terminate`.

## Checklist

- [x] I have read the contributing guidelines
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
