### PR TITLE
fix: include cstdint in iqk_common

### DIFF
--- a/ggml/src/iqk/iqk_common.h
+++ b/ggml/src/iqk/iqk_common.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "iqk_config.h"
+#include <cstdint>
 
 #if defined IQK_IMPLEMENT
 


### PR DESCRIPTION
## Summary
- Add missing `<cstdint>` include to `ggml/src/iqk/iqk_common.h`.
- Fixes builds where fixed-width integer types like `uint8_t`, `uint16_t`, `uint32_t`, and `uint64_t` are not provided transitively by other headers.

## Context
While building on Linux aarch64 with GCC 11.5, compilation failed in `iqk_common.h` because these fixed-width integer types were used without including `<cstdint>`.

## Test
- Local aarch64 build progressed past the original `iqk_common.h` missing type errors after this include was added.