### PR TITLE
MTP: reduce per-step qkv checkpoint rows

### DIFF
--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -91,8 +91,9 @@ struct llama_kv_cache {
         std::vector<std::vector<ggml_tensor *>> per_step_ssm;
 
         // Per-step conv feature buffer: stores qkv_mixed features from the
-        // verification forward pass so conv state can be reconstructed at any step.
-        // One tensor per recurrent layer, each sized [conv_dim * max_tokens].
+        // verification forward pass so conv state can be reconstructed at any
+        // restorable step. The final verification token is never restored after
+        // full acceptance, so it does not need a checkpoint row.
         std::vector<std::vector<ggml_tensor *>> per_step_qkv;
 
         int32_t per_step_n_tokens = 0;

--- a/src/llama-delta-net.cpp
+++ b/src/llama-delta-net.cpp
@@ -70,8 +70,8 @@ delta_net::delta_net(llama_context & _lctx, const llama_batch & _batch) : lctx(_
         GGML_ASSERT((uint32_t) s < qnext_state_slots);
     }
 
-    int max_per_step = lctx.kv_self.save_per_step_ssm ? std::min<int>(8, lctx.kv_self.ckpt.per_step_max_allocated) : 0;
-    save_per_step_states = lctx.kv_self.save_per_step_ssm && batch.n_tokens > 1 && batch.n_tokens <= max_per_step;
+    const int max_restore_steps = lctx.kv_self.save_per_step_ssm ? std::min<int>(8, lctx.kv_self.ckpt.per_step_max_allocated) : 0;
+    save_per_step_states = lctx.kv_self.save_per_step_ssm && batch.n_tokens > 1 && batch.n_tokens <= max_restore_steps + 1;
 }
 
 delta_net::~delta_net() = default;
@@ -432,9 +432,18 @@ static ggml_tensor * get_input_tensor_sm_graph(ggml_context * ctx, ggml_tensor *
 static void build_qkv_cpy(ggml_context * ctx0, ggml_cgraph * gf, ggml_tensor * qkv_mixed, ggml_tensor * per_step_qkv) {
     const int64_t conv_dim = qkv_mixed->ne[0];
     const int64_t n_tok_qkv = qkv_mixed->ne[1] * qkv_mixed->ne[2];
+    const int64_t n_restore_qkv = n_tok_qkv - 1;
+
+    if (n_restore_qkv <= 0) {
+        return;
+    }
+
+    GGML_ASSERT(ggml_nelements(per_step_qkv) >= n_restore_qkv * conv_dim);
+
     ggml_tensor * qkv_flat = ggml_reshape_2d(ctx0, qkv_mixed, conv_dim, n_tok_qkv);
-    ggml_tensor * qkv_dst = ggml_view_2d(ctx0, per_step_qkv, conv_dim, n_tok_qkv, conv_dim * sizeof(float), 0);
-    auto qkv_cpy = ggml_cpy(ctx0, qkv_flat, qkv_dst);
+    ggml_tensor * qkv_src = ggml_view_2d(ctx0, qkv_flat, conv_dim, n_restore_qkv, qkv_flat->nb[1], 0);
+    ggml_tensor * qkv_dst = ggml_view_2d(ctx0, per_step_qkv, conv_dim, n_restore_qkv, conv_dim * sizeof(float), 0);
+    ggml_tensor * qkv_cpy = ggml_cpy(ctx0, qkv_src, qkv_dst);
     ggml_build_forward_expand(gf, qkv_cpy);
 }
 
@@ -660,4 +669,3 @@ ggml_tensor * delta_net::build_layer_attn_linear(ggml_context * ctx0, ggml_cgrap
     return out;
 
 }
-

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1477,7 +1477,12 @@ void llama_kv_cache::checkpoint_delete() {
 }
 
 bool llama_kv_cache::per_step_alloc(const llama_model & model, int max_tokens) {
-    if (ckpt.per_step_max_allocated >= max_tokens) {
+    // Only rejected drafts need recurrent-state restoration. The last
+    // verification token is never restored after full acceptance, so keep
+    // checkpoint storage to the restorable rows.
+    const int max_restore_steps = std::max(1, max_tokens - 1);
+
+    if (ckpt.per_step_max_allocated >= max_restore_steps) {
         return true;
     }
 
@@ -1544,18 +1549,18 @@ bool llama_kv_cache::per_step_alloc(const llama_model & model, int max_tokens) {
 
         for (auto & [p, bt] : layers) {
             auto [il, id] = p;
-            // SSM state: max_tokens * ssm_state_dim
+            // SSM state: max_restore_steps * ssm_state_dim
             if (id < 0) {
-                if (max_tokens > 1) {
+                if (max_restore_steps > 0) {
                     GGML_ASSERT(ckpt.per_step_ssm[il].empty());
                     GGML_ASSERT(ckpt.per_step_qkv[il].empty());
-                    ggml_tensor * t_ssm = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)(max_tokens - 1) * ssm_state_dim);
+                    ggml_tensor * t_ssm = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)max_restore_steps * ssm_state_dim);
                     ggml_format_name(t_ssm, "per_step_ssm_l%d", il);
                     ckpt.per_step_ssm[il].push_back(t_ssm);
                 }
 
-                // Conv features (qkv_mixed): max_tokens * conv_dim
-                ggml_tensor * t_qkv = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)max_tokens * conv_dim);
+                // Conv features (qkv_mixed): max_restore_steps * conv_dim
+                ggml_tensor * t_qkv = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)max_restore_steps * conv_dim);
                 ggml_format_name(t_qkv, "per_step_qkv_l%d", il);
                 ckpt.per_step_qkv[il].push_back(t_qkv);
             } else {
@@ -1576,13 +1581,13 @@ bool llama_kv_cache::per_step_alloc(const llama_model & model, int max_tokens) {
                 int nv = split->ne[0] / head_v_dim; // number of heads handled by this device
                 auto [this_conv_dim, this_ssm_dim] = model.hparams.n_embd_v_s_dims(nv);
 
-                if (max_tokens > 1) {
-                    auto t_ssm = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)(max_tokens - 1) * this_ssm_dim);
+                if (max_restore_steps > 0) {
+                    auto t_ssm = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)max_restore_steps * this_ssm_dim);
                     ggml_format_name(t_ssm, "per_step_ssm_l%d_%d", il, id);
                     ckpt.per_step_ssm[il][id] = t_ssm;
                 }
 
-                auto t_qkv = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)max_tokens * this_conv_dim);
+                auto t_qkv = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, (int64_t)max_restore_steps * this_conv_dim);
                 ggml_format_name(t_qkv, "per_step_qkv_l%d_%d", il, id);
                 ckpt.per_step_qkv[il][id] = t_qkv;
             }
@@ -1595,13 +1600,13 @@ bool llama_kv_cache::per_step_alloc(const llama_model & model, int max_tokens) {
             return false;
         }
         ggml_backend_buffer_clear(buf, 0);
-        LLAMA_LOG_INFO("%s: %10s per-step buffer = %8.2f MiB (max_tokens=%d)\n", __func__,
-                       ggml_backend_buffer_name(buf), ggml_backend_buffer_get_size(buf) / 1024.0 / 1024.0, max_tokens);
+        LLAMA_LOG_INFO("%s: %10s per-step buffer = %8.2f MiB (max_restore_steps=%d, max_tokens=%d)\n", __func__,
+                       ggml_backend_buffer_name(buf), ggml_backend_buffer_get_size(buf) / 1024.0 / 1024.0, max_restore_steps, max_tokens);
         ckpt.per_step_ctxs.push_back(ctx);
         ckpt.per_step_bufs.push_back(buf);
     }
 
-    ckpt.per_step_max_allocated = max_tokens;
+    ckpt.per_step_max_allocated = max_restore_steps;
     return true;
 }
 
@@ -1662,7 +1667,7 @@ static void restore_recurrent_cache_tensors(int step, ggml_backend_sched_t sched
 }
 
 bool llama_kv_cache::per_step_restore(const llama_model & model, ggml_backend_sched_t sched, int step) {
-    if (ckpt.per_step_ssm.empty() || step < 0) {
+    if (ckpt.per_step_ssm.empty() || step < 0 || step >= ckpt.per_step_max_allocated) {
         return false;
     }
 


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

## Summary

This is a small cleanup for MTP per-step recurrent checkpoints. The per-step restore path never restores the final verification token after full draft acceptance, so the qkv feature checkpoint buffer does not need to keep that final row.

The change makes `per_step_max_allocated` track restorable rows, allocates qkv checkpoints with `max_tokens - 1` rows to match the existing SSM checkpoint shape, and copies only those restorable qkv rows from the verification forward pass.

This is intended as a small memory cleanup, not a throughput change.

## Local validation

Built locally with CUDA on an RTX 4070:

```bash
cmake --build build-cuda --target llama-server -j "$(nproc)"
```

Also ran `git diff --check`.

Dense Qwen3.6 27B IQ4 MTP guardrail, `--draft-max 1`, 3x256-token runs, clean `main` vs this branch:

- clean per-step buffers: host `76.95 MiB`, CUDA0 `70.80 MiB`; TG mean `8.19 tok/s`; acceptance `117/137` in all 3 runs
- patched per-step buffers: host `75.98 MiB`, CUDA0 `69.90 MiB`; TG mean `8.16 tok/s`; acceptance `117/137` in all 3 runs

MoE Qwen3.6 35B A3B IQ2 MTP smoke, `--draft-max 4`, 1x64-token run:

- clean per-step buffer: CUDA0 `244.69 MiB`, acceptance `30/128`
- patched per-step buffer: CUDA0 `243.75 MiB`, acceptance `30/128`

The generated preview text matched in both clean-vs-patched checks.
