### PR TITLE
imatrix: use data for ffn_up when data for ffn_gate is missing

### DIFF
--- a/src/llama-quantize.cpp
+++ b/src/llama-quantize.cpp
@@ -1477,6 +1477,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
                     } else if (auto pos = name.find("ffn_gate_up_exps.weight"); pos != std::string::npos) {
                         auto not_merged_name = name.substr(0, pos) + "ffn_up_exps.weight";
                         it = imatrix_data->find(not_merged_name);
+                    } else if (auto pos2 = name.find("ffn_gate.weight"); pos2 != std::string::npos) {
+                        auto up_name = name.substr(0, pos2) + "ffn_up.weight";
+                        it = imatrix_data->find(up_name);
                     } else {
                         // MLA hack: most imatrix files floating around the Internet have been computed with standard attention.
                         //           This means that the imatrix file does not contain data for the *.attn_k_b.weight and *.attn_v_b.weight


### PR DESCRIPTION

I was calculating some imatrix data for a dense model and kept forgetting to add `-no-fug` to the `llama-imatrix` command line. The result is that we end up without imatrix data for the `ffn_gate` tensors. But the `ffn_gate` tensors "see" the exact same activations as `ffn_up`, so we can simply use the `ffn_up` data if `ffn_gate` data is missing. This PR adds this change to `llama-quantize`.  