### PR TITLE
fix: Use MMQ for large-batch quantized matmuls on Volta

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -1604,33 +1604,6 @@ static void ggml_cuda_op_mul_mat_cublas(
         }
         const half * src1_ptr = src1->type == GGML_TYPE_F16 ? (const half *) src1_ddf_i : src1_as_f16.get();
 
-        // On Volta, avoid storing f32 graph outputs in a temporary f16 buffer;
-        // finite matmul results outside fp16 range would become +/-inf there.
-        const bool sm70_f32_output =
-            compute_capability <= CC_VOLTA &&
-            dst->type == GGML_TYPE_F32;
-        if (sm70_f32_output) {
-            const float alpha_f32 = 1.0f;
-            const float beta_f32  = 0.0f;
-
-            static std::atomic<int> sm70_f32_output_logs{0};
-            if (sm70_f32_output_logs.fetch_add(1) < 8) {
-                GGML_CUDA_LOG_WARN(
-                        "%s: using f32 cublas output for %s on cc=%d to avoid fp16 output saturation\n",
-                        __func__, dst->name, compute_capability);
-            }
-
-            CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
-            CUBLAS_CHECK(
-                cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
-                        row_diff, src1_ncols, ne10,
-                        &alpha_f32, src0_ptr,  CUDA_R_16F, ne00,
-                                    src1_ptr,  CUDA_R_16F, ne10,
-                        &beta_f32,  dst_dd_i,  CUDA_R_32F, ldc,
-                        CUBLAS_COMPUTE_32F,
-                        CUBLAS_GEMM_DEFAULT_TENSOR_OP));
-            return;
-        }
         ggml_cuda_pool_alloc<half> dst_f16(ctx.pool(id), row_diff*src1_ncols);
 
         const half alpha_f16 = 1.0f;

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -247,7 +247,9 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11) {
 #endif //GGML_CUDA_FORCE_MMQ
 
     if (cc < CC_OFFSET_AMD) {
-        return cc < CC_VOLTA || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
+        // On Volta, large-batch quantized matmuls otherwise fall back through
+        // fp16 cuBLAS temporaries. Keep using MMQ for pre-Turing NVIDIA.
+        return cc < CC_TURING || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
     }
 
     return cc < CC_RDNA3 || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;

--- a/ggml/src/ggml-cuda/mmq_id.cu
+++ b/ggml/src/ggml-cuda/mmq_id.cu
@@ -566,7 +566,9 @@ bool ggml_cuda_can_use_mmq_id(enum ggml_type type, int cc, int64_t ne11) {
 #endif //GGML_CUDA_FORCE_MMQ
 
     if (GGML_CUDA_CC_IS_NVIDIA(cc)) {
-        return !fp16_mma_hardware_available(cc) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
+        // Match the plain MMQ policy: use MMQ for pre-Turing NVIDIA, including
+        // Volta, so indexed/expert matmuls avoid the fp16 cuBLAS fallback.
+        return cc < CC_TURING || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
     }
 
    if (amd_mfma_available(cc)) {


### PR DESCRIPTION
This follow-up replaces the Volta f32-output cuBLAS workaround from PR #1776 with a runtime MMQ dispatch-policy change for pre-Turing NVIDIA GPUs.

The core idea is to avoid the problematic Volta large-batch quantized-to-f16 cuBLAS fallback entirely. This matches the behavior of `-DGGML_CUDA_FORCE_MMQ=ON` for the affected Volta quantized path, but does it at runtime rather than requiring a special build flag.

## Patch

Branch:

```text
fix-volta-runtime-mmq
f2acd15e fix: use mmq for volta quantized matmuls
```

The patch is based on current upstream after PR #1776 was merged:

```text
8b0cd035 fix: keep sm70 cublas f32 outputs in f32 (#1776)
```

It reverts the f32-output cuBLAS special case and changes the MMQ heuristics:

```diff
// ggml/src/ggml-cuda/mmq.cu
- return cc < CC_VOLTA || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
+ return cc < CC_TURING || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;

// ggml/src/ggml-cuda/mmq_id.cu
- return !fp16_mma_hardware_available(cc) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
+ return cc < CC_TURING || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
```

`mmq.cu` covers ordinary quantized `MUL_MAT`. `mmq_id.cu` covers indexed/expert-selected matmuls, i.e. `MUL_MAT_ID` style MoE paths. They are separate dispatch paths, so changing only one would leave part of the Volta expert/routed matmul behavior on the old fallback policy.

## Why This May Be Better Than PR #1776

PR #1776 fixed the observed crash by keeping f32 graph outputs out of a temporary f16 cuBLAS output buffer on SM70. That was targeted and passed the 397B repro, but it still keeps the quantized large-batch path on the cuBLAS fallback.

The runtime-MMQ version avoids that fallback path instead:

```text
quantized weight
  -> MMQ selected on Volta, including large batches
  -> no quantized-to-f16 cuBLAS output temporary
  -> avoids finite f32 values saturating to +/-inf in f16 storage
```

This is broader than PR #1776 because it changes the Volta dispatch policy for supported quantized large-batch matmuls. But it is still scoped to pre-Turing NVIDIA in these branches. Turing and newer NVIDIA GPUs keep their existing behavior, and AMD logic is unchanged.

The risk is mostly for Volta users: MMQ may be a different performance tradeoff from the previous cuBLAS fallback for some workloads. Based on the numbers below, that tradeoff looks reasonable, and it avoids the obvious 27B slowdown seen with the f32-output cuBLAS workaround.

## Benchmark Notes

These are long-prompt task runs from the same local six-model set. The force-MMQ and PR #1776 patch tables are 3-run averages. The runtime-MMQ table is currently one run per model.

The main comparison I would point at:

- Build-time force-MMQ passes the 397B repro and gets `387.86` prompt tok/s on 27B.
- PR #1776 f32-output cuBLAS patch passes the 397B repro, but gets `315.83` prompt tok/s on 27B.
- Runtime-MMQ passes the 397B repro and gets `378.64` prompt tok/s on 27B.

So runtime-MMQ looks much closer to build-time force-MMQ than to the slower f32-output cuBLAS workaround for the smaller Qwen 27B case.

## Matrix 1: Upstream Main With Build-Time Force-MMQ

Build:

```text
origin/main be843579
-DGGML_CUDA_FORCE_MMQ=ON
tmp/benchmark-fix/20260512-force-mmq-main-3run
```

Average of 3 runs:

| Model | Result | Prompt tok/s | Eval tok/s |
|---|---:|---:|---:|
| `qwen3.5-397b-a17b-q4_k_m` | pass | `67.60` | `10.47` |
| `qwen3.5-122b-a10b-q4_k_m` | pass | `171.83` | `20.79` |
| `qwen3.5-122b-a10b-ud-q6_k_xl` | pass | `146.89` | `14.76` |
| `qwen3.6-27b-q4_k_m` | pass | `387.86` | `22.85` |
| `minimax-m2.7-ud-q4_k_m` | pass | `76.29` | `11.20` |
| `minimax-m2.7-ud-q6_k_xl` | pass | `69.67` | `8.57` |

## Matrix 2: PR #1776 F32-Output cuBLAS Patch

Build:

```text
fix-sm70-cublas-f32-output fa4e9c03
tmp/benchmark-fix/20260512-pr-fa4e9c03-3run
```

Average of 3 runs:

| Model | Result | Prompt tok/s | Eval tok/s |
|---|---:|---:|---:|
| `qwen3.5-397b-a17b-q4_k_m` | pass | `70.85` | `10.53` |
| `qwen3.5-122b-a10b-q4_k_m` | pass | `177.75` | `19.53` |
| `qwen3.5-122b-a10b-ud-q6_k_xl` | pass | `147.14` | `16.17` |
| `qwen3.6-27b-q4_k_m` | pass | `315.83` | `21.85` |
| `minimax-m2.7-ud-q4_k_m` | pass | `79.14` | `10.90` |
| `minimax-m2.7-ud-q6_k_xl` | pass | `74.61` | `9.15` |

## Matrix 3: Runtime Volta MMQ Patch

Build:

```text
fix-volta-runtime-mmq f2acd15e
tmp/benchmark-fix/20260512-volta-runtime-mmq-1run
```

One run:

| Model | Result | Prompt tok/s | Eval tok/s |
|---|---:|---:|---:|
| `qwen3.5-397b-a17b-q4_k_m` | pass | `65.96` | `10.44` |
| `qwen3.5-122b-a10b-q4_k_m` | pass | `183.98` | `20.30` |
| `qwen3.5-122b-a10b-ud-q6_k_xl` | pass | `150.13` | `16.47` |
| `qwen3.6-27b-q4_k_m` | pass | `378.64` | `23.21` |
| `minimax-m2.7-ud-q4_k_m` | pass | `77.58` | `10.62` |
| `minimax-m2.7-ud-q6_k_xl` | pass | `68.89` | `8.98` |
| `glm-5.1-ud-iq3_s` | pending | pending | pending |

## Interpretation

Runtime-MMQ and build-time force-MMQ are broadly similar in the data we have. They are not identical builds or identical run counts, so I would avoid overclaiming exact performance equivalence. But the 27B result is useful because it was the clearest performance concern with PR #1776:

```text
27B prompt tok/s:
  build-time force-MMQ: 387.86 avg
  PR #1776 f32-output patch: 315.83 avg
  runtime-MMQ patch: 378.64 one run
```

That makes runtime-MMQ look like the cleaner tradeoff: it follows the successful force-MMQ diagnostic, keeps the change limited to Volta/pre-Turing NVIDIA dispatch policy, and avoids the broader f32-output cuBLAS behavior change that appeared costly on the smaller Qwen 27B model.

