### PR TITLE
fix(server): reset chat parser on slot reuse to prevent crash (#1763)

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -1427,6 +1427,9 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
         slot.params.chat_parser_params.parse_tool_calls = json_value(data, "parse_tool_calls", false);
         if (data.contains("chat_parser")) {
             slot.params.chat_parser_params.parser.load(data.at("chat_parser").get<std::string>());
+        } else {
+            // Reset to default; otherwise a reused slot would apply the previous chat's PEG parser to non-chat outputs (e.g., /v1/completions).
+            slot.params.chat_parser_params.parser = defaults.chat_parser_params.parser;
         }
     }
     {


### PR DESCRIPTION
Fixes https://github.com/ikawrakow/ik_llama.cpp/issues/1763

If a slot is reused for a standard completion (`/v1/completions`) *after* being used for a chat completion (`/v1/chat/completions`), the previous chat's PEG parser would remain active in the slot's parameters. 
This caused standard text completions to throw on the raw text.

I've tested this fix using [ubergarm/Qwen3.5-122B-A10B-GGUF](https://huggingface.co/ubergarm/Qwen3.5-122B-A10B-GGUF/blob/main/Qwen3.5-122B-A10B-IQ4_KSS.gguf)

- /v1/completions works after using `/v1/chat/completions`
- tool calls are still working via the Anthropic `/messages` endpoint (claude code)
- tool calls are still working via /v1/chat/completions (pi agent)