### PR TITLE
Update repository clone instructions in build.md

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,8 +5,8 @@
 **To get the Code:**
 
 ```bash
-git clone https://github.com/ggerganov/llama.cpp
-cd llama.cpp
+git clone https://github.com/ikawrakow/ik_llama.cpp
+cd ik_llama.cpp
 ```
 
 In order to build `ik_llama.cpp` you have four different options.


### PR DESCRIPTION
This PR changes the build docs to clone this repo instead of the original llama.cpp repo.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
