### PR TITLE
runtime : add `--run-time-repack auto` mode for swap-bound MoE safety

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2183,8 +2183,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
     }
     if (arg == "-rtr" || arg == "--run-time-repack") {
         // Optional value: 0|off to disable, 1|on to force on, auto to enable
-        // with safety net that auto-disables on swap-bound MoE (model > 90%
-        // of available memory). No value (legacy form) behaves like "1".
+        // with a safety-first memory headroom check. No value (legacy form)
+        // behaves like "1".
         bool repack      = true;
         bool repack_auto = false;
 
@@ -2211,22 +2211,15 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
 
         params.repack_tensors      = repack;
         params.repack_tensors_auto = repack_auto;
-        // Legacy behaviour: forcing run-time repack on requires use_mmap=false
-        // because the repack pass writes back into the tensor buffers. Only
-        // apply that coupling when repack is actually going to run unconditionally
-        // (-rtr / -rtr 1). For -rtr 0 (disable) we leave use_mmap alone so the
-        // user's existing mmap intent is respected; for -rtr auto we defer the
-        // mmap decision to llama_model_load (after the auto policy decides).
-        if (repack && !repack_auto) {
-            params.use_mmap = false;
-        }
+        // Do not couple repack and mmap in the parser. The model loader resolves
+        // the final mmap state after all CLI arguments have been parsed. This
+        // makes repeated options obey last-option-wins semantics, e.g.
+        // "-rtr 1 -rtr auto" can still preserve mmap when auto disables repack.
         return true;
     }
     if (arg == "-rtra" || arg == "--run-time-repack-auto") {
         params.repack_tensors      = true;
         params.repack_tensors_auto = true;
-        // Same reasoning as for -rtr auto above: don't force use_mmap=false at
-        // parse time, because the auto policy may end up disabling repack.
         return true;
     }
     if (arg == "-thp" || arg == "--transparent-huge-pages") {
@@ -3307,7 +3300,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-rtr,  --run-time-repack [0|1|auto]",
                                                                         "repack tensors if interleaved variant is available.\n"
                                                                         "0/off = disable, 1/on = always (legacy), auto = enable with auto-disable\n"
-                                                                        "for swap-bound MoE (model > 90%% of available memory). Default: 0."});
+                                                                        "when estimated peak memory exceeds safe headroom. Default: 0."});
     options.push_back({ "*",           "       --cpu-moe",              "keep all MoE weights in CPU memory"});
     options.push_back({ "*",           "       --n-cpu-moe N",          "keep MoE weights of the first N layers in CPU memory"});
     options.push_back({ "*",           "       --defer-experts",        "defer expert mmap residency on Linux to reduce model load time"});

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2182,8 +2182,51 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "-rtr" || arg == "--run-time-repack") {
-        params.repack_tensors = true;
-        params.use_mmap = false;
+        // Optional value: 0|off → disable, 1|on → force on, auto → enable with
+        // safety net that auto-disables on swap-bound MoE (model > 90% of RAM).
+        // No value (legacy form) → behave like "1".
+        bool repack      = true;
+        bool repack_auto = false;
+
+        if (i + 1 < argc) {
+            std::string v = argv[i + 1];
+            std::transform(v.begin(), v.end(), v.begin(),
+                    [](unsigned char c) { return (char)std::tolower(c); });
+            const bool is_mode_token =
+                    v == "0" || v == "1" || v == "off" || v == "on" || v == "auto";
+            if (is_mode_token) {
+                ++i;  // consume the value
+                if (v == "0" || v == "off") {
+                    repack      = false;
+                    repack_auto = false;
+                } else if (v == "1" || v == "on") {
+                    repack      = true;
+                    repack_auto = false;
+                } else { // "auto"
+                    repack      = true;
+                    repack_auto = true;
+                }
+            }
+        }
+
+        params.repack_tensors      = repack;
+        params.repack_tensors_auto = repack_auto;
+        // Legacy behaviour: forcing run-time repack on requires use_mmap=false
+        // because the repack pass writes back into the tensor buffers. Only
+        // apply that coupling when repack is actually going to run unconditionally
+        // (-rtr / -rtr 1). For -rtr 0 (disable) we leave use_mmap alone so the
+        // user's existing mmap intent is respected; for -rtr auto we defer the
+        // mmap decision to llama_model_load (after the auto policy decides).
+        if (repack && !repack_auto) {
+            params.use_mmap = false;
+        }
+        return true;
+    }
+    if (arg == "-rtra" || arg == "--run-time-repack-auto") {
+        params.repack_tensors      = true;
+        params.repack_tensors_auto = true;
+        // Same reasoning as for -rtr auto above: don't force use_mmap=false at
+        // parse time, because the auto policy may end up disabling repack.
         return true;
     }
     if (arg == "-thp" || arg == "--transparent-huge-pages") {
@@ -3261,7 +3304,10 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     if (llama_supports_mmap()) {
         options.push_back({ "*",           "       --no-mmap",              "do not memory-map model (slower load but may reduce pageouts if not using mlock)" });
     }
-    options.push_back({ "*",           "       --run-time-repack",      "repack tensors if interleaved variant is available"});
+    options.push_back({ "*",           "-rtr,  --run-time-repack [0|1|auto]",
+                                                                        "repack tensors if interleaved variant is available.\n"
+                                                                        "0/off = disable, 1/on = always (legacy), auto = enable with auto-disable\n"
+                                                                        "for swap-bound MoE (model > 90%% of RAM). Default: 0."});
     options.push_back({ "*",           "       --cpu-moe",              "keep all MoE weights in CPU memory"});
     options.push_back({ "*",           "       --n-cpu-moe N",          "keep MoE weights of the first N layers in CPU memory"});
     options.push_back({ "*",           "       --defer-experts",        "defer expert mmap residency on Linux to reduce model load time"});
@@ -4215,6 +4261,7 @@ struct llama_model_params common_model_params_to_llama(const gpt_params & params
     mparams.use_mlock       = params.use_mlock;
     mparams.check_tensors   = params.check_tensors;
     mparams.repack_tensors  = params.repack_tensors;
+    mparams.repack_tensors_auto = params.repack_tensors_auto;
     mparams.use_thp         = params.use_thp;
     mparams.validate_quants = params.validate_quants;
     mparams.merge_qkv       = params.merge_qkv;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2182,9 +2182,9 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "-rtr" || arg == "--run-time-repack") {
-        // Optional value: 0|off → disable, 1|on → force on, auto → enable with
-        // safety net that auto-disables on swap-bound MoE (model > 90% of RAM).
-        // No value (legacy form) → behave like "1".
+        // Optional value: 0|off to disable, 1|on to force on, auto to enable
+        // with safety net that auto-disables on swap-bound MoE (model > 90%
+        // of available memory). No value (legacy form) behaves like "1".
         bool repack      = true;
         bool repack_auto = false;
 
@@ -3307,7 +3307,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",           "-rtr,  --run-time-repack [0|1|auto]",
                                                                         "repack tensors if interleaved variant is available.\n"
                                                                         "0/off = disable, 1/on = always (legacy), auto = enable with auto-disable\n"
-                                                                        "for swap-bound MoE (model > 90%% of RAM). Default: 0."});
+                                                                        "for swap-bound MoE (model > 90%% of available memory). Default: 0."});
     options.push_back({ "*",           "       --cpu-moe",              "keep all MoE weights in CPU memory"});
     options.push_back({ "*",           "       --n-cpu-moe N",          "keep MoE weights of the first N layers in CPU memory"});
     options.push_back({ "*",           "       --defer-experts",        "defer expert mmap residency on Linux to reduce model load time"});

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -3301,6 +3301,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
                                                                         "repack tensors if interleaved variant is available.\n"
                                                                         "0/off = disable, 1/on = always (legacy), auto = enable with auto-disable\n"
                                                                         "when estimated peak memory exceeds safe headroom. Default: 0."});
+    options.push_back({ "*",           "-rtra, --run-time-repack-auto", "alias for --run-time-repack auto" });
     options.push_back({ "*",           "       --cpu-moe",              "keep all MoE weights in CPU memory"});
     options.push_back({ "*",           "       --n-cpu-moe N",          "keep MoE weights of the first N layers in CPU memory"});
     options.push_back({ "*",           "       --defer-experts",        "defer expert mmap residency on Linux to reduce model load time"});
@@ -4262,6 +4263,7 @@ struct llama_model_params common_model_params_to_llama(const gpt_params & params
     mparams.mtp             = params.speculative.has_stage_type(COMMON_SPECULATIVE_TYPE_MTP);
     mparams.flash_attn      = params.flash_attn;
     mparams.defer_experts   = params.defer_experts;
+    mparams.prefetch_experts = params.prefetch_experts;
     if (params.kv_overrides.empty()) {
         mparams.kv_overrides = NULL;
     } else {

--- a/common/common.h
+++ b/common/common.h
@@ -440,7 +440,7 @@ struct gpt_params {
     bool batch_warmup      = false; // batch warmup run
     bool check_tensors     = false; // validate tensor data
     bool repack_tensors    = false; // repack tensors if interleaved variant is available
-    bool repack_tensors_auto = false; // if true, may auto-disable run-time repack on swap-bound MoE
+    bool repack_tensors_auto = false; // if true, use a safety-first memory check before run-time repack
     bool use_thp           = false; // use transparent huge pages (linux only)
     bool validate_quants   = false; // if true, check for NaNs while loading the model
     bool only_active_exps  = true;  // if true, offload only active experts (relevant only for hybrid CPU/GPU)

--- a/common/common.h
+++ b/common/common.h
@@ -440,6 +440,7 @@ struct gpt_params {
     bool batch_warmup      = false; // batch warmup run
     bool check_tensors     = false; // validate tensor data
     bool repack_tensors    = false; // repack tensors if interleaved variant is available
+    bool repack_tensors_auto = false; // if true, may auto-disable run-time repack on swap-bound MoE
     bool use_thp           = false; // use transparent huge pages (linux only)
     bool validate_quants   = false; // if true, check for NaNs while loading the model
     bool only_active_exps  = true;  // if true, offload only active experts (relevant only for hybrid CPU/GPU)

--- a/docs/RTR_AUTO_PR_FOLLOWUP_PLAN.md
+++ b/docs/RTR_AUTO_PR_FOLLOWUP_PLAN.md
@@ -1,0 +1,99 @@
+# RTR auto: план реализации pre-PR follow-up
+
+Связанная спецификация: [RTR_AUTO_PR_FOLLOWUP_SPEC.md](RTR_AUTO_PR_FOLLOWUP_SPEC.md).
+
+## Этап 1 — безопасные helpers и cgroup
+
+1. В `llama-cgroup-resolver.h` заменить выбор most-specific mount на сбор всех
+   host-relative mappings с dedup `(mountpoint,path)`; оставить namespace
+   fallback только при отсутствии host-relative mapping.
+2. Вынести cgroup headroom traversal в testable seam, позволяющий fixture reader
+   симулировать limits/ошибки чтения. Пересекать все applicable hierarchy;
+   unreadable unique hierarchy => unknown.
+3. Добавить fixture full root + bind mount, stricter parent, unreadable mapping,
+   v1/v2 mixed membership и duplicate dedup. Для v2 отдельно зафиксировать:
+   missing `memory.max` + `memory.current` допустим только ровно на mountpoint;
+   partial pair и missing pair ниже mountpoint дают unknown.
+
+**Gate:** `test-cgroup-resolver` доказывает отсутствие ancestor loss и fail-closed
+результат.
+
+## Этап 2 — conservative peak budget
+
+1. В `llama-model-loader.h/.cpp` создать shared constants для worker count и
+   CUDA staging size, используемые `load_all_data()`.
+2. Вынести overflow-safe peak arithmetic в deterministic helper: model bytes,
+   workspace, `workers * max_read_buffer`, optional CUDA staging.
+3. Derive helper inputs from the same finalized placement/buffer-type decision
+   as loader; unknown backend applicability => AUTO_UNKNOWN. Largest probe
+   tensor is admitted only after asserting it bounds every `read_buf.resize()`
+   path, including Windows graph/split path.
+4. Добавить unit tests для CPU, active CUDA, requested-but-inactive CUDA,
+   Windows non-CUDA split read path, 8-worker term и overflow.
+
+**Gate:** policy cannot keep when helper cannot bound loader transient memory.
+
+## Этап 3 — mmap/prefetch/defer lifecycle
+
+1. Добавить trailing `prefetch_experts` compatibility field в
+   `llama_model_params`, default params и propagation всех model-load callers
+   (common, bench/server/examples and direct aggregate initializers); обновить
+   public ABI/matching-header documentation.
+2. On Linux, `-rtr auto + prefetch` => AUTO_UNKNOWN before memory probe. On
+   unsupported platforms, prefetch does not alter RTR policy and is explicitly
+   disabled with a warning during context creation.
+3. После construction loader записать effective mmap; обновить после tensor
+   load. `vocab_only` получает correct constructor-effective value.
+4. `defer_experts` index использует `ml.use_mmap`; forced incompatibility
+   логируется и не индексируется.
+5. В context creation gate prefetch на `!model->mappings.empty()`; при false —
+   единственный warning, без init/register. Define idempotent ownership for
+   global init/registration across repeated contexts and cleanup. Forced path
+   не выдаёт false success.
+6. Добавить loader/context test seam или tiny GGUF tests: forced mmap, auto
+   prefetch UNKNOWN, forced defer/prefetch, direct API caller, repeated context
+   creation и vocab-only.
+
+**Gate:** no mmap-only feature silently no-ops.
+
+## Этап 4 — versioned benchmark schema и consumer
+
+1. Перевести SQL writer c `test_v2` на `test_v3`; сохранить historical
+   `use_mmap`, добавить explicit requested/effective/buffer columns и
+   require all v3 RTR/mmap columns before reading.
+2. Расширить reader allowlist на `test`, `test_v2`, `test_v3`; fixed internal
+   `source_schema` включить в every UNION projection and JOIN. Historical
+   schemas compare only within the same schema; `test↔v2` и `v2↔v3` never join.
+3. For v3 use `use_mmap_effective` as canonical comparison key; requested mmap
+   remains report-only. Replace NULL wildcard with SQLite `IS`; centralize an
+   early no-common diagnostic before any `rows[0]` or rendering in default and
+   explicit-show flows; nullable bool renders `Unknown`.
+4. Persist and SQLite-inspect v3 requested/effective/buffer getters, including
+   forced `requested=1,effective=0,mmap_backed=0` fixture.
+5. Update README/examples and Python fixtures: legacy-only, v2-only, v3-only,
+   test/v2/v3 mixed rejection, malformed v3, multi-RTR variants, every nullable
+   bool display, and no-common default/show.
+
+**Gate:** no existing v2 schema is modified; no semantic cross-version speedup.
+
+## Этап 5 — review and verification
+
+1. Run formatter/style checks and `git diff --check`.
+2. Build MSVC Release targets: `test-rtr-params`, `test-cgroup-resolver`,
+   new policy/bench tests, `llama-bench`.
+3. Run relevant CTest and Python consumer tests, then `llama-bench --help`
+   smoke.
+4. Review final `upstream/main...HEAD` diff specifically for public ABI fields,
+   cgroup fail-closed paths, SQL migrations and direct API context behaviour.
+5. Document Linux cgroup test as CI-required if no Linux environment is present.
+
+## Commit structure
+
+1. `fix: make RTR cgroup and peak policy conservative`
+2. `fix: guard RTR mmap-only feature interactions`
+3. `fix: version RTR benchmark mmap metadata`
+4. `test: cover RTR policy and benchmark schema regressions`
+5. `docs: record RTR pre-PR remediation` (spec + plan)
+
+Commits must remain independently buildable where practical; public API and its
+tests land in the same commit.

--- a/docs/RTR_AUTO_PR_FOLLOWUP_SPEC.md
+++ b/docs/RTR_AUTO_PR_FOLLOWUP_SPEC.md
@@ -1,0 +1,169 @@
+# RTR auto: спецификация закрытия pre-PR review
+
+**Дата:** 2026-07-19
+**Ветка:** `feature/rtr-auto-pr-prep`
+**База:** `upstream/main`
+
+## Цель и границы
+
+Довести `--run-time-repack auto` до safety-first контракта: авто-режим не делает
+`AUTO_KEEP`, когда память/placement/mmap consequences неизвестны или оценены
+неполно; benchmark и SQL consumer не выдают ложный speedup.
+
+Forced `-rtr 1` остаётся explicit opt-in и по-прежнему отключает mmap в loader.
+Эта серия не меняет его в silent auto-disable, но делает несовместимые mmap-only
+features явными и не позволяет им притворяться работающими.
+
+## Findings, которые закрывает серия
+
+1. **P1 cgroup ancestor loss:** наиболее специфичный bind mount вытесняет full
+   hierarchy mount; скрытый stricter parent limit не участвует в headroom.
+2. **P1 loader peak undercount:** policy не учитывает persistent `read_bufs`
+   всех 8 workers и CUDA staging buffers.
+3. **P1 benchmark mmap mislabel:** `use_mmap` хранит CLI request, а не
+   loader-effective состояние.
+4. **P1 SQL wildcard:** legacy `NULL` RTR fields сопоставляются с любым known
+   `test_v2` setting и смешивают результаты.
+5. **P2 prefetch/defer incompatibilities:** AUTO_KEEP может убрать mmap для
+   `--prefetch-experts`; forced path проверяет requested вместо loader mmap.
+6. **P2 consumer crashes:** no common configuration и nullable boolean ломают
+   штатный compare script.
+7. **P3 effective-state edge:** `vocab_only` не записывает loader mmap state.
+8. **Coverage gap:** current tests не исполняют policy/loader interactions.
+
+## Инварианты
+
+- `AUTO_KEEP` допустим, только когда placement, memory peak и последствия
+  отключения mmap полностью смоделированы.
+- Любая неопределённость => `AUTO_UNKNOWN`, repack выключается, requested mmap
+  сохраняется.
+- Все host-relative cgroup mappings, которые могут ограничивать process,
+  участвуют в пересечении. Непрочитываемая единственная applicable hierarchy
+  делает результат unknown; duplicate mapping той же полной hierarchy может
+  быть deduplicated после доказательства одинакового `(mountpoint,path)`.
+- Unknown legacy RTR/mmap-effective metadata не равна known setting.
+- `llama_model_loader_mmap_enabled()` означает loader decision, а
+  `llama_model_has_mmap_buffers()` — отдельный факт наличия mmap-backed buffer.
+  Getters meaningful только для успешно возвращённой модели.
+
+## A. Cgroup hierarchy
+
+`llama_resolve_cgroup_mounts()` сохраняет все host-relative matching mounts:
+full hierarchy и bind mounts. Namespace-relative fallback возможен только при
+отсутствии любого host-relative match. Каждая уникальная resolved
+`(mountpoint,path)` hierarchy читается до mountpoint; итоговый headroom —
+minimum по всем successfully resolved applicable hierarchy.
+
+Для cgroup v2 отсутствие одновременно `memory.max` и `memory.current` ровно на
+mountpoint означает unlimited/неэкспонированный корневой уровень и пропускается.
+Та же отсутствующая пара ниже mountpoint, несовпадающая пара файлов или ошибка
+доступа остаются unknown (fail closed).
+
+Нельзя выбирать только «самый специфичный» root. Неразборчивый membership/mount
+или unreadable unique applicable hierarchy => unknown, а не host fallback. Tests
+должны доказать: (1) full + bind mapping оба сохранены, (2) stricter ancestor
+полной hierarchy выигрывает, (3) unreadable applicable hierarchy даёт unknown,
+(4) missing pair пропускается только на mountpoint.
+
+## B. Conservative loader peak
+
+Общий helper с checked multiplication/addition считает:
+
+```text
+CPU-resident model bytes
++ maximum repack workspace
++ n_load_workers * maximum non-mmap read buffer
++ n_load_workers * CUDA staging buffer size, если фактический loader path
+  способен использовать CUDA async upload
+```
+
+`maximum non-mmap read buffer` допускается консервативно принять равным largest
+tensor среди probe tensors. Это покрывает persistent worker capacities и Windows
+parallel split path. CUDA staging учитывается по runtime-applicability
+(`!use_mmap`, `!check_tensors`, active CUDA upload backend); если определить путь
+по metadata/placement нельзя, policy возвращает UNKNOWN. Shared constants worker
+count/staging size имеют единый источник с `load_all_data()`.
+
+Overflow любого промежуточного расчёта => UNKNOWN. Tests покрывают CPU-only,
+active CUDA, unknown backend applicability, `8 * max_read_buffer` и overflow.
+
+## C. mmap metadata и versioned SQL schema
+
+Нельзя менять значение existing `test_v2.use_mmap`: historical rows используют
+его как requested setting. SQL writer переключается на immutable **`test_v3`**:
+
+- `use_mmap` — retained requested compatibility field;
+- `use_mmap_requested` — явный requested setting;
+- `use_mmap_effective` — `llama_model_loader_mmap_enabled()`;
+- `mmap_backed_buffers` — `llama_model_has_mmap_buffers()`.
+
+`test_v3` avoids `CREATE TABLE IF NOT EXISTS test_v2` schema collision. Consumer
+reads `test`, `test_v2`, `test_v3`. Comparison of v3 uses
+`use_mmap_effective`; historical tables with no effective field may compare only
+with the same historical schema. **`test_v2` and `test_v3` are never compared**:
+v2 has no effective-mmap semantics and must never be interpreted as
+requested==effective.
+
+Loader records `use_mmap_loader_enabled` immediately after construction (for
+successful `vocab_only`) and again after tensor loading (for later fallback).
+
+## D. SQL consumer contract
+
+SQLite-only equality for optional RTR/effective mmap properties is:
+
+```sql
+tb.column IS tc.column
+```
+
+Thus `NULL` matches only `NULL`. No wildcard semantics. If no full comparable
+configuration remains, every output mode (default and explicit `--show`) exits
+non-zero and prints `no comparable configurations` to stderr. Nullable boolean
+display is `Unknown`, never `int(None)`.
+
+Tests cover legacy-only, v2-only, v3-only, legacy/v3 rejection, multiple v3 RTR
+variants without cross-product, `--show repack` on NULL, and no-common failure
+in default and explicit-show modes.
+
+## E. Prefetch/defer interactions and API callers
+
+Add `prefetch_experts` to model-load params and propagate it from common CLI so,
+on Linux where expert prefetch is implemented, `-rtr auto --prefetch-experts`
+returns AUTO_UNKNOWN before memory probe and preserves mmap. On unsupported
+platforms the request must not affect RTR auto and context creation must emit an
+explicit warning before disabling prefetch.
+
+Because prefetch is also a public **context** API request, context creation is
+the final authority. Its exact eligibility predicate is
+`!model->mappings.empty()`: these are the address ranges registered with the
+prefetch backend. When false, context emits one deterministic warning and does
+not initialize/register prefetch. `mmap_backed_buffers` is benchmark metadata,
+not this eligibility predicate. Direct API callers therefore cannot get a silent
+no-op even if model was loaded without the CLI compatibility flag.
+
+For forced RTR, prefetch/defer are explicitly disabled at their effective use
+point, not merely logged at model load. Deferred expert index checks
+`ml.use_mmap`, not requested `params.use_mmap`, and logs its incompatibility.
+All new model-param fields are trailing, default-initialized and documented as
+C-ABI matching-header requirements; defaults and aggregate initializers update.
+
+## F. Tests and acceptance
+
+1. Cgroup resolver plus injectable/fixture headroom seam prove A.
+2. Deterministic peak helper tests prove B.
+3. Tiny GGUF or test seam proves forced requested=true/effective=false plus
+   actual `n_repacked>0`; auto UNKNOWN prefetch keeps mmap; vocab-only records
+   constructor-effective mmap; forced defer/prefetch takes explicit disabled
+   path.
+4. SQL/output integration proves test_v3 stores requested/effective/buffer
+   state and compare keys use effective state; historical v2 remains readable
+   but v2↔v3 is rejected. README/examples and schema-detection tests update for
+   `test_v3`.
+5. MSVC Release build, relevant CTest/Python tests and `llama-bench` smoke pass.
+   Linux cgroup build/test is required in CI or explicitly reported as an
+   external pending check; local Windows success is not evidence for Linux.
+
+## Не-цели
+
+- Точный Windows Job Object accounting (current AUTO_UNKNOWN fallback remains).
+- SQL ALTER/migration или dual-write existing tables.
+- Изменение forced RTR в automatic disable.

--- a/examples/llama-bench/README.md
+++ b/examples/llama-bench/README.md
@@ -240,12 +240,12 @@ $ ./llama-bench -o json
 
 ### SQL
 
-SQL output is suitable for importing into a SQLite database. The current writer uses the versioned `test_v2` table; it can be piped into the `sqlite3` command line tool to add results to a database.
+SQL output is suitable for importing into a SQLite database. The current writer uses the immutable versioned `test_v3` table; it can be piped into the `sqlite3` command line tool to add results to a database. `use_mmap` remains the requested compatibility field. `use_mmap_requested`, `use_mmap_effective`, and `mmap_backed_buffers` record the requested setting, loader decision, and actual mmap-backed buffers separately.
 
 ```sh
 $ ./llama-bench -o sql | sqlite3 llama-bench.sqlite
-$ sqlite3 llama-bench.sqlite '.schema test_v2'
+$ sqlite3 llama-bench.sqlite '.schema test_v3'
 $ ./scripts/compare-llama-bench.py -i llama-bench.sqlite
 ```
 
-The compare script reads both legacy `test` data and current `test_v2` data. It combines the two only while the writer emits one table per run; a future dual-write schema must provide a stable run identifier and deduplication.
+The compare script reads legacy `test`, historical `test_v2`, and current `test_v3` data. It compares rows only within the same schema generation: `test_v2` has no effective-mmap semantics and is never compared with `test_v3`. The schema column is therefore always included in comparison output, including when `--show` is specified. A future dual-write schema must provide a stable run identifier and deduplication.

--- a/examples/llama-bench/README.md
+++ b/examples/llama-bench/README.md
@@ -240,42 +240,12 @@ $ ./llama-bench -o json
 
 ### SQL
 
-SQL output is suitable for importing into a SQLite database. The output can be piped into the `sqlite3` command line tool to add the results to a database.
+SQL output is suitable for importing into a SQLite database. The current writer uses the versioned `test_v2` table; it can be piped into the `sqlite3` command line tool to add results to a database.
 
 ```sh
-$ ./llama-bench -o sql
+$ ./llama-bench -o sql | sqlite3 llama-bench.sqlite
+$ sqlite3 llama-bench.sqlite '.schema test_v2'
+$ ./scripts/compare-llama-bench.py -i llama-bench.sqlite
 ```
 
-```sql
-CREATE TABLE IF NOT EXISTS test (
-  build_commit TEXT,
-  build_number INTEGER,
-  cuda INTEGER,
-  metal INTEGER,
-  gpu_blas INTEGER,
-  blas INTEGER,
-  cpu_info TEXT,
-  gpu_info TEXT,
-  model_filename TEXT,
-  model_type TEXT,
-  model_size INTEGER,
-  model_n_params INTEGER,
-  n_batch INTEGER,
-  n_threads INTEGER,
-  f16_kv INTEGER,
-  n_gpu_layers INTEGER,
-  main_gpu INTEGER,
-  mul_mat_q INTEGER,
-  tensor_split TEXT,
-  n_prompt INTEGER,
-  n_gen INTEGER,
-  test_time TEXT,
-  avg_ns INTEGER,
-  stddev_ns INTEGER,
-  avg_ts REAL,
-  stddev_ts REAL
-);
-
-INSERT INTO test (build_commit, build_number, cuda, metal, gpu_blas, blas, cpu_info, gpu_info, model_filename, model_type, model_size, model_n_params, n_batch, n_threads, f16_kv, n_gpu_layers, main_gpu, mul_mat_q, tensor_split, n_prompt, n_gen, test_time, avg_ns, stddev_ns, avg_ts, stddev_ts) VALUES ('3469684', '1275', '1', '0', '0', '1', '1', '13th Gen Intel(R) Core(TM) i9-13900K', 'NVIDIA GeForce RTX 3090 Ti', 'models/7B/ggml-model-q4_0.gguf', 'llama 7B mostly Q4_0', '3825065984', '6738415616', '512', '16', '1', '99', '0', '1', '0.00', '512', '0', '2023-09-23T12:10:30Z', '212693772', '743623', '2407.240204', '8.409634');
-INSERT INTO test (build_commit, build_number, cuda, metal, gpu_blas, blas, cpu_info, gpu_info, model_filename, model_type, model_size, model_n_params, n_batch, n_threads, f16_kv, n_gpu_layers, main_gpu, mul_mat_q, tensor_split, n_prompt, n_gen, test_time, avg_ns, stddev_ns, avg_ts, stddev_ts) VALUES ('3469684', '1275', '1', '0', '0', '1', '1', '13th Gen Intel(R) Core(TM) i9-13900K', 'NVIDIA GeForce RTX 3090 Ti', 'models/7B/ggml-model-q4_0.gguf', 'llama 7B mostly Q4_0', '3825065984', '6738415616', '512', '16', '1', '99', '0', '1', '0.00', '0', '128', '2023-09-23T12:10:31Z', '977925003', '4037361', '130.891159', '0.537692');
-```
+The compare script reads both legacy `test` data and current `test_v2` data. It combines the two only while the writer emits one table per run; a future dual-write schema must provide a stable run identifier and deduplication.

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -262,6 +262,7 @@ struct cmd_params {
     bool verbose;
     bool warmup;
     bool repack = false;
+    bool repack_auto = false;
     bool fmoe = true;
     bool ger = false;     // ger = Grouped Expert Routing
     bool no_fug = false;
@@ -311,6 +312,7 @@ static const cmd_params cmd_params_defaults = {
     /* verbose              */ false,
     /* warmup               */ true,
     /* repack               */ false,
+    /* repack_auto          */ false,
     /* fmoe                 */ true,
     /* ger                  */ false,
     /* no_fug               */ false,
@@ -365,7 +367,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -oe, --output-err <csv|json|md|sql> (default: %s)\n", output_format_str(cmd_params_defaults.output_format_stderr));
     printf("  -v, --verbose                       (default: %s)\n", cmd_params_defaults.verbose ? "1" : "0");
     printf("  -w, --warmup <0|1>                  (default: %s)\n", cmd_params_defaults.warmup ? "1" : "0");
-    printf("  -rtr, --run-time-repack <0|1>       (default: %s)\n", cmd_params_defaults.repack ? "1" : "0");
+    printf("  -rtr, --run-time-repack <0|1|auto>  (default: %s)\n", cmd_params_defaults.repack ? (cmd_params_defaults.repack_auto ? "auto" : "1") : "0");
     printf("  -cuda, --cuda-params <string>       (default: %s)\n", cmd_params_defaults.cuda_params.c_str());
     printf("  -mqkv, --merge-qkv                  (default: %s)\n", cmd_params_defaults.mqkv ? "1" : "0");
     printf("  -muge, --merge-up-gate-experts      (default: %s)\n", cmd_params_defaults.muge ? "1" : "0");
@@ -797,7 +799,23 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 invalid_param = true;
                 break;
             }
-            params.repack = std::stoi(argv[i]);
+            std::string v = argv[i];
+            std::transform(v.begin(), v.end(), v.begin(),
+                    [](unsigned char c) { return (char)std::tolower(c); });
+            if (v == "auto") {
+                params.repack = true;
+                params.repack_auto = true;
+            } else if (v == "1" || v == "on") {
+                params.repack = true;
+                params.repack_auto = false;
+            } else if (v == "0" || v == "off") {
+                params.repack = false;
+                params.repack_auto = false;
+            } else {
+                // numeric fallback (legacy `0|1`)
+                params.repack = std::stoi(argv[i]) != 0;
+                params.repack_auto = false;
+            }
         } else if (arg == "-cuda" || arg == "--cuda-params") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -979,6 +997,7 @@ struct cmd_params_instance {
     bool use_mmap;
     bool embeddings;
     bool repack = false;
+    bool repack_auto = false;
     bool fmoe = true;
     bool ger = false;
     bool no_fug = false;
@@ -1006,6 +1025,7 @@ struct cmd_params_instance {
         mparams.tensor_split = tensor_split.data();
         mparams.use_mmap = use_mmap;
         mparams.repack_tensors = repack;
+        mparams.repack_tensors_auto = repack_auto;
         mparams.use_thp = use_thp;
         mparams.merge_qkv = mqkv;
         mparams.merge_up_gate_exps = muge;
@@ -1029,6 +1049,7 @@ struct cmd_params_instance {
                main_gpu == other.main_gpu &&
                use_mmap == other.use_mmap &&
                repack == other.repack &&
+               repack_auto == other.repack_auto &&
                mqkv == other.mqkv &&
                muge == other.muge &&
                defer_experts == other.defer_experts &&
@@ -1120,6 +1141,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .use_mmap     = */ mmp,
                 /* .embeddings   = */ embd,
                 /* .repack       = */ params.repack,
+                /* .repack_auto  = */ params.repack_auto,
                 /* .fmoe         = */ params.fmoe,
                 /* .ger          = */ params.ger,
                 /* .no_fug       = */ params.no_fug,
@@ -1167,6 +1189,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .use_mmap     = */ mmp,
                 /* .embeddings   = */ embd,
                 /* .repack       = */ params.repack,
+                /* .repack_auto  = */ params.repack_auto,
                 /* .fmoe         = */ params.fmoe,
                 /* .ger          = */ params.ger,
                 /* .no_fug       = */ params.no_fug,
@@ -1214,6 +1237,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .use_mmap     = */ mmp,
                 /* .embeddings   = */ embd,
                 /* .repack       = */ params.repack,
+                /* .repack_auto  = */ params.repack_auto,
                 /* .fmoe         = */ params.fmoe,
                 /* .ger          = */ params.ger,
                 /* .no_fug       = */ params.no_fug,
@@ -1261,6 +1285,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .use_mmap     = */ mmp,
                 /* .embeddings   = */ embd,
                 /* .repack       = */ params.repack,
+                /* .repack_auto  = */ params.repack_auto,
                 /* .fmoe         = */ params.fmoe,
                 /* .ger          = */ params.ger,
                 /* .no_fug       = */ params.no_fug,

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1341,7 +1341,13 @@ struct test {
     Ser  ser;
     std::vector<float> tensor_split;
     std::string cuda_params;
+    // `use_mmap` is retained as the command-line request for compatibility
+    // with historical SQL output.  The other three fields describe what the
+    // successfully loaded model actually did.
     bool use_mmap;
+    bool use_mmap_requested = false;
+    bool use_mmap_effective = false;
+    bool mmap_backed_buffers = false;
     bool embeddings;
     bool repack = false;
     bool repack_auto = false;
@@ -1393,6 +1399,9 @@ struct test {
         tensor_split = inst.tensor_split;
         cuda_params = inst.cuda_params;
         use_mmap = inst.use_mmap;
+        use_mmap_requested = llama_model_mmap_requested(lmodel);
+        use_mmap_effective = llama_model_loader_mmap_enabled(lmodel);
+        mmap_backed_buffers = llama_model_has_mmap_buffers(lmodel);
         embeddings = inst.embeddings;
         repack = inst.repack;
         repack_auto = inst.repack_auto;
@@ -1531,7 +1540,8 @@ struct test {
         }
         if (field == "cuda" || field == "vulkan" || field == "metal" ||
             field == "gpu_blas" || field == "blas" || field == "sycl" || field == "no_kv_offload" ||
-            field == "flash_attn" || field == "use_mmap" || field == "embeddings" || field == "repack" ||
+            field == "flash_attn" || field == "use_mmap" || field == "use_mmap_requested" ||
+            field == "use_mmap_effective" || field == "mmap_backed_buffers" || field == "embeddings" || field == "repack" ||
             field == "repack_auto" || field == "repack_effective" || field == "use_thp" ||
             field == "fused_moe" || field == "grouped_er" || field == "no_fused_up_gate" || field == "no_ooae" || field == "mqkv" ||
             field == "rcache" || field == "reuse" || field == "muge" || field == "defer_experts" || field == "sas") {
@@ -1576,7 +1586,8 @@ struct test {
             std::to_string(n_gpu_layers), split_mode_str(split_mode),
             std::to_string(main_gpu), std::to_string(no_kv_offload), std::to_string(flash_attn),
             std::to_string(mla_attn), std::to_string(attn_max_batch), ser_to_string(ser), std::to_string(reuse),
-            tensor_split_str, std::to_string(use_mmap), std::to_string(embeddings),
+            tensor_split_str, std::to_string(use_mmap), std::to_string(use_mmap_requested),
+            std::to_string(use_mmap_effective), std::to_string(mmap_backed_buffers), std::to_string(embeddings),
             std::to_string(repack), std::to_string(repack_auto), std::to_string(repack_effective), repack_status,
             std::to_string(mqkv), std::to_string(muge), std::to_string(defer_experts), std::to_string(fmoe), std::to_string(ger),
             std::to_string(no_fug), std::to_string(use_thp), std::to_string(no_ooae), std::to_string(rcache), std::to_string(sas),
@@ -1600,7 +1611,7 @@ struct test {
             "n_threads", "type_k", "type_v",
             "n_gpu_layers", "split_mode",
             "main_gpu", "no_kv_offload", "flash_attn", "mla_attn", "attn_max_batch", "ser", "reuse",
-            "tensor_split", "use_mmap", "embeddings", "repack", "repack_auto", "repack_effective", "repack_status",
+            "tensor_split", "use_mmap", "use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers", "embeddings", "repack", "repack_auto", "repack_effective", "repack_status",
             "mqkv", "muge", "defer_experts", "fused_moe", "grouped_er",
             "no_fused_up_gate", "use_thp", "no_ooae", "rcache", "sas", "max_gpu", "cuda_params", "override_tensor",
             "n_prompt", "n_gen", "test_time",
@@ -2117,11 +2128,11 @@ struct markdown_printer : public printer {
 };
 
 struct sql_printer : public printer {
-    // Schema v2 adds the effective RTR decision fields. Keep a versioned table
+    // Schema v3 adds requested/effective mmap state. Keep a versioned table
     // name so SQL output can be appended to databases created by older builds
     // without failing on missing columns in the legacy `test` table.
     static const char * table_name() {
-        return "test_v2";
+        return "test_v3";
     }
 
     static std::string escape_sql(const std::string & value) {

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -1396,13 +1396,12 @@ struct test {
         embeddings = inst.embeddings;
         repack = inst.repack;
         repack_auto = inst.repack_auto;
+        repack_effective = llama_model_n_repacked(lmodel) > 0;
         switch (llama_model_rtr_status(lmodel)) {
             case LLAMA_RTR_STATUS_ENABLED:
-                repack_effective = true;
                 repack_status = "enabled";
                 break;
             case LLAMA_RTR_STATUS_AUTO_KEEP:
-                repack_effective = true;
                 repack_status = "auto_keep";
                 break;
             case LLAMA_RTR_STATUS_AUTO_DISABLE:

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -2118,6 +2118,13 @@ struct markdown_printer : public printer {
 };
 
 struct sql_printer : public printer {
+    // Schema v2 adds the effective RTR decision fields. Keep a versioned table
+    // name so SQL output can be appended to databases created by older builds
+    // without failing on missing columns in the legacy `test` table.
+    static const char * table_name() {
+        return "test_v2";
+    }
+
     static std::string escape_sql(const std::string & value) {
         std::string escaped;
         for (auto c : value) {
@@ -2146,7 +2153,7 @@ struct sql_printer : public printer {
 
     void print_header(const cmd_params & params) override {
         std::vector<std::string> fields = test::get_fields();
-        fprintf(fout, "CREATE TABLE IF NOT EXISTS test (\n");
+        fprintf(fout, "CREATE TABLE IF NOT EXISTS %s (\n", table_name());
         for (size_t i = 0; i < fields.size(); i++) {
             fprintf(fout, "  %s %s%s\n", fields.at(i).c_str(), get_sql_field_type(fields.at(i)).c_str(),  i < fields.size() - 1 ? "," : "");
         }
@@ -2156,7 +2163,7 @@ struct sql_printer : public printer {
     }
 
     void print_test(const test & t) override {
-        fprintf(fout, "INSERT INTO test (%s) ", join(test::get_fields(), ", ").c_str());
+        fprintf(fout, "INSERT INTO %s (%s) ", table_name(), join(test::get_fields(), ", ").c_str());
         fprintf(fout, "VALUES (");
         std::vector<std::string> values = t.get_values();
         std::transform(values.begin(), values.end(), values.begin(), escape_sql);

--- a/examples/llama-bench/llama-bench.cpp
+++ b/examples/llama-bench/llama-bench.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cctype>
 #include <chrono>
 #include <cinttypes>
 #include <clocale>
@@ -1343,6 +1344,9 @@ struct test {
     bool use_mmap;
     bool embeddings;
     bool repack = false;
+    bool repack_auto = false;
+    bool repack_effective = false;
+    std::string repack_status;
     bool fmoe = false;
     bool ger = false;
     bool no_fug = false;
@@ -1391,6 +1395,27 @@ struct test {
         use_mmap = inst.use_mmap;
         embeddings = inst.embeddings;
         repack = inst.repack;
+        repack_auto = inst.repack_auto;
+        switch (llama_model_rtr_status(lmodel)) {
+            case LLAMA_RTR_STATUS_ENABLED:
+                repack_effective = true;
+                repack_status = "enabled";
+                break;
+            case LLAMA_RTR_STATUS_AUTO_KEEP:
+                repack_effective = true;
+                repack_status = "auto_keep";
+                break;
+            case LLAMA_RTR_STATUS_AUTO_DISABLE:
+                repack_status = "auto_disable";
+                break;
+            case LLAMA_RTR_STATUS_AUTO_UNKNOWN:
+                repack_status = "auto_unknown";
+                break;
+            case LLAMA_RTR_STATUS_DISABLED:
+            default:
+                repack_status = "disabled";
+                break;
+        }
         mqkv = inst.mqkv;
         muge = inst.muge;
         defer_experts = inst.defer_experts;
@@ -1507,7 +1532,8 @@ struct test {
         }
         if (field == "cuda" || field == "vulkan" || field == "metal" ||
             field == "gpu_blas" || field == "blas" || field == "sycl" || field == "no_kv_offload" ||
-            field == "flash_attn" || field == "use_mmap" || field == "embeddings" || field == "repack" || field == "use_thp" ||
+            field == "flash_attn" || field == "use_mmap" || field == "embeddings" || field == "repack" ||
+            field == "repack_auto" || field == "repack_effective" || field == "use_thp" ||
             field == "fused_moe" || field == "grouped_er" || field == "no_fused_up_gate" || field == "no_ooae" || field == "mqkv" ||
             field == "rcache" || field == "reuse" || field == "muge" || field == "defer_experts" || field == "sas") {
             return BOOL;
@@ -1552,7 +1578,8 @@ struct test {
             std::to_string(main_gpu), std::to_string(no_kv_offload), std::to_string(flash_attn),
             std::to_string(mla_attn), std::to_string(attn_max_batch), ser_to_string(ser), std::to_string(reuse),
             tensor_split_str, std::to_string(use_mmap), std::to_string(embeddings),
-            std::to_string(repack), std::to_string(mqkv), std::to_string(muge), std::to_string(defer_experts), std::to_string(fmoe), std::to_string(ger),
+            std::to_string(repack), std::to_string(repack_auto), std::to_string(repack_effective), repack_status,
+            std::to_string(mqkv), std::to_string(muge), std::to_string(defer_experts), std::to_string(fmoe), std::to_string(ger),
             std::to_string(no_fug), std::to_string(use_thp), std::to_string(no_ooae), std::to_string(rcache), std::to_string(sas),
             std::to_string(max_gpu),
             cuda_params, override_tensor,
@@ -1574,7 +1601,8 @@ struct test {
             "n_threads", "type_k", "type_v",
             "n_gpu_layers", "split_mode",
             "main_gpu", "no_kv_offload", "flash_attn", "mla_attn", "attn_max_batch", "ser", "reuse",
-            "tensor_split", "use_mmap", "embeddings", "repack", "mqkv", "muge", "defer_experts", "fused_moe", "grouped_er",
+            "tensor_split", "use_mmap", "embeddings", "repack", "repack_auto", "repack_effective", "repack_status",
+            "mqkv", "muge", "defer_experts", "fused_moe", "grouped_er",
             "no_fused_up_gate", "use_thp", "no_ooae", "rcache", "sas", "max_gpu", "cuda_params", "override_tensor",
             "n_prompt", "n_gen", "test_time",
             "avg_ns", "stddev_ns",
@@ -1755,6 +1783,15 @@ struct markdown_printer : public printer {
         if (field == "repack") {
             return 3;
         }
+        if (field == "repack_auto") {
+            return 8;
+        }
+        if (field == "repack_effective") {
+            return 7;
+        }
+        if (field == "repack_status") {
+            return -12;
+        }
         if (field == "mqkv") {
             return 4;
         }
@@ -1833,6 +1870,15 @@ struct markdown_printer : public printer {
         }
         if (field == "repack") {
             return "rtr";
+        }
+        if (field == "repack_auto") {
+            return "rtr_auto";
+        }
+        if (field == "repack_effective") {
+            return "rtr_eff";
+        }
+        if (field == "repack_status") {
+            return "rtr_status";
         }
         if (field == "mqkv") {
             return "mqkv";
@@ -1952,6 +1998,9 @@ struct markdown_printer : public printer {
         }
         if (params.repack != cmd_params_defaults.repack) {
             fields.emplace_back("repack");
+            fields.emplace_back("repack_auto");
+            fields.emplace_back("repack_effective");
+            fields.emplace_back("repack_status");
         }
         if (params.mqkv != cmd_params_defaults.mqkv) {
             fields.emplace_back("mqkv");

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -8440,8 +8440,7 @@ int iqk_repacked_type(const struct ggml_tensor * tensor) {
 
 uint64_t iqk_repack_workspace_size(const struct ggml_tensor * tensor) {
     constexpr int kChunk = 8;
-    if (!tensor || tensor->ne[1] % 4 != 0 ||
-        iqk_repacked_type(tensor) == (int) tensor->type) {
+    if (!tensor || iqk_repacked_type(tensor) == (int) tensor->type) {
         return 0;
     }
 
@@ -8468,8 +8467,6 @@ void iqk_repack_tensor(struct ggml_tensor * tensor) {
     if (!tensor) return;
     if (!ggml_is_contiguous(tensor)) return;
     if (is_forbidden_tensor(tensor->name)) return;
-    if (tensor->ne[1] % 4) return;
-
     auto rptr = get_repack_info(tensor->type);
     if (!rptr) return;
     if (tensor->ne[1] % rptr->num_rows) return;

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -8438,6 +8438,31 @@ int iqk_repacked_type(const struct ggml_tensor * tensor) {
     return rptr && tensor->ne[1] % rptr->num_rows == 0 ? (int)rptr->new_type : (int)tensor->type;
 }
 
+uint64_t iqk_repack_workspace_size(const struct ggml_tensor * tensor) {
+    constexpr int kChunk = 8;
+    if (!tensor || tensor->ne[1] % 4 != 0 ||
+        iqk_repacked_type(tensor) == (int) tensor->type) {
+        return 0;
+    }
+
+    const auto rptr = get_repack_info(tensor->type);
+    if (!rptr) {
+        return 0;
+    }
+
+    const int64_t nrows = ggml_nrows(tensor);
+    const int64_t rows_per_chunk = (int64_t) kChunk * rptr->num_rows;
+    const int64_t num_chunks = (nrows + rows_per_chunk - 1) / rows_per_chunk;
+    const uint64_t max_threads = std::max(1u, std::thread::hardware_concurrency() / 2);
+    const uint64_t nthreads = std::min<uint64_t>((uint64_t) num_chunks, max_threads);
+    const uint64_t row_size = (uint64_t) ggml_row_size(tensor->type, tensor->ne[0]);
+    const uint64_t rows_in_workspace = nthreads * (uint64_t) rptr->num_rows;
+    if (row_size != 0 && rows_in_workspace > UINT64_MAX / row_size) {
+        return UINT64_MAX;
+    }
+    return rows_in_workspace * row_size;
+}
+
 void iqk_repack_tensor(struct ggml_tensor * tensor) {
     constexpr int kChunk = 8;
     if (!tensor) return;

--- a/ggml/src/iqk/iqk_quantize.h
+++ b/ggml/src/iqk/iqk_quantize.h
@@ -322,6 +322,7 @@ void iqk_repack_tensor(struct ggml_tensor * tensor);
 bool iqk_modify_tensor(struct ggml_tensor * tensor);
 
 int iqk_repacked_type(const struct ggml_tensor * tensor); // int instead of ggml_type so we don't need to include ggml.h
+uint64_t iqk_repack_workspace_size(const struct ggml_tensor * tensor);
 bool iqk_should_modify_tensor(const struct ggml_tensor * tensor);
 
 // So we can re-pack Microsoft's BitNet I2_S quants

--- a/include/llama.h
+++ b/include/llama.h
@@ -693,6 +693,9 @@ extern "C" {
     // Returns the effective run-time repack decision used for this model load.
     LLAMA_API enum llama_rtr_status llama_model_rtr_status(const struct llama_model * model);
 
+    // Returns the mmap setting requested before loader fallbacks.
+    LLAMA_API bool llama_model_mmap_requested(const struct llama_model * model);
+
     // Returns the mmap setting used by the model loader after its own fallbacks.
     LLAMA_API bool llama_model_loader_mmap_enabled(const struct llama_model * model);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -444,6 +444,9 @@ extern "C" {
         // Appended to preserve the source layout of all pre-existing fields.
         // The C ABI still requires callers and the library to use matching headers.
         bool repack_tensors_auto; // if true, may auto-disable run-time repack
+        // Appended to preserve the source layout of all pre-existing fields.
+        // The C ABI still requires callers and the library to use matching headers.
+        bool prefetch_experts; // if true, auto RTR preserves mmap for expert prefetch
     };
 
     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations

--- a/include/llama.h
+++ b/include/llama.h
@@ -283,6 +283,15 @@ extern "C" {
         LLAMA_SPLIT_MODE_GRAPH   = 3, // splits computations across GPUs
     };
 
+    // Effective run-time repack state recorded by the model loader.
+    enum llama_rtr_status {
+        LLAMA_RTR_STATUS_DISABLED     = 0,
+        LLAMA_RTR_STATUS_ENABLED      = 1,
+        LLAMA_RTR_STATUS_AUTO_KEEP    = 2,
+        LLAMA_RTR_STATUS_AUTO_DISABLE = 3,
+        LLAMA_RTR_STATUS_AUTO_UNKNOWN = 4,
+    };
+
     enum llama_mtp_op_type {
         MTP_OP_NONE             = 0,
         MTP_OP_WARMUP           = 1,
@@ -424,7 +433,6 @@ extern "C" {
         bool use_mlock;     // force system to keep model in RAM
         bool check_tensors; // validate model tensor data
         bool repack_tensors;// repack if available
-        bool repack_tensors_auto; // if true, may auto-disable run-time repack on swap-bound MoE
         bool use_thp;       // use transparent huge pages (linux only)
         bool validate_quants; // if true, check for NaNs while loading the model
         bool merge_qkv;     // if true, merge separate Q, K, V tensors into a single, contiguous tensor
@@ -433,6 +441,9 @@ extern "C" {
         bool dry_run;       // skip loading tensors
         bool flash_attn;
         bool defer_experts;    // defer expert mmap residency to speed up model loading (Linux only)
+        // Appended to preserve the source layout of all pre-existing fields.
+        // The C ABI still requires callers and the library to use matching headers.
+        bool repack_tensors_auto; // if true, may auto-disable run-time repack
     };
 
     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations
@@ -678,6 +689,9 @@ extern "C" {
 
     // Returns the total number of parameters in the model
     LLAMA_API uint64_t llama_model_n_params(const struct llama_model * model);
+
+    // Returns the effective run-time repack decision used for this model load.
+    LLAMA_API enum llama_rtr_status llama_model_rtr_status(const struct llama_model * model);
 
     // Get a llama model tensor
     LLAMA_API struct ggml_tensor * llama_get_model_tensor(struct llama_model * model, const char * name);

--- a/include/llama.h
+++ b/include/llama.h
@@ -693,6 +693,18 @@ extern "C" {
     // Returns the effective run-time repack decision used for this model load.
     LLAMA_API enum llama_rtr_status llama_model_rtr_status(const struct llama_model * model);
 
+    // Returns the mmap setting used by the model loader after its own fallbacks.
+    LLAMA_API bool llama_model_loader_mmap_enabled(const struct llama_model * model);
+
+    // Returns true if at least one model buffer was created from a mmap region.
+    LLAMA_API bool llama_model_has_mmap_buffers(const struct llama_model * model);
+
+    // Returns true if the loader entered the run-time repack pass.
+    LLAMA_API bool llama_model_repack_pass_executed(const struct llama_model * model);
+
+    // Returns the number of tensors whose type changed in the run-time repack pass.
+    LLAMA_API uint64_t llama_model_n_repacked(const struct llama_model * model);
+
     // Get a llama model tensor
     LLAMA_API struct ggml_tensor * llama_get_model_tensor(struct llama_model * model, const char * name);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -424,6 +424,7 @@ extern "C" {
         bool use_mlock;     // force system to keep model in RAM
         bool check_tensors; // validate model tensor data
         bool repack_tensors;// repack if available
+        bool repack_tensors_auto; // if true, may auto-disable run-time repack on swap-bound MoE
         bool use_thp;       // use transparent huge pages (linux only)
         bool validate_quants; // if true, check for NaNs while loading the model
         bool merge_qkv;     // if true, merge separate Q, K, V tensors into a single, contiguous tensor

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -119,7 +119,54 @@ if input_file is None:
 
 connection = sqlite3.connect(input_file)
 cursor = connection.cursor()
-builds = cursor.execute("SELECT DISTINCT build_commit FROM test;").fetchall()
+
+# The SQL printer used to write `test`, and now writes the immutable versioned
+# table `test_v2`.  Keep the consumer compatible with both without mutating the
+# user's database or guessing arbitrary table names.
+BENCH_TABLE_NAMES = ("test", "test_v2")
+BENCH_SOURCE_COLUMNS = list(dict.fromkeys(
+    ["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES + ["n_prompt", "n_gen"]
+))
+
+
+def get_bench_source_query():
+    tables = cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?)",
+        BENCH_TABLE_NAMES,
+    ).fetchall()
+    tables = {name for (name,) in tables}
+
+    if not tables:
+        logger.error("No compatible llama-bench table found; expected `test` or `test_v2`.")
+        sys.exit(1)
+
+    selects = []
+    for table in BENCH_TABLE_NAMES:
+        if table not in tables:
+            continue
+
+        columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
+        missing = [column for column in BENCH_SOURCE_COLUMNS if column not in columns]
+        if missing:
+            logger.error(
+                "table %s is not compatible; missing required columns: %s",
+                table,
+                ", ".join(missing),
+            )
+            sys.exit(1)
+
+        # `table` is selected only from BENCH_TABLE_NAMES above.
+        selects.append(f"SELECT {', '.join(BENCH_SOURCE_COLUMNS)} FROM {table}")
+
+    # UNION ALL is safe while the writer emits into exactly one versioned table.
+    # Any future dual-write must replace this with run_id-based deduplication.
+    return " UNION ALL ".join(selects)
+
+
+bench_source_query = get_bench_source_query()
+builds = cursor.execute(
+    f"WITH bench AS ({bench_source_query}) SELECT DISTINCT build_commit FROM bench;"
+).fetchall()
 
 try:
     repo = git.Repo(".", search_parent_directories=True)
@@ -234,7 +281,8 @@ if known_args.compare is not None:
 elif repo is not None:
     hexsha8s_master = get_all_parent_hexsha8s(repo.heads.master.commit)
     builds_timestamp = cursor.execute(
-        "SELECT build_commit, test_time FROM test ORDER BY test_time;").fetchall()
+        f"WITH bench AS ({bench_source_query}) "
+        "SELECT build_commit, test_time FROM bench ORDER BY test_time;").fetchall()
     for (hexsha8, _) in reversed(builds_timestamp):
         if hexsha8 not in hexsha8s_master:
             hexsha8_compare = hexsha8
@@ -267,7 +315,8 @@ def get_rows(properties):
             f"tb.build_commit = '{hexsha8_baseline}'", f"tc.build_commit = '{hexsha8_compare}'"]
     )
     group_order_string = ", ".join([f"tb.{p}" for p in properties] + ["tb.n_gen", "tb.n_prompt"])
-    query = (f"SELECT {select_string} FROM test tb JOIN test tc ON {equal_string} "
+    query = (f"WITH bench AS ({bench_source_query}) "
+             f"SELECT {select_string} FROM bench tb JOIN bench tc ON {equal_string} "
              f"GROUP BY {group_order_string} ORDER BY {group_order_string};")
     return cursor.execute(query).fetchall()
 

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -21,17 +21,24 @@ logger = logging.getLogger("compare-llama-bench")
 KEY_PROPERTIES = [
     "cpu_info", "gpu_info", "n_gpu_layers", "cuda", "vulkan", "metal", "sycl", "rpc", "gpu_blas",
     "blas", "model_filename", "model_type", "model_size", "model_n_params", "n_batch", "n_ubatch", "embeddings", "n_threads",
-    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn",
+    "type_k", "type_v", "mmap_comparison", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn",
     "repack", "repack_auto", "repack_effective", "repack_status", "n_prompt", "n_gen"
 ]
 
 # These columns were introduced with the RTR metadata. Old `test` tables can
 # still be compared, but their RTR configuration is unknown rather than assumed
 # to match a newer run.
-OPTIONAL_SOURCE_COLUMNS = {"repack", "repack_auto", "repack_effective", "repack_status"}
+# Older schemas cannot truthfully report the new state.  They remain readable,
+# but source-schema provenance prevents NULL metadata from becoming a wildcard.
+OPTIONAL_SOURCE_COLUMNS = {
+    "repack", "repack_auto", "repack_effective", "repack_status",
+    "use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers",
+}
+V3_MMAP_COLUMNS = {"use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers"}
 
 # Properties that are boolean and are converted to Yes/No for the table:
-BOOL_PROPERTIES = ["cuda", "vulkan", "metal", "sycl", "gpu_blas", "blas", "embeddings", "use_mmap", "no_kv_offload", "flash_attn", "repack", "repack_auto", "repack_effective"]
+SHOW_PROPERTIES = ["source_schema"] + KEY_PROPERTIES[:-2] + ["use_mmap", "use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers"]
+BOOL_PROPERTIES = ["cuda", "vulkan", "metal", "sycl", "gpu_blas", "blas", "embeddings", "mmap_comparison", "use_mmap", "use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers", "no_kv_offload", "flash_attn", "repack", "repack_auto", "repack_effective"]
 
 # Header names for the table:
 PRETTY_NAMES = {
@@ -40,7 +47,7 @@ PRETTY_NAMES = {
     "model_size": "Model Size [GiB]", "model_n_params": "Num. of Par.", "n_batch": "Batch size", "n_ubatch": "Microbatch size",
     "n_threads": "Threads", "type_k": "K type", "type_v": "V type", "n_gpu_layers": "GPU layers", "split_mode": "Split mode",
     "main_gpu": "Main GPU", "no_kv_offload": "NKVO", "flash_attn": "FlashAttention", "tensor_split": "Tensor split",
-    "use_mmap": "Use mmap", "embeddings": "Embeddings", "repack": "RTR", "repack_auto": "RTR auto",
+    "source_schema": "Schema", "mmap_comparison": "Mmap state", "use_mmap": "Requested mmap", "use_mmap_requested": "Requested mmap", "use_mmap_effective": "Effective mmap", "mmap_backed_buffers": "Mmap buffers", "embeddings": "Embeddings", "repack": "RTR", "repack_auto": "RTR auto",
     "repack_effective": "RTR effective", "repack_status": "RTR status",
 }
 
@@ -93,7 +100,8 @@ parser.add_argument("-o", "--output", help=help_o, default="pipe")
 help_s = (
     "Columns to add to the table. "
     "Accepts a comma-separated list of values. "
-    f"Legal values: {', '.join(KEY_PROPERTIES[:-2])}. "
+    f"Legal values: {', '.join(SHOW_PROPERTIES)}. "
+    "Schema provenance is always added so results from incompatible table generations are never combined. "
     "Defaults to model name (model_type) and CPU and/or GPU name (cpu_info, gpu_info) "
     "plus any column where not all data points are the same. "
     "If the columns are manually specified, then the results for each unique combination of the "
@@ -127,27 +135,28 @@ if input_file is None:
 connection = sqlite3.connect(input_file)
 cursor = connection.cursor()
 
-# The SQL printer used to write `test`, and now writes the immutable versioned
-# table `test_v2`.  Keep the consumer compatible with both without mutating the
-# user's database or guessing arbitrary table names.
-BENCH_TABLE_NAMES = ("test", "test_v2")
+# The SQL printer wrote `test`, then `test_v2`, and now writes immutable
+# `test_v3`.  The schemas have different mmap semantics, so table provenance is
+# carried through the query and joins never cross generations.
+BENCH_TABLE_NAMES = ("test", "test_v2", "test_v3")
 BENCH_SOURCE_COLUMNS = list(dict.fromkeys(
-    ["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES + ["n_prompt", "n_gen"]
+    ["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES + ["use_mmap", "use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers", "n_prompt", "n_gen"]
 ))
 REQUIRED_BENCH_SOURCE_COLUMNS = [
-    column for column in BENCH_SOURCE_COLUMNS if column not in OPTIONAL_SOURCE_COLUMNS
+    column for column in BENCH_SOURCE_COLUMNS
+    if column not in OPTIONAL_SOURCE_COLUMNS and column != "mmap_comparison"
 ]
 
 
 def get_bench_source_query():
     tables = cursor.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?)",
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
         BENCH_TABLE_NAMES,
     ).fetchall()
     tables = {name for (name,) in tables}
 
     if not tables:
-        logger.error("No compatible llama-bench table found; expected `test` or `test_v2`.")
+        logger.error("No compatible llama-bench table found; expected `test`, `test_v2`, or `test_v3`.")
         sys.exit(1)
 
     selects = []
@@ -156,7 +165,12 @@ def get_bench_source_query():
             continue
 
         columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
-        missing = [column for column in REQUIRED_BENCH_SOURCE_COLUMNS if column not in columns]
+        required = set(REQUIRED_BENCH_SOURCE_COLUMNS)
+        if table in ("test_v2", "test_v3"):
+            required.update({"repack", "repack_auto", "repack_effective", "repack_status"})
+        if table == "test_v3":
+            required.update(V3_MMAP_COLUMNS)
+        missing = sorted(column for column in required if column not in columns)
         if missing:
             logger.error(
                 "table %s is not compatible; missing required columns: %s",
@@ -167,10 +181,16 @@ def get_bench_source_query():
 
         # `table` and every selected column are from fixed local allowlists.
         # NULL preserves the fact that an old table cannot report RTR settings.
-        projection = [
-            column if column in columns else f"NULL AS {column}"
-            for column in BENCH_SOURCE_COLUMNS
-        ]
+        projection = []
+        for column in BENCH_SOURCE_COLUMNS:
+            if column == "mmap_comparison":
+                # v3 is the only schema whose value is loader-effective.
+                # Historical rows retain requested mmap and never join with v3.
+                projection.append(
+                    ("use_mmap_effective" if table == "test_v3" else "use_mmap") + " AS mmap_comparison"
+                )
+            else:
+                projection.append(column if column in columns else f"NULL AS {column}")
         unavailable_optional = OPTIONAL_SOURCE_COLUMNS - columns
         if unavailable_optional:
             logger.warning(
@@ -178,7 +198,7 @@ def get_bench_source_query():
                 table,
                 ", ".join(sorted(unavailable_optional)),
             )
-        selects.append(f"SELECT {', '.join(projection)} FROM {table}")
+        selects.append(f"SELECT '{table}' AS source_schema, {', '.join(projection)} FROM {table}")
 
     # UNION ALL is safe while the writer emits into exactly one versioned table.
     # Any future dual-write must replace this with run_id-based deduplication.
@@ -330,14 +350,17 @@ def get_rows(properties):
     The resulting rows are then grouped by the provided properties and the t/s values are averaged.
     The returned rows are unique in terms of property combinations.
     """
+    # Keep schema provenance through aggregation as well as the JOIN. Without
+    # this, compatible pairs from different immutable schema generations could
+    # be averaged into one misleading result row.
+    properties = list(properties)
+    if "source_schema" not in properties:
+        properties.insert(0, "source_schema")
     select_string = ", ".join(
         [f"tb.{p}" for p in properties] + ["tb.n_prompt", "tb.n_gen", "AVG(tb.avg_ts)", "AVG(tc.avg_ts)"])
     equal_string = " AND ".join(
-        [
-            (f"(tb.{p} IS tc.{p} OR tb.{p} IS NULL OR tc.{p} IS NULL)"
-             if p in OPTIONAL_SOURCE_COLUMNS else f"tb.{p} IS tc.{p}")
-            for p in KEY_PROPERTIES
-        ] + [
+        [f"tb.{p} IS tc.{p}" for p in KEY_PROPERTIES] +
+        ["tb.source_schema IS tc.source_schema"] + [
             f"tb.build_commit = '{hexsha8_baseline}'", f"tc.build_commit = '{hexsha8_compare}'"]
     )
     group_order_string = ", ".join([f"tb.{p}" for p in properties] + ["tb.n_gen", "tb.n_prompt"])
@@ -347,35 +370,48 @@ def get_rows(properties):
     return cursor.execute(query).fetchall()
 
 
+def exit_no_comparable_configurations():
+    logger.error("no comparable configurations between baseline and compare data")
+    sys.exit(1)
+
+
 # If the user provided columns to group the results by, use them:
 if known_args.show is not None:
     show = known_args.show.split(",")
     unknown_cols = []
     for prop in show:
-        if prop not in KEY_PROPERTIES[:-2]:  # Last two values are n_prompt, n_gen.
+        if prop not in SHOW_PROPERTIES:
             unknown_cols.append(prop)
     if unknown_cols:
         logger.error(f"Unknown values for --show: {', '.join(unknown_cols)}")
         parser.print_usage()
         sys.exit(1)
+    if "source_schema" not in show:
+        show.insert(0, "source_schema")
     rows_show = get_rows(show)
+    if not rows_show:
+        exit_no_comparable_configurations()
 # Otherwise, select those columns where the values are not all the same:
 else:
     rows_full = get_rows(KEY_PROPERTIES)
+    if not rows_full:
+        exit_no_comparable_configurations()
     properties_different = []
     for i, kp_i in enumerate(KEY_PROPERTIES):
         if kp_i in DEFAULT_SHOW or kp_i == "n_prompt" or kp_i == "n_gen":
             continue
         for row_full in rows_full:
-            if row_full[i] != rows_full[0][i]:
+            # get_rows() prepends source_schema to retain provenance through
+            # grouping; KEY_PROPERTIES begins one column later in these rows.
+            if row_full[i + 1] != rows_full[0][i + 1]:
                 properties_different.append(kp_i)
                 break
 
     show = []
     # Show CPU and/or GPU by default even if the hardware for all results is the same:
     if "gpu_blas" not in properties_different and "n_gpu_layers" not in properties_different:
-        gpu_blas = bool(rows_full[0][KEY_PROPERTIES.index("gpu_blas")])
-        ngl = int(rows_full[0][KEY_PROPERTIES.index("n_gpu_layers")])
+        gpu_blas = bool(int(rows_full[0][KEY_PROPERTIES.index("gpu_blas") + 1]))
+        ngl = int(rows_full[0][KEY_PROPERTIES.index("n_gpu_layers") + 1])
 
         if not gpu_blas or ngl != 99 and "cpu_info" not in properties_different:
             show.append("cpu_info")
@@ -383,6 +419,9 @@ else:
             show.append("gpu_info")
 
     show += properties_different
+
+    if "source_schema" not in show:
+        show.insert(0, "source_schema")
 
     index_default = 0
     for prop in ["cpu_info", "gpu_info", "n_gpu_layers", "main_gpu"]:
@@ -395,6 +434,8 @@ else:
         except ValueError:
             pass
     rows_show = get_rows(show)
+    if not rows_show:
+        exit_no_comparable_configurations()
 
 table = []
 for row in rows_show:
@@ -415,7 +456,14 @@ for bool_property in BOOL_PROPERTIES:
     if bool_property in show:
         ip = show.index(bool_property)
         for row_table in table:
-            row_table[ip] = "Yes" if int(row_table[ip]) == 1 else "No"
+            value = row_table[ip]
+            row_table[ip] = "Unknown" if value is None else ("Yes" if int(value) == 1 else "No")
+
+if "repack_status" in show:
+    ip = show.index("repack_status")
+    for row_table in table:
+        if row_table[ip] is None:
+            row_table[ip] = "Unknown"
 
 if "model_type" in show:
     ip = show.index("model_type")

--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -21,11 +21,17 @@ logger = logging.getLogger("compare-llama-bench")
 KEY_PROPERTIES = [
     "cpu_info", "gpu_info", "n_gpu_layers", "cuda", "vulkan", "metal", "sycl", "rpc", "gpu_blas",
     "blas", "model_filename", "model_type", "model_size", "model_n_params", "n_batch", "n_ubatch", "embeddings", "n_threads",
-    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn", "n_prompt", "n_gen"
+    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn",
+    "repack", "repack_auto", "repack_effective", "repack_status", "n_prompt", "n_gen"
 ]
 
+# These columns were introduced with the RTR metadata. Old `test` tables can
+# still be compared, but their RTR configuration is unknown rather than assumed
+# to match a newer run.
+OPTIONAL_SOURCE_COLUMNS = {"repack", "repack_auto", "repack_effective", "repack_status"}
+
 # Properties that are boolean and are converted to Yes/No for the table:
-BOOL_PROPERTIES = ["cuda", "vulkan", "metal", "sycl", "gpu_blas", "blas", "embeddings", "use_mmap", "no_kv_offload", "flash_attn"]
+BOOL_PROPERTIES = ["cuda", "vulkan", "metal", "sycl", "gpu_blas", "blas", "embeddings", "use_mmap", "no_kv_offload", "flash_attn", "repack", "repack_auto", "repack_effective"]
 
 # Header names for the table:
 PRETTY_NAMES = {
@@ -34,7 +40,8 @@ PRETTY_NAMES = {
     "model_size": "Model Size [GiB]", "model_n_params": "Num. of Par.", "n_batch": "Batch size", "n_ubatch": "Microbatch size",
     "n_threads": "Threads", "type_k": "K type", "type_v": "V type", "n_gpu_layers": "GPU layers", "split_mode": "Split mode",
     "main_gpu": "Main GPU", "no_kv_offload": "NKVO", "flash_attn": "FlashAttention", "tensor_split": "Tensor split",
-    "use_mmap": "Use mmap", "embeddings": "Embeddings",
+    "use_mmap": "Use mmap", "embeddings": "Embeddings", "repack": "RTR", "repack_auto": "RTR auto",
+    "repack_effective": "RTR effective", "repack_status": "RTR status",
 }
 
 DEFAULT_SHOW = ["model_type"]  # Always show these properties by default.
@@ -127,6 +134,9 @@ BENCH_TABLE_NAMES = ("test", "test_v2")
 BENCH_SOURCE_COLUMNS = list(dict.fromkeys(
     ["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES + ["n_prompt", "n_gen"]
 ))
+REQUIRED_BENCH_SOURCE_COLUMNS = [
+    column for column in BENCH_SOURCE_COLUMNS if column not in OPTIONAL_SOURCE_COLUMNS
+]
 
 
 def get_bench_source_query():
@@ -146,7 +156,7 @@ def get_bench_source_query():
             continue
 
         columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
-        missing = [column for column in BENCH_SOURCE_COLUMNS if column not in columns]
+        missing = [column for column in REQUIRED_BENCH_SOURCE_COLUMNS if column not in columns]
         if missing:
             logger.error(
                 "table %s is not compatible; missing required columns: %s",
@@ -155,8 +165,20 @@ def get_bench_source_query():
             )
             sys.exit(1)
 
-        # `table` is selected only from BENCH_TABLE_NAMES above.
-        selects.append(f"SELECT {', '.join(BENCH_SOURCE_COLUMNS)} FROM {table}")
+        # `table` and every selected column are from fixed local allowlists.
+        # NULL preserves the fact that an old table cannot report RTR settings.
+        projection = [
+            column if column in columns else f"NULL AS {column}"
+            for column in BENCH_SOURCE_COLUMNS
+        ]
+        unavailable_optional = OPTIONAL_SOURCE_COLUMNS - columns
+        if unavailable_optional:
+            logger.warning(
+                "table %s has no RTR metadata (%s); comparisons involving it cannot distinguish RTR settings",
+                table,
+                ", ".join(sorted(unavailable_optional)),
+            )
+        selects.append(f"SELECT {', '.join(projection)} FROM {table}")
 
     # UNION ALL is safe while the writer emits into exactly one versioned table.
     # Any future dual-write must replace this with run_id-based deduplication.
@@ -311,7 +333,11 @@ def get_rows(properties):
     select_string = ", ".join(
         [f"tb.{p}" for p in properties] + ["tb.n_prompt", "tb.n_gen", "AVG(tb.avg_ts)", "AVG(tc.avg_ts)"])
     equal_string = " AND ".join(
-        [f"tb.{p} = tc.{p}" for p in KEY_PROPERTIES] + [
+        [
+            (f"(tb.{p} IS tc.{p} OR tb.{p} IS NULL OR tc.{p} IS NULL)"
+             if p in OPTIONAL_SOURCE_COLUMNS else f"tb.{p} IS tc.{p}")
+            for p in KEY_PROPERTIES
+        ] + [
             f"tb.build_commit = '{hexsha8_baseline}'", f"tc.build_commit = '{hexsha8_compare}'"]
     )
     group_order_string = ", ".join([f"tb.{p}" for p in properties] + ["tb.n_gen", "tb.n_prompt"])

--- a/src/llama-cgroup-resolver.h
+++ b/src/llama-cgroup-resolver.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <istream>
 #include <sstream>
@@ -12,7 +13,7 @@
 // cgroup paths in /proc files are absolute, lexical paths.  Never feed a
 // malformed path (in particular one containing "..") back into the host
 // filesystem: an unresolved cgroup must make the auto policy conservative.
-static bool llama_normalize_cgroup_path(const std::string & path, std::string & result) {
+static inline bool llama_normalize_cgroup_path(const std::string & path, std::string & result) {
     if (path.empty() || path[0] != '/') {
         return false;
     }
@@ -44,12 +45,12 @@ static bool llama_normalize_cgroup_path(const std::string & path, std::string & 
     return true;
 }
 
-static bool llama_cgroup_path_has_prefix(const std::string & path, const std::string & prefix) {
+static inline bool llama_cgroup_path_has_prefix(const std::string & path, const std::string & prefix) {
     return (prefix == "/" && !path.empty() && path[0] == '/') || path == prefix ||
         (prefix != "/" && path.size() > prefix.size() && path.compare(0, prefix.size(), prefix) == 0 && path[prefix.size()] == '/');
 }
 
-static std::string llama_cgroup_join_path(const std::string & base, const std::string & suffix) {
+static inline std::string llama_cgroup_join_path(const std::string & base, const std::string & suffix) {
     if (suffix == "/") {
         return base;
     }
@@ -58,7 +59,7 @@ static std::string llama_cgroup_join_path(const std::string & base, const std::s
 
 // Decode the four escapes permitted by proc(5) mountinfo. Reject any other
 // backslash sequence rather than guessing which host path it denotes.
-static bool llama_decode_mountinfo_path(const std::string & encoded, std::string & decoded) {
+static inline bool llama_decode_mountinfo_path(const std::string & encoded, std::string & decoded) {
     decoded.clear();
     for (size_t i = 0; i < encoded.size(); ++i) {
         if (encoded[i] != '\\') {
@@ -85,7 +86,7 @@ static bool llama_decode_mountinfo_path(const std::string & encoded, std::string
     return true;
 }
 
-static bool llama_comma_list_contains(const std::string & values, const std::string & needle) {
+static inline bool llama_comma_list_contains(const std::string & values, const std::string & needle) {
     std::stringstream stream(values);
     std::string value;
     while (std::getline(stream, value, ',')) {
@@ -108,11 +109,37 @@ struct llama_cgroup_mount {
 };
 
 struct llama_resolved_cgroup_mount {
+    bool        v2;
     std::string mountpoint;
     std::string path;
 };
 
-static bool llama_parse_cgroup_memberships(std::istream & file, std::vector<llama_cgroup_membership> & result) {
+// Intersect all visible hierarchy headrooms. The reader must fail closed for a
+// mapping it cannot evaluate; ignoring an unreadable bind/full-hierarchy mount
+// could otherwise turn an unknown ancestor limit into an unsafe AUTO_KEEP.
+template<typename Reader>
+static inline bool llama_intersect_cgroup_headrooms(
+        const std::vector<llama_resolved_cgroup_mount> & mappings,
+        Reader reader,
+        bool & limited,
+        uint64_t & bytes) {
+    uint64_t headroom = UINT64_MAX;
+    for (const auto & mapping : mappings) {
+        bool candidate_limited = false;
+        uint64_t candidate_bytes = 0;
+        if (!reader(mapping, candidate_limited, candidate_bytes)) {
+            return false;
+        }
+        if (candidate_limited) {
+            headroom = std::min(headroom, candidate_bytes);
+        }
+    }
+    limited = headroom != UINT64_MAX;
+    bytes = limited ? headroom : 0;
+    return true;
+}
+
+static inline bool llama_parse_cgroup_memberships(std::istream & file, std::vector<llama_cgroup_membership> & result) {
     result.clear();
     std::string line;
     while (std::getline(file, line)) {
@@ -139,12 +166,12 @@ static bool llama_parse_cgroup_memberships(std::istream & file, std::vector<llam
     return !file.bad();
 }
 
-static bool llama_read_cgroup_memberships(std::vector<llama_cgroup_membership> & result) {
+static inline bool llama_read_cgroup_memberships(std::vector<llama_cgroup_membership> & result) {
     std::ifstream file("/proc/self/cgroup");
     return file.is_open() && llama_parse_cgroup_memberships(file, result);
 }
 
-static bool llama_parse_cgroup_mounts(std::istream & file, std::vector<llama_cgroup_mount> & result) {
+static inline bool llama_parse_cgroup_mounts(std::istream & file, std::vector<llama_cgroup_mount> & result) {
     result.clear();
     std::string line;
     while (std::getline(file, line)) {
@@ -189,39 +216,38 @@ static bool llama_parse_cgroup_mounts(std::istream & file, std::vector<llama_cgr
     return !file.bad();
 }
 
-static bool llama_read_cgroup_mounts(std::vector<llama_cgroup_mount> & result) {
+static inline bool llama_read_cgroup_mounts(std::vector<llama_cgroup_mount> & result) {
     std::ifstream file("/proc/self/mountinfo");
     return file.is_open() && llama_parse_cgroup_mounts(file, result);
 }
 
-// Resolve one membership against its cgroup mounts. Host-relative mappings are
-// preferred; among them, use the most specific root. Keep equally-specific
-// duplicates (including bind mounts), whose headroom must be intersected.
-static bool llama_resolve_cgroup_mounts(
+// Resolve one membership against its cgroup mounts. Keep every host-relative
+// mapping: a less-specific/full-hierarchy mount can expose an ancestor limit
+// hidden by a more-specific bind mount. Namespace-relative mappings are only a
+// fallback when no host-relative mapping exists.
+static inline bool llama_resolve_cgroup_mounts(
         const llama_cgroup_membership & membership,
         const std::vector<llama_cgroup_mount> & mounts,
         std::vector<llama_resolved_cgroup_mount> & result) {
     result.clear();
-    size_t best_root_size = 0;
     bool have_host_relative = false;
-    bool have_exact = false;
+
+    auto append_unique = [&result, &membership] (const llama_cgroup_mount & mount, const std::string & path) {
+        const auto duplicate = std::find_if(result.begin(), result.end(), [&mount, &path, &membership] (const auto & existing) {
+            return existing.v2 == membership.v2 && existing.mountpoint == mount.mountpoint && existing.path == path;
+        });
+        if (duplicate == result.end()) {
+            result.push_back({ membership.v2, mount.mountpoint, path });
+        }
+    };
 
     for (const llama_cgroup_mount & mount : mounts) {
         if (mount.v2 != membership.v2 || !llama_cgroup_path_has_prefix(membership.path, mount.root)) {
             continue;
         }
-        const bool exact = membership.path == mount.root;
-        const size_t root_size = mount.root.size();
-        if (!have_host_relative || (exact && !have_exact) || (exact == have_exact && root_size > best_root_size)) {
-            result.clear();
-            best_root_size = root_size;
-            have_host_relative = true;
-            have_exact = exact;
-        }
-        if (exact == have_exact && root_size == best_root_size) {
-            const std::string suffix = mount.root == "/" ? membership.path : membership.path.substr(mount.root.size());
-            result.push_back({ mount.mountpoint, llama_cgroup_join_path(mount.mountpoint, suffix.empty() ? "/" : suffix) });
-        }
+        have_host_relative = true;
+        const std::string suffix = mount.root == "/" ? membership.path : membership.path.substr(mount.root.size());
+        append_unique(mount, llama_cgroup_join_path(mount.mountpoint, suffix.empty() ? "/" : suffix));
     }
     if (have_host_relative) {
         return true;
@@ -231,13 +257,13 @@ static bool llama_resolve_cgroup_mounts(
     // mounted hierarchy. In that case the membership is appended directly.
     for (const llama_cgroup_mount & mount : mounts) {
         if (mount.v2 == membership.v2) {
-            result.push_back({ mount.mountpoint, llama_cgroup_join_path(mount.mountpoint, membership.path) });
+            append_unique(mount, llama_cgroup_join_path(mount.mountpoint, membership.path));
         }
     }
     return !result.empty();
 }
 
-static bool llama_cgroup_parent_path(const std::string & path, const std::string & mountpoint, std::string & parent) {
+static inline bool llama_cgroup_parent_path(const std::string & path, const std::string & mountpoint, std::string & parent) {
     if (path == mountpoint) return false;
     const size_t slash = path.find_last_of('/');
     if (slash == std::string::npos) return false;
@@ -248,4 +274,28 @@ static bool llama_cgroup_parent_path(const std::string & path, const std::string
     }
     parent = path.substr(0, slash);
     return llama_cgroup_path_has_prefix(parent, mountpoint);
+}
+
+// A cgroup-v2 hierarchy root can be visible without exposing the memory
+// interface files at that exact mountpoint (for example through a namespace or
+// delegated mount).  A missing pair is safe to skip only at the mountpoint;
+// below it, or when just one file is missing, the hierarchy is unreadable and
+// the auto policy must fail closed.
+static inline bool llama_cgroup_v2_level_files(
+        bool limit_exists,
+        bool usage_exists,
+        bool at_mountpoint,
+        bool & skip_level) {
+    skip_level = false;
+    if (limit_exists != usage_exists) {
+        return false;
+    }
+    if (limit_exists) {
+        return true;
+    }
+    if (at_mountpoint) {
+        skip_level = true;
+        return true;
+    }
+    return false;
 }

--- a/src/llama-cgroup-resolver.h
+++ b/src/llama-cgroup-resolver.h
@@ -1,0 +1,251 @@
+// Internal cgroup mount resolver. Kept header-only so Linux fixtures can test
+// the exact parser and resolver used by llama.cpp without touching /proc.
+#pragma once
+
+#include <algorithm>
+#include <fstream>
+#include <istream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// cgroup paths in /proc files are absolute, lexical paths.  Never feed a
+// malformed path (in particular one containing "..") back into the host
+// filesystem: an unresolved cgroup must make the auto policy conservative.
+static bool llama_normalize_cgroup_path(const std::string & path, std::string & result) {
+    if (path.empty() || path[0] != '/') {
+        return false;
+    }
+
+    std::vector<std::string> components;
+    size_t begin = 1;
+    while (begin <= path.size()) {
+        const size_t end = path.find('/', begin);
+        const std::string component = path.substr(begin, end == std::string::npos ? std::string::npos : end - begin);
+        if (component == "..") {
+            return false;
+        }
+        if (!component.empty() && component != ".") {
+            components.push_back(component);
+        }
+        if (end == std::string::npos) {
+            break;
+        }
+        begin = end + 1;
+    }
+
+    result = "/";
+    for (const std::string & component : components) {
+        if (result.size() > 1) {
+            result += '/';
+        }
+        result += component;
+    }
+    return true;
+}
+
+static bool llama_cgroup_path_has_prefix(const std::string & path, const std::string & prefix) {
+    return (prefix == "/" && !path.empty() && path[0] == '/') || path == prefix ||
+        (prefix != "/" && path.size() > prefix.size() && path.compare(0, prefix.size(), prefix) == 0 && path[prefix.size()] == '/');
+}
+
+static std::string llama_cgroup_join_path(const std::string & base, const std::string & suffix) {
+    if (suffix == "/") {
+        return base;
+    }
+    return base == "/" ? suffix : base + suffix;
+}
+
+// Decode the four escapes permitted by proc(5) mountinfo. Reject any other
+// backslash sequence rather than guessing which host path it denotes.
+static bool llama_decode_mountinfo_path(const std::string & encoded, std::string & decoded) {
+    decoded.clear();
+    for (size_t i = 0; i < encoded.size(); ++i) {
+        if (encoded[i] != '\\') {
+            decoded += encoded[i];
+            continue;
+        }
+        if (i + 3 >= encoded.size()) {
+            return false;
+        }
+        const std::string escape = encoded.substr(i, 4);
+        if (escape == "\\040") {
+            decoded += ' ';
+        } else if (escape == "\\011") {
+            decoded += '\t';
+        } else if (escape == "\\012") {
+            decoded += '\n';
+        } else if (escape == "\\134") {
+            decoded += '\\';
+        } else {
+            return false;
+        }
+        i += 3;
+    }
+    return true;
+}
+
+static bool llama_comma_list_contains(const std::string & values, const std::string & needle) {
+    std::stringstream stream(values);
+    std::string value;
+    while (std::getline(stream, value, ',')) {
+        if (value == needle) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct llama_cgroup_membership {
+    bool        v2;
+    std::string path;
+};
+
+struct llama_cgroup_mount {
+    bool        v2;
+    std::string root;
+    std::string mountpoint;
+};
+
+struct llama_resolved_cgroup_mount {
+    std::string mountpoint;
+    std::string path;
+};
+
+static bool llama_parse_cgroup_memberships(std::istream & file, std::vector<llama_cgroup_membership> & result) {
+    result.clear();
+    std::string line;
+    while (std::getline(file, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        const size_t c1 = line.find(':');
+        const size_t c2 = c1 == std::string::npos ? std::string::npos : line.find(':', c1 + 1);
+        if (c1 == std::string::npos || c2 == std::string::npos || c1 == 0 || c2 + 1 >= line.size()) {
+            return false;
+        }
+
+        std::string path;
+        if (!llama_normalize_cgroup_path(line.substr(c2 + 1), path)) {
+            return false;
+        }
+        const std::string controllers = line.substr(c1 + 1, c2 - c1 - 1);
+        if (controllers.empty()) {
+            result.push_back({ true, path });
+        } else if (llama_comma_list_contains(controllers, "memory")) {
+            result.push_back({ false, path });
+        }
+    }
+    return !file.bad();
+}
+
+static bool llama_read_cgroup_memberships(std::vector<llama_cgroup_membership> & result) {
+    std::ifstream file("/proc/self/cgroup");
+    return file.is_open() && llama_parse_cgroup_memberships(file, result);
+}
+
+static bool llama_parse_cgroup_mounts(std::istream & file, std::vector<llama_cgroup_mount> & result) {
+    result.clear();
+    std::string line;
+    while (std::getline(file, line)) {
+        std::istringstream stream(line);
+        std::vector<std::string> fields;
+        std::string field;
+        while (stream >> field) {
+            fields.push_back(field);
+        }
+        if (fields.size() < 10) {
+            return false;
+        }
+        const auto dash = std::find(fields.begin() + 6, fields.end(), "-");
+        if (dash == fields.end() || std::distance(dash, fields.end()) < 4) {
+            return false;
+        }
+        const size_t dash_index = (size_t) std::distance(fields.begin(), dash);
+        const std::string & fstype = fields[dash_index + 1];
+        const bool v2 = fstype == "cgroup2";
+        if (!v2 && fstype != "cgroup") {
+            continue;
+        }
+        // For v1, the controllers are listed in super options (after source).
+        if (!v2 && !llama_comma_list_contains(fields[dash_index + 3], "memory")) {
+            continue;
+        }
+
+        std::string root_encoded;
+        std::string mountpoint_encoded;
+        if (!llama_decode_mountinfo_path(fields[3], root_encoded) ||
+            !llama_decode_mountinfo_path(fields[4], mountpoint_encoded)) {
+            return false;
+        }
+        std::string root;
+        std::string mountpoint;
+        if (!llama_normalize_cgroup_path(root_encoded, root) ||
+            !llama_normalize_cgroup_path(mountpoint_encoded, mountpoint)) {
+            return false;
+        }
+        result.push_back({ v2, root, mountpoint });
+    }
+    return !file.bad();
+}
+
+static bool llama_read_cgroup_mounts(std::vector<llama_cgroup_mount> & result) {
+    std::ifstream file("/proc/self/mountinfo");
+    return file.is_open() && llama_parse_cgroup_mounts(file, result);
+}
+
+// Resolve one membership against its cgroup mounts. Host-relative mappings are
+// preferred; among them, use the most specific root. Keep equally-specific
+// duplicates (including bind mounts), whose headroom must be intersected.
+static bool llama_resolve_cgroup_mounts(
+        const llama_cgroup_membership & membership,
+        const std::vector<llama_cgroup_mount> & mounts,
+        std::vector<llama_resolved_cgroup_mount> & result) {
+    result.clear();
+    size_t best_root_size = 0;
+    bool have_host_relative = false;
+    bool have_exact = false;
+
+    for (const llama_cgroup_mount & mount : mounts) {
+        if (mount.v2 != membership.v2 || !llama_cgroup_path_has_prefix(membership.path, mount.root)) {
+            continue;
+        }
+        const bool exact = membership.path == mount.root;
+        const size_t root_size = mount.root.size();
+        if (!have_host_relative || (exact && !have_exact) || (exact == have_exact && root_size > best_root_size)) {
+            result.clear();
+            best_root_size = root_size;
+            have_host_relative = true;
+            have_exact = exact;
+        }
+        if (exact == have_exact && root_size == best_root_size) {
+            const std::string suffix = mount.root == "/" ? membership.path : membership.path.substr(mount.root.size());
+            result.push_back({ mount.mountpoint, llama_cgroup_join_path(mount.mountpoint, suffix.empty() ? "/" : suffix) });
+        }
+    }
+    if (have_host_relative) {
+        return true;
+    }
+
+    // cgroup namespaces commonly expose membership paths relative to the
+    // mounted hierarchy. In that case the membership is appended directly.
+    for (const llama_cgroup_mount & mount : mounts) {
+        if (mount.v2 == membership.v2) {
+            result.push_back({ mount.mountpoint, llama_cgroup_join_path(mount.mountpoint, membership.path) });
+        }
+    }
+    return !result.empty();
+}
+
+static bool llama_cgroup_parent_path(const std::string & path, const std::string & mountpoint, std::string & parent) {
+    if (path == mountpoint) return false;
+    const size_t slash = path.find_last_of('/');
+    if (slash == std::string::npos) return false;
+    if (slash == 0) {
+        if (mountpoint != "/") return false;
+        parent = "/";
+        return true;
+    }
+    parent = path.substr(0, slash);
+    return llama_cgroup_path_has_prefix(parent, mountpoint);
+}

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1066,13 +1066,13 @@ bool llama_model_loader::load_all_data(
     std::vector<std::future<std::pair<ggml_tensor *, bool>>> validation_result;
 
     // Number of worker threads for cuda and host tensor loading.
-    const int n_workers = 8;
+    constexpr int n_workers = LLAMA_MODEL_LOADER_N_LOAD_WORKERS;
 
     std::vector<std::vector<no_init<uint8_t>>> read_bufs(n_workers);
 
 #if defined(GGML_USE_CUDA)
     // One pinned staging buffer per worker for async uploads
-    constexpr size_t buffer_size = 16 * 1024 * 1024; // 16MB
+    constexpr size_t buffer_size = LLAMA_MODEL_LOADER_CUDA_STAGING_BYTES;
 
     std::vector<ggml_backend_buffer_t> host_buffers;
     std::vector<void*> host_ptrs;

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -32,6 +32,10 @@ static const char * llama_file_version_name(llama_fver version) {
 
 using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
 
+// Keep RTR auto peak accounting in sync with load_all_data().
+constexpr int    LLAMA_MODEL_LOADER_N_LOAD_WORKERS       = 8;
+constexpr size_t LLAMA_MODEL_LOADER_CUDA_STAGING_BYTES   = 16 * 1024 * 1024;
+
 struct llama_layer;
 
 struct llama_model_loader {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -523,6 +523,11 @@ struct llama_model {
     int64_t t_load_us = 0;
     int64_t t_start_us = 0;
     llama_rtr_status rtr_status = LLAMA_RTR_STATUS_DISABLED;
+    bool     use_mmap_requested      = false;
+    bool     use_mmap_loader_enabled = false;
+    bool     has_mmap_backed_buffers = false;
+    bool     repack_pass_executed    = false;
+    uint64_t n_repacked              = 0;
 
     // keep track of loaded lora adapters
     std::set<llama_lora_adapter *> lora_adapters;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -522,6 +522,7 @@ struct llama_model {
 
     int64_t t_load_us = 0;
     int64_t t_start_us = 0;
+    llama_rtr_status rtr_status = LLAMA_RTR_STATUS_DISABLED;
 
     // keep track of loaded lora adapters
     std::set<llama_lora_adapter *> lora_adapters;

--- a/src/llama-rtr-auto.h
+++ b/src/llama-rtr-auto.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+struct llama_rtr_auto_peak_inputs {
+    uint64_t model_bytes;
+    uint64_t repack_workspace_bytes;
+    uint64_t max_read_buffer_bytes;
+    uint64_t n_load_workers;
+    uint64_t cuda_staging_bytes;
+    bool     use_cuda_staging;
+};
+
+// Returns false rather than wrapping on any arithmetic overflow.
+static inline bool llama_rtr_auto_peak_bytes(
+        const llama_rtr_auto_peak_inputs & input,
+        uint64_t & peak_bytes) {
+    const uint64_t max = std::numeric_limits<uint64_t>::max();
+    if (input.n_load_workers != 0 && input.max_read_buffer_bytes > max / input.n_load_workers) {
+        return false;
+    }
+    const uint64_t read_bytes = input.n_load_workers * input.max_read_buffer_bytes;
+    uint64_t staging_bytes = 0;
+    if (input.use_cuda_staging) {
+        if (input.n_load_workers != 0 && input.cuda_staging_bytes > max / input.n_load_workers) {
+            return false;
+        }
+        staging_bytes = input.n_load_workers * input.cuda_staging_bytes;
+    }
+    if (input.model_bytes > max - input.repack_workspace_bytes) {
+        return false;
+    }
+    const uint64_t with_workspace = input.model_bytes + input.repack_workspace_bytes;
+    if (with_workspace > max - read_bytes) {
+        return false;
+    }
+    const uint64_t with_reads = with_workspace + read_bytes;
+    if (with_reads > max - staging_bytes) {
+        return false;
+    }
+    peak_bytes = with_reads + staging_bytes;
+    return true;
+}

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4785,7 +4785,12 @@ static llama_available_memory_result llama_get_available_ram_bytes() {
     // nested memory limit is visible to this process. Treat any job membership
     // as unknown rather than risking AUTO_KEEP from host-wide headroom.
     BOOL in_job = FALSE;
-    if (!IsProcessInJob(GetCurrentProcess(), NULL, &in_job) || in_job) {
+    if (!IsProcessInJob(GetCurrentProcess(), NULL, &in_job)) {
+        LLAMA_LOG_WARN("%s: could not determine Windows Job Object membership; RTR auto memory headroom is unknown\n", __func__);
+        return { false, 0 };
+    }
+    if (in_job) {
+        LLAMA_LOG_INFO("%s: process is in a Windows Job Object; RTR auto memory headroom is unknown\n", __func__);
         return { false, 0 };
     }
 
@@ -9080,6 +9085,10 @@ uint64_t llama_model_size(const struct llama_model * model) {
 
 enum llama_rtr_status llama_model_rtr_status(const struct llama_model * model) {
     return model ? model->rtr_status : LLAMA_RTR_STATUS_DISABLED;
+}
+
+bool llama_model_mmap_requested(const struct llama_model * model) {
+    return model && model->use_mmap_requested;
 }
 
 bool llama_model_loader_mmap_enabled(const struct llama_model * model) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4584,9 +4584,139 @@ static bool llm_load_tensors(
     return true;
 }
 
+// --- run-time-repack auto policy ----------------------------------------------------
+//
+// `--run-time-repack auto` (a.k.a. `-rtr auto`) flips repacking on by default, but
+// disables it when the GGUF is known to overflow physical RAM and would otherwise
+// trigger swap thrashing during the repack pass. The check is conservative: probe
+// metadata only, compare model size against ~90% of physical RAM, and flip off
+// only when the model is a MoE that would not fit. Anything that we cannot
+// reliably check (RAM detection failed, probe threw, GPU offload may shift the
+// CPU-side footprint) leaves the user-supplied -rtr setting untouched.
+
+#if defined(_WIN32)
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#elif defined(__linux__)
+#  include <unistd.h>
+#elif defined(__APPLE__)
+#  include <sys/sysctl.h>
+#endif
+
+static uint64_t llama_get_total_ram_bytes() {
+#if defined(_WIN32)
+    MEMORYSTATUSEX mem_info = {};
+    mem_info.dwLength = sizeof(mem_info);
+    if (GlobalMemoryStatusEx(&mem_info)) {
+        return (uint64_t) mem_info.ullTotalPhys;
+    }
+#elif defined(__linux__)
+    long pages     = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    if (pages > 0 && page_size > 0) {
+        return (uint64_t) pages * (uint64_t) page_size;
+    }
+#elif defined(__APPLE__)
+    int mib[2] = { CTL_HW, HW_MEMSIZE };
+    uint64_t mem = 0;
+    size_t   len = sizeof(mem);
+    if (sysctl(mib, 2, &mem, &len, nullptr, 0) == 0 && mem > 0) {
+        return mem;
+    }
+#endif
+    return 0;
+}
+
+// Returns true iff `--run-time-repack auto` should disable run-time repack for
+// this load. False means "do nothing" — preserves the user's -rtr setting.
+static bool llama_rtr_auto_should_disable(
+        const std::string         & fname,
+        const llama_model_params  & params,
+        std::string               & reason) {
+    if (!params.repack_tensors || !params.repack_tensors_auto) {
+        return false;
+    }
+
+    // GPU offload (or n-cpu-moe) shifts the actual CPU-side footprint and the
+    // raw on-disk model size is no longer a reliable proxy for RAM pressure.
+    // Defer to the user's explicit -rtr choice in that case.
+    if (params.n_gpu_layers > 0) {
+        return false;
+    }
+
+    const uint64_t phys_ram = llama_get_total_ram_bytes();
+    if (phys_ram == 0) {
+        return false;
+    }
+
+    try {
+        // Metadata-only probe: mmap + no repack to inspect arch/hparams cheaply.
+        llama_model_loader probe(
+                fname,
+                params.ncmoe,
+                /*use_mmap*/      true,
+                /*check_tensors*/ false,
+                /*repack_tensors*/false,
+                params.use_thp,
+                params.merge_qkv,
+                params.merge_up_gate_exps,
+                params.defer_experts,
+                params.kv_overrides,
+                params.tensor_buft_overrides);
+
+        llama_model probe_model;
+        probe_model.hparams.vocab_only = params.vocab_only;
+        llm_load_arch(probe, probe_model);
+        llm_load_hparams(probe, probe_model);
+
+        const bool is_moe = probe_model.hparams.n_expert > 0
+                         && probe_model.hparams.n_expert_used > 0;
+        if (!is_moe) {
+            // Dense models have not shown the same swap regression in our testing,
+            // so the auto policy stays out of the way.
+            return false;
+        }
+
+        const uint64_t model_bytes = (uint64_t) probe.n_bytes;
+        // 90% of physical RAM, conservative buffer for kernel + other processes.
+        const uint64_t threshold = phys_ram - phys_ram / 10;
+        if (model_bytes <= threshold) {
+            return false;
+        }
+
+        reason = format("MoE model %.1f GiB > 90%% of RAM %.1f GiB",
+                model_bytes / 1073741824.0, phys_ram / 1073741824.0);
+        return true;
+    } catch (const std::exception & e) {
+        LLAMA_LOG_WARN("%s: --run-time-repack auto: probe failed (%s); leaving repack as-is\n",
+                __func__, e.what());
+        return false;
+    }
+}
+
 // Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
 static int llama_model_load(const std::string & fname, llama_model & model, llama_model_params & params) {
     try {
+        if (params.repack_tensors && params.repack_tensors_auto) {
+            std::string reason;
+            if (llama_rtr_auto_should_disable(fname, params, reason)) {
+                // Auto policy turns repack off — leave use_mmap as the user
+                // configured it (default true, or whatever --no-mmap chose).
+                params.repack_tensors = false;
+                LLAMA_LOG_INFO("%s: --run-time-repack auto: disabled (%s)\n",
+                        __func__, reason.c_str());
+            } else {
+                // Auto keeps repack enabled — match the legacy `-rtr 1`
+                // coupling and force use_mmap=false so the repack pass can
+                // write back into the tensor buffers.
+                params.use_mmap = false;
+                LLAMA_LOG_INFO("%s: --run-time-repack auto: keeping repack enabled\n",
+                        __func__);
+            }
+        }
+
         llama_model_loader ml(fname, params.ncmoe, params.use_mmap, params.check_tensors,
                 params.repack_tensors, params.use_thp, params.merge_qkv, params.merge_up_gate_exps,
                 params.defer_experts,
@@ -7106,6 +7236,7 @@ struct llama_model_params llama_model_default_params() {
         /*.use_mlock                   =*/ false,
         /*.check_tensors               =*/ false,
         /*.repack_tensors              =*/ false,
+        /*.repack_tensors_auto         =*/ false,
         /*.use_thp                     =*/ false,
         /*.validate_quants             =*/ false,
         /*.merge_qkv                   =*/ false,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4587,12 +4587,16 @@ static bool llm_load_tensors(
 // --- run-time-repack auto policy ----------------------------------------------------
 //
 // `--run-time-repack auto` (a.k.a. `-rtr auto`) flips repacking on by default, but
-// disables it when the GGUF is known to overflow physical RAM and would otherwise
-// trigger swap thrashing during the repack pass. The check is conservative: probe
-// metadata only, compare model size against ~90% of physical RAM, and flip off
-// only when the model is a MoE that would not fit. Anything that we cannot
-// reliably check (RAM detection failed, probe threw, GPU offload may shift the
-// CPU-side footprint) leaves the user-supplied -rtr setting untouched.
+// disables it when the GGUF is known to overflow available memory and would
+// otherwise trigger swap thrashing during the repack pass. The check is
+// conservative: probe metadata only, compare model size against ~90% of available
+// memory, and flip off only when the model is a MoE that would not fit.
+//
+// The decision is tri-state-plus-one (KEEP / DISABLE / NOT_APPLICABLE / UNKNOWN).
+// On dense models the policy does not apply (NOT_APPLICABLE) and leaves both
+// repack and use_mmap untouched. On uncertainty (probe exception or OS query
+// failure) the policy is safety-first: disable repack with a WARN log so the
+// load gets the same chance to succeed as plain `-rtr` would.
 
 #if defined(_WIN32)
 #  ifndef WIN32_LEAN_AND_MEAN
@@ -4603,52 +4607,240 @@ static bool llm_load_tensors(
 #  include <unistd.h>
 #elif defined(__APPLE__)
 #  include <sys/sysctl.h>
+#  include <mach/mach.h>
+#  include <mach/vm_statistics.h>
 #endif
 
-static uint64_t llama_get_total_ram_bytes() {
+#if defined(__linux__)
+// Read a single uint64_t from a path. Returns true on success. Treats the
+// cgroup v2 sentinel "max" as success returning UINT64_MAX so the caller
+// can detect "no limit" without re-reading the file.
+static bool llama_read_uint64_file(const std::string & path, uint64_t & out) {
+    FILE * f = std::fopen(path.c_str(), "r");
+    if (!f) return false;
+    char buf[64] = {0};
+    bool ok = std::fgets(buf, sizeof(buf), f) != nullptr;
+    std::fclose(f);
+    if (!ok) return false;
+    std::string s(buf);
+    while (!s.empty() && (s.back() == '\n' || s.back() == ' ' || s.back() == '\t')) {
+        s.pop_back();
+    }
+    if (s == "max") {
+        out = UINT64_MAX;
+        return true;
+    }
+    try {
+        out = std::stoull(s);
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+// Resolve the cgroup path for the current process from /proc/self/cgroup.
+// For cgroup v2 the line has the form "0::/path"; for v1 controllers it is
+// "<id>:<controllers>:/path" and we look for the "memory" controller.
+// Returns empty string on failure.
+static std::string llama_resolve_cgroup_path(const std::string & controller) {
+    FILE * f = std::fopen("/proc/self/cgroup", "r");
+    if (!f) return {};
+    char buf[512];
+    std::string result;
+    while (std::fgets(buf, sizeof(buf), f)) {
+        std::string line(buf);
+        while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
+            line.pop_back();
+        }
+        // Expected format: <hierarchy_id>:<controllers>:<path>
+        size_t c1 = line.find(':');
+        if (c1 == std::string::npos) continue;
+        size_t c2 = line.find(':', c1 + 1);
+        if (c2 == std::string::npos) continue;
+        const std::string controllers = line.substr(c1 + 1, c2 - c1 - 1);
+        const std::string path        = line.substr(c2 + 1);
+        if (controller == "v2") {
+            // cgroup v2 unified hierarchy: "0::/path"
+            if (controllers.empty()) {
+                result = path;
+                break;
+            }
+        } else {
+            // cgroup v1: comma-separated controller list
+            std::string token;
+            std::stringstream ss(controllers);
+            while (std::getline(ss, token, ',')) {
+                if (token == controller) {
+                    result = path;
+                    break;
+                }
+            }
+            if (!result.empty()) break;
+        }
+    }
+    std::fclose(f);
+    return result;
+}
+
+// Compute effective cgroup memory headroom for the current process. Walks the
+// cgroup path upward to honor inherited limits, capped at 32 levels. Returns
+// 0 when no finite limit is in effect. Tries v2 first, falls back to v1.
+static uint64_t llama_get_cgroup_available_bytes() {
+    // cgroup v2
+    {
+        const std::string cgpath = llama_resolve_cgroup_path("v2");
+        if (!cgpath.empty()) {
+            std::string cur = "/sys/fs/cgroup" + cgpath;
+            uint64_t headroom = UINT64_MAX;
+            for (int depth = 0; depth < 32; ++depth) {
+                uint64_t limit = 0;
+                uint64_t used  = 0;
+                if (llama_read_uint64_file(cur + "/memory.max", limit) &&
+                    llama_read_uint64_file(cur + "/memory.current", used) &&
+                    limit != UINT64_MAX) {
+                    const uint64_t free_here = (limit > used) ? (limit - used) : 0;
+                    if (free_here < headroom) {
+                        headroom = free_here;
+                    }
+                }
+                if (cur == "/sys/fs/cgroup" || cur.empty()) break;
+                size_t slash = cur.find_last_of('/');
+                if (slash == std::string::npos || slash < std::string{"/sys/fs/cgroup"}.size()) break;
+                cur = cur.substr(0, slash);
+            }
+            if (headroom != UINT64_MAX) {
+                return headroom;
+            }
+        }
+    }
+    // cgroup v1 memory controller
+    {
+        const std::string cgpath = llama_resolve_cgroup_path("memory");
+        if (!cgpath.empty()) {
+            std::string cur = "/sys/fs/cgroup/memory" + cgpath;
+            uint64_t headroom = UINT64_MAX;
+            for (int depth = 0; depth < 32; ++depth) {
+                uint64_t limit = 0;
+                uint64_t used  = 0;
+                if (llama_read_uint64_file(cur + "/memory.limit_in_bytes", limit) &&
+                    llama_read_uint64_file(cur + "/memory.usage_in_bytes", used)) {
+                    // v1 reports an effectively-infinite limit when none is set
+                    // (close to INT64_MAX rounded down to page size). Treat
+                    // anything within ~1 PiB of UINT64_MAX as "unlimited".
+                    const uint64_t v1_unlimited_floor = UINT64_MAX - (1ull << 50);
+                    if (limit < v1_unlimited_floor) {
+                        const uint64_t free_here = (limit > used) ? (limit - used) : 0;
+                        if (free_here < headroom) {
+                            headroom = free_here;
+                        }
+                    }
+                }
+                if (cur == "/sys/fs/cgroup/memory" || cur.empty()) break;
+                size_t slash = cur.find_last_of('/');
+                if (slash == std::string::npos || slash < std::string{"/sys/fs/cgroup/memory"}.size()) break;
+                cur = cur.substr(0, slash);
+            }
+            if (headroom != UINT64_MAX) {
+                return headroom;
+            }
+        }
+    }
+    return 0;
+}
+#endif // __linux__
+
+// Returns currently-available memory in bytes for "would this allocation
+// succeed" decisions. 0 means the OS query failed; caller treats that as
+// UNKNOWN. On Linux this honors cgroup v2/v1 limits when running inside a
+// container by taking min(MemAvailable, cgroup headroom).
+static uint64_t llama_get_available_ram_bytes() {
 #if defined(_WIN32)
     MEMORYSTATUSEX mem_info = {};
     mem_info.dwLength = sizeof(mem_info);
     if (GlobalMemoryStatusEx(&mem_info)) {
-        return (uint64_t) mem_info.ullTotalPhys;
+        return (uint64_t) mem_info.ullAvailPhys;
     }
-#elif defined(__linux__)
-    long pages     = sysconf(_SC_PHYS_PAGES);
-    long page_size = sysconf(_SC_PAGE_SIZE);
-    if (pages > 0 && page_size > 0) {
-        return (uint64_t) pages * (uint64_t) page_size;
-    }
-#elif defined(__APPLE__)
-    int mib[2] = { CTL_HW, HW_MEMSIZE };
-    uint64_t mem = 0;
-    size_t   len = sizeof(mem);
-    if (sysctl(mib, 2, &mem, &len, nullptr, 0) == 0 && mem > 0) {
-        return mem;
-    }
-#endif
     return 0;
+#elif defined(__linux__)
+    uint64_t mem_avail = 0;
+    {
+        FILE * f = std::fopen("/proc/meminfo", "r");
+        if (f) {
+            char line[256];
+            while (std::fgets(line, sizeof(line), f)) {
+                unsigned long long kb = 0;
+                if (std::sscanf(line, "MemAvailable: %llu kB", &kb) == 1) {
+                    mem_avail = (uint64_t) kb * 1024ull;
+                    break;
+                }
+            }
+            std::fclose(f);
+        }
+    }
+    if (mem_avail == 0) {
+        // Fallback to sysconf for older kernels without MemAvailable
+        long avail_pages = sysconf(_SC_AVPHYS_PAGES);
+        long page_size   = sysconf(_SC_PAGE_SIZE);
+        if (avail_pages > 0 && page_size > 0) {
+            mem_avail = (uint64_t) avail_pages * (uint64_t) page_size;
+        }
+    }
+    const uint64_t cg_avail = llama_get_cgroup_available_bytes();
+    if (cg_avail > 0 && (mem_avail == 0 || cg_avail < mem_avail)) {
+        return cg_avail;
+    }
+    return mem_avail;
+#elif defined(__APPLE__)
+    mach_port_t host_port = mach_host_self();
+    vm_size_t   page_size = 0;
+    if (host_page_size(host_port, &page_size) != KERN_SUCCESS || page_size == 0) {
+        int    mib[2] = { CTL_HW, HW_PAGESIZE };
+        int    ps = 0;
+        size_t plen = sizeof(ps);
+        if (sysctl(mib, 2, &ps, &plen, nullptr, 0) == 0 && ps > 0) {
+            page_size = (vm_size_t) ps;
+        } else {
+            return 0;
+        }
+    }
+    vm_statistics64_data_t vm_stat = {};
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    if (host_statistics64(host_port, HOST_VM_INFO64, (host_info64_t) &vm_stat, &count) != KERN_SUCCESS) {
+        return 0;
+    }
+    const uint64_t free_pages     = (uint64_t) vm_stat.free_count;
+    const uint64_t inactive_pages = (uint64_t) vm_stat.inactive_count;
+    return (free_pages + inactive_pages) * (uint64_t) page_size;
+#else
+    return 0;
+#endif
 }
 
-// Returns true iff `--run-time-repack auto` should disable run-time repack for
-// this load. False means "do nothing" — preserves the user's -rtr setting.
-static bool llama_rtr_auto_should_disable(
+enum class llama_rtr_auto_decision {
+    KEEP,           // Repack is safe for this load.
+    DISABLE,        // Repack is unsafe; turn it off, log INFO with reason.
+    NOT_APPLICABLE, // Policy does not apply (dense non-MoE); leave both
+                    // repack and use_mmap as the user/default.
+    UNKNOWN,        // Could not determine; safety-first disable, log WARN.
+};
+
+// Decide whether `--run-time-repack auto` should disable repack for this load.
+// Compares full GGUF tensor bytes against 90% of currently-available memory.
+// If anything goes wrong (probe exception, OS query failure) the result is
+// UNKNOWN, which the caller treats as safety-first disable. On dense models
+// the policy does not apply and the result is NOT_APPLICABLE.
+static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         const std::string         & fname,
         const llama_model_params  & params,
         std::string               & reason) {
     if (!params.repack_tensors || !params.repack_tensors_auto) {
-        return false;
+        return llama_rtr_auto_decision::KEEP;
     }
 
-    // GPU offload (or n-cpu-moe) shifts the actual CPU-side footprint and the
-    // raw on-disk model size is no longer a reliable proxy for RAM pressure.
-    // Defer to the user's explicit -rtr choice in that case.
-    if (params.n_gpu_layers > 0) {
-        return false;
-    }
-
-    const uint64_t phys_ram = llama_get_total_ram_bytes();
-    if (phys_ram == 0) {
-        return false;
+    const uint64_t avail_ram = llama_get_available_ram_bytes();
+    if (avail_ram == 0) {
+        reason = "could not query available memory";
+        return llama_rtr_auto_decision::UNKNOWN;
     }
 
     try {
@@ -4674,25 +4866,26 @@ static bool llama_rtr_auto_should_disable(
         const bool is_moe = probe_model.hparams.n_expert > 0
                          && probe_model.hparams.n_expert_used > 0;
         if (!is_moe) {
-            // Dense models have not shown the same swap regression in our testing,
-            // so the auto policy stays out of the way.
-            return false;
+            reason = "dense model";
+            return llama_rtr_auto_decision::NOT_APPLICABLE;
         }
 
         const uint64_t model_bytes = (uint64_t) probe.n_bytes;
-        // 90% of physical RAM, conservative buffer for kernel + other processes.
-        const uint64_t threshold = phys_ram - phys_ram / 10;
+        // 90% of available memory, conservative buffer for kernel + other
+        // processes. Note: probe.n_bytes is full GGUF tensor bytes across
+        // shards, not exact CPU-resident bytes after placement; this is a
+        // safe over-estimate on the swap-bound side.
+        const uint64_t threshold = avail_ram - avail_ram / 10;
         if (model_bytes <= threshold) {
-            return false;
+            return llama_rtr_auto_decision::KEEP;
         }
 
-        reason = format("MoE model %.1f GiB > 90%% of RAM %.1f GiB",
-                model_bytes / 1073741824.0, phys_ram / 1073741824.0);
-        return true;
+        reason = format("MoE model %.1f GiB > 90%% of available memory %.1f GiB",
+                model_bytes / 1073741824.0, avail_ram / 1073741824.0);
+        return llama_rtr_auto_decision::DISABLE;
     } catch (const std::exception & e) {
-        LLAMA_LOG_WARN("%s: --run-time-repack auto: probe failed (%s); leaving repack as-is\n",
-                __func__, e.what());
-        return false;
+        reason = format("probe failed (%s)", e.what());
+        return llama_rtr_auto_decision::UNKNOWN;
     }
 }
 
@@ -4701,19 +4894,37 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
     try {
         if (params.repack_tensors && params.repack_tensors_auto) {
             std::string reason;
-            if (llama_rtr_auto_should_disable(fname, params, reason)) {
-                // Auto policy turns repack off — leave use_mmap as the user
-                // configured it (default true, or whatever --no-mmap chose).
-                params.repack_tensors = false;
-                LLAMA_LOG_INFO("%s: --run-time-repack auto: disabled (%s)\n",
-                        __func__, reason.c_str());
-            } else {
-                // Auto keeps repack enabled — match the legacy `-rtr 1`
-                // coupling and force use_mmap=false so the repack pass can
-                // write back into the tensor buffers.
-                params.use_mmap = false;
-                LLAMA_LOG_INFO("%s: --run-time-repack auto: keeping repack enabled\n",
-                        __func__);
+            const auto d = llama_rtr_auto_should_disable(fname, params, reason);
+            switch (d) {
+                case llama_rtr_auto_decision::DISABLE:
+                    // Auto policy turns repack off — leave use_mmap as the
+                    // user configured it (default true, or whatever
+                    // --no-mmap chose).
+                    params.repack_tensors = false;
+                    LLAMA_LOG_INFO("%s: --run-time-repack auto: disabled (%s)\n",
+                            __func__, reason.c_str());
+                    break;
+                case llama_rtr_auto_decision::UNKNOWN:
+                    // Could not determine. Safety-first: disable repack and
+                    // keep mmap so a swap-bound load still has a chance.
+                    params.repack_tensors = false;
+                    LLAMA_LOG_WARN("%s: --run-time-repack auto: disabled (uncertainty: %s)\n",
+                            __func__, reason.c_str());
+                    break;
+                case llama_rtr_auto_decision::NOT_APPLICABLE:
+                    // Policy does not apply (e.g. dense model). Leave
+                    // repack and use_mmap untouched.
+                    LLAMA_LOG_INFO("%s: --run-time-repack auto: policy does not apply (%s)\n",
+                            __func__, reason.c_str());
+                    break;
+                case llama_rtr_auto_decision::KEEP:
+                    // Auto keeps repack enabled — match the legacy `-rtr 1`
+                    // coupling and force use_mmap=false so the repack pass
+                    // can write back into the tensor buffers.
+                    params.use_mmap = false;
+                    LLAMA_LOG_INFO("%s: --run-time-repack auto: keeping repack enabled\n",
+                            __func__);
+                    break;
             }
         }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4835,6 +4835,14 @@ struct llama_available_memory_result {
 // cgroup v2/v1 limits by taking min(MemAvailable, cgroup headroom).
 static llama_available_memory_result llama_get_available_ram_bytes() {
 #if defined(_WIN32)
+    // The public Job Object APIs cannot generally prove that every parent or
+    // nested memory limit is visible to this process. Treat any job membership
+    // as unknown rather than risking AUTO_KEEP from host-wide headroom.
+    BOOL in_job = FALSE;
+    if (!IsProcessInJob(GetCurrentProcess(), NULL, &in_job) || in_job) {
+        return { false, 0 };
+    }
+
     MEMORYSTATUSEX mem_info = {};
     mem_info.dwLength = sizeof(mem_info);
     if (GlobalMemoryStatusEx(&mem_info)) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -90,6 +90,7 @@ void llama_set_mtp_n_heads(struct llama_context * ctx, int32_t mtp_n_heads);
 #include <array>
 #include <cassert>
 #include <cctype>
+#include <cerrno>
 #include <cfloat>
 #include <cinttypes>
 #include <climits>
@@ -4646,12 +4647,14 @@ static bool llama_read_uint64_file(const std::string & path, uint64_t & out) {
 // path with a true return means that the requested controller is not present.
 static bool llama_resolve_cgroup_path(const std::string & controller, std::string & result) {
     result.clear();
-    FILE * f = std::fopen("/proc/self/cgroup", "r");
-    if (!f) return false;
-    char buf[512];
-    while (std::fgets(buf, sizeof(buf), f)) {
-        std::string line(buf);
-        while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
+    std::ifstream file("/proc/self/cgroup");
+    if (!file.is_open()) {
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        while (!line.empty() && line.back() == '\r') {
             line.pop_back();
         }
         // Expected format: <hierarchy_id>:<controllers>:<path>
@@ -4680,8 +4683,7 @@ static bool llama_resolve_cgroup_path(const std::string & controller, std::strin
             if (!result.empty()) break;
         }
     }
-    std::fclose(f);
-    return true;
+    return !file.bad();
 }
 
 struct llama_cgroup_memory_result {
@@ -4694,49 +4696,79 @@ struct llama_cgroup_memory_result {
 // cgroup path upward to honor inherited limits. Inspection errors are reported
 // separately from an unlimited hierarchy so callers can remain safety-first.
 static llama_cgroup_memory_result llama_get_cgroup_available_bytes() {
+    std::string v2_cgpath;
+    std::string v1_cgpath;
+    if (!llama_resolve_cgroup_path("v2", v2_cgpath) ||
+        !llama_resolve_cgroup_path("memory", v1_cgpath)) {
+        return { false, false, 0 };
+    }
+
     // cgroup v2
     {
-        std::string cgpath;
-        if (!llama_resolve_cgroup_path("v2", cgpath)) {
-            return { false, false, 0 };
-        }
-        if (!cgpath.empty()) {
-            std::string cur = "/sys/fs/cgroup" + cgpath;
-            uint64_t headroom = UINT64_MAX;
-            while (true) {
-                uint64_t limit = 0;
-                uint64_t used  = 0;
-                if (!llama_read_uint64_file(cur + "/memory.max", limit) ||
-                    !llama_read_uint64_file(cur + "/memory.current", used)) {
-                    // This also catches non-standard/bind-mounted cgroup roots.
-                    // Falling back to host MemAvailable would be unsafe.
+        if (!v2_cgpath.empty()) {
+            std::string cur = "/sys/fs/cgroup" + v2_cgpath;
+            const std::string leaf_limit = cur + "/memory.max";
+            const std::string leaf_used  = cur + "/memory.current";
+            bool leaf_limit_exists = false;
+            bool leaf_used_exists  = false;
+            const auto check_exists = [](const std::string & path, bool & exists) {
+                errno = 0;
+                if (access(path.c_str(), F_OK) == 0) {
+                    exists = true;
+                    return true;
+                }
+                exists = false;
+                return errno == ENOENT || errno == ENOTDIR;
+            };
+            if (!check_exists(leaf_limit, leaf_limit_exists) ||
+                !check_exists(leaf_used,  leaf_used_exists)) {
+                return { false, false, 0 };
+            }
+            if (leaf_limit_exists != leaf_used_exists) {
+                return { false, false, 0 };
+            }
+
+            // On a hybrid hierarchy the process has a v2 membership even when
+            // the memory controller is still attached to v1. Only fall through
+            // when both v2 memory files are absent and a v1 memory membership
+            // was found.
+            if (!leaf_limit_exists) {
+                if (v1_cgpath.empty()) {
                     return { false, false, 0 };
                 }
-                if (limit != UINT64_MAX) {
-                    const uint64_t free_here = (limit > used) ? (limit - used) : 0;
-                    if (free_here < headroom) {
-                        headroom = free_here;
+            } else {
+                uint64_t headroom = UINT64_MAX;
+                while (true) {
+                    uint64_t limit = 0;
+                    uint64_t used  = 0;
+                    if (!llama_read_uint64_file(cur + "/memory.max", limit) ||
+                        !llama_read_uint64_file(cur + "/memory.current", used)) {
+                        // This also catches non-standard/bind-mounted cgroup roots.
+                        // Falling back to host MemAvailable would be unsafe.
+                        return { false, false, 0 };
                     }
+                    if (limit != UINT64_MAX) {
+                        const uint64_t free_here = (limit > used) ? (limit - used) : 0;
+                        if (free_here < headroom) {
+                            headroom = free_here;
+                        }
+                    }
+                    if (cur == "/sys/fs/cgroup" || cur.empty()) break;
+                    size_t slash = cur.find_last_of('/');
+                    if (slash == std::string::npos || slash < std::string{"/sys/fs/cgroup"}.size()) break;
+                    cur = cur.substr(0, slash);
                 }
-                if (cur == "/sys/fs/cgroup" || cur.empty()) break;
-                size_t slash = cur.find_last_of('/');
-                if (slash == std::string::npos || slash < std::string{"/sys/fs/cgroup"}.size()) break;
-                cur = cur.substr(0, slash);
+                if (headroom != UINT64_MAX) {
+                    return { true, true, headroom };
+                }
+                return { true, false, 0 };
             }
-            if (headroom != UINT64_MAX) {
-                return { true, true, headroom };
-            }
-            return { true, false, 0 };
         }
     }
     // cgroup v1 memory controller
     {
-        std::string cgpath;
-        if (!llama_resolve_cgroup_path("memory", cgpath)) {
-            return { false, false, 0 };
-        }
-        if (!cgpath.empty()) {
-            std::string cur = "/sys/fs/cgroup/memory" + cgpath;
+        if (!v1_cgpath.empty()) {
+            std::string cur = "/sys/fs/cgroup/memory" + v1_cgpath;
             uint64_t headroom = UINT64_MAX;
             while (true) {
                 uint64_t limit = 0;
@@ -4935,8 +4967,10 @@ static bool llama_rtr_auto_manual_override_cpu(
 static bool llama_rtr_auto_ncmoe_cpu_override(
         const std::string        & name,
         const llama_hparams      & hparams,
+        const llama_model        & model,
         const llama_model_params & params,
-        bool                     & cpu) {
+        bool                     & cpu,
+        std::string              & reason) {
     if (params.ncmoe <= 0 || !llama_rtr_auto_is_expert_tensor(name)) {
         return true;
     }
@@ -4947,8 +4981,16 @@ static bool llama_rtr_auto_ncmoe_cpu_override(
     }
 
     const int n_layer = (int) hparams.n_layer;
-    // The loader applies -ncmoe as a deterministic per-layer CPU override
-    // before distributing the remaining tensors across accelerator devices.
+    if (params.split_mode == LLAMA_SPLIT_MODE_LAYER &&
+        params.ncmoe < n_layer &&
+        model.devices.size() >= 2) {
+        // The loader distributes the requested CPU-MoE layers proportionally
+        // across devices and then selects layers by walking backwards. A simple
+        // first-N rule can undercount models with dense leading layers.
+        reason = "-ncmoe with multi-device layer split needs loader placement";
+        return false;
+    }
+
     cpu = il < std::min(params.ncmoe, n_layer);
     return true;
 }
@@ -4966,7 +5008,7 @@ static bool llama_rtr_auto_tensor_is_cpu(
         return true;
     }
 
-    if (!llama_rtr_auto_ncmoe_cpu_override(name, hparams, params, cpu)) {
+    if (!llama_rtr_auto_ncmoe_cpu_override(name, hparams, model, params, cpu, reason)) {
         return false;
     }
     if (cpu) {
@@ -5130,13 +5172,14 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
                 return llama_rtr_auto_decision::UNKNOWN;
             }
             cpu_total_bytes += nbytes;
-            if ((ggml_type) iqk_repacked_type(tensor) != tensor->type) {
+            const uint64_t workspace_bytes = iqk_repack_workspace_size(tensor);
+            if (workspace_bytes > 0) {
                 if (nbytes > UINT64_MAX - cpu_repackable_bytes) {
                     reason = "CPU-resident repackable tensor byte count overflow";
                     return llama_rtr_auto_decision::UNKNOWN;
                 }
                 cpu_repackable_bytes += nbytes;
-                max_repack_temp_bytes = std::max(max_repack_temp_bytes, nbytes);
+                max_repack_temp_bytes = std::max(max_repack_temp_bytes, workspace_bytes);
             }
         }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4592,11 +4592,12 @@ static bool llm_load_tensors(
 // simple CPU/GPU placement, and compare CPU-resident repackable bytes against
 // ~90% of available memory.
 //
-// The decision is tri-state-plus-one (KEEP / DISABLE / NOT_APPLICABLE / UNKNOWN).
-// On dense models the swap-bound MoE policy does not apply (NOT_APPLICABLE).
-// On uncertainty (probe exception, OS query failure, unsupported placement)
-// the policy is safety-first: disable repack with a WARN log and preserve the
-// user/default mmap setting.
+// The decision is tri-state (KEEP / DISABLE / UNKNOWN). DISABLE also fires
+// when no CPU-resident tensor would actually be repacked, since keeping
+// repack=true in that case only forces the loader's mmap=false coupling
+// without any benefit. On uncertainty (probe exception, OS query failure,
+// unsupported placement) the policy is safety-first: disable repack with a
+// WARN log and preserve the user/default mmap setting.
 
 #if defined(_WIN32)
 #  ifndef WIN32_LEAN_AND_MEAN
@@ -4817,10 +4818,9 @@ static uint64_t llama_get_available_ram_bytes() {
 }
 
 enum class llama_rtr_auto_decision {
-    KEEP,           // Repack is safe for this load.
-    DISABLE,        // Repack is unsafe; turn it off, log INFO with reason.
-    NOT_APPLICABLE, // Policy does not apply (dense non-MoE); keep repack.
-    UNKNOWN,        // Could not determine; safety-first disable, log WARN.
+    KEEP,    // Repack is safe for this load.
+    DISABLE, // Repack is unsafe or has no work to do; turn it off, log INFO.
+    UNKNOWN, // Could not determine; safety-first disable, log WARN.
 };
 
 struct llama_rtr_auto_override {
@@ -4978,6 +4978,33 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         return llama_rtr_auto_decision::KEEP;
     }
 
+    // Early UNKNOWN exits — modes whose placement we cannot accurately
+    // simulate from probe metadata alone. Resolve before the probe so we
+    // do not pay the metadata-load cost just to bail out anyway.
+    if (params.fit) {
+        reason = "--fit changes tensor placement during load";
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
+    if (params.merge_qkv || params.merge_up_gate_exps) {
+        reason = "merged tensor placement is resolved during load";
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
+    if (params.split_mode == LLAMA_SPLIT_MODE_ATTN || params.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+        reason = "split-mode graph/attention tensor placement is not modeled";
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
+
+    const uint64_t avail_ram = llama_get_available_ram_bytes();
+    if (avail_ram == 0) {
+        reason = "could not query available memory";
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
+
+    std::vector<llama_rtr_auto_override> overrides;
+    if (!llama_rtr_auto_compile_overrides(params.tensor_buft_overrides, overrides, reason)) {
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
+
     try {
         // Metadata-only probe: mmap + no repack to inspect arch/hparams cheaply.
         llama_model_loader probe(
@@ -4997,37 +5024,6 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         probe_model.hparams.vocab_only = params.vocab_only;
         llm_load_arch(probe, probe_model);
         llm_load_hparams(probe, probe_model);
-
-        const bool is_moe = probe_model.hparams.n_expert > 0
-                         && probe_model.hparams.n_expert_used > 0;
-        if (!is_moe) {
-            reason = "dense model";
-            return llama_rtr_auto_decision::NOT_APPLICABLE;
-        }
-
-        if (params.fit) {
-            reason = "--fit changes tensor placement during load";
-            return llama_rtr_auto_decision::UNKNOWN;
-        }
-        if (params.merge_qkv || params.merge_up_gate_exps) {
-            reason = "merged tensor placement is resolved during load";
-            return llama_rtr_auto_decision::UNKNOWN;
-        }
-        if (params.split_mode == LLAMA_SPLIT_MODE_ATTN || params.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
-            reason = "split-mode graph/attention tensor placement is not modeled";
-            return llama_rtr_auto_decision::UNKNOWN;
-        }
-
-        const uint64_t avail_ram = llama_get_available_ram_bytes();
-        if (avail_ram == 0) {
-            reason = "could not query available memory";
-            return llama_rtr_auto_decision::UNKNOWN;
-        }
-
-        std::vector<llama_rtr_auto_override> overrides;
-        if (!llama_rtr_auto_compile_overrides(params.tensor_buft_overrides, overrides, reason)) {
-            return llama_rtr_auto_decision::UNKNOWN;
-        }
 
         uint64_t cpu_total_bytes      = 0;
         uint64_t cpu_repackable_bytes = 0;
@@ -5052,6 +5048,9 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
             }
         }
 
+        // If no CPU-resident tensor would actually be repacked, keeping
+        // repack=true buys nothing but still forces the loader's mmap=false
+        // coupling. Strictly safer to disable in this case.
         if (cpu_repackable_bytes == 0) {
             reason = "no CPU-resident tensors need repacking";
             return llama_rtr_auto_decision::DISABLE;
@@ -5069,17 +5068,12 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
             return llama_rtr_auto_decision::DISABLE;
         }
 
-        if (cpu_repackable_bytes <= threshold) {
-            LLAMA_LOG_INFO("%s: --run-time-repack auto: CPU-resident repackable %.1f GiB, total CPU-resident %.1f GiB, available %.1f GiB\n",
-                    __func__,
-                    cpu_repackable_bytes / 1073741824.0,
-                    cpu_total_bytes / 1073741824.0,
-                    avail_ram / 1073741824.0);
-            return llama_rtr_auto_decision::KEEP;
-        }
-
-        reason = "internal policy fallthrough";
-        return llama_rtr_auto_decision::UNKNOWN;
+        LLAMA_LOG_INFO("%s: --run-time-repack auto: CPU-resident repackable %.1f GiB, total CPU-resident %.1f GiB, available %.1f GiB\n",
+                __func__,
+                cpu_repackable_bytes / 1073741824.0,
+                cpu_total_bytes / 1073741824.0,
+                avail_ram / 1073741824.0);
+        return llama_rtr_auto_decision::KEEP;
     } catch (const std::exception & e) {
         reason = format("probe failed (%s)", e.what());
         return llama_rtr_auto_decision::UNKNOWN;
@@ -5109,12 +5103,6 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                     LLAMA_LOG_WARN("%s: --run-time-repack auto: disabled (uncertainty: %s)\n",
                             __func__, reason.c_str());
                     llama_rtr_auto_log_mmap_override_note(params);
-                    break;
-                case llama_rtr_auto_decision::NOT_APPLICABLE:
-                    // Policy does not apply (e.g. dense model). Leave
-                    // repack and use_mmap untouched.
-                    LLAMA_LOG_INFO("%s: --run-time-repack auto: policy does not apply (%s)\n",
-                            __func__, reason.c_str());
                     break;
                 case llama_rtr_auto_decision::KEEP:
                     // Auto keeps repack enabled — match the legacy `-rtr 1`

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4587,16 +4587,16 @@ static bool llm_load_tensors(
 // --- run-time-repack auto policy ----------------------------------------------------
 //
 // `--run-time-repack auto` (a.k.a. `-rtr auto`) flips repacking on by default, but
-// disables it when the GGUF is known to overflow available memory and would
-// otherwise trigger swap thrashing during the repack pass. The check is
-// conservative: probe metadata only, compare model size against ~90% of available
-// memory, and flip off only when the model is a MoE that would not fit.
+// disables it when CPU-resident tensors that would lose mmap are known to exceed
+// available memory. The check is metadata-only: probe tensor metadata, resolve
+// simple CPU/GPU placement, and compare CPU-resident repackable bytes against
+// ~90% of available memory.
 //
 // The decision is tri-state-plus-one (KEEP / DISABLE / NOT_APPLICABLE / UNKNOWN).
-// On dense models the policy does not apply (NOT_APPLICABLE) and leaves both
-// repack and use_mmap untouched. On uncertainty (probe exception or OS query
-// failure) the policy is safety-first: disable repack with a WARN log so the
-// load gets the same chance to succeed as plain `-rtr` would.
+// On dense models the swap-bound MoE policy does not apply (NOT_APPLICABLE).
+// On uncertainty (probe exception, OS query failure, unsupported placement)
+// the policy is safety-first: disable repack with a WARN log and preserve the
+// user/default mmap setting.
 
 #if defined(_WIN32)
 #  ifndef WIN32_LEAN_AND_MEAN
@@ -4819,28 +4819,163 @@ static uint64_t llama_get_available_ram_bytes() {
 enum class llama_rtr_auto_decision {
     KEEP,           // Repack is safe for this load.
     DISABLE,        // Repack is unsafe; turn it off, log INFO with reason.
-    NOT_APPLICABLE, // Policy does not apply (dense non-MoE); leave both
-                    // repack and use_mmap as the user/default.
+    NOT_APPLICABLE, // Policy does not apply (dense non-MoE); keep repack.
     UNKNOWN,        // Could not determine; safety-first disable, log WARN.
 };
 
+struct llama_rtr_auto_override {
+    std::regex pattern;
+    bool       cpu;
+};
+
+static bool llama_rtr_auto_parse_layer(const std::string & name, int & il) {
+    int parsed = -1;
+    int nchars = 0;
+    if (std::sscanf(name.c_str(), "blk.%d.%n", &parsed, &nchars) == 1 && nchars > 0) {
+        il = parsed;
+        return true;
+    }
+    return false;
+}
+
+static bool llama_rtr_auto_is_output_tensor(const std::string & name) {
+    return name == "output.weight" ||
+           name == "output.bias"   ||
+           name.rfind("output_norm", 0) == 0;
+}
+
+static bool llama_rtr_auto_is_expert_tensor(const std::string & name) {
+    return name.find(".ffn_") != std::string::npos &&
+           name.find("_exps.") != std::string::npos;
+}
+
+static bool llama_rtr_auto_compile_overrides(
+        const llama_model_tensor_buft_override * overrides,
+        std::vector<llama_rtr_auto_override>   & out,
+        std::string                            & reason) {
+    if (!overrides) {
+        return true;
+    }
+    try {
+        for (const auto * o = overrides; o->pattern != nullptr; ++o) {
+            out.push_back({ std::regex(o->pattern), ggml_backend_buft_is_host(o->buft) });
+        }
+    } catch (const std::regex_error & e) {
+        reason = format("tensor override regex failed (%s)", e.what());
+        return false;
+    }
+    return true;
+}
+
+static bool llama_rtr_auto_manual_override_cpu(
+        const std::vector<llama_rtr_auto_override> & overrides,
+        const std::string                          & name,
+        bool                                       & cpu) {
+    for (const auto & o : overrides) {
+        if (std::regex_search(name, o.pattern)) {
+            cpu = o.cpu;
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool llama_rtr_auto_ncmoe_cpu_override(
+        const std::string        & name,
+        const llama_hparams      & hparams,
+        const llama_model        & model,
+        const llama_model_params & params,
+        bool                     & cpu,
+        std::string              & reason) {
+    if (params.ncmoe <= 0 || !llama_rtr_auto_is_expert_tensor(name)) {
+        return true;
+    }
+
+    int il = -1;
+    if (!llama_rtr_auto_parse_layer(name, il)) {
+        return true;
+    }
+
+    const int n_layer = (int) hparams.n_layer;
+    if (params.split_mode == LLAMA_SPLIT_MODE_ATTN ||
+        params.split_mode == LLAMA_SPLIT_MODE_GRAPH ||
+        params.ncmoe >= n_layer ||
+        model.devices.size() < 2) {
+        cpu = il < std::min(params.ncmoe, n_layer);
+        return true;
+    }
+
+    reason = "-ncmoe with multi-device layer split needs loader placement";
+    return false;
+}
+
+static bool llama_rtr_auto_tensor_is_cpu(
+        const std::string                          & name,
+        const llama_hparams                        & hparams,
+        const llama_model                          & model,
+        const llama_model_params                   & params,
+        const std::vector<llama_rtr_auto_override> & overrides,
+        bool                                       & cpu,
+        std::string                                & reason) {
+    if (llama_rtr_auto_manual_override_cpu(overrides, name, cpu)) {
+        return true;
+    }
+
+    if (!llama_rtr_auto_ncmoe_cpu_override(name, hparams, model, params, cpu, reason)) {
+        return false;
+    }
+    if (cpu) {
+        return true;
+    }
+
+    if (model.devices.empty() || params.n_gpu_layers <= 0) {
+        cpu = true;
+        return true;
+    }
+
+    const int n_layer = (int) hparams.n_layer;
+    const int i_gpu_start = std::max(n_layer - params.n_gpu_layers, 0);
+
+    int il = -1;
+    if (llama_rtr_auto_parse_layer(name, il)) {
+        cpu = il < i_gpu_start;
+        return true;
+    }
+
+    if (llama_rtr_auto_is_output_tensor(name)) {
+        cpu = params.n_gpu_layers <= n_layer;
+        return true;
+    }
+
+    // Input embeddings and miscellaneous metadata tensors are kept on CPU.
+    cpu = true;
+    return true;
+}
+
+static void llama_rtr_auto_log_mmap_override_note(const llama_model_params & params) {
+    if (!params.tensor_buft_overrides || std::getenv("GGML_CUDA_NO_PINNED") != nullptr) {
+        return;
+    }
+    for (const auto * o = params.tensor_buft_overrides; o->pattern != nullptr; ++o) {
+        if (ggml_backend_buft_is_host(o->buft)) {
+            LLAMA_LOG_WARN("%s: --run-time-repack auto: CPU tensor overrides may still disable mmap unless GGML_CUDA_NO_PINNED=1 is set\n",
+                    __func__);
+            return;
+        }
+    }
+}
+
 // Decide whether `--run-time-repack auto` should disable repack for this load.
-// Compares full GGUF tensor bytes against 90% of currently-available memory.
-// If anything goes wrong (probe exception, OS query failure) the result is
-// UNKNOWN, which the caller treats as safety-first disable. On dense models
-// the policy does not apply and the result is NOT_APPLICABLE.
+// If anything goes wrong (probe exception, OS query failure, unsupported
+// placement mode) the result is UNKNOWN, which the caller treats as
+// safety-first disable.
 static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         const std::string         & fname,
+        const llama_model         & model,
         const llama_model_params  & params,
         std::string               & reason) {
     if (!params.repack_tensors || !params.repack_tensors_auto) {
         return llama_rtr_auto_decision::KEEP;
-    }
-
-    const uint64_t avail_ram = llama_get_available_ram_bytes();
-    if (avail_ram == 0) {
-        reason = "could not query available memory";
-        return llama_rtr_auto_decision::UNKNOWN;
     }
 
     try {
@@ -4870,19 +5005,81 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
             return llama_rtr_auto_decision::NOT_APPLICABLE;
         }
 
-        const uint64_t model_bytes = (uint64_t) probe.n_bytes;
-        // 90% of available memory, conservative buffer for kernel + other
-        // processes. Note: probe.n_bytes is full GGUF tensor bytes across
-        // shards, not exact CPU-resident bytes after placement; this is a
-        // safe over-estimate on the swap-bound side.
+        if (params.fit) {
+            reason = "--fit changes tensor placement during load";
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+        if (params.merge_qkv || params.merge_up_gate_exps) {
+            reason = "merged tensor placement is resolved during load";
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+        if (params.split_mode == LLAMA_SPLIT_MODE_ATTN || params.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+            reason = "split-mode graph/attention tensor placement is not modeled";
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+
+        const uint64_t avail_ram = llama_get_available_ram_bytes();
+        if (avail_ram == 0) {
+            reason = "could not query available memory";
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+
+        std::vector<llama_rtr_auto_override> overrides;
+        if (!llama_rtr_auto_compile_overrides(params.tensor_buft_overrides, overrides, reason)) {
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+
+        uint64_t cpu_total_bytes      = 0;
+        uint64_t cpu_repackable_bytes = 0;
+
+        for (const auto & w : probe.weights) {
+            const ggml_tensor * tensor = w.tensor;
+            if (!tensor) {
+                continue;
+            }
+            bool is_cpu = false;
+            if (!llama_rtr_auto_tensor_is_cpu(tensor->name, probe_model.hparams, model, params, overrides, is_cpu, reason)) {
+                return llama_rtr_auto_decision::UNKNOWN;
+            }
+            if (!is_cpu) {
+                continue;
+            }
+
+            const uint64_t nbytes = (uint64_t) ggml_nbytes(tensor);
+            cpu_total_bytes += nbytes;
+            if ((ggml_type) iqk_repacked_type(tensor) != tensor->type) {
+                cpu_repackable_bytes += nbytes;
+            }
+        }
+
+        if (cpu_repackable_bytes == 0) {
+            reason = "no CPU-resident tensors need repacking";
+            return llama_rtr_auto_decision::DISABLE;
+        }
+
         const uint64_t threshold = avail_ram - avail_ram / 10;
-        if (model_bytes <= threshold) {
+        if (cpu_repackable_bytes > threshold) {
+            reason = format("CPU-resident repackable tensors %.1f GiB > 90%% of available memory %.1f GiB",
+                    cpu_repackable_bytes / 1073741824.0, avail_ram / 1073741824.0);
+            return llama_rtr_auto_decision::DISABLE;
+        }
+        if (cpu_total_bytes > threshold) {
+            reason = format("CPU-resident tensors %.1f GiB > 90%% of available memory %.1f GiB",
+                    cpu_total_bytes / 1073741824.0, avail_ram / 1073741824.0);
+            return llama_rtr_auto_decision::DISABLE;
+        }
+
+        if (cpu_repackable_bytes <= threshold) {
+            LLAMA_LOG_INFO("%s: --run-time-repack auto: CPU-resident repackable %.1f GiB, total CPU-resident %.1f GiB, available %.1f GiB\n",
+                    __func__,
+                    cpu_repackable_bytes / 1073741824.0,
+                    cpu_total_bytes / 1073741824.0,
+                    avail_ram / 1073741824.0);
             return llama_rtr_auto_decision::KEEP;
         }
 
-        reason = format("MoE model %.1f GiB > 90%% of available memory %.1f GiB",
-                model_bytes / 1073741824.0, avail_ram / 1073741824.0);
-        return llama_rtr_auto_decision::DISABLE;
+        reason = "internal policy fallthrough";
+        return llama_rtr_auto_decision::UNKNOWN;
     } catch (const std::exception & e) {
         reason = format("probe failed (%s)", e.what());
         return llama_rtr_auto_decision::UNKNOWN;
@@ -4894,7 +5091,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
     try {
         if (params.repack_tensors && params.repack_tensors_auto) {
             std::string reason;
-            const auto d = llama_rtr_auto_should_disable(fname, params, reason);
+            const auto d = llama_rtr_auto_should_disable(fname, model, params, reason);
             switch (d) {
                 case llama_rtr_auto_decision::DISABLE:
                     // Auto policy turns repack off — leave use_mmap as the
@@ -4903,6 +5100,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                     params.repack_tensors = false;
                     LLAMA_LOG_INFO("%s: --run-time-repack auto: disabled (%s)\n",
                             __func__, reason.c_str());
+                    llama_rtr_auto_log_mmap_override_note(params);
                     break;
                 case llama_rtr_auto_decision::UNKNOWN:
                     // Could not determine. Safety-first: disable repack and
@@ -4910,6 +5108,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                     params.repack_tensors = false;
                     LLAMA_LOG_WARN("%s: --run-time-repack auto: disabled (uncertainty: %s)\n",
                             __func__, reason.c_str());
+                    llama_rtr_auto_log_mmap_override_note(params);
                     break;
                 case llama_rtr_auto_decision::NOT_APPLICABLE:
                     // Policy does not apply (e.g. dense model). Leave

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4369,6 +4369,7 @@ static bool llm_load_tensors(
                     throw std::runtime_error("unable to allocate backend CPU buffer");
                 }
                 model.bufs.push_back(buf);
+                model.has_mmap_backed_buffers = true;
                 bufs.emplace(idx, buf);
 #ifdef GGML_USE_CUDA
                 if (n_layer >= n_gpu_layers) {
@@ -4394,6 +4395,7 @@ static bool llm_load_tensors(
                     throw std::runtime_error("unable to allocate backend metal buffer");
                 }
                 model.bufs.push_back(buf);
+                model.has_mmap_backed_buffers = true;
                 bufs.emplace(idx, buf);
             }
         }
@@ -4534,6 +4536,7 @@ static bool llm_load_tensors(
     }
 
     if (!ml.use_mmap && ml.repack_tensors) {
+        model.repack_pass_executed = true;
         int n_repacked = 0;
         for (auto& it : model.tensors_by_name) {
             if (ggml_backend_buffer_is_host(it.second->buffer)) {
@@ -4543,6 +4546,7 @@ static bool llm_load_tensors(
                 if (it.second->type != orig_type) ++n_repacked;
             }
         }
+        model.n_repacked = n_repacked;
         if (n_repacked > 0) LLAMA_LOG_INFO("============ Repacked %d tensors\n", n_repacked);
     }
 
@@ -5244,6 +5248,7 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
 // Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
 static int llama_model_load(const std::string & fname, llama_model & model, llama_model_params & params) {
     try {
+        model.use_mmap_requested = params.use_mmap;
         model.rtr_status = params.repack_tensors ?
                 LLAMA_RTR_STATUS_ENABLED : LLAMA_RTR_STATUS_DISABLED;
         if (params.repack_tensors && params.repack_tensors_auto) {
@@ -5347,11 +5352,12 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
         )) {
             return -2;
         }
+        model.use_mmap_loader_enabled = ml.use_mmap;
 
         // ---- populate reload registry ONLY when hot-swap is requested ----
         if (std::getenv("LLAMA_HOTSWAP_ENABLED") != nullptr) {
             model.reload = std::make_unique<reload_info>(ml);
-				}
+        }
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error loading model: %s\n", __func__, err.what());
         return -1;
@@ -9120,6 +9126,22 @@ uint64_t llama_model_size(const struct llama_model * model) {
 
 enum llama_rtr_status llama_model_rtr_status(const struct llama_model * model) {
     return model ? model->rtr_status : LLAMA_RTR_STATUS_DISABLED;
+}
+
+bool llama_model_loader_mmap_enabled(const struct llama_model * model) {
+    return model && model->use_mmap_loader_enabled;
+}
+
+bool llama_model_has_mmap_buffers(const struct llama_model * model) {
+    return model && model->has_mmap_backed_buffers;
+}
+
+bool llama_model_repack_pass_executed(const struct llama_model * model) {
+    return model && model->repack_pass_executed;
+}
+
+uint64_t llama_model_n_repacked(const struct llama_model * model) {
+    return model ? model->n_repacked : 0;
 }
 
 const char* llama_model_chat_template(const struct llama_model* model, const char* name) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -12,6 +12,7 @@
 #include "llama-arch.h"
 #include "llama-mmap.h"
 #include "llama-model-loader.h"
+#include "llama-rtr-auto.h"
 #include "llama-model.h"
 #include "llama-build-context.h"
 #include "llama-cparams.h"
@@ -4684,10 +4685,22 @@ static bool llama_get_v2_cgroup_headroom(const llama_resolved_cgroup_mount & res
     uint64_t headroom = UINT64_MAX;
     std::string cur = resolved.path;
     while (true) {
+        const std::string limit_path = cur + "/memory.max";
+        const std::string used_path  = cur + "/memory.current";
+        bool limit_exists = false;
+        bool used_exists  = false;
+        if (!llama_cgroup_file_exists(limit_path, limit_exists) ||
+            !llama_cgroup_file_exists(used_path, used_exists)) return false;
+
+        bool skip_level = false;
+        if (!llama_cgroup_v2_level_files(
+                limit_exists, used_exists, cur == resolved.mountpoint, skip_level)) return false;
+        if (skip_level) break;
+
         uint64_t limit = 0;
         uint64_t used = 0;
-        if (!llama_read_uint64_file(cur + "/memory.max", limit) ||
-            !llama_read_uint64_file(cur + "/memory.current", used)) return false;
+        if (!llama_read_uint64_file(limit_path, limit) ||
+            !llama_read_uint64_file(used_path, used)) return false;
         if (limit != UINT64_MAX) headroom = std::min(headroom, limit > used ? limit - used : 0);
         if (cur == resolved.mountpoint) break;
         std::string parent;
@@ -4743,31 +4756,26 @@ static llama_cgroup_memory_result llama_get_cgroup_available_bytes() {
         return { false, false, 0 };
     }
 
-    bool limited = false;
-    uint64_t headroom = UINT64_MAX;
+    std::vector<llama_resolved_cgroup_mount> candidates;
     for (const llama_cgroup_membership & membership : memberships) {
         std::vector<llama_resolved_cgroup_mount> resolved;
         if (!llama_resolve_cgroup_mounts(membership, mounts, resolved)) return { false, false, 0 };
-        for (const llama_resolved_cgroup_mount & candidate : resolved) {
-            bool candidate_limited = false;
-            uint64_t candidate_headroom = 0;
-            if (membership.v2) {
-                bool has_memory = false;
-                if (!llama_read_cgroup_controllers(candidate.mountpoint, has_memory)) return { false, false, 0 };
-                // Unified hierarchy without the memory controller is not a
-                // memory constraint; a v1 membership may still constrain it.
-                if (!has_memory) continue;
-                if (!llama_get_v2_cgroup_headroom(candidate, candidate_limited, candidate_headroom)) return { false, false, 0 };
-            } else if (!llama_get_v1_cgroup_headroom(candidate, candidate_limited, candidate_headroom)) {
-                return { false, false, 0 };
-            }
-            if (candidate_limited) {
-                limited = true;
-                headroom = std::min(headroom, candidate_headroom);
-            }
-        }
+        candidates.insert(candidates.end(), resolved.begin(), resolved.end());
     }
-    return { true, limited, limited ? headroom : 0 };
+    bool limited = false;
+    uint64_t headroom = 0;
+    const bool ok = llama_intersect_cgroup_headrooms(candidates,
+            [] (const llama_resolved_cgroup_mount & candidate, bool & candidate_limited, uint64_t & candidate_headroom) {
+                if (candidate.v2) {
+                    bool has_memory = false;
+                    if (!llama_read_cgroup_controllers(candidate.mountpoint, has_memory)) return false;
+                    // Unified hierarchy without the memory controller is not a
+                    // memory constraint; a v1 membership may still constrain it.
+                    return !has_memory || llama_get_v2_cgroup_headroom(candidate, candidate_limited, candidate_headroom);
+                }
+                return llama_get_v1_cgroup_headroom(candidate, candidate_limited, candidate_headroom);
+            }, limited, headroom);
+    return { ok, limited, headroom };
 }
 #endif // __linux__
 
@@ -5054,6 +5062,15 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         reason = "--defer-experts requires mmap and is incompatible with run-time repack";
         return llama_rtr_auto_decision::UNKNOWN;
     }
+#if defined(__linux__)
+    if (params.prefetch_experts) {
+        // Expert prefetch registers the model mmap ranges with the backend.
+        // AUTO_KEEP would remove those ranges, turning the requested feature
+        // into a silent no-op.
+        reason = "--prefetch-experts requires mmap and is incompatible with run-time repack";
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
+#endif
     if (params.split_mode == LLAMA_SPLIT_MODE_ATTN || params.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
         reason = "split-mode graph/attention tensor placement is not modeled";
         return llama_rtr_auto_decision::UNKNOWN;
@@ -5107,6 +5124,7 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         uint64_t cpu_total_bytes      = 0;
         uint64_t cpu_repackable_bytes = 0;
         uint64_t max_repack_temp_bytes = 0;
+        uint64_t max_loader_read_buffer_bytes = 0;
         const ggml_tensor * token_embd = nullptr;
         bool has_output_weight = false;
 
@@ -5121,6 +5139,8 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
             } else if (tensor_name == "output.weight") {
                 has_output_weight = true;
             }
+            const uint64_t nbytes = (uint64_t) ggml_nbytes(tensor);
+            max_loader_read_buffer_bytes = std::max(max_loader_read_buffer_bytes, nbytes);
             bool is_cpu = false;
             if (!llama_rtr_auto_tensor_is_cpu(tensor_name, nullptr, probe_model.hparams, model, params, overrides, is_cpu, reason)) {
                 return llama_rtr_auto_decision::UNKNOWN;
@@ -5129,7 +5149,6 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
                 continue;
             }
 
-            const uint64_t nbytes = (uint64_t) ggml_nbytes(tensor);
             if (nbytes > UINT64_MAX - cpu_total_bytes) {
                 reason = "CPU-resident tensor byte count overflow";
                 return llama_rtr_auto_decision::UNKNOWN;
@@ -5180,11 +5199,26 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
                     cpu_repackable_bytes / 1073741824.0, avail_ram / 1073741824.0);
             return llama_rtr_auto_decision::DISABLE;
         }
-        if (max_repack_temp_bytes > UINT64_MAX - cpu_total_bytes) {
-            reason = "CPU-resident load plus repack workspace byte count overflow";
+        // load_all_data() keeps one read buffer per worker.  A conservative
+        // max-tensor bound covers backend and Windows split paths where several
+        // worker capacities can coexist. CUDA may additionally allocate one
+        // 16 MiB staging buffer per worker for asynchronous uploads.
+        bool cuda_staging_may_apply = false;
+#if defined(GGML_USE_CUDA)
+        cuda_staging_may_apply = !params.check_tensors && params.n_gpu_layers > 0 && !model.devices.empty();
+#endif
+        uint64_t peak_load_bytes = 0;
+        if (!llama_rtr_auto_peak_bytes({
+                    cpu_total_bytes,
+                    max_repack_temp_bytes,
+                    max_loader_read_buffer_bytes,
+                    LLAMA_MODEL_LOADER_N_LOAD_WORKERS,
+                    LLAMA_MODEL_LOADER_CUDA_STAGING_BYTES,
+                    cuda_staging_may_apply,
+                }, peak_load_bytes)) {
+            reason = "CPU-resident load plus loader transient byte count overflow";
             return llama_rtr_auto_decision::UNKNOWN;
         }
-        const uint64_t peak_load_bytes = cpu_total_bytes + max_repack_temp_bytes;
         if (peak_load_bytes > threshold) {
             reason = format("CPU-resident tensors plus repack workspace %.1f GiB > 90%% of available memory %.1f GiB",
                     peak_load_bytes / 1073741824.0, avail_ram / 1073741824.0);
@@ -5273,11 +5307,17 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                 throw std::runtime_error(error_msg);
             }
         }
-        if (params.defer_experts && params.use_mmap) {
+        if (params.defer_experts) {
 #ifdef __linux__
-            ml.build_expert_tensor_index(model.hparams);
+            if (ml.use_mmap) {
+                ml.build_expert_tensor_index(model.hparams);
+            } else {
+                LLAMA_LOG_WARN("%s: deferred expert loading requires effective mmap; disabling defer_experts\n", __func__);
+                params.defer_experts = false;
+            }
 #else
             LLAMA_LOG_WARN("%s: deferred expert loading is only supported on Linux; ignoring defer_experts\n", __func__);
+            params.defer_experts = false;
 #endif
         }
         try {
@@ -5293,6 +5333,11 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
             model.hparams.n_vocab != model.vocab.n_tokens()) {
             throw std::runtime_error("vocab size mismatch");
         }
+
+        // The loader has resolved mmap policy even for a vocabulary-only
+        // model.  Publish it before the early return so the effective-state
+        // API remains truthful for every successful load mode.
+        model.use_mmap_loader_enabled = ml.use_mmap;
 
         if (params.vocab_only) {
             LLAMA_LOG_INFO("%s: vocab only - skipping tensors\n", __func__);
@@ -5311,8 +5356,10 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
         )) {
             return -2;
         }
+        // Tensor creation can still disable mmap (for example, when a runtime
+        // tensor merge requires writable buffers), so refresh this after a
+        // successful full load.
         model.use_mmap_loader_enabled = ml.use_mmap;
-
         // ---- populate reload registry ONLY when hot-swap is requested ----
         if (std::getenv("LLAMA_HOTSWAP_ENABLED") != nullptr) {
             model.reload = std::make_unique<reload_info>(ml);
@@ -7774,6 +7821,7 @@ struct llama_model_params llama_model_default_params() {
         /*.flash_attn                  =*/ true,
         /*.defer_experts               =*/ false,
         /*.repack_tensors_auto         =*/ false,
+        /*.prefetch_experts             =*/ false,
     };
 
 #ifdef GGML_USE_METAL
@@ -8806,11 +8854,29 @@ struct llama_context * llama_init_from_model(
         ggml_backend_sched_set_only_active_experts(ctx->sched, true);
     }
     if (params.prefetch_experts) {
-        LLAMA_LOG_INFO("%s: enabling MoE expert read-ahead (prefetch_experts), %s\n", __func__,
-                ggml_backend_prefetch_init(params.prefetch_experts_threads) ? "threaded populate engine" : "madvise fallback");
-        for (const auto & mapping : model->mappings) {
-            ggml_backend_prefetch_register_mapping(mapping->addr(), mapping->size());
+#if !defined(__linux__)
+        // The prefetch backend is currently implemented only on Linux. Do not
+        // advertise a fallback or let an unsupported request affect RTR auto.
+        LLAMA_LOG_WARN("%s: --prefetch-experts is only supported on Linux; disabling expert prefetch\n", __func__);
+        cparams.prefetch_experts = false;
+#else
+        // Model mappings are the exact address ranges the prefetch backend can
+        // register. Do not use mmap-backed-buffer metadata here: a model can
+        // have such buffers without retaining mapping ranges for prefetch.
+        if (model->mappings.empty()) {
+            LLAMA_LOG_WARN("%s: --prefetch-experts requested, but the model has no mmap ranges; disabling expert prefetch\n", __func__);
+            // cparams is consumed later by graph execution. Clearing it here
+            // prevents the legacy madvise hook from running on non-mmap
+            // buffers after this feature has been declared unavailable.
+            cparams.prefetch_experts = false;
+        } else {
+            LLAMA_LOG_INFO("%s: enabling MoE expert read-ahead (prefetch_experts), %s\n", __func__,
+                    ggml_backend_prefetch_init(params.prefetch_experts_threads) ? "threaded populate engine" : "madvise fallback");
+            for (const auto & mapping : model->mappings) {
+                ggml_backend_prefetch_register_mapping(mapping->addr(), mapping->size());
+            }
         }
+#endif
     }
     if (model->split_mode == LLAMA_SPLIT_MODE_GRAPH && (!model->has_tensor_overrides() || cparams.split_mode_graph_scheduling)) {
         ggml_backend_sched_set_split_mode_graph(ctx->sched, true, cparams.scheduler_async);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4642,12 +4642,13 @@ static bool llama_read_uint64_file(const std::string & path, uint64_t & out) {
 // Resolve the cgroup path for the current process from /proc/self/cgroup.
 // For cgroup v2 the line has the form "0::/path"; for v1 controllers it is
 // "<id>:<controllers>:/path" and we look for the "memory" controller.
-// Returns empty string on failure.
-static std::string llama_resolve_cgroup_path(const std::string & controller) {
+// Returns false when the membership file itself cannot be inspected. An empty
+// path with a true return means that the requested controller is not present.
+static bool llama_resolve_cgroup_path(const std::string & controller, std::string & result) {
+    result.clear();
     FILE * f = std::fopen("/proc/self/cgroup", "r");
-    if (!f) return {};
+    if (!f) return false;
     char buf[512];
-    std::string result;
     while (std::fgets(buf, sizeof(buf), f)) {
         std::string line(buf);
         while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
@@ -4680,25 +4681,38 @@ static std::string llama_resolve_cgroup_path(const std::string & controller) {
         }
     }
     std::fclose(f);
-    return result;
+    return true;
 }
 
-// Compute effective cgroup memory headroom for the current process. Walks the
-// cgroup path upward to honor inherited limits, capped at 32 levels. Returns
-// 0 when no finite limit is in effect. Tries v2 first, falls back to v1.
-static uint64_t llama_get_cgroup_available_bytes() {
+struct llama_cgroup_memory_result {
+    bool     ok;
+    bool     limited;
+    uint64_t bytes;
+};
+
+// Compute effective cgroup memory headroom for the current process. Walk the
+// cgroup path upward to honor inherited limits. Inspection errors are reported
+// separately from an unlimited hierarchy so callers can remain safety-first.
+static llama_cgroup_memory_result llama_get_cgroup_available_bytes() {
     // cgroup v2
     {
-        const std::string cgpath = llama_resolve_cgroup_path("v2");
+        std::string cgpath;
+        if (!llama_resolve_cgroup_path("v2", cgpath)) {
+            return { false, false, 0 };
+        }
         if (!cgpath.empty()) {
             std::string cur = "/sys/fs/cgroup" + cgpath;
             uint64_t headroom = UINT64_MAX;
-            for (int depth = 0; depth < 32; ++depth) {
+            while (true) {
                 uint64_t limit = 0;
                 uint64_t used  = 0;
-                if (llama_read_uint64_file(cur + "/memory.max", limit) &&
-                    llama_read_uint64_file(cur + "/memory.current", used) &&
-                    limit != UINT64_MAX) {
+                if (!llama_read_uint64_file(cur + "/memory.max", limit) ||
+                    !llama_read_uint64_file(cur + "/memory.current", used)) {
+                    // This also catches non-standard/bind-mounted cgroup roots.
+                    // Falling back to host MemAvailable would be unsafe.
+                    return { false, false, 0 };
+                }
+                if (limit != UINT64_MAX) {
                     const uint64_t free_here = (limit > used) ? (limit - used) : 0;
                     if (free_here < headroom) {
                         headroom = free_here;
@@ -4710,27 +4724,51 @@ static uint64_t llama_get_cgroup_available_bytes() {
                 cur = cur.substr(0, slash);
             }
             if (headroom != UINT64_MAX) {
-                return headroom;
+                return { true, true, headroom };
             }
+            return { true, false, 0 };
         }
     }
     // cgroup v1 memory controller
     {
-        const std::string cgpath = llama_resolve_cgroup_path("memory");
+        std::string cgpath;
+        if (!llama_resolve_cgroup_path("memory", cgpath)) {
+            return { false, false, 0 };
+        }
         if (!cgpath.empty()) {
             std::string cur = "/sys/fs/cgroup/memory" + cgpath;
             uint64_t headroom = UINT64_MAX;
-            for (int depth = 0; depth < 32; ++depth) {
+            while (true) {
                 uint64_t limit = 0;
                 uint64_t used  = 0;
-                if (llama_read_uint64_file(cur + "/memory.limit_in_bytes", limit) &&
-                    llama_read_uint64_file(cur + "/memory.usage_in_bytes", used)) {
-                    // v1 reports an effectively-infinite limit when none is set
-                    // (close to INT64_MAX rounded down to page size). Treat
-                    // anything within ~1 PiB of UINT64_MAX as "unlimited".
-                    const uint64_t v1_unlimited_floor = UINT64_MAX - (1ull << 50);
-                    if (limit < v1_unlimited_floor) {
-                        const uint64_t free_here = (limit > used) ? (limit - used) : 0;
+                if (!llama_read_uint64_file(cur + "/memory.limit_in_bytes", limit) ||
+                    !llama_read_uint64_file(cur + "/memory.usage_in_bytes", used)) {
+                    return { false, false, 0 };
+                }
+                // Linux commonly reports an unlimited v1 controller as a
+                // page-aligned value close to INT64_MAX, not UINT64_MAX.
+                const uint64_t v1_unlimited_floor = 1ull << 62;
+                if (limit < v1_unlimited_floor) {
+                    const uint64_t free_here = (limit > used) ? (limit - used) : 0;
+                    if (free_here < headroom) {
+                        headroom = free_here;
+                    }
+                }
+
+                // When the optional mem+swap controller exists it can be more
+                // restrictive than the memory-only controller.
+                const std::string memsw_limit_path = cur + "/memory.memsw.limit_in_bytes";
+                const std::string memsw_used_path  = cur + "/memory.memsw.usage_in_bytes";
+                if (access(memsw_limit_path.c_str(), F_OK) == 0 ||
+                    access(memsw_used_path.c_str(),  F_OK) == 0) {
+                    uint64_t memsw_limit = 0;
+                    uint64_t memsw_used  = 0;
+                    if (!llama_read_uint64_file(memsw_limit_path, memsw_limit) ||
+                        !llama_read_uint64_file(memsw_used_path,  memsw_used)) {
+                        return { false, false, 0 };
+                    }
+                    if (memsw_limit < v1_unlimited_floor) {
+                        const uint64_t free_here = memsw_limit > memsw_used ? memsw_limit - memsw_used : 0;
                         if (free_here < headroom) {
                             headroom = free_here;
                         }
@@ -4742,26 +4780,33 @@ static uint64_t llama_get_cgroup_available_bytes() {
                 cur = cur.substr(0, slash);
             }
             if (headroom != UINT64_MAX) {
-                return headroom;
+                return { true, true, headroom };
             }
+            return { true, false, 0 };
         }
     }
-    return 0;
+    return { true, false, 0 };
 }
 #endif // __linux__
 
-// Returns currently-available memory in bytes for "would this allocation
-// succeed" decisions. 0 means the OS query failed; caller treats that as
-// UNKNOWN. On Linux this honors cgroup v2/v1 limits when running inside a
-// container by taking min(MemAvailable, cgroup headroom).
-static uint64_t llama_get_available_ram_bytes() {
+struct llama_available_memory_result {
+    bool     ok;
+    uint64_t bytes;
+};
+
+// Returns currently-available memory for "would this allocation succeed"
+// decisions. A successful result may contain zero bytes. On Linux this honors
+// cgroup v2/v1 limits by taking min(MemAvailable, cgroup headroom).
+static llama_available_memory_result llama_get_available_ram_bytes() {
 #if defined(_WIN32)
     MEMORYSTATUSEX mem_info = {};
     mem_info.dwLength = sizeof(mem_info);
     if (GlobalMemoryStatusEx(&mem_info)) {
-        return (uint64_t) mem_info.ullAvailPhys;
+        // Anonymous model buffers consume commit as well as physical pages.
+        return { true, std::min((uint64_t) mem_info.ullAvailPhys,
+                                (uint64_t) mem_info.ullAvailPageFile) };
     }
-    return 0;
+    return { false, 0 };
 #elif defined(__linux__)
     uint64_t mem_avail = 0;
     {
@@ -4786,11 +4831,14 @@ static uint64_t llama_get_available_ram_bytes() {
             mem_avail = (uint64_t) avail_pages * (uint64_t) page_size;
         }
     }
-    const uint64_t cg_avail = llama_get_cgroup_available_bytes();
-    if (cg_avail > 0 && (mem_avail == 0 || cg_avail < mem_avail)) {
-        return cg_avail;
+    if (mem_avail == 0) {
+        return { false, 0 };
     }
-    return mem_avail;
+    const llama_cgroup_memory_result cg = llama_get_cgroup_available_bytes();
+    if (!cg.ok) {
+        return { false, 0 };
+    }
+    return { true, cg.limited ? std::min(mem_avail, cg.bytes) : mem_avail };
 #elif defined(__APPLE__)
     mach_port_t host_port = mach_host_self();
     vm_size_t   page_size = 0;
@@ -4801,19 +4849,23 @@ static uint64_t llama_get_available_ram_bytes() {
         if (sysctl(mib, 2, &ps, &plen, nullptr, 0) == 0 && ps > 0) {
             page_size = (vm_size_t) ps;
         } else {
-            return 0;
+            mach_port_deallocate(mach_task_self(), host_port);
+            return { false, 0 };
         }
     }
     vm_statistics64_data_t vm_stat = {};
     mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
     if (host_statistics64(host_port, HOST_VM_INFO64, (host_info64_t) &vm_stat, &count) != KERN_SUCCESS) {
-        return 0;
+        mach_port_deallocate(mach_task_self(), host_port);
+        return { false, 0 };
     }
     const uint64_t free_pages     = (uint64_t) vm_stat.free_count;
     const uint64_t inactive_pages = (uint64_t) vm_stat.inactive_count;
-    return (free_pages + inactive_pages) * (uint64_t) page_size;
+    const uint64_t result = (free_pages + inactive_pages) * (uint64_t) page_size;
+    mach_port_deallocate(mach_task_self(), host_port);
+    return { true, result };
 #else
-    return 0;
+    return { false, 0 };
 #endif
 }
 
@@ -4883,10 +4935,8 @@ static bool llama_rtr_auto_manual_override_cpu(
 static bool llama_rtr_auto_ncmoe_cpu_override(
         const std::string        & name,
         const llama_hparams      & hparams,
-        const llama_model        & model,
         const llama_model_params & params,
-        bool                     & cpu,
-        std::string              & reason) {
+        bool                     & cpu) {
     if (params.ncmoe <= 0 || !llama_rtr_auto_is_expert_tensor(name)) {
         return true;
     }
@@ -4897,31 +4947,26 @@ static bool llama_rtr_auto_ncmoe_cpu_override(
     }
 
     const int n_layer = (int) hparams.n_layer;
-    if (params.split_mode == LLAMA_SPLIT_MODE_ATTN ||
-        params.split_mode == LLAMA_SPLIT_MODE_GRAPH ||
-        params.ncmoe >= n_layer ||
-        model.devices.size() < 2) {
-        cpu = il < std::min(params.ncmoe, n_layer);
-        return true;
-    }
-
-    reason = "-ncmoe with multi-device layer split needs loader placement";
-    return false;
+    // The loader applies -ncmoe as a deterministic per-layer CPU override
+    // before distributing the remaining tensors across accelerator devices.
+    cpu = il < std::min(params.ncmoe, n_layer);
+    return true;
 }
 
 static bool llama_rtr_auto_tensor_is_cpu(
         const std::string                          & name,
+        const std::string                          * override_name,
         const llama_hparams                        & hparams,
         const llama_model                          & model,
         const llama_model_params                   & params,
         const std::vector<llama_rtr_auto_override> & overrides,
         bool                                       & cpu,
         std::string                                & reason) {
-    if (llama_rtr_auto_manual_override_cpu(overrides, name, cpu)) {
+    if (llama_rtr_auto_manual_override_cpu(overrides, override_name ? *override_name : name, cpu)) {
         return true;
     }
 
-    if (!llama_rtr_auto_ncmoe_cpu_override(name, hparams, model, params, cpu, reason)) {
+    if (!llama_rtr_auto_ncmoe_cpu_override(name, hparams, params, cpu)) {
         return false;
     }
     if (cpu) {
@@ -4932,6 +4977,14 @@ static bool llama_rtr_auto_tensor_is_cpu(
         cpu = true;
         return true;
     }
+
+#ifdef GGML_USE_METAL
+    // Metal buffers are host-accessible unified memory and the repack pass
+    // treats them as host buffers. Account them as committed host memory even
+    // when the layer is nominally offloaded.
+    cpu = true;
+    return true;
+#endif
 
     const int n_layer = (int) hparams.n_layer;
     const int i_gpu_start = std::max(n_layer - params.n_gpu_layers, 0);
@@ -4989,16 +5042,24 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         reason = "merged tensor placement is resolved during load";
         return llama_rtr_auto_decision::UNKNOWN;
     }
+    if (params.defer_experts) {
+        // Deferred expert loading requires mmap. KEEP would force mmap off
+        // globally and silently turn the requested deferral into a full
+        // committed-RAM load.
+        reason = "--defer-experts requires mmap and is incompatible with run-time repack";
+        return llama_rtr_auto_decision::UNKNOWN;
+    }
     if (params.split_mode == LLAMA_SPLIT_MODE_ATTN || params.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
         reason = "split-mode graph/attention tensor placement is not modeled";
         return llama_rtr_auto_decision::UNKNOWN;
     }
 
-    const uint64_t avail_ram = llama_get_available_ram_bytes();
-    if (avail_ram == 0) {
+    const llama_available_memory_result available = llama_get_available_ram_bytes();
+    if (!available.ok) {
         reason = "could not query available memory";
         return llama_rtr_auto_decision::UNKNOWN;
     }
+    const uint64_t avail_ram = available.bytes;
 
     std::vector<llama_rtr_auto_override> overrides;
     if (!llama_rtr_auto_compile_overrides(params.tensor_buft_overrides, overrides, reason)) {
@@ -5025,16 +5086,38 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
         llm_load_arch(probe, probe_model);
         llm_load_hparams(probe, probe_model);
 
+#ifdef GGML_USE_KOMPUTE
+        if (params.n_gpu_layers > 0 &&
+            ((probe_model.arch != LLM_ARCH_LLAMA && probe_model.arch != LLM_ARCH_FALCON) ||
+             probe_model.ftype < LLAMA_FTYPE_MOSTLY_Q4_0 ||
+             probe_model.ftype > LLAMA_FTYPE_MOSTLY_BF16)) {
+            // The real loader will fall back to CPU after this decision.
+            // Its resulting placement is not represented by the requested
+            // n_gpu_layers value used by the probe.
+            reason = "Kompute will change tensor placement during load";
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+#endif
+
         uint64_t cpu_total_bytes      = 0;
         uint64_t cpu_repackable_bytes = 0;
+        uint64_t max_repack_temp_bytes = 0;
+        const ggml_tensor * token_embd = nullptr;
+        bool has_output_weight = false;
 
         for (const auto & w : probe.weights) {
             const ggml_tensor * tensor = w.tensor;
             if (!tensor) {
                 continue;
             }
+            const std::string tensor_name = tensor->name;
+            if (tensor_name == "token_embd.weight") {
+                token_embd = tensor;
+            } else if (tensor_name == "output.weight") {
+                has_output_weight = true;
+            }
             bool is_cpu = false;
-            if (!llama_rtr_auto_tensor_is_cpu(tensor->name, probe_model.hparams, model, params, overrides, is_cpu, reason)) {
+            if (!llama_rtr_auto_tensor_is_cpu(tensor_name, nullptr, probe_model.hparams, model, params, overrides, is_cpu, reason)) {
                 return llama_rtr_auto_decision::UNKNOWN;
             }
             if (!is_cpu) {
@@ -5042,9 +5125,38 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
             }
 
             const uint64_t nbytes = (uint64_t) ggml_nbytes(tensor);
+            if (nbytes > UINT64_MAX - cpu_total_bytes) {
+                reason = "CPU-resident tensor byte count overflow";
+                return llama_rtr_auto_decision::UNKNOWN;
+            }
             cpu_total_bytes += nbytes;
             if ((ggml_type) iqk_repacked_type(tensor) != tensor->type) {
+                if (nbytes > UINT64_MAX - cpu_repackable_bytes) {
+                    reason = "CPU-resident repackable tensor byte count overflow";
+                    return llama_rtr_auto_decision::UNKNOWN;
+                }
                 cpu_repackable_bytes += nbytes;
+                max_repack_temp_bytes = std::max(max_repack_temp_bytes, nbytes);
+            }
+        }
+
+        // Many decoder models synthesize a tied output tensor when
+        // output.weight is absent from the GGUF. The probe only sees on-disk
+        // tensors, while the real loader can allocate a second output buffer.
+        if (token_embd && !has_output_weight) {
+            bool output_is_cpu = false;
+            const std::string tied_source_name = ggml_get_name(token_embd);
+            if (!llama_rtr_auto_tensor_is_cpu(
+                        "output.weight", &tied_source_name, probe_model.hparams, model, params, overrides, output_is_cpu, reason)) {
+                return llama_rtr_auto_decision::UNKNOWN;
+            }
+            if (output_is_cpu) {
+                const uint64_t tied_output_bytes = (uint64_t) ggml_nbytes(token_embd);
+                if (tied_output_bytes > UINT64_MAX - cpu_total_bytes) {
+                    reason = "CPU-resident tied output byte count overflow";
+                    return llama_rtr_auto_decision::UNKNOWN;
+                }
+                cpu_total_bytes += tied_output_bytes;
             }
         }
 
@@ -5062,16 +5174,22 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
                     cpu_repackable_bytes / 1073741824.0, avail_ram / 1073741824.0);
             return llama_rtr_auto_decision::DISABLE;
         }
-        if (cpu_total_bytes > threshold) {
-            reason = format("CPU-resident tensors %.1f GiB > 90%% of available memory %.1f GiB",
-                    cpu_total_bytes / 1073741824.0, avail_ram / 1073741824.0);
+        if (max_repack_temp_bytes > UINT64_MAX - cpu_total_bytes) {
+            reason = "CPU-resident load plus repack workspace byte count overflow";
+            return llama_rtr_auto_decision::UNKNOWN;
+        }
+        const uint64_t peak_load_bytes = cpu_total_bytes + max_repack_temp_bytes;
+        if (peak_load_bytes > threshold) {
+            reason = format("CPU-resident tensors plus repack workspace %.1f GiB > 90%% of available memory %.1f GiB",
+                    peak_load_bytes / 1073741824.0, avail_ram / 1073741824.0);
             return llama_rtr_auto_decision::DISABLE;
         }
 
-        LLAMA_LOG_INFO("%s: --run-time-repack auto: CPU-resident repackable %.1f GiB, total CPU-resident %.1f GiB, available %.1f GiB\n",
+        LLAMA_LOG_INFO("%s: --run-time-repack auto: CPU-resident repackable %.1f GiB, total CPU-resident %.1f GiB, peak load estimate %.1f GiB, available %.1f GiB\n",
                 __func__,
                 cpu_repackable_bytes / 1073741824.0,
                 cpu_total_bytes / 1073741824.0,
+                peak_load_bytes / 1073741824.0,
                 avail_ram / 1073741824.0);
         return llama_rtr_auto_decision::KEEP;
     } catch (const std::exception & e) {
@@ -5083,6 +5201,8 @@ static llama_rtr_auto_decision llama_rtr_auto_should_disable(
 // Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
 static int llama_model_load(const std::string & fname, llama_model & model, llama_model_params & params) {
     try {
+        model.rtr_status = params.repack_tensors ?
+                LLAMA_RTR_STATUS_ENABLED : LLAMA_RTR_STATUS_DISABLED;
         if (params.repack_tensors && params.repack_tensors_auto) {
             std::string reason;
             const auto d = llama_rtr_auto_should_disable(fname, model, params, reason);
@@ -5092,6 +5212,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                     // user configured it (default true, or whatever
                     // --no-mmap chose).
                     params.repack_tensors = false;
+                    model.rtr_status = LLAMA_RTR_STATUS_AUTO_DISABLE;
                     LLAMA_LOG_INFO("%s: --run-time-repack auto: disabled (%s)\n",
                             __func__, reason.c_str());
                     llama_rtr_auto_log_mmap_override_note(params);
@@ -5100,6 +5221,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                     // Could not determine. Safety-first: disable repack and
                     // keep mmap so a swap-bound load still has a chance.
                     params.repack_tensors = false;
+                    model.rtr_status = LLAMA_RTR_STATUS_AUTO_UNKNOWN;
                     LLAMA_LOG_WARN("%s: --run-time-repack auto: disabled (uncertainty: %s)\n",
                             __func__, reason.c_str());
                     llama_rtr_auto_log_mmap_override_note(params);
@@ -5109,6 +5231,7 @@ static int llama_model_load(const std::string & fname, llama_model & model, llam
                     // coupling and force use_mmap=false so the repack pass
                     // can write back into the tensor buffers.
                     params.use_mmap = false;
+                    model.rtr_status = LLAMA_RTR_STATUS_AUTO_KEEP;
                     LLAMA_LOG_INFO("%s: --run-time-repack auto: keeping repack enabled\n",
                             __func__);
                     break;
@@ -7634,7 +7757,6 @@ struct llama_model_params llama_model_default_params() {
         /*.use_mlock                   =*/ false,
         /*.check_tensors               =*/ false,
         /*.repack_tensors              =*/ false,
-        /*.repack_tensors_auto         =*/ false,
         /*.use_thp                     =*/ false,
         /*.validate_quants             =*/ false,
         /*.merge_qkv                   =*/ false,
@@ -7643,6 +7765,7 @@ struct llama_model_params llama_model_default_params() {
         /*.dry_run                     =*/ false,
         /*.flash_attn                  =*/ true,
         /*.defer_experts               =*/ false,
+        /*.repack_tensors_auto         =*/ false,
     };
 
 #ifdef GGML_USE_METAL
@@ -8950,6 +9073,10 @@ uint64_t llama_model_size(const struct llama_model * model) {
         size += ggml_nbytes(it.second);
     }
     return size;
+}
+
+enum llama_rtr_status llama_model_rtr_status(const struct llama_model * model) {
+    return model ? model->rtr_status : LLAMA_RTR_STATUS_DISABLED;
 }
 
 const char* llama_model_chat_template(const struct llama_model* model, const char* name) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -106,6 +106,7 @@ void llama_set_mtp_n_heads(struct llama_context * ctx, int32_t mtp_n_heads);
 #include <functional>
 #include <future>
 #include <initializer_list>
+#include <iterator>
 #include <locale>
 #include <map>
 #include <memory>
@@ -4644,184 +4645,129 @@ static bool llama_read_uint64_file(const std::string & path, uint64_t & out) {
     return true;
 }
 
-// Resolve the cgroup path for the current process from /proc/self/cgroup.
-// For cgroup v2 the line has the form "0::/path"; for v1 controllers it is
-// "<id>:<controllers>:/path" and we look for the "memory" controller.
-// Returns false when the membership file itself cannot be inspected. An empty
-// path with a true return means that the requested controller is not present.
-static bool llama_resolve_cgroup_path(const std::string & controller, std::string & result) {
-    result.clear();
-    std::ifstream file("/proc/self/cgroup");
-    if (!file.is_open()) {
-        return false;
-    }
-
-    std::string line;
-    while (std::getline(file, line)) {
-        while (!line.empty() && line.back() == '\r') {
-            line.pop_back();
-        }
-        // Expected format: <hierarchy_id>:<controllers>:<path>
-        size_t c1 = line.find(':');
-        if (c1 == std::string::npos) continue;
-        size_t c2 = line.find(':', c1 + 1);
-        if (c2 == std::string::npos) continue;
-        const std::string controllers = line.substr(c1 + 1, c2 - c1 - 1);
-        const std::string path        = line.substr(c2 + 1);
-        if (controller == "v2") {
-            // cgroup v2 unified hierarchy: "0::/path"
-            if (controllers.empty()) {
-                result = path;
-                break;
-            }
-        } else {
-            // cgroup v1: comma-separated controller list
-            std::string token;
-            std::stringstream ss(controllers);
-            while (std::getline(ss, token, ',')) {
-                if (token == controller) {
-                    result = path;
-                    break;
-                }
-            }
-            if (!result.empty()) break;
-        }
-    }
-    return !file.bad();
-}
-
+#include "llama-cgroup-resolver.h"
 struct llama_cgroup_memory_result {
     bool     ok;
     bool     limited;
     uint64_t bytes;
 };
 
-// Compute effective cgroup memory headroom for the current process. Walk the
-// cgroup path upward to honor inherited limits. Inspection errors are reported
-// separately from an unlimited hierarchy so callers can remain safety-first.
+
+static bool llama_cgroup_file_exists(const std::string & path, bool & exists) {
+    errno = 0;
+    if (access(path.c_str(), F_OK) == 0) {
+        exists = true;
+        return true;
+    }
+    exists = false;
+    return errno == ENOENT || errno == ENOTDIR;
+}
+
+static bool llama_read_cgroup_controllers(const std::string & mountpoint, bool & has_memory) {
+    std::ifstream file(mountpoint + "/cgroup.controllers");
+    if (!file.is_open()) return false;
+    std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (file.bad()) return false;
+    std::istringstream stream(contents);
+    std::string controller;
+    has_memory = false;
+    while (stream >> controller) {
+        if (controller == "memory") {
+            has_memory = true;
+            break;
+        }
+    }
+    return true;
+}
+
+static bool llama_get_v2_cgroup_headroom(const llama_resolved_cgroup_mount & resolved, bool & limited, uint64_t & bytes) {
+    uint64_t headroom = UINT64_MAX;
+    std::string cur = resolved.path;
+    while (true) {
+        uint64_t limit = 0;
+        uint64_t used = 0;
+        if (!llama_read_uint64_file(cur + "/memory.max", limit) ||
+            !llama_read_uint64_file(cur + "/memory.current", used)) return false;
+        if (limit != UINT64_MAX) headroom = std::min(headroom, limit > used ? limit - used : 0);
+        if (cur == resolved.mountpoint) break;
+        std::string parent;
+        if (!llama_cgroup_parent_path(cur, resolved.mountpoint, parent)) return false;
+        cur = parent;
+    }
+    limited = headroom != UINT64_MAX;
+    bytes = limited ? headroom : 0;
+    return true;
+}
+
+static bool llama_get_v1_cgroup_headroom(const llama_resolved_cgroup_mount & resolved, bool & limited, uint64_t & bytes) {
+    const uint64_t v1_unlimited_floor = 1ull << 62;
+    uint64_t headroom = UINT64_MAX;
+    std::string cur = resolved.path;
+    while (true) {
+        uint64_t limit = 0;
+        uint64_t used = 0;
+        if (!llama_read_uint64_file(cur + "/memory.limit_in_bytes", limit) ||
+            !llama_read_uint64_file(cur + "/memory.usage_in_bytes", used)) return false;
+        if (limit < v1_unlimited_floor) headroom = std::min(headroom, limit > used ? limit - used : 0);
+
+        const std::string memsw_limit_path = cur + "/memory.memsw.limit_in_bytes";
+        const std::string memsw_used_path = cur + "/memory.memsw.usage_in_bytes";
+        bool memsw_limit_exists = false;
+        bool memsw_used_exists = false;
+        if (!llama_cgroup_file_exists(memsw_limit_path, memsw_limit_exists) ||
+            !llama_cgroup_file_exists(memsw_used_path, memsw_used_exists) ||
+            memsw_limit_exists != memsw_used_exists) return false;
+        if (memsw_limit_exists) {
+            uint64_t memsw_limit = 0;
+            uint64_t memsw_used = 0;
+            if (!llama_read_uint64_file(memsw_limit_path, memsw_limit) ||
+                !llama_read_uint64_file(memsw_used_path, memsw_used)) return false;
+            if (memsw_limit < v1_unlimited_floor) headroom = std::min(headroom, memsw_limit > memsw_used ? memsw_limit - memsw_used : 0);
+        }
+        if (cur == resolved.mountpoint) break;
+        std::string parent;
+        if (!llama_cgroup_parent_path(cur, resolved.mountpoint, parent)) return false;
+        cur = parent;
+    }
+    limited = headroom != UINT64_MAX;
+    bytes = limited ? headroom : 0;
+    return true;
+}
+
+// Resolve membership through the actual mount namespace. A declared memory
+// hierarchy that cannot be mapped or read remains unknown (never host fallback).
 static llama_cgroup_memory_result llama_get_cgroup_available_bytes() {
-    std::string v2_cgpath;
-    std::string v1_cgpath;
-    if (!llama_resolve_cgroup_path("v2", v2_cgpath) ||
-        !llama_resolve_cgroup_path("memory", v1_cgpath)) {
+    std::vector<llama_cgroup_membership> memberships;
+    std::vector<llama_cgroup_mount> mounts;
+    if (!llama_read_cgroup_memberships(memberships) || !llama_read_cgroup_mounts(mounts)) {
         return { false, false, 0 };
     }
 
-    // cgroup v2
-    {
-        if (!v2_cgpath.empty()) {
-            std::string cur = "/sys/fs/cgroup" + v2_cgpath;
-            const std::string leaf_limit = cur + "/memory.max";
-            const std::string leaf_used  = cur + "/memory.current";
-            bool leaf_limit_exists = false;
-            bool leaf_used_exists  = false;
-            const auto check_exists = [](const std::string & path, bool & exists) {
-                errno = 0;
-                if (access(path.c_str(), F_OK) == 0) {
-                    exists = true;
-                    return true;
-                }
-                exists = false;
-                return errno == ENOENT || errno == ENOTDIR;
-            };
-            if (!check_exists(leaf_limit, leaf_limit_exists) ||
-                !check_exists(leaf_used,  leaf_used_exists)) {
+    bool limited = false;
+    uint64_t headroom = UINT64_MAX;
+    for (const llama_cgroup_membership & membership : memberships) {
+        std::vector<llama_resolved_cgroup_mount> resolved;
+        if (!llama_resolve_cgroup_mounts(membership, mounts, resolved)) return { false, false, 0 };
+        for (const llama_resolved_cgroup_mount & candidate : resolved) {
+            bool candidate_limited = false;
+            uint64_t candidate_headroom = 0;
+            if (membership.v2) {
+                bool has_memory = false;
+                if (!llama_read_cgroup_controllers(candidate.mountpoint, has_memory)) return { false, false, 0 };
+                // Unified hierarchy without the memory controller is not a
+                // memory constraint; a v1 membership may still constrain it.
+                if (!has_memory) continue;
+                if (!llama_get_v2_cgroup_headroom(candidate, candidate_limited, candidate_headroom)) return { false, false, 0 };
+            } else if (!llama_get_v1_cgroup_headroom(candidate, candidate_limited, candidate_headroom)) {
                 return { false, false, 0 };
             }
-            if (leaf_limit_exists != leaf_used_exists) {
-                return { false, false, 0 };
-            }
-
-            // On a hybrid hierarchy the process has a v2 membership even when
-            // the memory controller is still attached to v1. Only fall through
-            // when both v2 memory files are absent and a v1 memory membership
-            // was found.
-            if (!leaf_limit_exists) {
-                if (v1_cgpath.empty()) {
-                    return { false, false, 0 };
-                }
-            } else {
-                uint64_t headroom = UINT64_MAX;
-                while (true) {
-                    uint64_t limit = 0;
-                    uint64_t used  = 0;
-                    if (!llama_read_uint64_file(cur + "/memory.max", limit) ||
-                        !llama_read_uint64_file(cur + "/memory.current", used)) {
-                        // This also catches non-standard/bind-mounted cgroup roots.
-                        // Falling back to host MemAvailable would be unsafe.
-                        return { false, false, 0 };
-                    }
-                    if (limit != UINT64_MAX) {
-                        const uint64_t free_here = (limit > used) ? (limit - used) : 0;
-                        if (free_here < headroom) {
-                            headroom = free_here;
-                        }
-                    }
-                    if (cur == "/sys/fs/cgroup" || cur.empty()) break;
-                    size_t slash = cur.find_last_of('/');
-                    if (slash == std::string::npos || slash < std::string{"/sys/fs/cgroup"}.size()) break;
-                    cur = cur.substr(0, slash);
-                }
-                if (headroom != UINT64_MAX) {
-                    return { true, true, headroom };
-                }
-                return { true, false, 0 };
+            if (candidate_limited) {
+                limited = true;
+                headroom = std::min(headroom, candidate_headroom);
             }
         }
     }
-    // cgroup v1 memory controller
-    {
-        if (!v1_cgpath.empty()) {
-            std::string cur = "/sys/fs/cgroup/memory" + v1_cgpath;
-            uint64_t headroom = UINT64_MAX;
-            while (true) {
-                uint64_t limit = 0;
-                uint64_t used  = 0;
-                if (!llama_read_uint64_file(cur + "/memory.limit_in_bytes", limit) ||
-                    !llama_read_uint64_file(cur + "/memory.usage_in_bytes", used)) {
-                    return { false, false, 0 };
-                }
-                // Linux commonly reports an unlimited v1 controller as a
-                // page-aligned value close to INT64_MAX, not UINT64_MAX.
-                const uint64_t v1_unlimited_floor = 1ull << 62;
-                if (limit < v1_unlimited_floor) {
-                    const uint64_t free_here = (limit > used) ? (limit - used) : 0;
-                    if (free_here < headroom) {
-                        headroom = free_here;
-                    }
-                }
-
-                // When the optional mem+swap controller exists it can be more
-                // restrictive than the memory-only controller.
-                const std::string memsw_limit_path = cur + "/memory.memsw.limit_in_bytes";
-                const std::string memsw_used_path  = cur + "/memory.memsw.usage_in_bytes";
-                if (access(memsw_limit_path.c_str(), F_OK) == 0 ||
-                    access(memsw_used_path.c_str(),  F_OK) == 0) {
-                    uint64_t memsw_limit = 0;
-                    uint64_t memsw_used  = 0;
-                    if (!llama_read_uint64_file(memsw_limit_path, memsw_limit) ||
-                        !llama_read_uint64_file(memsw_used_path,  memsw_used)) {
-                        return { false, false, 0 };
-                    }
-                    if (memsw_limit < v1_unlimited_floor) {
-                        const uint64_t free_here = memsw_limit > memsw_used ? memsw_limit - memsw_used : 0;
-                        if (free_here < headroom) {
-                            headroom = free_here;
-                        }
-                    }
-                }
-                if (cur == "/sys/fs/cgroup/memory" || cur.empty()) break;
-                size_t slash = cur.find_last_of('/');
-                if (slash == std::string::npos || slash < std::string{"/sys/fs/cgroup/memory"}.size()) break;
-                cur = cur.substr(0, slash);
-            }
-            if (headroom != UINT64_MAX) {
-                return { true, true, headroom };
-            }
-            return { true, false, 0 };
-        }
-    }
-    return { true, false, 0 };
+    return { true, limited, limited ? headroom : 0 };
 }
 #endif // __linux__
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -202,6 +202,7 @@ llama_build_and_test(
 )
 llama_build_and_test(test-regex-partial.cpp)
 llama_build_and_test(test-rtr-params.cpp)
+llama_build_and_test(test-cgroup-resolver.cpp)
 
 # llama_target_and_test(test-opt.cpp) # SLOW
 
@@ -213,4 +214,3 @@ llama_target_and_test(test-autorelease.cpp        LABEL "model")
 get_filename_component(TEST_TARGET test-c.c NAME_WE)
 add_executable(${TEST_TARGET} test-c.c)
 target_link_libraries(${TEST_TARGET} PRIVATE llama)
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -201,6 +201,7 @@ llama_build_and_test(
     peg-parser/tests.h
 )
 llama_build_and_test(test-regex-partial.cpp)
+llama_build_and_test(test-rtr-params.cpp)
 
 # llama_target_and_test(test-opt.cpp) # SLOW
 
@@ -212,5 +213,4 @@ llama_target_and_test(test-autorelease.cpp        LABEL "model")
 get_filename_component(TEST_TARGET test-c.c NAME_WE)
 add_executable(${TEST_TARGET} test-c.c)
 target_link_libraries(${TEST_TARGET} PRIVATE llama)
-
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,6 +203,7 @@ llama_build_and_test(
 llama_build_and_test(test-regex-partial.cpp)
 llama_build_and_test(test-rtr-params.cpp)
 llama_build_and_test(test-cgroup-resolver.cpp)
+llama_build_and_test(test-rtr-auto-peak.cpp)
 
 # llama_target_and_test(test-opt.cpp) # SLOW
 

--- a/tests/test-cgroup-resolver.cpp
+++ b/tests/test-cgroup-resolver.cpp
@@ -9,7 +9,9 @@
 int main() {
     {
         std::istringstream memberships_file("0::/tenant/workload\n");
-        std::istringstream mounts_file("36 25 0:32 /tenant /custom rw,relatime - cgroup2 cgroup rw\n");
+        std::istringstream mounts_file(
+            "35 25 0:31 / /sys/fs/cgroup rw,relatime - cgroup2 cgroup rw\n"
+            "36 25 0:32 /tenant /custom rw,relatime - cgroup2 cgroup rw\n");
         std::vector<llama_cgroup_membership> memberships;
         std::vector<llama_cgroup_mount> mounts;
         std::vector<llama_resolved_cgroup_mount> resolved;
@@ -17,9 +19,26 @@ int main() {
         assert(llama_parse_cgroup_mounts(mounts_file, mounts));
         assert(memberships.size() == 1 && memberships[0].v2);
         assert(llama_resolve_cgroup_mounts(memberships[0], mounts, resolved));
-        assert(resolved.size() == 1);
-        assert(resolved[0].mountpoint == "/custom");
-        assert(resolved[0].path == "/custom/workload");
+        assert(resolved.size() == 2);
+        assert(resolved[0].mountpoint == "/sys/fs/cgroup");
+        assert(resolved[0].path == "/sys/fs/cgroup/tenant/workload");
+        assert(resolved[1].mountpoint == "/custom");
+        assert(resolved[1].path == "/custom/workload");
+
+        bool limited = false;
+        uint64_t bytes = 0;
+        assert(llama_intersect_cgroup_headrooms(resolved,
+            [] (const llama_resolved_cgroup_mount & mapping, bool & candidate_limited, uint64_t & candidate_bytes) {
+                candidate_limited = true;
+                candidate_bytes = mapping.mountpoint == "/sys/fs/cgroup" ? 64 : 512;
+                return true;
+            }, limited, bytes));
+        assert(limited && bytes == 64);
+
+        assert(!llama_intersect_cgroup_headrooms(resolved,
+            [] (const llama_resolved_cgroup_mount & mapping, bool &, uint64_t &) {
+                return mapping.mountpoint != "/sys/fs/cgroup";
+            }, limited, bytes));
     }
 
     {
@@ -49,6 +68,22 @@ int main() {
         std::string parent;
         assert(llama_cgroup_parent_path("/slice", "/", parent));
         assert(parent == "/");
+    }
+
+    {
+        bool skip = false;
+        assert(llama_cgroup_v2_level_files(true, true, false, skip));
+        assert(!skip);
+
+        assert(llama_cgroup_v2_level_files(false, false, true, skip));
+        assert(skip);
+
+        assert(!llama_cgroup_v2_level_files(false, false, false, skip));
+        assert(!skip);
+        assert(!llama_cgroup_v2_level_files(true, false, true, skip));
+        assert(!skip);
+        assert(!llama_cgroup_v2_level_files(false, true, true, skip));
+        assert(!skip);
     }
 
     {

--- a/tests/test-cgroup-resolver.cpp
+++ b/tests/test-cgroup-resolver.cpp
@@ -1,0 +1,63 @@
+#include "../src/llama-cgroup-resolver.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+#include <sstream>
+
+int main() {
+    {
+        std::istringstream memberships_file("0::/tenant/workload\n");
+        std::istringstream mounts_file("36 25 0:32 /tenant /custom rw,relatime - cgroup2 cgroup rw\n");
+        std::vector<llama_cgroup_membership> memberships;
+        std::vector<llama_cgroup_mount> mounts;
+        std::vector<llama_resolved_cgroup_mount> resolved;
+        assert(llama_parse_cgroup_memberships(memberships_file, memberships));
+        assert(llama_parse_cgroup_mounts(mounts_file, mounts));
+        assert(memberships.size() == 1 && memberships[0].v2);
+        assert(llama_resolve_cgroup_mounts(memberships[0], mounts, resolved));
+        assert(resolved.size() == 1);
+        assert(resolved[0].mountpoint == "/custom");
+        assert(resolved[0].path == "/custom/workload");
+    }
+
+    {
+        std::istringstream memberships_file("29:cpu,memory:/docker root/service\n");
+        std::istringstream mounts_file("35 25 0:31 /docker\\040root /cg\\040memory rw,relatime - cgroup cgroup rw,memory\n");
+        std::vector<llama_cgroup_membership> memberships;
+        std::vector<llama_cgroup_mount> mounts;
+        std::vector<llama_resolved_cgroup_mount> resolved;
+        assert(llama_parse_cgroup_memberships(memberships_file, memberships));
+        assert(llama_parse_cgroup_mounts(mounts_file, mounts));
+        assert(memberships.size() == 1 && !memberships[0].v2);
+        assert(llama_resolve_cgroup_mounts(memberships[0], mounts, resolved));
+        assert(resolved.size() == 1);
+        assert(resolved[0].path == "/cg memory/service");
+    }
+
+    {
+        // Namespace-relative membership: it does not share the host mount root.
+        const llama_cgroup_membership membership = { true, "/slice" };
+        const std::vector<llama_cgroup_mount> mounts = { { true, "/host-root", "/ns-cgroup" } };
+        std::vector<llama_resolved_cgroup_mount> resolved;
+        assert(llama_resolve_cgroup_mounts(membership, mounts, resolved));
+        assert(resolved.size() == 1 && resolved[0].path == "/ns-cgroup/slice");
+    }
+
+    {
+        std::string parent;
+        assert(llama_cgroup_parent_path("/slice", "/", parent));
+        assert(parent == "/");
+    }
+
+    {
+        std::istringstream malformed_membership("0::relative\n");
+        std::istringstream malformed_mount("36 25 0:32 / /sys/fs/cgroup rw cgroup2 cgroup rw\n");
+        std::vector<llama_cgroup_membership> memberships;
+        std::vector<llama_cgroup_mount> mounts;
+        assert(!llama_parse_cgroup_memberships(malformed_membership, memberships));
+        assert(!llama_parse_cgroup_mounts(malformed_mount, mounts));
+    }
+    return 0;
+}

--- a/tests/test-compare-llama-bench.py
+++ b/tests/test-compare-llama-bench.py
@@ -12,15 +12,14 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "compare-llama-bench.py"
 
-# Keep this fixture schema at the compare script's cross-version contract, not
-# at either printer's full schema. New printer-only fields must not be required
-# to compare legacy results.
 KEY_PROPERTIES = [
     "cpu_info", "gpu_info", "n_gpu_layers", "cuda", "vulkan", "kompute", "metal", "sycl", "rpc", "gpu_blas",
     "blas", "model_filename", "model_type", "model_size", "model_n_params", "n_batch", "n_ubatch", "embeddings", "n_threads",
-    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn", "n_prompt", "n_gen",
+    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn",
+    "repack", "repack_auto", "repack_effective", "repack_status", "n_prompt", "n_gen",
 ]
 SOURCE_COLUMNS = list(dict.fromkeys(["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES))
+RTR_COLUMNS = {"repack", "repack_auto", "repack_effective", "repack_status"}
 
 
 class CompareLlamaBenchTest(unittest.TestCase):
@@ -50,21 +49,31 @@ class CompareLlamaBenchTest(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
-    def create_db(self, table_names):
+    def create_db(self, table_names, legacy_tables=()):
         path = self.root / "llama-bench.sqlite"
         connection = sqlite3.connect(path)
         try:
-            columns = ", ".join(f"{name} TEXT" for name in SOURCE_COLUMNS)
             for table in table_names:
+                source_columns = [
+                    name for name in SOURCE_COLUMNS
+                    if table not in legacy_tables or name not in RTR_COLUMNS
+                ]
+                columns = ", ".join(f"{name} TEXT" for name in source_columns)
                 connection.execute(f"CREATE TABLE {table} ({columns})")
             connection.commit()
         finally:
             connection.close()
         return path
 
-    def insert_run(self, path, table, commit, avg_ts):
-        values = {name: "0" for name in SOURCE_COLUMNS}
-        values.update({
+    def insert_run(self, path, table, commit, avg_ts, **overrides):
+        connection = sqlite3.connect(path)
+        try:
+            table_columns = {row[1] for row in connection.execute(f"PRAGMA table_info({table})")}
+        finally:
+            connection.close()
+
+        source_values = {name: "0" for name in SOURCE_COLUMNS}
+        source_values.update({
             "build_commit": commit,
             "test_time": commit,
             "avg_ts": str(avg_ts),
@@ -85,24 +94,27 @@ class CompareLlamaBenchTest(unittest.TestCase):
             "main_gpu": "0",
             "tensor_split": "0",
             "n_prompt": "16",
-            "n_gen": "0",
+            "n_gen": "0", "repack": "0", "repack_auto": "0",
+            "repack_effective": "0", "repack_status": "disabled",
         })
+        source_values.update(overrides)
+        values = {name: source_values[name] for name in SOURCE_COLUMNS if name in table_columns}
         connection = sqlite3.connect(path)
         try:
             connection.execute(
-                f"INSERT INTO {table} ({', '.join(SOURCE_COLUMNS)}) "
-                f"VALUES ({', '.join('?' for _ in SOURCE_COLUMNS)})",
-                [values[column] for column in SOURCE_COLUMNS],
+                f"INSERT INTO {table} ({', '.join(values)}) "
+                f"VALUES ({', '.join('?' for _ in values)})",
+                list(values.values()),
             )
             connection.commit()
         finally:
             connection.close()
 
-    def run_compare(self, path):
+    def run_compare(self, path, show="model_type"):
         env = os.environ.copy()
         env["PYTHONPATH"] = str(self.deps) + os.pathsep + env.get("PYTHONPATH", "")
         return subprocess.run(
-            [sys.executable, str(SCRIPT), "-i", str(path), "-b", "base0001", "-c", "comp0002", "-s", "model_type", "-o", "plain"],
+            [sys.executable, str(SCRIPT), "-i", str(path), "-b", "base0001", "-c", "comp0002", "-s", show, "-o", "plain"],
             cwd=ROOT,
             env=env,
             text=True,
@@ -120,7 +132,7 @@ class CompareLlamaBenchTest(unittest.TestCase):
         self.assertIn("2.0", result.stdout)
 
     def test_legacy_test_table(self):
-        path = self.create_db(["test"])
+        path = self.create_db(["test"], legacy_tables=("test",))
         self.insert_run(path, "test", "base0001", 10.0)
         self.insert_run(path, "test", "comp0002", 20.0)
         self.assert_successful_comparison(path)
@@ -132,7 +144,7 @@ class CompareLlamaBenchTest(unittest.TestCase):
         self.assert_successful_comparison(path)
 
     def test_mixed_tables_compare_across_versions(self):
-        path = self.create_db(["test", "test_v2"])
+        path = self.create_db(["test", "test_v2"], legacy_tables=("test",))
         self.insert_run(path, "test", "base0001", 10.0)
         self.insert_run(path, "test_v2", "comp0002", 20.0)
         self.assert_successful_comparison(path)
@@ -143,6 +155,22 @@ class CompareLlamaBenchTest(unittest.TestCase):
         result = self.run_compare(path)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("expected `test` or `test_v2`", result.stderr)
+
+    def test_rtr_configuration_is_a_join_key_when_available(self):
+        path = self.create_db(["test_v2"])
+        self.insert_run(path, "test_v2", "base0001", 10.0)
+        self.insert_run(path, "test_v2", "comp0002", 20.0)
+        self.insert_run(
+            path, "test_v2", "base0001", 30.0,
+            repack="1", repack_effective="1", repack_status="enabled")
+        self.insert_run(
+            path, "test_v2", "comp0002", 40.0,
+            repack="1", repack_effective="1", repack_status="enabled")
+
+        result = self.run_compare(path, "model_type,repack,repack_effective,repack_status")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("2.0", result.stdout)
+        self.assertIn("1.333", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test-compare-llama-bench.py
+++ b/tests/test-compare-llama-bench.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "compare-llama-bench.py"
+
+# Keep this fixture schema at the compare script's cross-version contract, not
+# at either printer's full schema. New printer-only fields must not be required
+# to compare legacy results.
+KEY_PROPERTIES = [
+    "cpu_info", "gpu_info", "n_gpu_layers", "cuda", "vulkan", "kompute", "metal", "sycl", "rpc", "gpu_blas",
+    "blas", "model_filename", "model_type", "model_size", "model_n_params", "n_batch", "n_ubatch", "embeddings", "n_threads",
+    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn", "n_prompt", "n_gen",
+]
+SOURCE_COLUMNS = list(dict.fromkeys(["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES))
+
+
+class CompareLlamaBenchTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        self.deps = self.root / "deps"
+        self.deps.mkdir()
+
+        # The script normally imports GitPython and tabulate. The fixture uses
+        # explicit commits and only verifies the data path, so small stubs keep
+        # this regression test hermetic without changing script dependencies.
+        (self.deps / "git.py").write_text(
+            "class InvalidGitRepositoryError(Exception): pass\n"
+            "class Repo:\n"
+            "    def __init__(self, *args, **kwargs):\n"
+            "        raise InvalidGitRepositoryError()\n"
+            "class Commit: pass\n",
+            encoding="utf-8",
+        )
+        (self.deps / "tabulate.py").write_text(
+            "def tabulate(rows, headers, **kwargs):\n"
+            "    return repr((headers, rows))\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def create_db(self, table_names):
+        path = self.root / "llama-bench.sqlite"
+        connection = sqlite3.connect(path)
+        try:
+            columns = ", ".join(f"{name} TEXT" for name in SOURCE_COLUMNS)
+            for table in table_names:
+                connection.execute(f"CREATE TABLE {table} ({columns})")
+            connection.commit()
+        finally:
+            connection.close()
+        return path
+
+    def insert_run(self, path, table, commit, avg_ts):
+        values = {name: "0" for name in SOURCE_COLUMNS}
+        values.update({
+            "build_commit": commit,
+            "test_time": commit,
+            "avg_ts": str(avg_ts),
+            "cpu_info": "fixture cpu",
+            "gpu_info": "fixture gpu",
+            "model_filename": "fixture.gguf",
+            "model_type": "fixture",
+            "model_size": "1",
+            "model_n_params": "1",
+            "n_gpu_layers": "0",
+            "n_batch": "1",
+            "n_ubatch": "1",
+            "n_threads": "1",
+            "type_k": "f16",
+            "type_v": "f16",
+            "use_mmap": "1",
+            "split_mode": "none",
+            "main_gpu": "0",
+            "tensor_split": "0",
+            "n_prompt": "16",
+            "n_gen": "0",
+        })
+        connection = sqlite3.connect(path)
+        try:
+            connection.execute(
+                f"INSERT INTO {table} ({', '.join(SOURCE_COLUMNS)}) "
+                f"VALUES ({', '.join('?' for _ in SOURCE_COLUMNS)})",
+                [values[column] for column in SOURCE_COLUMNS],
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def run_compare(self, path):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(self.deps) + os.pathsep + env.get("PYTHONPATH", "")
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "-i", str(path), "-b", "base0001", "-c", "comp0002", "-s", "model_type", "-o", "plain"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def assert_successful_comparison(self, path):
+        result = self.run_compare(path)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("fixture", result.stdout)
+        self.assertIn("pp16", result.stdout)
+        self.assertIn("10.0", result.stdout)
+        self.assertIn("20.0", result.stdout)
+        self.assertIn("2.0", result.stdout)
+
+    def test_legacy_test_table(self):
+        path = self.create_db(["test"])
+        self.insert_run(path, "test", "base0001", 10.0)
+        self.insert_run(path, "test", "comp0002", 20.0)
+        self.assert_successful_comparison(path)
+
+    def test_v2_table(self):
+        path = self.create_db(["test_v2"])
+        self.insert_run(path, "test_v2", "base0001", 10.0)
+        self.insert_run(path, "test_v2", "comp0002", 20.0)
+        self.assert_successful_comparison(path)
+
+    def test_mixed_tables_compare_across_versions(self):
+        path = self.create_db(["test", "test_v2"])
+        self.insert_run(path, "test", "base0001", 10.0)
+        self.insert_run(path, "test_v2", "comp0002", 20.0)
+        self.assert_successful_comparison(path)
+
+    def test_empty_database_reports_expected_tables(self):
+        path = self.root / "empty.sqlite"
+        sqlite3.connect(path).close()
+        result = self.run_compare(path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected `test` or `test_v2`", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-compare-llama-bench.py
+++ b/tests/test-compare-llama-bench.py
@@ -15,11 +15,14 @@ SCRIPT = ROOT / "scripts" / "compare-llama-bench.py"
 KEY_PROPERTIES = [
     "cpu_info", "gpu_info", "n_gpu_layers", "cuda", "vulkan", "kompute", "metal", "sycl", "rpc", "gpu_blas",
     "blas", "model_filename", "model_type", "model_size", "model_n_params", "n_batch", "n_ubatch", "embeddings", "n_threads",
-    "type_k", "type_v", "use_mmap", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn",
+    "type_k", "type_v", "mmap_comparison", "no_kv_offload", "split_mode", "main_gpu", "tensor_split", "flash_attn",
     "repack", "repack_auto", "repack_effective", "repack_status", "n_prompt", "n_gen",
 ]
-SOURCE_COLUMNS = list(dict.fromkeys(["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES))
+SOURCE_COLUMNS = list(dict.fromkeys(
+    ["build_commit", "test_time", "avg_ts"] + KEY_PROPERTIES + ["use_mmap", "use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers"]
+))
 RTR_COLUMNS = {"repack", "repack_auto", "repack_effective", "repack_status"}
+V3_MMAP_COLUMNS = {"use_mmap_requested", "use_mmap_effective", "mmap_backed_buffers"}
 
 
 class CompareLlamaBenchTest(unittest.TestCase):
@@ -49,15 +52,18 @@ class CompareLlamaBenchTest(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
-    def create_db(self, table_names, legacy_tables=()):
+    def create_db(self, table_names):
         path = self.root / "llama-bench.sqlite"
         connection = sqlite3.connect(path)
         try:
             for table in table_names:
-                source_columns = [
-                    name for name in SOURCE_COLUMNS
-                    if table not in legacy_tables or name not in RTR_COLUMNS
-                ]
+                source_columns = list(SOURCE_COLUMNS)
+                if table == "test":
+                    source_columns = [name for name in source_columns if name not in RTR_COLUMNS | V3_MMAP_COLUMNS | {"mmap_comparison"}]
+                elif table == "test_v2":
+                    source_columns = [name for name in source_columns if name not in V3_MMAP_COLUMNS | {"mmap_comparison"}]
+                else:
+                    source_columns = [name for name in source_columns if name != "mmap_comparison"]
                 columns = ", ".join(f"{name} TEXT" for name in source_columns)
                 connection.execute(f"CREATE TABLE {table} ({columns})")
             connection.commit()
@@ -90,6 +96,7 @@ class CompareLlamaBenchTest(unittest.TestCase):
             "type_k": "f16",
             "type_v": "f16",
             "use_mmap": "1",
+            "use_mmap_requested": "1", "use_mmap_effective": "1", "mmap_backed_buffers": "1",
             "split_mode": "none",
             "main_gpu": "0",
             "tensor_split": "0",
@@ -113,8 +120,12 @@ class CompareLlamaBenchTest(unittest.TestCase):
     def run_compare(self, path, show="model_type"):
         env = os.environ.copy()
         env["PYTHONPATH"] = str(self.deps) + os.pathsep + env.get("PYTHONPATH", "")
+        args = [sys.executable, str(SCRIPT), "-i", str(path), "-b", "base0001", "-c", "comp0002"]
+        if show is not None:
+            args.extend(["-s", show])
+        args.extend(["-o", "plain"])
         return subprocess.run(
-            [sys.executable, str(SCRIPT), "-i", str(path), "-b", "base0001", "-c", "comp0002", "-s", show, "-o", "plain"],
+            args,
             cwd=ROOT,
             env=env,
             text=True,
@@ -132,7 +143,7 @@ class CompareLlamaBenchTest(unittest.TestCase):
         self.assertIn("2.0", result.stdout)
 
     def test_legacy_test_table(self):
-        path = self.create_db(["test"], legacy_tables=("test",))
+        path = self.create_db(["test"])
         self.insert_run(path, "test", "base0001", 10.0)
         self.insert_run(path, "test", "comp0002", 20.0)
         self.assert_successful_comparison(path)
@@ -143,18 +154,75 @@ class CompareLlamaBenchTest(unittest.TestCase):
         self.insert_run(path, "test_v2", "comp0002", 20.0)
         self.assert_successful_comparison(path)
 
-    def test_mixed_tables_compare_across_versions(self):
-        path = self.create_db(["test", "test_v2"], legacy_tables=("test",))
-        self.insert_run(path, "test", "base0001", 10.0)
-        self.insert_run(path, "test_v2", "comp0002", 20.0)
+    def test_v3_table_uses_effective_mmap(self):
+        path = self.create_db(["test_v3"])
+        self.insert_run(path, "test_v3", "base0001", 10.0, use_mmap="1", use_mmap_effective="0")
+        self.insert_run(path, "test_v3", "comp0002", 20.0, use_mmap="0", use_mmap_effective="0")
         self.assert_successful_comparison(path)
+
+    def test_mixed_schemas_are_not_compared(self):
+        path = self.create_db(["test", "test_v3"])
+        self.insert_run(path, "test", "base0001", 10.0)
+        self.insert_run(path, "test_v3", "comp0002", 20.0)
+        result = self.run_compare(path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no comparable configurations", result.stderr)
+
+    def test_v2_and_v3_are_not_compared(self):
+        path = self.create_db(["test_v2", "test_v3"])
+        self.insert_run(path, "test_v2", "base0001", 10.0)
+        self.insert_run(path, "test_v3", "comp0002", 20.0)
+        result = self.run_compare(path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no comparable configurations", result.stderr)
+
+    def test_matching_schema_generations_are_not_averaged_together(self):
+        path = self.create_db(["test_v2", "test_v3"])
+        self.insert_run(path, "test_v2", "base0001", 10.0)
+        self.insert_run(path, "test_v2", "comp0002", 20.0)
+        self.insert_run(path, "test_v3", "base0001", 30.0)
+        self.insert_run(path, "test_v3", "comp0002", 90.0)
+        result = self.run_compare(path, "model_type")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.count("pp16"), 2, result.stdout)
+        self.assertIn("test_v2", result.stdout)
+        self.assertIn("test_v3", result.stdout)
+        self.assertIn("2.0", result.stdout)
+        self.assertIn("3.0", result.stdout)
+
+    def test_default_output_keeps_schema_generations_separate(self):
+        path = self.create_db(["test_v2", "test_v3"])
+        self.insert_run(path, "test_v2", "base0001", 10.0)
+        self.insert_run(path, "test_v2", "comp0002", 20.0)
+        self.insert_run(path, "test_v3", "base0001", 30.0)
+        self.insert_run(path, "test_v3", "comp0002", 90.0)
+        result = self.run_compare(path, None)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.count("pp16"), 2, result.stdout)
+        self.assertIn("test_v2", result.stdout)
+        self.assertIn("test_v3", result.stdout)
 
     def test_empty_database_reports_expected_tables(self):
         path = self.root / "empty.sqlite"
         sqlite3.connect(path).close()
         result = self.run_compare(path)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("expected `test` or `test_v2`", result.stderr)
+        self.assertIn("expected `test`, `test_v2`, or `test_v3`", result.stderr)
+
+    def test_incomplete_v3_schema_is_rejected(self):
+        path = self.create_db(["test_v3"])
+        connection = sqlite3.connect(path)
+        try:
+            connection.execute("DROP TABLE test_v3")
+            columns = [name for name in SOURCE_COLUMNS if name not in {"mmap_comparison", "use_mmap_effective"}]
+            connection.execute(f"CREATE TABLE test_v3 ({', '.join(f'{name} TEXT' for name in columns)})")
+            connection.commit()
+        finally:
+            connection.close()
+        result = self.run_compare(path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("test_v3 is not compatible", result.stderr)
+        self.assertIn("use_mmap_effective", result.stderr)
 
     def test_rtr_configuration_is_a_join_key_when_available(self):
         path = self.create_db(["test_v2"])
@@ -171,6 +239,43 @@ class CompareLlamaBenchTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("2.0", result.stdout)
         self.assertIn("1.333", result.stdout)
+
+    def test_v3_variants_do_not_cross_product(self):
+        path = self.create_db(["test_v3"])
+        self.insert_run(path, "test_v3", "base0001", 10.0, repack="0", repack_effective="0", repack_status="disabled")
+        self.insert_run(path, "test_v3", "comp0002", 20.0, repack="0", repack_effective="0", repack_status="disabled")
+        self.insert_run(path, "test_v3", "base0001", 30.0, repack="1", repack_effective="1", repack_status="enabled")
+        self.insert_run(path, "test_v3", "comp0002", 40.0, repack="1", repack_effective="1", repack_status="enabled")
+        result = self.run_compare(path, "model_type,repack,repack_effective,repack_status")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.count("pp16"), 2, result.stdout)
+        self.assertIn("2.0", result.stdout)
+        self.assertIn("1.333", result.stdout)
+
+    def test_nullable_boolean_is_displayed_as_unknown(self):
+        path = self.create_db(["test"])
+        self.insert_run(path, "test", "base0001", 10.0)
+        self.insert_run(path, "test", "comp0002", 20.0)
+        result = self.run_compare(path, "repack")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Unknown", result.stdout)
+
+    def test_nullable_repack_status_is_displayed_as_unknown(self):
+        path = self.create_db(["test"])
+        self.insert_run(path, "test", "base0001", 10.0)
+        self.insert_run(path, "test", "comp0002", 20.0)
+        result = self.run_compare(path, "repack_status")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Unknown", result.stdout)
+        self.assertNotIn("None", result.stdout)
+
+    def test_no_common_configuration_with_explicit_show_fails_cleanly(self):
+        path = self.create_db(["test_v3"])
+        self.insert_run(path, "test_v3", "base0001", 10.0, repack="0", repack_status="disabled")
+        self.insert_run(path, "test_v3", "comp0002", 20.0, repack="1", repack_effective="1", repack_status="enabled")
+        result = self.run_compare(path, "model_type,repack")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no comparable configurations", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test-rtr-auto-peak.cpp
+++ b/tests/test-rtr-auto-peak.cpp
@@ -1,0 +1,29 @@
+#include "../src/llama-rtr-auto.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+int main() {
+    uint64_t peak = 0;
+    assert(llama_rtr_auto_peak_bytes({
+        100, 20, 10, 8, 16, false,
+    }, peak));
+    assert(peak == 200); // 100 + 20 + 8 * 10
+
+    assert(llama_rtr_auto_peak_bytes({
+        100, 20, 10, 8, 16, true,
+    }, peak));
+    assert(peak == 328); // plus 8 * 16 CUDA staging
+
+    assert(!llama_rtr_auto_peak_bytes({
+        std::numeric_limits<uint64_t>::max(), 1, 0, 8, 0, false,
+    }, peak));
+    assert(!llama_rtr_auto_peak_bytes({
+        0, 0, std::numeric_limits<uint64_t>::max(), 2, 0, false,
+    }, peak));
+    return 0;
+}

--- a/tests/test-rtr-params.cpp
+++ b/tests/test-rtr-params.cpp
@@ -68,11 +68,22 @@ int main() {
         assert(params.use_mmap);
     }
 
+    {
+        const llama_model_params defaults = llama_model_default_params();
+        assert(!defaults.prefetch_experts);
+
+        gpt_params common_params;
+        common_params.prefetch_experts = true;
+        const llama_model_params model_params = common_model_params_to_llama(common_params);
+        assert(model_params.prefetch_experts);
+    }
+
     assert(!llama_model_mmap_requested(nullptr));
     assert(!llama_model_loader_mmap_enabled(nullptr));
     assert(!llama_model_has_mmap_buffers(nullptr));
     assert(!llama_model_repack_pass_executed(nullptr));
     assert(llama_model_n_repacked(nullptr) == 0);
+    assert(llama_model_rtr_status(nullptr) == LLAMA_RTR_STATUS_DISABLED);
 
     return 0;
 }

--- a/tests/test-rtr-params.cpp
+++ b/tests/test-rtr-params.cpp
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "llama.h"
 
 #ifdef NDEBUG
 #undef NDEBUG
@@ -54,6 +55,23 @@ int main() {
         // The loader, not the parser, applies the legacy forced-repack coupling.
         assert(params.use_mmap);
     }
+    {
+        const gpt_params params = parse({ "-rtr" });
+        assert(params.repack_tensors);
+        assert(!params.repack_tensors_auto);
+        assert(params.use_mmap);
+    }
+    {
+        const gpt_params params = parse({ "-rtra" });
+        assert(params.repack_tensors);
+        assert(params.repack_tensors_auto);
+        assert(params.use_mmap);
+    }
+
+    assert(!llama_model_loader_mmap_enabled(nullptr));
+    assert(!llama_model_has_mmap_buffers(nullptr));
+    assert(!llama_model_repack_pass_executed(nullptr));
+    assert(llama_model_n_repacked(nullptr) == 0);
 
     return 0;
 }

--- a/tests/test-rtr-params.cpp
+++ b/tests/test-rtr-params.cpp
@@ -68,6 +68,7 @@ int main() {
         assert(params.use_mmap);
     }
 
+    assert(!llama_model_mmap_requested(nullptr));
     assert(!llama_model_loader_mmap_enabled(nullptr));
     assert(!llama_model_has_mmap_buffers(nullptr));
     assert(!llama_model_repack_pass_executed(nullptr));

--- a/tests/test-rtr-params.cpp
+++ b/tests/test-rtr-params.cpp
@@ -1,0 +1,59 @@
+#include "common.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+static gpt_params parse(std::initializer_list<const char *> args) {
+    std::vector<std::string> storage;
+    storage.reserve(args.size() + 1);
+    storage.emplace_back("test-rtr-params");
+    for (const char * arg : args) {
+        storage.emplace_back(arg);
+    }
+
+    std::vector<char *> argv;
+    argv.reserve(storage.size());
+    for (std::string & arg : storage) {
+        argv.push_back(&arg[0]);
+    }
+
+    gpt_params params;
+    const bool ok = gpt_params_parse_ex((int) argv.size(), argv.data(), params);
+    assert(ok);
+    return params;
+}
+
+int main() {
+    {
+        const gpt_params params = parse({ "-rtr", "1", "-rtr", "auto" });
+        assert(params.repack_tensors);
+        assert(params.repack_tensors_auto);
+        assert(params.use_mmap);
+    }
+    {
+        const gpt_params params = parse({ "-rtr", "1", "-rtr", "0" });
+        assert(!params.repack_tensors);
+        assert(!params.repack_tensors_auto);
+        assert(params.use_mmap);
+    }
+    {
+        const gpt_params params = parse({ "--no-mmap", "-rtr", "auto" });
+        assert(params.repack_tensors);
+        assert(params.repack_tensors_auto);
+        assert(!params.use_mmap);
+    }
+    {
+        const gpt_params params = parse({ "-rtr", "auto", "-rtr", "on" });
+        assert(params.repack_tensors);
+        assert(!params.repack_tensors_auto);
+        // The loader, not the parser, applies the legacy forced-repack coupling.
+        assert(params.use_mmap);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [x] High

## What

Adds `auto` to `--run-time-repack` / `-rtr` and documents the `-rtra` / `--run-time-repack-auto` alias.

| Mode | Behaviour |
|---|---|
| `0` / `off` | Disable run-time repack |
| `1` / `on` / bare `-rtr` | Force legacy run-time repack |
| `auto` | Repack only when the loader can conservatively prove that the non-mmap load fits; uncertainty disables repack and preserves requested mmap |

The default remains `0`.

## Safety contract

This revision turns RTR auto into a fail-closed loader policy rather than a parser-only heuristic:

- forced RTR is coupled to effective loader mmap (`repack_tensors=true` forces loader mmap off), so the repack pass actually executes;
- auto uses metadata-only placement analysis and checked peak-memory arithmetic before constructing the real loader;
- every unsupported/ambiguous placement, overflow, memory-accounting failure, incompatible prefetch/defer mode, or platform uncertainty produces `AUTO_UNKNOWN`, disables repack, and preserves the requested mmap setting;
- peak accounting includes CPU-resident tensor bytes, maximum repack workspace, loader worker read buffers, and active CUDA staging buffers;
- tensor buffer overrides use the loader's first-match regex semantics;
- simple single-device GPU and `-ncmoe` placement is modeled; multi-device/merged/fit and other ambiguous paths remain UNKNOWN rather than optimistic;
- Linux memory headroom resolves `/proc/self/cgroup` and `/proc/self/mountinfo`, cgroup v1/v2 namespaces, bind/full mounts, ancestors, and v1 memsw, intersecting all applicable limits;
- cgroup errors remain fail-closed. For v2 only, a missing `memory.max` + `memory.current` pair is skipped as unbounded exactly at the resolved mountpoint; a partial pair or missing pair below it is UNKNOWN;
- Windows Job Object membership is conservatively UNKNOWN instead of using unsafe host-wide headroom; macOS/unsupported platform fallbacks are also conservative.

## Effective state and tooling

The public model API exposes requested/effective mmap and RTR state separately, including whether mmap-backed buffers exist, whether the repack pass ran, the number of repacked tensors, and the final RTR status.

`llama-bench` writes an immutable `test_v3` schema with requested/effective mmap and RTR fields. `compare-llama-bench.py` reads compatible `test`, `test_v2`, and `test_v3` sources without cross-schema joins/averaging, uses effective mmap for v3 comparison, and renders unknown legacy RTR metadata explicitly.

## ABI/API note

This PR adds trailing fields to the public `llama_model_params` structure (`repack_tensors_auto` and `prefetch_experts`). Applications linking the library must rebuild against matching headers; mixing old binaries/aggregate initializers with the new library is unsupported.

## Validation for head `843de95f`

Executed locally:

- Windows MSVC/Ninja: `llama-bench`, `test-rtr-params`, `test-cgroup-resolver`, `test-rtr-auto-peak` built successfully;
- CTest RTR/cgroup suite: **3/3 passed**;
- compare-script Python suite: **14/14 passed**;
- `py_compile` and `git diff --check`: passed;
- Linux/WSL g++ 13.3 with `-std=c++17 -Wall -Wextra -Werror`: cgroup resolver and peak-accounting tests passed;
- live cgroup-v2 smoke reproduced the root-mount missing-pair topology and resolved it correctly;
- real forced-RTR GGUF smoke verified: requested mmap=true, effective loader mmap=false, no mmap-backed model buffers, repack pass executed, `n_repacked > 0`, status=`enabled`;
- Windows auto smoke verified conservative `auto_unknown` under a Job Object while preserving mmap;
- real 60-column `test_v3` SQL output was imported into SQLite and compared successfully.

A second independent review was run with Claude Code through Maestro Duet across five phases. Its final whole-PR verdict was **GO** after the cgroup-v2 root case and carry-forward cleanups were fixed.

These are evidence-backed guarantees for the exercised CPU/MSVC, Linux resolver, and Python/SQLite paths—not a universal platform guarantee. CUDA, Metal, MinGW, and the complete upstream matrix remain for upstream CI.

## Scope deliberately left out

- changing the default RTR mode;
- making forced legacy `-rtr 1` memory-safe (use `auto` for that policy);
- selective per-tensor mmap/repack decoupling;
- exact Windows Job Object limit accounting;
- changing malformed-present benchmark schemas from fail-hard to skip-with-warning.

## Design notes

The safety contract, implementation stages, and regression matrix are recorded in:

- `docs/RTR_AUTO_PR_FOLLOWUP_SPEC.md`
- `docs/RTR_AUTO_PR_FOLLOWUP_PLAN.md`
