### PR TITLE
MTP improvements

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <iomanip>
 #include <map>
+#include <unordered_map>
 
 #define SPEC_VOCAB_MAX_SIZE_DIFFERENCE  128
 #define SPEC_VOCAB_CHECK_START_TOKEN_ID 5
@@ -197,6 +198,7 @@ struct common_speculative_state_mtp : public common_speculative_state {
         llama_seq_id seq_id = 0;
 
         llama_pos mtp_pos_max = llama_kv_cache_seq_pos_max(ctx_mtp, seq_id);
+        //printf("%s: n_past = %d, mtp_pos_max = %d\n", __func__, n_past, mtp_pos_max);
         if (mtp_pos_max >= n_past) {
             llama_kv_cache_seq_rm(ctx_mtp, seq_id, n_past, -1);
         }
@@ -217,6 +219,9 @@ struct common_speculative_state_mtp : public common_speculative_state {
     void accept(uint16_t n_accepted) override {
         GGML_UNUSED(n_accepted);
     }
+
+    std::vector<float> last_logits;
+    bool               accepted = false;
 };
 
 
@@ -1213,6 +1218,23 @@ void common_speculative_begin(common_speculative * spec, const llama_tokens & pr
     }
 }
 
+struct mtp_last_embd {
+    std::vector<float> embd;
+    float prob;
+    int   last_id = -1;
+};
+
+// Hopefully never called concurrently from multiple threads
+static mtp_last_embd & mtp_get_last_embd(const llama_context * ctx) {
+    static std::unordered_map<const llama_context *, mtp_last_embd> map;
+    auto & last = map[ctx];
+    if (last.embd.empty()) {
+        auto n_embd = llama_model_n_embd(llama_get_model(ctx));
+        last.embd.resize(n_embd);
+    }
+    return last;
+}
+
 llama_tokens common_speculative_draft(
         common_speculative * spec,
         common_params_speculative & params,
@@ -1361,7 +1383,7 @@ std::vector<llama_token> mtp_speculative_gen_draft(
     llama_token id_last,
     int32_t n_past,
     llama_seq_id seq_id) {
-    
+
     llama_tokens drafts;
     drafts.reserve(n_draft);
 
@@ -1372,12 +1394,30 @@ std::vector<llama_token> mtp_speculative_gen_draft(
     llama_batch mtp_batch = llama_batch_init(1, 0, 1);
     llama_set_mtp_op_type(ctx, MTP_OP_DRAFT_GEN);
 
+    float prob;
+    auto prob_ptr = p_min > 0 ? &prob : nullptr;
+
     llama_token current_input_id = id_last;
     int32_t current_n_past = n_past;
     const int n_embd = llama_model_n_embd(llama_get_model(ctx));
-    std::vector<float> draft_hidden_state(n_embd);
 
-    for (int i = 0; i < n_draft; ++i) {
+    //std::vector<float> draft_hidden_state(n_embd);
+    auto & last = mtp_get_last_embd(ctx);
+    int i0 = 0;
+    if (last.last_id >= 0) {
+        //printf("%s(%p): adding previously sampled token id = %d, p = %g. n_past = %d\n", __func__, (const void *)ctx, last.last_id, last.prob, n_past);
+        if (last.prob < p_min) {
+            return drafts;
+        }
+        current_input_id = last.last_id;
+        last.last_id = -1;
+        drafts.push_back(current_input_id);
+        current_n_past++;
+        llama_set_draft_input_hidden_state(ctx, last.embd.data());
+        i0 = 1;
+    }
+
+    for (int i = i0; i < n_draft; ++i) {
         mtp_batch.n_tokens = 0;
         common_batch_add(mtp_batch, current_input_id, current_n_past, {seq_id}, true);
 
@@ -1385,8 +1425,10 @@ std::vector<llama_token> mtp_speculative_gen_draft(
             break;
         }
 
-        float prob;
-        llama_token id_next = common_sampler_sample_speculative(smpl, ctx, 0, &prob);
+        llama_token id_next = common_sampler_sample_speculative(smpl, ctx, 0, prob_ptr);
+        if (i > 0 && prob_ptr && prob < p_min) {
+            return drafts;
+        }
 
         drafts.push_back(id_next);
 
@@ -1394,18 +1436,21 @@ std::vector<llama_token> mtp_speculative_gen_draft(
         if (!emb) {
             break;
         }
-        
+
         // Keep a stable copy because later decode steps reuse ctx->embd storage.
-        memcpy(draft_hidden_state.data(), emb, n_embd * sizeof(float));
-        llama_set_draft_input_hidden_state(ctx, draft_hidden_state.data());
+        memcpy(last.embd.data(), emb, n_embd * sizeof(float));
+        llama_set_draft_input_hidden_state(ctx, last.embd.data());
 
         current_input_id = id_next;
         current_n_past++;
 
-        if (prob < p_min) {
+        if (prob_ptr && prob < p_min) {
             break;
         }
     }
+    //printf("%s: sampled", __func__);
+    //for (auto id : drafts) printf(" %d", id);
+    //printf("\n");
     llama_batch_free(mtp_batch);
     llama_set_mtp_op_type(ctx, MTP_OP_NONE);
 
@@ -1431,8 +1476,8 @@ void mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, b
         llama_kv_cache_seq_rm(ctx, seq_id, start_pos, -1);
     }
 
-    LOG_DBG("[MTP-UPDATE|%s] Updating %d tokens from pos %d...\n",
-            is_prompt_warmup ? "PROMPT_WARMUP" : "GEN_ACCEPTED", batch.n_tokens, (int)start_pos);
+    LOG_DBG("[MTP-UPDATE|%s] Updating %d tokens for seq_id %d from pos %d...\n",
+            is_prompt_warmup ? "PROMPT_WARMUP" : "GEN_ACCEPTED", batch.n_tokens, seq_id, (int)start_pos);
 
     llama_batch mtp_batch = batch;
     if (is_prompt_warmup) {
@@ -1452,18 +1497,31 @@ void mtp_accept_tokens(
     struct llama_context * ctx,
     const std::vector<llama_token> & ids,
     int32_t n_past_base,
-    llama_seq_id seq_id
-) {
+    llama_seq_id seq_id) {
     if (ids.empty()) {
         return;
     }
 
     llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
+    //printf("%s(%p): have", __func__, (const void *)ctx);
     for (size_t i = 0; i < ids.size(); ++i) {
+        //printf(" %d", ids[i]);
         common_batch_add(accepted_batch, ids[i], n_past_base + i, { seq_id }, true);
     }
+    //printf("\n");
 
     mtp_update_kv_cache(ctx, accepted_batch, false);
+
+    auto & last = mtp_get_last_embd(ctx);
+    //llama_set_mtp_op_type(ctx, MTP_OP_UPDATE_ACCEPTED);
+    auto embd = llama_get_embeddings_ith(ctx, ids.size() - 1);
+    if (embd) {
+        std::memcpy(last.embd.data(), embd, last.embd.size()*sizeof(float));
+        llama_set_draft_input_hidden_state(ctx, last.embd.data());
+        last.last_id = common_sampler_sample_speculative(nullptr, ctx, ids.size() - 1, &last.prob);
+        //printf("%s: sampled next token. id = %d, p = %g\n", __func__, last.last_id, last.prob);
+    }
+    //llama_set_mtp_op_type(ctx, MTP_OP_NONE);
 
     llama_batch_free(accepted_batch);
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -198,7 +198,6 @@ struct common_speculative_state_mtp : public common_speculative_state {
         llama_seq_id seq_id = 0;
 
         llama_pos mtp_pos_max = llama_kv_cache_seq_pos_max(ctx_mtp, seq_id);
-        //printf("%s: n_past = %d, mtp_pos_max = %d\n", __func__, n_past, mtp_pos_max);
         if (mtp_pos_max >= n_past) {
             llama_kv_cache_seq_rm(ctx_mtp, seq_id, n_past, -1);
         }
@@ -219,11 +218,7 @@ struct common_speculative_state_mtp : public common_speculative_state {
     void accept(uint16_t n_accepted) override {
         GGML_UNUSED(n_accepted);
     }
-
-    std::vector<float> last_logits;
-    bool               accepted = false;
 };
-
 
 struct common_speculative_state_draft : public common_speculative_state {
     llama_context * ctx_tgt; // only used for retokenizing from ctx_dft
@@ -1401,11 +1396,9 @@ std::vector<llama_token> mtp_speculative_gen_draft(
     int32_t current_n_past = n_past;
     const int n_embd = llama_model_n_embd(llama_get_model(ctx));
 
-    //std::vector<float> draft_hidden_state(n_embd);
     auto & last = mtp_get_last_embd(ctx);
     int i0 = 0;
     if (last.last_id >= 0) {
-        //printf("%s(%p): adding previously sampled token id = %d, p = %g. n_past = %d\n", __func__, (const void *)ctx, last.last_id, last.prob, n_past);
         if (last.prob < p_min) {
             return drafts;
         }
@@ -1448,9 +1441,6 @@ std::vector<llama_token> mtp_speculative_gen_draft(
             break;
         }
     }
-    //printf("%s: sampled", __func__);
-    //for (auto id : drafts) printf(" %d", id);
-    //printf("\n");
     llama_batch_free(mtp_batch);
     llama_set_mtp_op_type(ctx, MTP_OP_NONE);
 
@@ -1503,25 +1493,19 @@ void mtp_accept_tokens(
     }
 
     llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
-    //printf("%s(%p): have", __func__, (const void *)ctx);
     for (size_t i = 0; i < ids.size(); ++i) {
-        //printf(" %d", ids[i]);
         common_batch_add(accepted_batch, ids[i], n_past_base + i, { seq_id }, true);
     }
-    //printf("\n");
 
     mtp_update_kv_cache(ctx, accepted_batch, false);
 
     auto & last = mtp_get_last_embd(ctx);
-    //llama_set_mtp_op_type(ctx, MTP_OP_UPDATE_ACCEPTED);
     auto embd = llama_get_embeddings_ith(ctx, ids.size() - 1);
     if (embd) {
         std::memcpy(last.embd.data(), embd, last.embd.size()*sizeof(float));
         llama_set_draft_input_hidden_state(ctx, last.embd.data());
         last.last_id = common_sampler_sample_speculative(nullptr, ctx, ids.size() - 1, &last.prob);
-        //printf("%s: sampled next token. id = %d, p = %g\n", __func__, last.last_id, last.prob);
     }
-    //llama_set_mtp_op_type(ctx, MTP_OP_NONE);
 
     llama_batch_free(accepted_batch);
 }

--- a/src/graphs/build_qwen35.cpp
+++ b/src/graphs/build_qwen35.cpp
@@ -147,8 +147,8 @@ struct ggml_tensor * llm_build_context::build_qwen35_mtp(
     struct ggml_tensor * prev_embeddings,
     int64_t n_embd_head,
     struct ggml_cgraph * gf,
-    struct ggml_tensor * inp_pos
-) {
+    struct ggml_tensor * inp_pos) {
+
     const int il = hparams.n_layer - 1;
 
     struct ggml_tensor * KQ_mask = build_inp_KQ_mask();

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4590,8 +4590,7 @@ static int llama_decode_internal(
             tim1 = ggml_time_us();
 #endif
             // Do not process logits if MTP is only updating the KV cache.
-            if (cparams.mtp_op_type != MTP_OP_WARMUP &&
-                cparams.mtp_op_type != MTP_OP_UPDATE_ACCEPTED) {
+            if (cparams.mtp_op_type != MTP_OP_WARMUP) { // && cparams.mtp_op_type != MTP_OP_UPDATE_ACCEPTED) {
                 ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(lctx.sched, res);
                 GGML_ASSERT(backend_res != nullptr);
                 GGML_ASSERT(lctx.logits != nullptr);
@@ -4627,7 +4626,8 @@ static int llama_decode_internal(
         }
 
         // extract embeddings
-        if (embd && (cparams.mtp_op_type == MTP_OP_NONE || cparams.mtp_op_type == MTP_OP_DRAFT_GEN)) { 
+        //if (embd && (cparams.mtp_op_type == MTP_OP_NONE || cparams.mtp_op_type == MTP_OP_DRAFT_GEN)) {
+        if (embd && cparams.mtp_op_type != MTP_OP_WARMUP) {
 #if IK_PRINT_TIMING
             tim1 = ggml_time_us();
 #endif


### PR DESCRIPTION

This PR improves MTP performance in a non-negligible way (see below for specific results).

One issue with the implementation on the main branch is that after accepting the current batch in the draft context, the result of that is thrown away and the next round of draft tokens is generated from the beginning. But when computing the accepted batch in the `mtp_accept_tokens` function, we can already sample the 1st draft tokens from the computed logits for the last token in the batch. This has two implications:
* We save the generation of one draft token in each generation round
* For recurrent models such as Qwen-3.6-27B, the recurrent state is not cleared after accepting the batch. Hence, we end up having the last token generated by the main model be present twice in the recurrent state of the draft model

Below are 3 example results for Qwen-3.6-27B quantized with `Q8_0` and running on a 2x3090 system using split mode `graph`
* Example 1: "Write a quick sort implementation in python"
* Example 2: "Extract all core events with their exact dates into a bulleted list from the following text", followed by the top section of https://en.wikipedia.org/wiki/YouTube# (ending at "History")
* Example 3: "Give me an extended summary of the history of Bulgaria"

Baseline (i.e., no MTP) for these 3 queries is about 48 t/s. The results are generated for `--mtp -draft-max 4 --draft-p-min 0.75`.

|  Case  |  t/s (main)  | t/s (PR) |  Speedup | Speedup vs no MTP |
| ---: | ---: | ---: | ---: | ---: |
| Example 1 | 70.07 | 82.92 | 1.183 | 1.728 |
| Example 2 | 64.93 | 75.26 | 1.159 |  1.568 |
| Example 3 | 48.78 | 58.48 | 1.199 |  1.218 |

Here is the draft acceptance rate for the 3 examples

|  Case  |  acceptance rate (main)  | acceptance rate (PR) |
| ---: | ---: | ---: |
| Example 1 | 0.863 | 0.969 |
| Example 2 | 0.812 | 0.926 |
| Example 3 | 0.719 | 0.914 |

@SamuelOliveirads 

What was the rationale for not using the `mtp_accept_tokens` result to produce the next draft token?

@ubergarm 

It would be interesting to see how your 3-way Qwen-3.6-27B comparison between vLLM, llama.cpp and ik_llama.cpp looks like with this PR.

