### PR TITLE
scripts : add build-zen.{sh,bat} helpers for AVX-512-capable CPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ build*
 !build-info.sh
 !build.zig
 !docs/build.md
+!scripts/build-*.sh
+!scripts/build-*.bat
 /libllama.so
 /llama-*
 /vulkan-shaders-gen

--- a/scripts/build-zen.bat
+++ b/scripts/build-zen.bat
@@ -1,0 +1,27 @@
+@echo off
+REM CPU-only build helper for AVX-512-capable CPUs (AMD Zen4 / Intel
+REM Sapphire Rapids+) on Windows + MSVC. Enables the IQK GEMM kernels
+REM gated by HAVE_FANCY_SIMD (see docs\build.md "CPU build flags for AVX-512").
+REM
+REM Run from a Visual Studio "x64 Native Tools Command Prompt" so that
+REM cl.exe and the rest of the MSVC toolchain are on PATH.
+REM
+REM Usage:
+REM   scripts\build-zen.bat [build-dir]
+REM
+REM Default build directory is "build".
+
+setlocal
+
+if "%~1"=="" (set BUILD_DIR=build) else (set BUILD_DIR=%~1)
+
+cmake -B "%BUILD_DIR%" -G "NMake Makefiles" ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DGGML_NATIVE=ON ^
+    -DGGML_AVX512=ON ^
+    -DGGML_AVX512_VBMI=ON ^
+    -DGGML_AVX512_VNNI=ON ^
+    -DGGML_AVX512_BF16=ON
+if errorlevel 1 exit /b 1
+
+cmake --build "%BUILD_DIR%" --config Release

--- a/scripts/build-zen.sh
+++ b/scripts/build-zen.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# CPU-only build helper for AVX-512-capable CPUs (AMD Zen4 / Intel
+# Sapphire Rapids+). Enables the IQK GEMM kernels gated by HAVE_FANCY_SIMD
+# (see docs/build.md "CPU build flags for AVX-512").
+#
+# Usage:
+#   ./scripts/build-zen.sh [build-dir]
+#
+# Default build directory is "build". A subsequent
+#
+#   objdump -d <build-dir>/bin/llama-cli | grep -c vpdpbusd
+#
+# should report a non-trivial count if VNNI was compiled in. The runtime
+# banner of any built binary will print "HAVE_FANCY_SIMD is defined" when
+# the AVX-512 quantized matmul path is active.
+
+set -e
+
+BUILD_DIR=${1:-build}
+
+cmake -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DGGML_NATIVE=ON \
+    -DGGML_AVX512=ON \
+    -DGGML_AVX512_VBMI=ON \
+    -DGGML_AVX512_VNNI=ON \
+    -DGGML_AVX512_BF16=ON
+
+cmake --build "$BUILD_DIR" --config Release -j


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

## Background

Follow-up to the docs work in #1729. That PR documented the cmake flags needed to actually compile the IQK quantized GEMM kernels for AVX-512-capable CPUs (AMD Zen4 / Intel Sapphire Rapids+). This PR turns those flags into two thin command-line helpers, so the user runs one script instead of remembering five `GGML_AVX512_*=ON` options.

## What's added

- **`scripts/build-zen.sh`** — Linux / macOS bash wrapper
- **`scripts/build-zen.bat`** — Windows MSVC wrapper (run from "x64 Native Tools Command Prompt")

Both:
- Default to `build` as the output directory; first arg overrides it.
- Pass through to the same cmake invocation:
  ```
  cmake -B "$BUILD_DIR" \
      -DCMAKE_BUILD_TYPE=Release \
      -DGGML_NATIVE=ON \
      -DGGML_AVX512=ON \
      -DGGML_AVX512_VBMI=ON \
      -DGGML_AVX512_VNNI=ON \
      -DGGML_AVX512_BF16=ON
  cmake --build "$BUILD_DIR" --config Release
  ```
- Reference `docs/build.md` for the per-flag rationale, so the scripts and the docs stay in lockstep.

No behavioural change to existing build flows — these are purely additive helpers.

## `.gitignore` adjustment

The existing `build*` pattern (line 46) was catching `scripts/build-zen.{sh,bat}` because of the leading "build". Added two exceptions in line with the existing pattern of explicit allowlists (`!build-info.sh`, `!build.zig`, `!docs/build.md`):

```
!scripts/build-*.sh
!scripts/build-*.bat
```

This also leaves room for future `scripts/build-*` helpers without re-tripping the rule.

## Verification

After running either script and the cmake build, the runtime banner of any built binary prints `HAVE_FANCY_SIMD is defined` and `system_info: AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1`, matching the verification snippet in `docs/build.md`. `objdump -d build/bin/llama-cli | grep -c vpdpbusd` likewise reports a non-trivial count.