### PR TITLE
docs : restructure AVX-512 build flags section, recommend GGML_AVX512_*=ON first

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -204,28 +204,57 @@ deliver. A few related gates are worth knowing about:
 - `f16`/`f32` GEMM is gated only by `__AVX512F__`.
 - Native `bf16` GEMM and the use of a `bf16` KV cache in flash attention is
   gated by `__AVX512BF16__`.
-- For AVX2-only CPUs that implement the VNNI extension (`vpdpbusd`), the
-  equivalent "fancy" path is gated by `__AVXVNNI__`. VNNI alone is
-  responsible for most of the speedup on quantized matmul.
+- A separate `HAVE_VNNI256` path (`iqk_config.h:52-54`) is gated by
+  `__AVXVNNI__` *or* (`__AVX512VNNI__ && __AVX512VL__`). This gives a
+  meaningful speedup on AVX2-only CPUs that have the VNNI extension
+  (e.g. some Alder Lake / Raptor Lake parts), even without full AVX-512.
+  VNNI alone (`vpdpbusd`) is responsible for most of the speedup on
+  quantized matmul.
 
-### Linux / GCC
+### Recommended: high-level CMake options
 
-Modern GCC with `GGML_NATIVE=ON` (the default unless cross-compiling)
-resolves `-march=native` on Zen4 / Sapphire Rapids hardware to a target that
-defines all of the macros above. No manual configuration is usually needed.
-Verification:
+The standard `GGML_AVX512_*` options work on both MSVC and GCC and are the
+shortest path that activates `HAVE_FANCY_SIMD`:
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DGGML_NATIVE=ON \
+    -DGGML_AVX512=ON \
+    -DGGML_AVX512_VBMI=ON \
+    -DGGML_AVX512_VNNI=ON \
+    -DGGML_AVX512_BF16=ON
+cmake --build build --config Release
+```
+
+Mechanics:
+- On MSVC, `GGML_AVX512=ON` adds `/arch:AVX512` (which itself defines
+  `__AVX512F__`, `__AVX512VL__`, `__AVX512BW__`, `__AVX512DQ__`,
+  `__AVX512CD__`), and the `GGML_AVX512_VNNI=ON` / `_VBMI=ON` / `_BF16=ON`
+  options add the corresponding `__AVX512VNNI__` / `__AVX512VBMI__` /
+  `__AVX512BF16__` definitions explicitly. See
+  [`ggml/src/CMakeLists.txt:1352-1374`](../ggml/src/CMakeLists.txt#L1352-L1374).
+- On GCC / Clang, `GGML_NATIVE=ON` resolves `-march=native` to a target
+  that defines the macros (on Zen4, `znver4`; on Sapphire Rapids,
+  `sapphirerapids`), and the same `GGML_AVX512_*=ON` options add explicit
+  `-mavx512vnni` / `-mavx512vbmi` / `-mavx512bf16` flags as belt-and-braces.
+
+Verification — confirm the quantized path is in the binary:
 
 ```bash
 objdump -d build/bin/llama-cli | grep -c vpdpbusd
-# A non-trivial count (hundreds) means VNNI compiled in.
+# A non-trivial count (hundreds+) means VNNI compiled in.
 # Zero means the IQK kernels fell back to AVX2.
 ```
 
-### Windows / MSVC and other cases that need explicit defines
+You can also check the runtime banner: a successful AVX-512 build prints
+`HAVE_FANCY_SIMD is defined` and `system_info: AVX512_VNNI = 1 ...`.
 
-MSVC does not propagate `-march=native` semantics, and in cross-compile
-scenarios `GGML_NATIVE` is intentionally disabled. In both cases the
-macros must be supplied explicitly via `GGML_ARCH_FLAGS`, which the build
+### Fallback: explicit `GGML_ARCH_FLAGS`
+
+If the recommended options above do not produce `HAVE_FANCY_SIMD is defined`
+on your toolchain (older MSVC versions, exotic compilers, or cross-compiles
+to ARM where `-march=native` does not propagate the relevant macros), the
+defines can be supplied explicitly via `GGML_ARCH_FLAGS`, which the build
 system forwards verbatim to the C/C++ compiler line:
 
 ```bash
@@ -241,8 +270,7 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release \
     -DGGML_ARCH_FLAGS="-D__AVXVNNI__"
 ```
 
-After the build completes, the same `objdump | grep -c vpdpbusd` check
-confirms the quantized path is in.
+The same `objdump | grep -c vpdpbusd` check applies.
 
 ### Note on Zen4 throughput
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

## Background

Follow-up to #1729 per @ikawrakow's [closing comment](https://github.com/ikawrakow/ik_llama.cpp/pull/1729#issuecomment-4366437691):

> *"Or perhaps, once you have written the current version, offer the original version at the beginning and note that in case that does not work, they can use `GGML_ARCH_FLAGS` in that way."*

This PR restructures the AVX-512 build flags section so that the high-level `GGML_AVX512_*=ON` CMake options are the recommended primary path, and `GGML_ARCH_FLAGS` is documented as a fallback for cases where the high-level options don't propagate the macros (older MSVC, ARM cross-compile, exotic toolchains).

## Empirical confirmation that `GGML_AVX512_*=ON` works

On MSVC 2022 + Zen4, building with:

```
-DGGML_AVX512=ON -DGGML_AVX512_VBMI=ON -DGGML_AVX512_VNNI=ON -DGGML_AVX512_BF16=ON -DGGML_NATIVE=ON
```

The CMake-generated `build/ggml/src/CMakeFiles/ggml.dir/flags.make` contains:

```
C_DEFINES = ... -D__AVX512BF16__ -D__AVX512VBMI__ -D__AVX512VNNI__ ...
C_FLAGS   = ... /arch:AVX512 ...
```

`/arch:AVX512` itself defines `__AVX512F__`, `__AVX512VL__`, `__AVX512BW__`, `__AVX512DQ__`, `__AVX512CD__` ([MSVC docs](https://learn.microsoft.com/en-us/cpp/build/reference/arch-x64)), and the matching `GGML_AVX512_VNNI=ON` / `_VBMI=ON` / `_BF16=ON` options add the corresponding macro definitions explicitly via `add_compile_definitions(...)` at [`ggml/src/CMakeLists.txt:1361-1372`](https://github.com/ikawrakow/ik_llama.cpp/blob/main/ggml/src/CMakeLists.txt#L1361-L1372). All five `HAVE_FANCY_SIMD` macros (F / VNNI / VL / BW / DQ) end up defined.

Runtime banner confirms: `HAVE_FANCY_SIMD is defined` and `system_info: AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1`. A post-merge benchmark on Qwen3-30B-A3B Q4_K_M shows +55% PP relative to a `Release` build without these flags.

## Changes

- **Recommended path first**: `GGML_AVX512_*=ON` block with mechanics explained for both MSVC (`/arch:AVX512` + `add_compile_definitions`) and GCC (`-march=native` + `-mavx512*`).
- **Verification**: `objdump | grep -c vpdpbusd` plus the runtime banner check.
- **Fallback section**: `GGML_ARCH_FLAGS` for cases where the high-level options don't reach `HAVE_FANCY_SIMD`. The AVX2+VNNI special case (`-D__AVXVNNI__`) lives here too, since there's no high-level CMake option for it.
- Brief mention of the separate `HAVE_VNNI256` gate in `iqk_config.h:52-54`, which gives meaningful speedups on AVX2-only CPUs that have the VNNI extension.
- Removed the strict Linux-vs-MSVC split (the recommended block works on both).

## Scope

Documentation only — no code changes, no behavioural changes, no new CMake options introduced.