### PR TITLE
Fix GLM-4.5 MTP loading

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2776,7 +2776,7 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
                     tn(LLM_TENSOR_NEXTN_HNORM, "weight", final_layer),
                     { n_embd },
                     flags);
-            layer.nextn.shared_head_head = create_tensor(nextn_host_ctx,
+            layer.nextn.shared_head_head = create_tensor(nextn_ctx,
                     tn(LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD, "weight", final_layer),
                     { n_embd, n_vocab },
                     flags | llama_model_loader::TENSOR_NOT_REQUIRED);


### PR DESCRIPTION

The MTP output tensor was being created on the CPU, which made MTP very slow when running on the GPU.

@SamuelOliveirads Was this intentional? IIRC, it wasn't like that last time I had tried. 