### PR TITLE
Fix ggml_nbytes

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -4738,7 +4738,7 @@ GGML_CALL size_t ggml_nbytes(const struct ggml_tensor * tensor) {
         }
     }
     else {
-        nbytes = tensor->nb[1]; //tensor->ne[0]*tensor->nb[0]/blck_size;
+        nbytes = ggml_row_size(tensor->type, tensor->ne[0]);
         for (int i = 1; i < GGML_MAX_DIMS; ++i) {
             nbytes += (tensor->ne[i] - 1)*tensor->nb[i];
         }


### PR DESCRIPTION

I had changed `ggml_nbytes` to work for tensors that have per-row meta data (e.g., `IQ4_KS`, etc.).

Or so I thought. Turns out my change does not work if the tensor is permuted and also quantized. As `ggml_nbytes` is a pretty fundamental function in `ggml`, it is interesting that we did not run into issues earlier.

The thing that triggers the `ggml_nbytes` bug is my change in PR #1786, where I pretend that the KV cache is `f32` when concatenating the KV cache pieces stored on different GPUs. There is a check that the number of bytes used by the fake `f32` tensor is the same as the number of bytes used by the original tensor. As the KV cache contains permuted tensors, this triggers the bug when the KV cache is quantized, and we run into an assert.

Closes #1790  