### PR TITLE
readme : link "Build for CPU" to AVX-512 build flags reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ cmake -B build -DGGML_NATIVE=ON
 cmake --build build --config Release -j$(nproc)
 ```
 
+For AVX-512-capable CPUs (AMD Zen4 / Intel Sapphire Rapids+), see
+[`docs/build.md`](docs/build.md) section "CPU build flags for AVX-512" for the
+additional flags that activate the IQK quantized GEMM kernels (the
+`HAVE_FANCY_SIMD` path). Without those flags, a vanilla `Release` build
+silently falls back to the AVX2 path on this hardware.
+
 ### Build for GPU
 
 Install Nvidia Drivers and [CUDA Toolkit](https://developer.nvidia.com/cuda/toolkit).


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

## What

Adds a short paragraph in `README.md`'s **Build for CPU** section pointing at the AVX-512 build flags reference in `docs/build.md` (added in #1729).

## Why

The example shown directly above in the same section:

```
cmake -B build -DGGML_NATIVE=ON
cmake --build build --config Release -j$(nproc)
```

silently falls back to the AVX2 path on AMD Zen4 / Intel Sapphire Rapids+ CPUs — `HAVE_FANCY_SIMD` is not defined, the IQK kernels in `ggml/src/iqk/iqk_gemm_*.cpp` skip their AVX-512 paths, and the user gets sub-optimal prompt-processing throughput without any build-time warning. Users hitting "my Zen4 build feels slow" reasonably look at the README's CPU section first; a single-paragraph cross-reference there saves them digging through `docs/` to find the right knob.

## Diff

Pure additive — six lines under the existing `Build for CPU` code block. README's vanilla example is preserved as-is; the paragraph only points to the deeper reference for the AVX-512 case.

```
For AVX-512-capable CPUs (AMD Zen4 / Intel Sapphire Rapids+), see
[`docs/build.md`](docs/build.md) section "CPU build flags for AVX-512" for the
additional flags that activate the IQK quantized GEMM kernels (the
`HAVE_FANCY_SIMD` path). Without those flags, a vanilla `Release` build
silently falls back to the AVX2 path on this hardware.
```

## Scope

Documentation only — no code changes, no behavioural changes.