### PR TITLE
Add Expiring Logit Bias

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -4796,7 +4796,6 @@ void argparse_expiring_logit_bias(const std::string& content, common_params_samp
                 const auto cpos = line.find(':');
                 if ((cpos != std::string::npos) && (1 < cpos) && (cpos < qqpos)) {
                     auto sub = line.substr(1, cpos - 1);
-                    string_strip(sub);
                     duration = std::stoi(sub);
                 }
                 if (duration == 0) {
@@ -4824,15 +4823,26 @@ void argparse_expiring_logit_bias(const std::string& content, common_params_samp
                     continue;   // next line
                 }
 
-                // (... : BIAS, ..., BIAS)
+                // (... : BIAS ...)
                 std::vector<float> biases;
+                bool is_range = false;
                 const auto rcpos = line.rfind(':');
                 if ((rcpos != std::string::npos) && (line.rfind('"') < rcpos)) {
                     auto sub = line.substr(rcpos + 1, n_char - rcpos - 2);
-                    for (auto split: string_split(sub, ',')) {
-                        string_strip(split);
-                        if (!split.empty()) {
-                            biases.push_back(std::stof(split));
+                    if (sub.find("~") != std::string::npos) {
+                        // (... : BIAS ~ BIAS)
+                        const auto splits = string_split(sub, '~');
+                        auto split = splits.front();
+                        biases.push_back(std::stof(split));
+                        split = splits.back();
+                        biases.push_back(std::stof(split));
+                        is_range = true;
+                    } else {
+                        // (... : BIAS, BIAS, ..., BIAS)
+                        for (auto split: string_split(sub, ',')) {
+                            if (!split.empty()) {
+                                biases.push_back(std::stof(split));
+                            }
                         }
                     }
                 }
@@ -4845,7 +4855,7 @@ void argparse_expiring_logit_bias(const std::string& content, common_params_samp
                     saved_phrases = std::move(phrases);
                     saved_biases = std::move(biases);
                 } else {
-                    elb_params.back().entries.push_back({ std::move(phrases), std::move(biases), duration });
+                    elb_params.back().entries.push_back({ std::move(phrases), std::move(biases), duration, is_range });
                 }
                 continue;   // next line
             }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -4760,9 +4760,10 @@ std::tuple<uint32_t, uint32_t, std::string, float> argparse_allowlist_unicode_ru
 void argparse_expiring_logit_bias(const std::string& content, common_params_sampling& sparams) {
     decltype(sparams.elb_params) elb_params = { { { }, "" } };
 
-    int32_t saved_duration;
+    int32_t saved_duration = 0;
     std::vector<std::string> saved_phrases;
     std::vector<float> saved_biases;
+    bool saved_is_range = false;
 
     for (auto line: string_split(content, "\n")) {
         string_strip(line);
@@ -4854,6 +4855,7 @@ void argparse_expiring_logit_bias(const std::string& content, common_params_samp
                     saved_duration = duration;
                     saved_phrases = std::move(phrases);
                     saved_biases = std::move(biases);
+                    saved_is_range = is_range;
                 } else {
                     elb_params.back().entries.push_back({ std::move(phrases), std::move(biases), duration, is_range });
                 }
@@ -4867,7 +4869,9 @@ void argparse_expiring_logit_bias(const std::string& content, common_params_samp
         }
         string_process_escapes(line);
         elb_params.back().exitword = std::move(line);
-        elb_params.back().entries.push_back({ saved_phrases, saved_biases, saved_duration });
+        if (!saved_phrases.empty() && !saved_biases.empty() && (saved_duration != 0)) {
+            elb_params.back().entries.push_back({ saved_phrases, saved_biases, saved_duration, saved_is_range });
+        }
         elb_params.push_back({ { }, "" });
     }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1781,6 +1781,12 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.allow_kw_delay = std::stoul(argv[i]);
         return true;
     }
+    if (arg == "--expiring-logit-bias-file") {
+        CHECK_ARG
+        std::string content = read_file(argv[i]);
+        argparse_expiring_logit_bias(content, sparams);
+        return true;
+    }
     if (arg == "-ld" || arg == "--logdir") {
         CHECK_ARG
         params.logdir = argv[i];
@@ -4749,4 +4755,111 @@ std::tuple<uint32_t, uint32_t, std::string, float> argparse_allowlist_unicode_ru
     }
 
     return { std::min(first, last), std::max(first, last), script, bias };
+}
+
+void argparse_expiring_logit_bias(const std::string& content, common_params_sampling& sparams) {
+    decltype(sparams.elb_params) elb_params = { { { }, "" } };
+
+    int32_t saved_duration;
+    std::vector<std::string> saved_phrases;
+    std::vector<float> saved_biases;
+
+    for (auto line: string_split(content, "\n")) {
+        string_strip(line);
+        const char c0 = line.empty() ? '#' : line[0];
+        if (c0 == '#') {
+            // comment
+            continue;   // next line
+        }
+
+        auto n_char = line.length();
+        const char cE = line[n_char - 1];
+
+        if (n_char > 1) {
+            if ('(' == c0 && cE == ')') {
+                const bool is_nested = '(' == line[1] && line[n_char - 2] == ')';
+                if (is_nested) {
+                    if (n_char == 4) {
+                        // (())
+                        saved_phrases.clear();
+                        saved_biases.clear();
+                        continue;   // next line
+                    }
+                    n_char -= 2;
+                    line = line.substr(1, n_char);
+                }
+
+                auto qqpos = line.find('"');
+
+                // (DURATION : ...)
+                int32_t duration = is_nested ? -1 : 1;
+                const auto cpos = line.find(':');
+                if ((cpos != std::string::npos) && (1 < cpos) && (cpos < qqpos)) {
+                    auto sub = line.substr(1, cpos - 1);
+                    string_strip(sub);
+                    duration = std::stoi(sub);
+                }
+                if (duration == 0) {
+                    continue;   // next line
+                }
+
+                // (... "PHRASE" ... "PHRASE" ...)
+                std::vector<std::string> phrases;
+                auto pos = line.find('"', qqpos + 1);
+                while (pos != std::string::npos) {
+                    if (line[pos - 1] == '\\') {
+                        pos = line.find('"', pos + 1);
+                    } else {
+                        auto phrase = line.substr(qqpos + 1, pos - qqpos - 1);
+                        string_process_escapes(phrase);
+                        phrases.push_back(std::move(phrase));
+                        qqpos = line.find('"', pos + 1);
+                        if (qqpos == std::string::npos) {
+                            break;
+                        }
+                        pos = line.find('"', qqpos + 1);
+                    }
+                }
+                if (phrases.empty()) {
+                    continue;   // next line
+                }
+
+                // (... : BIAS, ..., BIAS)
+                std::vector<float> biases;
+                const auto rcpos = line.rfind(':');
+                if ((rcpos != std::string::npos) && (line.rfind('"') < rcpos)) {
+                    auto sub = line.substr(rcpos + 1, n_char - rcpos - 2);
+                    for (auto split: string_split(sub, ',')) {
+                        string_strip(split);
+                        if (!split.empty()) {
+                            biases.push_back(std::stof(split));
+                        }
+                    }
+                }
+                if (biases.empty()) {
+                    continue;   // next line
+                }
+
+                if (is_nested) {
+                    saved_duration = duration;
+                    saved_phrases = std::move(phrases);
+                    saved_biases = std::move(biases);
+                } else {
+                    elb_params.back().entries.push_back({ std::move(phrases), std::move(biases), duration });
+                }
+                continue;   // next line
+            }
+        }
+
+        // exitword
+        if ('"' == c0 && cE == '"') {
+            line = line.substr(1, n_char - 2);
+        }
+        string_process_escapes(line);
+        elb_params.back().exitword = std::move(line);
+        elb_params.back().entries.push_back({ saved_phrases, saved_biases, saved_duration });
+        elb_params.push_back({ { }, "" });
+    }
+
+    sparams.elb_params = std::move(elb_params);
 }

--- a/common/common.h
+++ b/common/common.h
@@ -777,3 +777,5 @@ std::string string_format(const char* fmt, ...);
 //
 
 std::tuple<uint32_t, uint32_t, std::string, float> argparse_allowlist_unicode_rule(std::string argstr);
+
+void argparse_expiring_logit_bias(const std::string& content, common_params_sampling& sparams);

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -162,6 +162,9 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, co
         }
     }
 
+    result->elb_idx = 0;
+    result->elb_search_pos = 0;
+
     return result;
 }
 
@@ -605,6 +608,10 @@ static llama_token_data_array llama_sampling_prepare_impl(
         llama_sample_apply_guidance(ctx_main, logits, logits_guidance, params.cfg_scale);
     }
 
+    if (ctx_sampling->elb_states.size() > ctx_sampling->elb_idx) {
+        common_expiring_logit_bias_apply(ctx_sampling, logits);
+    }
+
     cur.resize(n_vocab);
 
     if ((ctx_sampling->server_biases != nullptr) && (ctx_sampling->server_biases->size() == n_vocab)) {
@@ -699,6 +706,10 @@ void common_sampler_accept(
     if (ctx_sampling->smpl) {
         llama_sampler_dry_accept(ctx_sampling->smpl, token);
     }
+
+    if (ctx_sampling->elb_states.size() > ctx_sampling->elb_idx) {
+        common_expiring_logit_bias_accept(ctx_sampling, ctx_main);
+    }
 }
 
 llama_token_data_array * common_sampler_get_candidates(struct common_sampler * gsmpl, bool do_sort) {
@@ -745,6 +756,8 @@ std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sample
     for (; i < draft.size(); i++) {
         const llama_token id = common_sampler_sample(gsmpl, ctx, idxs[i], grammar_first);
 
+        gsmpl->drafted_text += common_token_to_piece(ctx, id, true);
+
         common_sampler_accept(gsmpl, ctx, id, true);
 
         result.push_back(id);
@@ -757,6 +770,8 @@ std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sample
     if (i == draft.size()) {
         const llama_token id = common_sampler_sample(gsmpl, ctx, idxs[i], grammar_first);
 
+        gsmpl->drafted_text += common_token_to_piece(ctx, id, true);
+
         common_sampler_accept(gsmpl, ctx, id, true);
 
         result.push_back(id);
@@ -765,8 +780,85 @@ std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sample
     return result;
 }
 
+void common_expiring_logit_bias_apply(struct common_sampler* ctx_sampling, float* logits) {
+    auto index_first_inactive = [](auto countup, auto& tokens) {
+        return std::distance(
+            tokens.begin(),
+            std::upper_bound(tokens.begin(), tokens.end(), countup, [](const auto& countup, const auto& token) {
+                return countup > token.duration;
+            })
+        );
+    };
 
+    const auto& elb = ctx_sampling->elb_states[ctx_sampling->elb_idx];
 
+    std::string combined_text;
+    const std::string* search_window = &combined_text;
+    if (!ctx_sampling->drafted_text.empty()) {
+        // add speculated tokens
+        combined_text = ctx_sampling->to_generated_text != nullptr ? (
+            ctx_sampling->to_generated_text->substr(std::max(0, int32_t(ctx_sampling->to_generated_text->length()) - elb.max_cond_len))
+        ) : "" + ctx_sampling->drafted_text;
+    } else if (ctx_sampling->to_generated_text != nullptr) {
+        search_window = ctx_sampling->to_generated_text;
+    }
+
+    if (!search_window->empty() && !elb.other_tokens.empty() && (elb.other_tokens.front().duration > elb.countup)) {
+        const auto ifi = index_first_inactive(elb.countup, elb.other_tokens);
+        for (size_t j = 0; j < ifi; ++j) {
+            const auto& [id, bias, _, cond] = elb.other_tokens[j];
+            if (string_ends_with(*search_window, cond)) {
+                logits[id] += bias;
+            }
+        }
+    }
+
+    if (!elb.first_tokens.empty() && (elb.first_tokens.front().duration > elb.countup)) {
+        const auto ifi = index_first_inactive(elb.countup, elb.first_tokens);
+        if (search_window->empty()) {
+            // empty case here
+            for (size_t j = 0; j < ifi; ++j) {
+                logits[elb.first_tokens[j].id] += elb.first_tokens[j].bias;
+            }
+        } else {
+            for (size_t j = 0; j < ifi; ++j) {
+                const auto& [id, bias, _, cond] = elb.first_tokens[j];
+                // no bias if seen (probably too late)
+                if (!string_ends_with(*search_window, cond)) {
+                    logits[id] += bias;
+                }
+            }
+        }
+    }
+}
+
+void common_expiring_logit_bias_accept(struct common_sampler* ctx_sampling, struct llama_context * ctx_main) {
+    if (ctx_sampling->to_generated_text == nullptr) {
+        // prompt processing
+        return;
+    }
+
+    auto& elb = ctx_sampling->elb_states[ctx_sampling->elb_idx];
+    const int32_t exitword_len = elb.exitword.length();
+    if ((elb.delay > ++elb.countup) || (exitword_len == 0)) {
+        return;
+    }
+
+    const std::string search_window = ctx_sampling->to_generated_text->substr(std::max(
+        ctx_sampling->to_generated_text->length(),
+        size_t(ctx_sampling->elb_search_pos)
+    )) + common_token_to_piece(ctx_main, ctx_sampling->prev.back(), true);
+
+    const auto exitword_pos = search_window.find(elb.exitword);
+    if (exitword_pos != std::string::npos) {
+        ++ctx_sampling->elb_idx;
+        // no double counting characters that matched
+        ctx_sampling->elb_search_pos += exitword_pos + exitword_len;
+    } else {
+        // move search position to include next token
+        ctx_sampling->elb_search_pos += std::max(0, int32_t(search_window.length()) - exitword_len + 1);
+    }
+}
 
 
 template <>

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -844,7 +844,7 @@ void common_expiring_logit_bias_accept(struct common_sampler* ctx_sampling, stru
         return;
     }
 
-    const std::string search_window = ctx_sampling->to_generated_text->substr(std::max(
+    const std::string search_window = ctx_sampling->to_generated_text->substr(std::min(
         ctx_sampling->to_generated_text->length(),
         size_t(ctx_sampling->elb_search_pos)
     )) + common_token_to_piece(ctx_main, ctx_sampling->prev.back(), true);

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -159,6 +159,28 @@ typedef struct common_params_sampling {
 
     std::vector<llama_token> penalty_prompt_tokens;
     bool                     use_penalty_prompt_tokens = false;
+
+    // expiring logit bias
+    struct elb_param {
+        struct elb_entry {
+            std::vector<std::string>    phrases;
+            std::vector<float>          biases;     // for each phrase, nth bias for nth token, extrapolate
+            int32_t                     duration;   // bias duration, unless exitword matches
+            bool operator == (const struct elb_entry& other) const {
+                return (duration == other.duration)
+                    && (biases == other.biases)
+                    && (phrases == other.phrases);
+            }
+        };
+        std::vector<struct elb_entry> entries;
+        std::string                   exitword;     // move to next state if matched during generation
+        bool operator == (const struct elb_param& other) const {
+            return (exitword == other.exitword)
+                && (entries == other.entries);
+        }
+    };
+    std::vector<struct elb_param> elb_params;
+
 } llama_sampling_params;
 
 // general sampler context
@@ -191,6 +213,28 @@ struct common_sampler {
     std::mt19937 rng;
 
     std::vector<float>* server_biases;
+
+    std::string  drafted_text;
+    std::string* to_generated_text = nullptr;
+
+    // expiring logit bias
+    struct elb_state {
+        struct elb_token {
+            int32_t     id;
+            float       bias;
+            size_t      duration;
+            std::string cond;       // bias activation condition
+        };
+        std::vector<struct elb_token> first_tokens;     // first token of each phrase
+        std::vector<struct elb_token> other_tokens;
+        std::string                   exitword;
+        size_t                        countup;          // compare against duration
+        size_t                        delay;            // to avoid early termination of positively biased phrases
+        int32_t                       max_cond_len;
+    };
+    std::vector<struct elb_state> elb_states;
+    size_t                        elb_idx;          // for elb_states
+    int32_t                       elb_search_pos;   // for exitword
 };
 
 
@@ -286,6 +330,10 @@ std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sample
 
 // Greedy argmax sampling for speculative drafting
 llama_token common_sampler_sample_speculative(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, float * out_prob = nullptr);
+
+void common_expiring_logit_bias_apply(struct common_sampler* ctx_sampling, float* logits);
+
+void common_expiring_logit_bias_accept(struct common_sampler* ctx_sampling, struct llama_context * ctx_main);
 
 llama_grammar* llama_sampler_init_llg(const llama_vocab* vocab,
     const char* grammar_kind, const char* grammar_data);

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -166,8 +166,10 @@ typedef struct common_params_sampling {
             std::vector<std::string>    phrases;
             std::vector<float>          biases;     // for each phrase, nth bias for nth token, extrapolate
             int32_t                     duration;   // bias duration, unless exitword matches
+            bool                        is_range;   // has lower and upper biases
             bool operator == (const struct elb_entry& other) const {
-                return (duration == other.duration)
+                return (is_range == other.is_range)
+                    && (duration == other.duration)
                     && (biases == other.biases)
                     && (phrases == other.phrases);
             }

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -1728,13 +1728,30 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
             auto& max_cond_len = slot.ctx_sampling->elb_states.back().max_cond_len;
 
             // 1 entry <-> 1 phrase <-> 1+ biases
-            for (auto [phrases, biases, duration]: entries) {
+            for (auto [phrases, biases, duration, is_range]: entries) {
                 for (const auto& phrase: phrases) {
                     if (phrase.empty()) {
                         continue;
                     }
+
                     const auto ids = common_tokenize(model, phrase, false, true);
-                    biases.resize(ids.size(), biases.back());
+                    if (!is_range) {
+                        // extrapolate
+                        biases.resize(ids.size(), biases.back());
+                    } else if (ids.size() == 1) {
+                        biases[0] = biases.back();
+                        biases.resize(1);
+                    } else {
+                        // interpolate
+                        float bb = biases.back();
+                        const float inc = (bb - biases.front()) / (ids.size() - 1);
+                        biases.resize(ids.size());
+                        for (int32_t j = ids.size() - 1; j >= 0; --j) {
+                            biases[j] = bb;
+                            bb -= inc;
+                        }
+                    }
+
                     if (biases[0] != 0.0f) {
                         // cond is piece for first_tokens (no match to bias)
                         first_tokens.push_back({ ids[0], biases[0], size_t(duration), common_token_to_piece(ctx, ids[0], true) });

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -974,7 +974,9 @@ int32_t server_context::populate_vocab_pieces() {
     vocab_pieces.clear();
     vocab_pieces.reserve(n_vocab);
     for (int32_t id = 0; id < n_vocab; ++id) {
-        vocab_pieces.push_back(common_token_to_piece(ctx, id, true));
+        auto piece = common_token_to_piece(ctx, id, true);
+        max_piece_len = std::max(piece.length(), max_piece_len);
+        vocab_pieces.push_back(std::move(piece));
     }
     return n_vocab;
 }
@@ -1674,6 +1676,104 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
             return false;
         }
     }
+
+    do  // populate expiring logit bias
+    {
+        const auto elb_prev_params = slot.sparams.elb_params;
+
+        const auto& expiring_logit_bias = data.find("expiring_logit_bias");
+        if (expiring_logit_bias != data.end() && expiring_logit_bias->is_array()) {
+            // has new params from api
+            std::string content;
+            for (const auto& line: data["expiring_logit_bias"]) {
+                if (line.is_string()) {
+                    content += line.get<std::string>() + "\n";
+                }
+            }
+            try {
+                argparse_expiring_logit_bias(content, slot.sparams);
+            } catch (const std::invalid_argument& e) {
+                std::cerr << e.what() << '\n';
+            } catch (const std::out_of_range& e) {
+                std::cerr << e.what() << '\n';
+            }
+        }
+
+        const auto& elb_params = slot.sparams.elb_params;
+        if (elb_params.empty()) {
+            slot.ctx_sampling->elb_states.clear();
+            break;
+        }
+
+        if (!slot.elb_prev_states.empty() && (elb_params == elb_prev_params)) {
+            // reset and reuse previous states
+            slot.ctx_sampling->elb_states = slot.elb_prev_states;
+            for (auto& elb_state: slot.ctx_sampling->elb_states) {
+                elb_state.countup = 0;
+            }
+            break;
+        }
+
+        const auto n_elb_param = elb_params.size();
+
+        slot.ctx_sampling->elb_states.clear();
+        slot.ctx_sampling->elb_states.reserve(n_elb_param);
+
+        // 1 state <-> 1 exitword <-> 1+ entries
+        for (const auto& [entries, exitword]: elb_params) {
+            slot.ctx_sampling->elb_states.push_back({ { }, { }, exitword, 0, 0, 0 });
+            auto& first_tokens = slot.ctx_sampling->elb_states.back().first_tokens;
+            auto& other_tokens = slot.ctx_sampling->elb_states.back().other_tokens;
+            auto& delay = slot.ctx_sampling->elb_states.back().delay;
+            auto& max_cond_len = slot.ctx_sampling->elb_states.back().max_cond_len;
+
+            // 1 entry <-> 1 phrase <-> 1+ biases
+            for (auto [phrases, biases, duration]: entries) {
+                for (const auto& phrase: phrases) {
+                    if (phrase.empty()) {
+                        continue;
+                    }
+                    const auto ids = common_tokenize(model, phrase, false, true);
+                    biases.resize(ids.size(), biases.back());
+                    if (biases[0] != 0.0f) {
+                        // cond is piece for first_tokens (no match to bias)
+                        first_tokens.push_back({ ids[0], biases[0], size_t(duration), common_token_to_piece(ctx, ids[0], true) });
+                    }
+
+                    int32_t m = 1;
+                    if (duration < 0) {
+                        // -1 is smallest infinite duration
+                        duration ^= 0x7FFFFFFF;
+                        m = -1;
+                    }
+
+                    std::string cond;
+                    for (int32_t j = 1; j < ids.size(); ++j) {
+                        // cond collects preceding string for other_tokens (match to bias)
+                        cond += common_token_to_piece(ctx, ids[j - 1], true);
+                        if (biases[j] == 0.0f) {
+                            continue;
+                        } else if (biases[j] > 0.0f) {
+                            delay = std::max(size_t(duration + m * j), delay);
+                        }
+                        other_tokens.push_back({ ids[j], biases[j], size_t(duration + m * j), cond });
+                    }
+                    max_cond_len = std::max(int32_t(cond.length()), max_cond_len);
+                }
+            }
+        }
+
+        // sort by duration in descending order
+        for (auto& elb_state: slot.ctx_sampling->elb_states) {
+            std::sort(elb_state.first_tokens.begin(), elb_state.first_tokens.end(), [](const auto& a, const auto& b) {
+                return a.duration > b.duration;
+            });
+            std::sort(elb_state.other_tokens.begin(), elb_state.other_tokens.end(), [](const auto& a, const auto& b) {
+                return a.duration > b.duration;
+            });
+        }
+    } while (false);
+    slot.elb_prev_states = slot.ctx_sampling->elb_states;
 
     slot.command = SLOT_COMMAND_LOAD_PROMPT;
     // slot.prompt_tokens.clear();
@@ -3807,6 +3907,13 @@ void server_context::speculative_decoding_accept() {
 
         size_t n_draft = slot.drafted.size();
 
+        slot.ctx_sampling->to_generated_text = &slot.generated_text;
+        if (n_draft > 0) {
+            (void) populate_vocab_pieces();     // max_piece_len
+            slot.ctx_sampling->drafted_text.reserve(max_piece_len * n_draft);
+            slot.ctx_sampling->drafted_text.clear();
+        }
+
         apply_server_biases(slot);
 
         // the accepted tokens from the speculation
@@ -4320,6 +4427,8 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
                     slot.ctx_sampling->params.logit_bias[tok] += slot.ban_phrases_bias;
                 }
             }
+
+            slot.ctx_sampling->to_generated_text = &slot.generated_text;
 
             completion_token_output result;
             const int tok_idx = slot.i_batch - i;

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -167,6 +167,9 @@ struct server_slot {
     struct common_params_sampling sparams;
     common_sampler * ctx_sampling = nullptr;
 
+    // expiring logit bias
+    decltype(ctx_sampling->elb_states) elb_prev_states;
+
     bool has_mtp = false;
     std::vector<float> mtp_hidden_state;
 
@@ -250,6 +253,7 @@ struct server_context {
     std::vector<control_vector_container> control_vectors;
 
     std::vector<std::string> vocab_pieces;
+    size_t max_piece_len = 0;
 
     gpt_params params_base;
 


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

This PR adds expiring logit bias, which allows logit biases to be applied to specific phrases for a limited duration (measured in tokens) or until a "exitword" match. The match triggers a transition to the next set of logit biases.

This is useful for guiding the model through structured outputs including thinking process, refusal busting, or any other applications where permanent alteration to the model's vocabulary distribution is not desirable.

## Configuration

- CLI: `--expiring-logit-bias-file FILENAME` to load bias states from a custom file format
- API: `"expiring_logit_bias": ["LINE1", "LINE2", ...]` to load from API payload (this overwrites CLI as the default state)

## Syntax

- Comments: lines starting with `#` are ignored
  - no inline comments
- Entries: `(DURATION : "PHRASE1" "PHRASE2" ... : BIAS1, BIAS2, ...)`
  - `DURATION` is 1 unless specified. Adjacent `:` should be omitted if the duration is not specified. Duration for second tokens in phrases is set to `DURATION + 1`, third tokens `DURATION + 2`, etc.
  - `BIAS1` is applied to the first token of each `PHRASE`, `BIAS2` to second, etc. For phrases with more tokens than defined biases, the last bias is extrapolated to the remaining tokens.
  - Any delimiter can be used between `PHRASE` but `,` for biases.
- Exit-Words: `EXITWORD` or `"EXITWORD"`.
  - Double quotes are meant to be be used when the desired exit-word starts and ends with parenthesis or whitespaces.
- Persistent Entry: `((DURATION : "PHRASE1" "PHRASE2" ... : BIAS1, BIAS2, ...))`
  - Persistent entry is added with each exit-word. i.e. it is global-ish
  - Can be cleared with `(())`
  - For persistent entry, default `DURATION` is -1, which is effectively infinite.
- Each line is evaluated seperately

## Implementation

The implementation matches strings instead of token IDs. This approach is chosen because models can (and do) generate short tokens that match a longer token, or a long token that matches multiple shorter ones.

Compatibility with speculative decoding is theoretical because I never have luck getting it to work.

## Use Cases

Getting Kimi to stop thinking gracefully. (I needed to launch llama-server with --special because `</think>` is special for some reason.)
```
# begin bias for paragraph 1 (no-op)
\n\n
# end bias for paragraph 1 (EXITWORD="\n\n")

# begin bias for paragraph 2 (no-op)
\n\n
# end bias for paragraph 2 (EXITWORD="\n\n")

# begin bias for paragraph 3
# trigger "In conclusion," in the beginning of paragraph 3
("In conclusion," : 999)
.
# end bias for paragraph 3, sentence 1 (EXITWORD=".")

# trigger end of thinking after paragraph 3, sentence 1
("</think>" : 999)
```

Similar but GLM which tends to short-think.
```
# end of thinking tag with bias -999 is now persistent
(("</think>" : -999))
# (-1: "</think>" : -999) is added to paragraph 1 automatically
\n\n

# (-1: "</think>" : -999) is added to paragraph 2 automatically
\n\n

# same here
("In conclusion," : 999)
.

# not here (right after paragraph 3, sentence 1) because there is no exitword
("</think>" : 999)
# but users can do this to be sure
(())
```

Force numbered list after paragraph 1:
```
\n\n
("1." : 999)
```

User is king.
```
(("But" " But" "Safety" " Safety": -999))

# because banning the word "I" may backfire
(-1 : "I cannot" " I cannot" : 0, -999)
# "I" and " I" get 0. -999 extends to " cannot"
# But bias -999 for " cannot" will not apply unless "I" or " I" is generated first
```

Progressive bias is probably the right way to bias a phrase.
```
("The quick brown fox jumps over the lazy dog" : -2, -3, -5, -8, -13, -21, -34)
```

## Notes

I think it works the best with a complementary system prompt in tandem.
Some models do not jive well with structured reasoning.