### PR TITLE
Fix discarding tokens from the KV cache during MTP drafting

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1410,17 +1410,19 @@ std::vector<llama_token> mtp_speculative_gen_draft(
         i0 = 1;
     }
 
+    int n_decode = 0;
     for (int i = i0; i < n_draft; ++i) {
         mtp_batch.n_tokens = 0;
         common_batch_add(mtp_batch, current_input_id, current_n_past, {seq_id}, true);
 
+        ++n_decode;
         if (llama_decode(ctx, mtp_batch) != 0) {
             break;
         }
 
         llama_token id_next = common_sampler_sample_speculative(smpl, ctx, 0, prob_ptr);
         if (i > 0 && prob_ptr && prob < p_min) {
-            return drafts;
+            break;
         }
 
         drafts.push_back(id_next);
@@ -1446,8 +1448,15 @@ std::vector<llama_token> mtp_speculative_gen_draft(
 
     // Purge the metadata for the draft tokens.
     // This prevents cache state corruption where two cells map to the same logical position.
-    if (!drafts.empty()) {
-        llama_kv_cache_seq_rm(ctx, seq_id, n_past, current_n_past);
+    // If the state contained in `last` had a valid token id and probability, it means that we
+    // have previously run an "accept" batch, where the token sampled from the main model was included.
+    // In that case, we need to discard all tokens that we ran here to get the KV cache to the correct state.
+    //   => for i0 = 1 we discard from n_past
+    // But if we did not have a valid last token_id, it means the first token we run was sampled from the
+    // main model. Hence we want to keep this token in the KV cache and discard all other tokens.
+    //   => for i0 = 0 we discard from n_past + 1
+    if (n_decode > 0) {
+        llama_kv_cache_seq_rm(ctx, seq_id, n_past + 1 - i0, n_past + n_decode + 2);
     }
 
     return drafts;


### PR DESCRIPTION

See #1747.

Basically, when drafting tokens with MTP of the Qwen3.5 variety, we can enter the `mtp_speculative_gen_draft` function, where the draft tokens get generated, with two different states:
1. We had previously run `mtp_accept_tokens` to accept the drafted tokens with the MTP context. In that case, the accepted tokens passed to `llama_decode` include the previously drafted tokens plus the next token sampled from the main model. 
2. We had previously run a "warm-up" batch with the MTP context to update the KV cache. In that case, we did not have the token sampled from the main model included in the batch, so the first generation we run in `mtp_speculative_gen_draft` is with the token that was sampled from the main model.

The issue is that in both of these cases all tokens generated in `mtp_speculative_gen_draft` were discarded from the KV cache, which is wrong in case 2, where the token generated by the main model does not get added to the KV cache of the MTP drafter. 

The PR fixes this issue.

The strange thing is that the fix does not really improve acceptance rate in a meaningful way, so performance is basically the same. I suspect that this is related to similar errors in the handling of the recurrent state (see #1754).