### PR TITLE
fix: keep sm70 cublas f32 outputs in f32

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -1603,6 +1603,34 @@ static void ggml_cuda_op_mul_mat_cublas(
             to_fp16_cuda(src1_ddf_i, src1_as_f16.get(), src1_ncols, ne10, stream);
         }
         const half * src1_ptr = src1->type == GGML_TYPE_F16 ? (const half *) src1_ddf_i : src1_as_f16.get();
+
+        // On Volta, avoid storing f32 graph outputs in a temporary f16 buffer;
+        // finite matmul results outside fp16 range would become +/-inf there.
+        const bool sm70_f32_output =
+            compute_capability <= CC_VOLTA &&
+            dst->type == GGML_TYPE_F32;
+        if (sm70_f32_output) {
+            const float alpha_f32 = 1.0f;
+            const float beta_f32  = 0.0f;
+
+            static std::atomic<int> sm70_f32_output_logs{0};
+            if (sm70_f32_output_logs.fetch_add(1) < 8) {
+                GGML_CUDA_LOG_WARN(
+                        "%s: using f32 cublas output for %s on cc=%d to avoid fp16 output saturation\n",
+                        __func__, dst->name, compute_capability);
+            }
+
+            CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
+            CUBLAS_CHECK(
+                cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
+                        row_diff, src1_ncols, ne10,
+                        &alpha_f32, src0_ptr,  CUDA_R_16F, ne00,
+                                    src1_ptr,  CUDA_R_16F, ne10,
+                        &beta_f32,  dst_dd_i,  CUDA_R_32F, ldc,
+                        CUBLAS_COMPUTE_32F,
+                        CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+            return;
+        }
         ggml_cuda_pool_alloc<half> dst_f16(ctx.pool(id), row_diff*src1_ncols);
 
         const half alpha_f16 = 1.0f;


### PR DESCRIPTION
On SM70 / Volta / V100, the CUDA cuBLAS fallback for some mixed-precision matmuls converts inputs to f16, computes with cuBLAS, writes the result into a temporary f16 output buffer, then converts that temporary back to f32.

That is wrong when the graph destination is f32: a finite f32 result outside fp16 range can become `+/-inf` in the temporary f16 buffer before the final f32 conversion.

The fix keeps the existing f16 input path, but when `dst->type == GGML_TYPE_F32` on SM70, it asks cuBLAS to write directly to the f32 destination using `CUBLAS_COMPUTE_32F` and `CUDA_R_32F` output.

This fixes issue https://github.com/ikawrakow/ik_llama.cpp/issues/1692
