### PR TITLE
Slightly expand the usage of VNNI256

### DIFF
--- a/ggml/src/iqk/iqk_common.h
+++ b/ggml/src/iqk/iqk_common.h
@@ -388,12 +388,12 @@ struct BaseDequantizer {
 template <typename Q8, typename Bits>
 static inline void multiply_add(const Bits& bits, const __m256i * scales, int j, int i, const Q8& q8, __m256i * sumi) {
     if (j == 0) {
-#ifdef HAVE_FANCY_SIMD
+#ifdef HAVE_VNNI256
         for (int iy = 0; iy < Q8::nrc_y; ++iy) {
-            sumi[iy] = _mm256_dpwssd_epi32(_mm256_setzero_si256(), scales[0], _mm256_maddubs_epi16(bits.values[0], q8.load_quants(iy, i, 0)));
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[1], _mm256_maddubs_epi16(bits.values[1], q8.load_quants(iy, i, 1)));
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[2], _mm256_maddubs_epi16(bits.values[2], q8.load_quants(iy, i, 2)));
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[3], _mm256_maddubs_epi16(bits.values[3], q8.load_quants(iy, i, 3)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(_mm256_setzero_si256(), scales[0], _mm256_maddubs_epi16(bits.values[0], q8.load_quants(iy, i, 0)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[1], _mm256_maddubs_epi16(bits.values[1], q8.load_quants(iy, i, 1)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[2], _mm256_maddubs_epi16(bits.values[2], q8.load_quants(iy, i, 2)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[3], _mm256_maddubs_epi16(bits.values[3], q8.load_quants(iy, i, 3)));
         }
 #else
         for (int iy = 0; iy < Q8::nrc_y; ++iy) {
@@ -405,12 +405,12 @@ static inline void multiply_add(const Bits& bits, const __m256i * scales, int j,
         }
 #endif
     } else {
-#ifdef HAVE_FANCY_SIMD
+#ifdef HAVE_VNNI256
         for (int iy = 0; iy < Q8::nrc_y; ++iy) {
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[0], _mm256_maddubs_epi16(bits.values[0], q8.load_quants(iy, i, 4)));
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[1], _mm256_maddubs_epi16(bits.values[1], q8.load_quants(iy, i, 5)));
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[2], _mm256_maddubs_epi16(bits.values[2], q8.load_quants(iy, i, 6)));
-            sumi[iy] = _mm256_dpwssd_epi32(sumi[iy], scales[3], _mm256_maddubs_epi16(bits.values[3], q8.load_quants(iy, i, 7)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[0], _mm256_maddubs_epi16(bits.values[0], q8.load_quants(iy, i, 4)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[1], _mm256_maddubs_epi16(bits.values[1], q8.load_quants(iy, i, 5)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[2], _mm256_maddubs_epi16(bits.values[2], q8.load_quants(iy, i, 6)));
+            sumi[iy] = ggml_mm256_dpwssd_epi32(sumi[iy], scales[3], _mm256_maddubs_epi16(bits.values[3], q8.load_quants(iy, i, 7)));
         }
 #else
         for (int iy = 0; iy < Q8::nrc_y; ++iy) {

--- a/ggml/src/iqk/iqk_config.h
+++ b/ggml/src/iqk/iqk_config.h
@@ -30,7 +30,7 @@
 
 #ifdef _MSC_VER
 #define IQK_NOINLINE __declspec(noinline)
-#define IQK_ALWAYS_INLINE inline
+#define IQK_ALWAYS_INLINE __forceinline
 #if !defined __x86_64__ && defined _M_X64
 #define __x86_64__
 #endif

--- a/ggml/src/iqk/iqk_gemm_1bit.cpp
+++ b/ggml/src/iqk/iqk_gemm_1bit.cpp
@@ -849,8 +849,8 @@ void mul_mat_iq1_s_q8_K(int n, const void * vx, size_t bx, const DataInfo& info,
                     sumi = _mm256_add_epi32(sumi, _mm256_madd_epi16(scales[ib64], dot));
 #endif
                 }
-#ifdef HAVE_FANCY_SIMD
-                sumi = _mm256_dpwssd_epi32(sumi, bsums, deltas);
+#ifdef HAVE_VNNI256
+                sumi = ggml_mm256_dpwssd_epi32(sumi, bsums, deltas);
 #else
                 sumi = _mm256_add_epi32(sumi, _mm256_madd_epi16(bsums, deltas));
 #endif

--- a/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_iqk_quants.cpp
@@ -1575,11 +1575,11 @@ inline void iq234_k_accum_mins(int ibl, __m256i i8scales1, __m256i i8scales2, co
         auto s4 = MM256_SET_M128I(_mm256_extracti128_si256(t4, 1), _mm256_extracti128_si256(t2, 1)); // blocks 6, 7, 14, 15
         auto sumi = _mm256_setzero_si256();
         auto bsums = q8.load_bsums(0, ibl);
-#ifdef HAVE_FANCY_SIMD
-        sumi = _mm256_dpwssd_epi32(sumi, s1, _mm256_shuffle_epi32(bsums, 0x00));
-        sumi = _mm256_dpwssd_epi32(sumi, s2, _mm256_shuffle_epi32(bsums, 0x55));
-        sumi = _mm256_dpwssd_epi32(sumi, s3, _mm256_shuffle_epi32(bsums, 0xaa));
-        sumi = _mm256_dpwssd_epi32(sumi, s4, _mm256_shuffle_epi32(bsums, 0xff));
+#ifdef HAVE_VNNI256
+        sumi = ggml_mm256_dpwssd_epi32(sumi, s1, _mm256_shuffle_epi32(bsums, 0x00));
+        sumi = ggml_mm256_dpwssd_epi32(sumi, s2, _mm256_shuffle_epi32(bsums, 0x55));
+        sumi = ggml_mm256_dpwssd_epi32(sumi, s3, _mm256_shuffle_epi32(bsums, 0xaa));
+        sumi = ggml_mm256_dpwssd_epi32(sumi, s4, _mm256_shuffle_epi32(bsums, 0xff));
 #else
         sumi = _mm256_add_epi32(sumi, _mm256_madd_epi16(s1, _mm256_shuffle_epi32(bsums, 0x00)));
         sumi = _mm256_add_epi32(sumi, _mm256_madd_epi16(s2, _mm256_shuffle_epi32(bsums, 0x55)));
@@ -1595,11 +1595,11 @@ inline void iq234_k_accum_mins(int ibl, __m256i i8scales1, __m256i i8scales2, co
         auto s4 = _mm256_mullo_epi16(_mm256_set1_epi16(min), MM256_SET_M128I(_mm256_extracti128_si256(t4, 1), _mm256_extracti128_si256(t2, 1))); // blocks 6, 7, 14, 15
         for (int iy = 0; iy < nrc_y; ++iy) {
             auto bsums = q8.load_bsums(iy, ibl);
-#ifdef HAVE_FANCY_SIMD
-            isum[iy] = _mm256_dpwssd_epi32(isum[iy], s1, _mm256_shuffle_epi32(bsums, 0x00));
-            isum[iy] = _mm256_dpwssd_epi32(isum[iy], s2, _mm256_shuffle_epi32(bsums, 0x55));
-            isum[iy] = _mm256_dpwssd_epi32(isum[iy], s3, _mm256_shuffle_epi32(bsums, 0xaa));
-            isum[iy] = _mm256_dpwssd_epi32(isum[iy], s4, _mm256_shuffle_epi32(bsums, 0xff));
+#ifdef HAVE_VNNI256
+            isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s1, _mm256_shuffle_epi32(bsums, 0x00));
+            isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s2, _mm256_shuffle_epi32(bsums, 0x55));
+            isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s3, _mm256_shuffle_epi32(bsums, 0xaa));
+            isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s4, _mm256_shuffle_epi32(bsums, 0xff));
 #else
             isum[iy] = _mm256_add_epi32(isum[iy], _mm256_madd_epi16(s1, _mm256_shuffle_epi32(bsums, 0x00)));
             isum[iy] = _mm256_add_epi32(isum[iy], _mm256_madd_epi16(s2, _mm256_shuffle_epi32(bsums, 0x55)));
@@ -1636,11 +1636,11 @@ inline void iq2345_k_accum_mins(int ibl, __m256i i8scales1, __m256i i8scales2, c
                                  MM256_SET_M128I(_mm256_extracti128_si256(t4, 1), _mm256_extracti128_si256(t2, 1))); // blocks 6, 7, 14, 15
     for (int iy = 0; iy < nrc_y; ++iy) {
         auto bsums = q8.load_bsums(iy, ibl);
-#ifdef HAVE_FANCY_SIMD
-        isum[iy] = _mm256_dpwssd_epi32(isum[iy], s1, _mm256_shuffle_epi32(bsums, 0x00));
-        isum[iy] = _mm256_dpwssd_epi32(isum[iy], s2, _mm256_shuffle_epi32(bsums, 0x55));
-        isum[iy] = _mm256_dpwssd_epi32(isum[iy], s3, _mm256_shuffle_epi32(bsums, 0xaa));
-        isum[iy] = _mm256_dpwssd_epi32(isum[iy], s4, _mm256_shuffle_epi32(bsums, 0xff));
+#ifdef HAVE_VNNI256
+        isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s1, _mm256_shuffle_epi32(bsums, 0x00));
+        isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s2, _mm256_shuffle_epi32(bsums, 0x55));
+        isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s3, _mm256_shuffle_epi32(bsums, 0xaa));
+        isum[iy] = ggml_mm256_dpwssd_epi32(isum[iy], s4, _mm256_shuffle_epi32(bsums, 0xff));
 #else
         isum[iy] = _mm256_add_epi32(isum[iy], _mm256_madd_epi16(s1, _mm256_shuffle_epi32(bsums, 0x00)));
         isum[iy] = _mm256_add_epi32(isum[iy], _mm256_madd_epi16(s2, _mm256_shuffle_epi32(bsums, 0x55)));

--- a/ggml/src/iqk/iqk_gemm_ktquants.cpp
+++ b/ggml/src/iqk/iqk_gemm_ktquants.cpp
@@ -121,8 +121,8 @@ struct Trellis3 {
     }
     inline __m256 gen8(uint32_t val1, uint32_t val2) const {
         auto v8 = _mm256_and_si256(next8(val1, val2), _mm256_set1_epi32(0x3f3f3f3f));
-#ifdef HAVE_FANCY_SIMD
-        auto i8 = _mm256_dpbusd_epi32(_mm256_set1_epi32(-126), _mm256_set1_epi32(0x01010101), v8);
+#ifdef HAVE_VNNI256
+        auto i8 = ggml_mm256_dpbusd_epi32(_mm256_set1_epi32(-126), _mm256_set1_epi32(0x01010101), v8);
 #else
         auto dot = _mm256_maddubs_epi16(v8, _mm256_set1_epi32(0x01010101));
         auto i8  = _mm256_add_epi32(_mm256_set1_epi32(-126), _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
@@ -135,8 +135,8 @@ struct Trellis3 {
     }
     inline __m256 gen8(uint32_t val) const {
         auto v8 = _mm256_and_si256(next8(val), _mm256_set1_epi32(0x3f3f3f3f));
-#ifdef HAVE_FANCY_SIMD
-        auto i8 = _mm256_dpbusd_epi32(_mm256_set1_epi32(-126), _mm256_set1_epi32(0x01010101), v8);
+#ifdef HAVE_VNNI256
+        auto i8 = ggml_mm256_dpbusd_epi32(_mm256_set1_epi32(-126), _mm256_set1_epi32(0x01010101), v8);
 #else
         auto dot = _mm256_maddubs_epi16(v8, _mm256_set1_epi32(0x01010101));
         auto i8  = _mm256_add_epi32(_mm256_set1_epi32(-126), _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
@@ -152,8 +152,8 @@ struct Trellis3 {
         __m256i aux[4];
         for (int i = 0; i < 4; ++i) {
             auto i8 = _mm256_and_si256(next8(val[2*i+0], val[2*i+1]), _mm256_set1_epi32(0x3f3f3f3f));
-#ifdef HAVE_FANCY_SIMD
-            aux[i] = _mm256_dpbusd_epi32(offset, _mm256_set1_epi32(0x01010101), i8);
+#ifdef HAVE_VNNI256
+            aux[i] = ggml_mm256_dpbusd_epi32(offset, _mm256_set1_epi32(0x01010101), i8);
 #else
             auto dot = _mm256_maddubs_epi16(i8, _mm256_set1_epi32(0x01010101));
             aux[i] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
@@ -190,14 +190,12 @@ struct Trellis3 {
             aux[i] = _mm256_and_si256(aux[i], mask);
         }
         auto offset = _mm256_set1_epi32(-126);
-#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__)
         auto m1     = _mm256_set1_epi32(0x01010101);
-#endif
         for (int i = 0; i < 16; ++i) {
-#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__)
-            aux[i] = _mm256_dpbusd_epi32(offset, aux[i], m1);
+#ifdef HAVE_VNNI256
+            aux[i] = ggml_mm256_dpbusd_epi32(offset, aux[i], m1);
 #else
-            auto dot = _mm256_maddubs_epi16(aux[i], _mm256_set1_epi32(0x01010101));
+            auto dot = _mm256_maddubs_epi16(aux[i], m1);
             aux[i] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
 #endif
         }
@@ -240,14 +238,12 @@ struct Trellis3 {
             aux[i] = _mm256_and_si256(aux[i], mask);
         }
         auto offset = _mm256_set1_epi32(-126);
-#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__)
         auto m1     = _mm256_set1_epi32(0x01010101);
-#endif
         for (int i = 0; i < 16; ++i) {
-#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__)
-            aux[i] = _mm256_dpbusd_epi32(offset, aux[i], m1);
+#ifdef HAVE_VNNI256
+            aux[i] = ggml_mm256_dpbusd_epi32(offset, aux[i], m1);
 #else
-            auto dot = _mm256_maddubs_epi16(aux[i], _mm256_set1_epi32(0x01010101));
+            auto dot = _mm256_maddubs_epi16(aux[i], m1);
             aux[i] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
 #endif
         }
@@ -281,14 +277,12 @@ struct Trellis3 {
             aux[i] = _mm256_and_si256(aux[i], mask);
         }
         auto offset = _mm256_set1_epi32(-126);
-#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__)
         auto m1     = _mm256_set1_epi32(0x01010101);
-#endif
         for (int i = 0; i < 16; ++i) {
-#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__)
-            aux[i] = _mm256_dpbusd_epi32(offset, aux[i], m1);
+#ifdef HAVE_VNNI256
+            aux[i] = ggml_mm256_dpbusd_epi32(offset, aux[i], m1);
 #else
-            auto dot = _mm256_maddubs_epi16(aux[i], _mm256_set1_epi32(0x01010101));
+            auto dot = _mm256_maddubs_epi16(aux[i], m1);
             aux[i] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
 #endif
         }
@@ -305,13 +299,14 @@ struct Trellis3 {
     }
     inline __m256i next32(const uint16_t * val, uint32_t v0) const {
         const __m256i offset = _mm256_set1_epi32(-126);
+        const __m256i m1     = _mm256_set1_epi32(0x01010101);
         __m256i aux[4];
         for (int i = 0; i < 4; ++i) {
             auto i8 = _mm256_and_si256(next8(v0 + val[i]), _mm256_set1_epi32(0x3f3f3f3f));
-#ifdef HAVE_FANCY_SIMD
-            aux[i] = _mm256_dpbusd_epi32(offset, _mm256_set1_epi32(0x01010101), i8);
+#ifdef HAVE_VNNI256
+            aux[i] = ggml_mm256_dpbusd_epi32(offset, m1, i8);
 #else
-            auto dot = _mm256_maddubs_epi16(i8, _mm256_set1_epi32(0x01010101));
+            auto dot = _mm256_maddubs_epi16(i8, m1);
             aux[i] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot, _mm256_set1_epi16(1)));
 #endif
         }
@@ -328,6 +323,7 @@ struct Trellis3 {
     }
     inline void next64(const uint32_t * val, __m256i * result) const {
         const __m256i offset = _mm256_set1_epi32(-126);
+        const __m256i m1     = _mm256_set1_epi32(0x01010101);
         auto vka3 = _mm256_set1_epi32(ka3);
         __m256i aux[8];
         for (int i = 0; i < 4; ++i) {
@@ -335,12 +331,12 @@ struct Trellis3 {
             auto i8_2 = _mm256_mullo_epi32(i8_1, vka3);
             i8_1 = _mm256_and_si256(i8_1, _mm256_set1_epi32(0x3f3f3f3f));
             i8_2 = _mm256_and_si256(i8_2, _mm256_set1_epi32(0x3f3f3f3f));
-#ifdef HAVE_FANCY_SIMD
-            aux[i+0] = _mm256_dpbusd_epi32(offset, _mm256_set1_epi32(0x01010101), i8_1);
-            aux[i+4] = _mm256_dpbusd_epi32(offset, _mm256_set1_epi32(0x01010101), i8_2);
+#ifdef HAVE_VNNI256
+            aux[i+0] = ggml_mm256_dpbusd_epi32(offset, m1, i8_1);
+            aux[i+4] = ggml_mm256_dpbusd_epi32(offset, m1, i8_2);
 #else
-            auto dot1 = _mm256_maddubs_epi16(i8_1, _mm256_set1_epi32(0x01010101));
-            auto dot2 = _mm256_maddubs_epi16(i8_2, _mm256_set1_epi32(0x01010101));
+            auto dot1 = _mm256_maddubs_epi16(i8_1, m1);
+            auto dot2 = _mm256_maddubs_epi16(i8_2, m1);
             aux[i+0] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot1, _mm256_set1_epi16(1)));
             aux[i+4] = _mm256_add_epi32(offset, _mm256_madd_epi16(dot2, _mm256_set1_epi16(1)));
 #endif
@@ -599,9 +595,9 @@ void mul_mat_iq1_kt_q8_2_x4_T(int n, const void * vx, size_t bx, const DataInfo&
     auto compute_dot = [&dot, &xv] (const int8_t * y) {
         for (int k = 0; k < 4; ++k) {
             auto yv = _mm256_loadu_si256((const __m256i *)y + k);
-#ifdef HAVE_FANCY_SIMD
-            //dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
-            dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), _mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
+#ifdef HAVE_VNNI256
+            //dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
+            dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), _mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
 #else
             auto p = _mm256_maddubs_epi16(_mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
             dot[k] = _mm256_madd_epi16(p, _mm256_set1_epi16(1));
@@ -690,9 +686,9 @@ void mul_mat_iq2_kt_q8_2_x4_T(int n, const void * vx, size_t bx, const DataInfo&
     auto compute_dot = [&dot, &xv] (const int8_t * y) {
         for (int k = 0; k < 4; ++k) {
             auto yv = _mm256_loadu_si256((const __m256i *)y + k);
-#ifdef HAVE_FANCY_SIMD
-            //dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
-            dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), _mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
+#ifdef HAVE_VNNI256
+            //dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
+            dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), _mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
 #else
             auto p = _mm256_maddubs_epi16(_mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
             dot[k] = _mm256_madd_epi16(p, _mm256_set1_epi16(1));
@@ -834,9 +830,9 @@ void mul_mat_iq3_kt_q8_2_x4_T(int n, const void * vx, size_t bx, const DataInfo&
     auto compute_dot = [&dot, &xv, &sv] (const int8_t * y) {
         for (int k = 0; k < 4; ++k) {
             auto yv = _mm256_loadu_si256((const __m256i *)y + k);
-#ifdef HAVE_FANCY_SIMD
-            //dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
-            dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], _mm256_sign_epi8(yv, sv[k]));
+#ifdef HAVE_VNNI256
+            //dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
+            dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], _mm256_sign_epi8(yv, sv[k]));
 #else
             auto p = _mm256_maddubs_epi16(xv[k], _mm256_sign_epi8(yv, sv[k]));
             dot[k] = _mm256_madd_epi16(p, _mm256_set1_epi16(1));
@@ -1135,9 +1131,9 @@ void mul_mat_iq4_kt_q8_2_x4_T(int n, const void * vx, size_t bx, const DataInfo&
     auto compute_dot = [&dot, &xv] (const int8_t * y) {
         for (int k = 0; k < 4; ++k) {
             auto yv = _mm256_loadu_si256((const __m256i *)y + k);
-#ifdef HAVE_FANCY_SIMD
-            //dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
-            dot[k] = _mm256_dpbusd_epi32(_mm256_setzero_si256(), _mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
+#ifdef HAVE_VNNI256
+            //dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), xv[k], yv);
+            dot[k] = ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), _mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
 #else
             auto p = _mm256_maddubs_epi16(_mm256_sign_epi8(xv[k], xv[k]), _mm256_sign_epi8(yv, xv[k]));
             dot[k] = _mm256_madd_epi16(p, _mm256_set1_epi16(1));

--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -20,9 +20,9 @@ namespace {
 
 struct DotHelper {
     const __m256i m1 = _mm256_set1_epi16(1);
-#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+#ifdef HAVE_VNNI256
     inline __m256i dot(__m256i x, __m256i y) const {
-        return _mm256_dpbusd_epi32(_mm256_setzero_si256(), x, y);
+        return ggml_mm256_dpbusd_epi32(_mm256_setzero_si256(), x, y);
     }
 #else
     inline __m256i dot(__m256i x, __m256i y) const {


### PR DESCRIPTION
I am applying the changes on common patterns like `_mm256_madd_epi16(_mm256_maddubs_epi16(a, b), ones)` and `_mm256_add_epi32(c, _mm256_madd_epi16(a, b))`.

The original logics inside and outside HAVE_FANCY_SIMD are the same, so these changes should be safe (unless there's overflow handling outside of those regions...).

Actually there's already ultility functions like `DotHelper::dot`, using them could be neater... 


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
