### PR TITLE
ggml : default GGML_WIN_VER to 0x0A00 (Windows 10)

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -100,7 +100,12 @@ option(GGML_SVE         "ggml: enable SVE"              OFF)
 option(GGML_NCCL        "ggml: enable NCCL"             ON)
 
 if (WIN32)
-    set(GGML_WIN_VER "0x602" CACHE STRING "ggml: Windows Version")
+    # Default to Windows 10 (0x0A00). Windows 8 / 8.1 reached end of support in
+    # January 2023, and the vendored cpp-httplib (used by the server target)
+    # rejects anything below 0x0A00 with `#error "cpp-httplib doesn't support
+    # Windows 8 or lower."`. Override with -DGGML_WIN_VER=0x602 if you really
+    # need to target Windows 8.
+    set(GGML_WIN_VER "0x0A00" CACHE STRING "ggml: Windows Version")
 endif()
 
 # ggml core


### PR DESCRIPTION
The default of `0x602` (Windows 8) causes a build failure on any toolchain where `_WIN32_WINNT` propagates into vendored `cpp-httplib` (notably MinGW with the bundled w64devkit GCC). `cpp-httplib`'s `httplib.h` rejects anything below `0x0A00`:

```c
#ifdef _WIN32
#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0A00
#error "cpp-httplib doesn't support Windows 8 or lower. Please use Windows 10 or later."
#endif
#endif
```

So the entire `llama-server` target fails to compile on Windows + MinGW unless the user passes `-DGGML_WIN_VER=0x0A00` manually.

Bumping the default to `0x0A00` (Windows 10) keeps Windows 8 reachable for anyone who explicitly requests it (`-DGGML_WIN_VER=0x602`), while letting the default Windows + MinGW build succeed end-to-end. Windows 8 / 8.1 reached end of support in January 2023, and Windows 10 is a strict superset of the Win8 surface used elsewhere (`PrefetchVirtualMemory` etc.), so the change is strictly additive on the API side.

**Verified by building with w64devkit 2.8.0 (gcc 16.1.0) on Windows 11 with no `-DGGML_WIN_VER` override:** all 266 ninja targets link cleanly including `bin/llama-server.exe`, and `llama-cli` runs `Qwen3-4B-Thinking-2507-IQ4_XS` at ~6.2 tok/s with `q8_0` KV at 4096 context.
