### PR TITLE
Gemma4: support public assistant GGUF schema

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -79,6 +79,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_MISTRAL4,        "mistral4"     },
     { LLM_ARCH_GEMMA4,          "gemma4"       },
     { LLM_ARCH_GEMMA4_MTP,      "gemma4_mtp"   },
+    { LLM_ARCH_GEMMA4_ASSISTANT, "gemma4_assistant" },
     { LLM_ARCH_UNKNOWN,         "(unknown)"    },
 };
 
@@ -280,3 +281,6 @@ bool llm_arch_is_hybrid(const llm_arch & arch) {
     }
 }
 
+bool llm_arch_is_gemma4_mtp_assistant(const llm_arch & arch) {
+    return arch == LLM_ARCH_GEMMA4_MTP || arch == LLM_ARCH_GEMMA4_ASSISTANT;
+}

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -78,6 +78,7 @@ enum llm_arch {
     LLM_ARCH_MISTRAL4,
     LLM_ARCH_GEMMA4,
     LLM_ARCH_GEMMA4_MTP,
+    LLM_ARCH_GEMMA4_ASSISTANT,
     LLM_ARCH_UNKNOWN,
 };
 
@@ -377,5 +378,6 @@ const char * llama_model_arch_name(llm_arch arch);
 
 bool llm_arch_is_recurrent(const llm_arch & arch);
 bool llm_arch_is_hybrid(const llm_arch & arch);
+bool llm_arch_is_gemma4_mtp_assistant(const llm_arch & arch);
 
 llm_tensor llm_tensor_type(llm_arch arch, const std::string & tensor_name, int il);

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -2356,6 +2356,7 @@ ggml_cgraph * llm_build_context::llama_build_graph(
                 result = llm.build_gemma4();
             } break;
         case LLM_ARCH_GEMMA4_MTP:
+        case LLM_ARCH_GEMMA4_ASSISTANT:
             {
                 result = llm.build_gemma4_mtp();
             } break;

--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -755,11 +755,19 @@ void llm_load_hparams(
                 }
             } break;
         case LLM_ARCH_GEMMA4_MTP:
+        case LLM_ARCH_GEMMA4_ASSISTANT:
             {
-                ml.get_key(LLM_KV_MTP_BACKBONE_EMBEDDING_LENGTH, hparams.mtp_backbone_n_embd);
-                ml.get_key(LLM_KV_MTP_USE_ORDERED_EMBEDDINGS,    hparams.mtp_use_ordered_embeddings, false);
-                ml.get_key(LLM_KV_MTP_CENTROID_COUNT,            hparams.mtp_num_centroids, false);
-                ml.get_key(LLM_KV_MTP_CENTROID_TOP_K,            hparams.mtp_centroid_top_k, false);
+                if (model.arch == LLM_ARCH_GEMMA4_ASSISTANT) {
+                    ml.get_key("gemma4_assistant.n_embd_backbone",        hparams.mtp_backbone_n_embd);
+                    ml.get_key("gemma4_assistant.use_ordered_embeddings", hparams.mtp_use_ordered_embeddings, false);
+                    ml.get_key("gemma4_assistant.n_centroids",            hparams.mtp_num_centroids, false);
+                    ml.get_key("gemma4_assistant.centroid_top_k",         hparams.mtp_centroid_top_k, false);
+                } else {
+                    ml.get_key(LLM_KV_MTP_BACKBONE_EMBEDDING_LENGTH, hparams.mtp_backbone_n_embd);
+                    ml.get_key(LLM_KV_MTP_USE_ORDERED_EMBEDDINGS,    hparams.mtp_use_ordered_embeddings, false);
+                    ml.get_key(LLM_KV_MTP_CENTROID_COUNT,            hparams.mtp_num_centroids, false);
+                    ml.get_key(LLM_KV_MTP_CENTROID_TOP_K,            hparams.mtp_centroid_top_k, false);
+                }
 
                 ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW,       hparams.n_swa);
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,    hparams.f_norm_rms_eps);

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2134,6 +2134,9 @@ bool create_tensors_helper::create_gemma4_mtp_tensors(const LLM_TN & tn) {
 
     model.mtp_token_ordering = create_tensor(ctx_output, tn(LLM_TENSOR_MTP_TOKEN_ORDERING, "weight"), {n_vocab}, llama_model_loader::TENSOR_NOT_REQUIRED);
     model.mtp_centroids      = create_tensor(ctx_output, tn(LLM_TENSOR_MTP_CENTROIDS,      "weight"), {n_embd, hparams.mtp_num_centroids}, llama_model_loader::TENSOR_NOT_REQUIRED);
+    create_tensor(ctx_output, tn(LLM_TENSOR_ROPE_FREQS, "weight"),
+            {hparams.n_rot_swa > 0 ? hparams.n_rot_swa : hparams.n_rot},
+            llama_model_loader::TENSOR_NOT_REQUIRED | llama_model_loader::TENSOR_SKIP);
 
     for (int i = 0; i < n_layer; ++i) {
         ggml_context * ctx_layer = ctx_for_layer(i);
@@ -4123,6 +4126,7 @@ bool create_tensors_helper::create_tensors() {
         case LLM_ARCH_GEMMA4:
             use_mmap_buffer = create_gemma4_tensors(tn); break;
         case LLM_ARCH_GEMMA4_MTP:
+        case LLM_ARCH_GEMMA4_ASSISTANT:
             use_mmap_buffer = create_gemma4_mtp_tensors(tn); break;
         case LLM_ARCH_STARCODER2:
             use_mmap_buffer = create_starcoder2_tensors(tn); break;
@@ -4195,13 +4199,13 @@ bool create_tensors_helper::create_tensors() {
 
     {
         const bool unsupported =
-            (model.arch == LLM_ARCH_GEMMA4_MTP) ||
+            llm_arch_is_gemma4_mtp_assistant(model.arch) ||
             (model.arch == LLM_ARCH_GEMMA4 && model.tok_embd_per_layer);
         if (unsupported && (model.split_mode == LLAMA_SPLIT_MODE_GRAPH || model.split_mode == LLAMA_SPLIT_MODE_ATTN)) {
             LLAMA_LOG_WARN("\n=========================================================\n");
             LLAMA_LOG_WARN("Split mode 'graph' is not supported for %s\n",
-                           model.arch == LLM_ARCH_GEMMA4_MTP ? "Gemma 4 MTP assistant"
-                                                              : "this Gemma4 variant");
+                           llm_arch_is_gemma4_mtp_assistant(model.arch) ? "Gemma 4 MTP assistant"
+                                                                        : "this Gemma4 variant");
             LLAMA_LOG_WARN("  => changing split mode to 'layer'\n");
             LLAMA_LOG_WARN("===========================================================\n\n");
             model.split_mode = LLAMA_SPLIT_MODE_LAYER;

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1255,10 +1255,11 @@ template bool llama_model_loader::get_key<bool>       (enum llm_kv kid, bool & r
 template bool llama_model_loader::get_key<float>      (enum llm_kv kid, float & result,       bool required);
 template bool llama_model_loader::get_key<uint32_t>   (enum llm_kv kid, uint32_t & result,    bool required);
 template bool llama_model_loader::get_key<std::string>(enum llm_kv kid, std::string & result, bool required);
+template bool llama_model_loader::get_key<bool>       (const std::string & key, bool & result,        bool required);
+template bool llama_model_loader::get_key<uint32_t>   (const std::string & key, uint32_t & result,    bool required);
 
 template bool llama_model_loader::get_key_or_arr<std::array<int, 4>>(enum llm_kv kid, std::array<int, 4> & result, uint32_t n, bool required);
 template bool llama_model_loader::get_key_or_arr<std::array<uint32_t, 512>>(enum llm_kv kid, std::array<uint32_t, 512> & result, uint32_t n, bool required);
 template bool llama_model_loader::get_key_or_arr<std::array<float, 512>>(enum llm_kv kid, std::array<float, 512> & result, uint32_t n, bool required);
 
 template std::enable_if<std::is_integral<unsigned int>::value, bool>::type llama_model_loader::get_arr_n<unsigned int>(enum llm_kv, unsigned int&, bool);
-

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -826,6 +826,29 @@ static const std::map<llm_arch, std::map<llm_tensor, std::string>> LLM_TENSOR_NA
         },
     },
     {
+        LLM_ARCH_GEMMA4_ASSISTANT,
+        {
+            { LLM_TENSOR_TOKEN_EMBD,           "token_embd" },
+            { LLM_TENSOR_OUTPUT_NORM,          "output_norm" },
+            { LLM_TENSOR_ROPE_FREQS,           "rope_freqs" },
+            { LLM_TENSOR_ATTN_NORM,            "blk.%d.attn_norm" },
+            { LLM_TENSOR_ATTN_Q,               "blk.%d.attn_q" },
+            { LLM_TENSOR_ATTN_Q_NORM,          "blk.%d.attn_q_norm" },
+            { LLM_TENSOR_ATTN_OUT,             "blk.%d.attn_output" },
+            { LLM_TENSOR_ATTN_POST_NORM,       "blk.%d.post_attention_norm" },
+            { LLM_TENSOR_FFN_NORM,             "blk.%d.ffn_norm" },
+            { LLM_TENSOR_FFN_GATE,             "blk.%d.ffn_gate" },
+            { LLM_TENSOR_FFN_DOWN,             "blk.%d.ffn_down" },
+            { LLM_TENSOR_FFN_UP,               "blk.%d.ffn_up" },
+            { LLM_TENSOR_FFN_POST_NORM,        "blk.%d.post_ffw_norm" },
+            { LLM_TENSOR_LAYER_OUT_SCALE,      "blk.%d.layer_output_scale" },
+            { LLM_TENSOR_MTP_PRE_PROJ,         "mtp.pre_projection" },
+            { LLM_TENSOR_MTP_POST_PROJ,        "mtp.post_projection" },
+            { LLM_TENSOR_MTP_TOKEN_ORDERING,   "mtp.token_ordering" },
+            { LLM_TENSOR_MTP_CENTROIDS,        "mtp.centroids" },
+        },
+    },
+    {
         LLM_ARCH_STARCODER2,
         {
             { LLM_TENSOR_TOKEN_EMBD,      "token_embd" },
@@ -1904,7 +1927,7 @@ bool llama_model_has_recurrent(const llama_model * model) {
 }
 
 bool llama_model_is_gemma4_mtp_assistant(const llama_model * model) {
-    return model && model->arch == LLM_ARCH_GEMMA4_MTP;
+    return model && llm_arch_is_gemma4_mtp_assistant(model->arch);
 }
 
 bool llama_is_gemma4_mtp_file(const char * path) {
@@ -1916,7 +1939,7 @@ bool llama_is_gemma4_mtp_file(const char * path) {
     const int key_id = gguf_find_key(ctx, "general.architecture");
     if (key_id >= 0) {
         const char * arch = gguf_get_val_str(ctx, key_id);
-        if (arch && strcmp(arch, "gemma4_mtp") == 0) {
+        if (arch && (strcmp(arch, "gemma4_mtp") == 0 || strcmp(arch, "gemma4_assistant") == 0)) {
             result = true;
         }
     }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -568,7 +568,7 @@ void llama_context::reset_scheduler() {
 bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
     if (!cparams.graph_reuse) return false;
     //if (kv_self.save_per_step_ssm) return false;
-    if (model.arch == LLM_ARCH_GEMMA4_MTP && mtp_target_ctx != nullptr) return false;
+    if (llm_arch_is_gemma4_mtp_assistant(model.arch) && mtp_target_ctx != nullptr) return false;
     auto the_prev = cparams.mtp_op_type == MTP_OP_NONE ? prev.get() : prev_mtp.get();
     if (!the_prev || !the_prev->graph) return false;
     //if (u_batch.n_tokens > 1) return false;
@@ -2677,7 +2677,10 @@ static std::pair<std::vector<double>, double> get_layer_sizes(const llama_model_
             continue;
         }
         if (name == "mtp_pre_proj.weight"  || name == "mtp_post_proj.weight" ||
-            name == "mtp_centroids.weight" || name == "mtp_token_ordering.weight") {
+            name == "mtp_centroids.weight" || name == "mtp_token_ordering.weight" ||
+            name == "mtp.pre_projection.weight" || name == "mtp.post_projection.weight" ||
+            name == "mtp.centroids.weight" || name == "mtp.token_ordering.weight" ||
+            name == "rope_freqs.weight") {
             continue;
         }
         auto pos = name.find("blk.");
@@ -2868,14 +2871,14 @@ static bool llm_load_tensors(
 
     if (split_mode == LLAMA_SPLIT_MODE_GRAPH || split_mode == LLAMA_SPLIT_MODE_ATTN) {
         const bool unsupported_gemma_split =
-            model.arch == LLM_ARCH_GEMMA4_MTP ||
+            llm_arch_is_gemma4_mtp_assistant(model.arch) ||
             (model.arch == LLM_ARCH_GEMMA4 && hparams.n_embd_per_layer > 0);
 
         if (unsupported_gemma_split) {
             LLAMA_LOG_WARN("\n=========================================================\n");
             LLAMA_LOG_WARN("Split mode 'graph' is not supported for %s\n",
-                    model.arch == LLM_ARCH_GEMMA4_MTP ? "Gemma 4 MTP assistant"
-                                                      : "this Gemma4 variant");
+                    llm_arch_is_gemma4_mtp_assistant(model.arch) ? "Gemma 4 MTP assistant"
+                                                                 : "this Gemma4 variant");
             LLAMA_LOG_WARN("  => changing split mode to 'layer'\n");
             LLAMA_LOG_WARN("===========================================================\n\n");
             split_mode = LLAMA_SPLIT_MODE_LAYER;
@@ -3201,7 +3204,7 @@ static bool llm_load_tensors(
             }
         }
     }
-    if (model.arch == LLM_ARCH_GEMMA4_MTP && split_mode == LLAMA_SPLIT_MODE_LAYER && device_count > 0 && n_gpu_layers > 0) {
+    if (llm_arch_is_gemma4_mtp_assistant(model.arch) && split_mode == LLAMA_SPLIT_MODE_LAYER && device_count > 0 && n_gpu_layers > 0) {
         const int mtp_device = std::clamp(main_gpu, 0, device_count - 1);
 
         LLAMA_LOG_INFO("%s: Gemma 4 MTP assistant forcing layer placement to GPU %d under layer split\n",
@@ -3797,7 +3800,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
         // NOTE: hparams.causal_attn indicates the model is capable of generation and uses the kv cache.
         if (cparams.causal_attn && !lctx.is_encoding) {
             const llama_kv_cache & mask_kv_self =
-                (lctx.model.arch == LLM_ARCH_GEMMA4_MTP && lctx.mtp_target_ctx != nullptr)
+                (llm_arch_is_gemma4_mtp_assistant(lctx.model.arch) && lctx.mtp_target_ctx != nullptr)
                     ? lctx.mtp_target_ctx->kv_self
                     : kv_self;
             const int64_t n_kv     = mask_kv_self.n;
@@ -4318,7 +4321,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 // Returns max number of outputs for which space was reserved.
 static uint32_t llama_output_embd_width(const llama_context & lctx) {
     const auto & hparams = lctx.model.hparams;
-    if (lctx.cparams.mtp && lctx.model.arch == LLM_ARCH_GEMMA4_MTP && hparams.mtp_backbone_n_embd > 0) {
+    if (lctx.cparams.mtp && llm_arch_is_gemma4_mtp_assistant(lctx.model.arch) && hparams.mtp_backbone_n_embd > 0) {
         return hparams.mtp_backbone_n_embd;
     }
     return hparams.n_embd;
@@ -4328,7 +4331,7 @@ static bool llama_context_has_mtp_outputs(const llama_context & lctx) {
     return lctx.cparams.mtp && (
         lctx.model.hparams.nextn_predict_layers > 0 ||
         lctx.model.arch == LLM_ARCH_GEMMA4 ||
-        lctx.model.arch == LLM_ARCH_GEMMA4_MTP);
+        llm_arch_is_gemma4_mtp_assistant(lctx.model.arch));
 }
 
 static size_t llama_output_reserve(llama_context & lctx, size_t n_outputs) {
@@ -4729,7 +4732,7 @@ static int llama_decode_internal(
 #endif
             //if (u_batch.n_tokens == 1 && u_batch.embd == nullptr && lctx.cparams.graph_reuse) {
             if (u_batch.embd == nullptr && lctx.cparams.graph_reuse &&
-                    !(lctx.model.arch == LLM_ARCH_GEMMA4_MTP && lctx.mtp_target_ctx != nullptr)) {
+                    !(llm_arch_is_gemma4_mtp_assistant(lctx.model.arch) && lctx.mtp_target_ctx != nullptr)) {
                 prev = std::make_unique<llama_context::Prev>(llama_context::Prev{
                         (int)u_batch.all_seq_id, (int)lctx.n_outputs, (int)lctx.kv_self.n,
                         (int)u_batch.n_tokens,
@@ -4758,7 +4761,8 @@ static int llama_decode_internal(
         else {
             const bool has_mtp = llama_context_has_mtp_outputs(lctx);
             const bool use_raw_mtp_embd = has_mtp && (lctx.model.arch == LLM_ARCH_QWEN35 ||
-                                                       lctx.model.arch == LLM_ARCH_QWEN35MOE || lctx.model.arch == LLM_ARCH_GEMMA4 || lctx.model.arch == LLM_ARCH_GEMMA4_MTP);
+                                                       lctx.model.arch == LLM_ARCH_QWEN35MOE || lctx.model.arch == LLM_ARCH_GEMMA4 ||
+                                                       llm_arch_is_gemma4_mtp_assistant(lctx.model.arch));
             if (cparams.embeddings || has_mtp) {
                 for (int i = gf->n_nodes - 1; i >= 0; --i) {
                     if (use_raw_mtp_embd && strcmp(gf->nodes[i]->name, "result_mtp_embd") == 0) {
@@ -6244,7 +6248,7 @@ struct llama_context * llama_init_from_model(
 
     if (model->arch != LLM_ARCH_GLM4_MOE && model->arch != LLM_ARCH_QWEN35 &&
         model->arch != LLM_ARCH_QWEN35MOE && model->arch != LLM_ARCH_GEMMA4 &&
-        model->arch != LLM_ARCH_GEMMA4_MTP && cparams.mtp != 0) {
+        !llm_arch_is_gemma4_mtp_assistant(model->arch) && cparams.mtp != 0) {
         cparams.mtp = 0;
     }
 
@@ -6784,6 +6788,7 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
         case LLM_ARCH_STEP35:
         case LLM_ARCH_GEMMA4:
         case LLM_ARCH_GEMMA4_MTP:
+        case LLM_ARCH_GEMMA4_ASSISTANT:
             return LLAMA_ROPE_TYPE_NEOX;
 
         case LLM_ARCH_QWEN2VL:


### PR DESCRIPTION
## Summary

This adds compatibility for public Gemma 4 assistant GGUFs that use `general.architecture = gemma4_assistant`.

The existing `gemma4_mtp` assistant path is preserved; this just lets the loader treat the public assistant architecture/schema as the same Gemma 4 external-MTP assistant case where appropriate.

## Notes

- Adds `LLM_ARCH_GEMMA4_ASSISTANT`.
- Shares Gemma 4 assistant handling between `gemma4_mtp` and `gemma4_assistant`.
- Accepts the public assistant metadata/tensor naming used by currently published assistant GGUFs.
- No performance claim intended; this is only a compatibility patch to make the setup loadable for further testing.

## Validation

- `git diff --check origin/main...HEAD`
- CUDA build: `build-cuda/bin/llama-server --version` reports `4486 (af8327f8)`
- Smoke-loaded an existing `gemma4_mtp` dense assistant and reached `common_speculative_state_mtp: MTP context ready`.
- Smoke-loaded public-schema `gemma4_assistant` MoE and dense assistants and reached `common_speculative_state_mtp: MTP context ready`.
