### PR TITLE
Initial refactoring of the spec in server-context

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1951,11 +1951,17 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         }
 
         params.has_mtp = true;
+        if (params.speculative.type == COMMON_SPECULATIVE_TYPE_NONE) {
+            params.speculative.type = COMMON_SPECULATIVE_TYPE_MTP;
+        }
         return true;
     }
     if (arg == "-no-mtp" || arg == "--no-multi-token-prediction") {
         params.has_mtp = false;
         common_speculative_remove_explicit_stage(params.speculative, COMMON_SPECULATIVE_TYPE_MTP);
+        if (params.speculative.stages.empty() && params.speculative.type == COMMON_SPECULATIVE_TYPE_MTP) {
+            params.speculative.type = COMMON_SPECULATIVE_TYPE_NONE;
+        }
         return true;
     }
     if (arg == "-draft" || arg == "--draft-params") {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -961,6 +961,7 @@ struct common_speculative {
     std::vector<common_speculative_config> configs; // resolved stage config for each implementation
     std::vector<std::unique_ptr<common_speculative_state>> impls; // list of implementations to use and their states
     common_speculative_state * curr_impl = nullptr; // current implementation in use (for stats)
+    size_t curr_impl_index = SIZE_MAX;
     std::unique_ptr<spec_tuner> tuner;
     int last_n_drafted = 0;
     int64_t t_step_start_us = 0;
@@ -1343,14 +1344,14 @@ static void mtp_invalidate_cached_draft(const llama_context * ctx) {
     last.prob = 0.0f;
 }
 
-llama_tokens common_speculative_draft(
+common_speculative_draft_result common_speculative_draft_ex(
         common_speculative * spec,
         common_params_speculative & params,
         const llama_tokens & prompt_tgt, // specified in target model vocab
         llama_token id_last,
         llama_pos draft_base_pos,
         llama_seq_id draft_seq_id) {
-    llama_tokens result;
+    common_speculative_draft_result result;
 
     spec->t_step_start_us = ggml_time_us();
 
@@ -1363,46 +1364,68 @@ llama_tokens common_speculative_draft(
     const bool use_runtime_stage_overrides = common_speculative_stage_chain_matches(runtime_stages, spec->configs);
 
     spec->curr_impl = nullptr; // reset current implementation
+    spec->curr_impl_index = SIZE_MAX;
 
     for (size_t i = 0; i < spec->impls.size(); ++i) {
         auto & impl = spec->impls[i];
         const auto & runtime_stage = use_runtime_stage_overrides ? runtime_stages[i] : spec->configs[i].stage;
         common_params_speculative impl_params = common_speculative_get_runtime_params(spec->configs[i], params, runtime_stage);
-        result.clear();
+        result.tokens.clear();
+        result.spans.clear();
+        result.active_type = COMMON_SPECULATIVE_TYPE_NONE;
 
         {
             common_time_meas tm(impl->t_draft_us, !impl->gen_perf);
-            impl->draft(impl_params, prompt_tgt, id_last, draft_base_pos, draft_seq_id, result);
+            impl->draft(impl_params, prompt_tgt, id_last, draft_base_pos, draft_seq_id, result.tokens);
             impl->n_call_draft++;
         }
 
-        if (result.empty()) {
+        if (result.tokens.empty()) {
             continue;
         }
 
-        if (common_speculative_type_is_self_spec(impl->type) && impl_params.n_min > 0 && (int)result.size() < impl_params.n_min) {
+        if (common_speculative_type_is_self_spec(impl->type) && impl_params.n_min > 0 && (int)result.tokens.size() < impl_params.n_min) {
             LOG_DBG("%s: impl %s drafted %zu tokens, below fallback threshold %d - trying next implementation\n",
-                    __func__, common_speculative_type_to_str(impl->type).c_str(), result.size(), impl_params.n_min);
-            result.clear();
+                    __func__, common_speculative_type_to_str(impl->type).c_str(), result.tokens.size(), impl_params.n_min);
+            result.tokens.clear();
             continue;
         }
         LOG_DBG("%s: called impl %s, hist size = %zu, call_count = %zu, gen = %zu\n", __func__,
                 common_speculative_type_to_str(impl.get()->type).c_str(), prompt_tgt.size(),
-                impl.get()->n_call_draft, result.size());
+                impl.get()->n_call_draft, result.tokens.size());
 
         spec->curr_impl = impl.get();
+        spec->curr_impl_index = i;
         impl->n_gen_drafts++;
-        impl->n_gen_tokens += result.size();
+        impl->n_gen_tokens += result.tokens.size();
+        result.active_type = impl->type;
+        result.spans.push_back({
+            /* .type         = */ impl->type,
+            /* .stage_index  = */ (uint32_t) i,
+            /* .token_offset = */ 0,
+            /* .n_tokens     = */ (uint32_t) result.tokens.size(),
+        });
 
         break; // We have a draft, so break out of the loop and return it.
     }
 
     // store draft count for tuner feedback
     if (spec->tuner && spec->tuner->enabled) {
-        spec->last_n_drafted = (int)result.size();
+        spec->last_n_drafted = (int)result.tokens.size();
     }
 
     return result;
+}
+
+llama_tokens common_speculative_draft(
+        common_speculative * spec,
+        common_params_speculative & params,
+        const llama_tokens & prompt_tgt,
+        llama_token id_last,
+        llama_pos draft_base_pos,
+        llama_seq_id draft_seq_id) {
+    auto result = common_speculative_draft_ex(spec, params, prompt_tgt, id_last, draft_base_pos, draft_seq_id);
+    return result.tokens;
 }
 
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
@@ -1437,6 +1460,37 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
             mtp_invalidate_cached_draft(ctx_mtp);
         }
     }
+}
+
+bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type) {
+    if (spec == nullptr) {
+        return false;
+    }
+
+    return std::any_of(spec->configs.begin(), spec->configs.end(), [type](const common_speculative_config & config) {
+        return config.type == type;
+    });
+}
+
+common_speculative_traits common_speculative_get_traits(const common_speculative * spec) {
+    common_speculative_traits traits;
+    if (spec == nullptr) {
+        return traits;
+    }
+
+    traits.configured_types.reserve(spec->configs.size());
+    for (const auto & config : spec->configs) {
+        traits.configured_types.push_back(config.type);
+        if (config.type == COMMON_SPECULATIVE_TYPE_MTP || config.type == COMMON_SPECULATIVE_TYPE_DRAFT) {
+            traits.companion_kind = COMMON_SPECULATIVE_COMPANION_MODEL;
+        }
+    }
+
+    if (spec->curr_impl != nullptr) {
+        traits.active_type = spec->curr_impl->type;
+    }
+
+    return traits;
 }
 
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps, int n_decoded, int n_past, common_params_speculative * active_params) {
@@ -1481,18 +1535,79 @@ void common_speculative_print_stats(const common_speculative * spec, double slot
 // MTP
 // ----------------------------------------------------------------------------
 
-llama_context * common_speculative_get_mtp_ctx(common_speculative * spec) {
-    if (!spec) return nullptr;
+static common_speculative_state_mtp * common_speculative_get_mtp_state(common_speculative * spec) {
+    if (!spec) {
+        return nullptr;
+    }
 
     for (auto & impl : spec->impls) {
-        if (impl->type == COMMON_SPECULATIVE_TYPE_MTP) {
-            auto * mtp_state = dynamic_cast<common_speculative_state_mtp *>(impl.get());
-            if (mtp_state) {
-                return mtp_state->ctx_mtp;
-            }
+        if (impl->type != COMMON_SPECULATIVE_TYPE_MTP) {
+            continue;
+        }
+
+        if (auto * mtp_state = dynamic_cast<common_speculative_state_mtp *>(impl.get())) {
+            return mtp_state;
         }
     }
+
     return nullptr;
+}
+
+llama_context * common_speculative_get_companion_ctx(common_speculative * spec) {
+    if (auto * mtp_state = common_speculative_get_mtp_state(spec); mtp_state != nullptr) {
+        return mtp_state->ctx_mtp;
+    }
+
+    return nullptr;
+}
+
+void common_speculative_seed_companion_hidden(common_speculative * spec, const float * hidden) {
+    if (hidden == nullptr) {
+        return;
+    }
+
+    if (auto * ctx_companion = common_speculative_get_companion_ctx(spec); ctx_companion != nullptr) {
+        llama_set_draft_input_hidden_state(ctx_companion, hidden);
+    }
+}
+
+int32_t common_speculative_on_prompt_batch(common_speculative * spec, const llama_batch & batch, const float * hidden) {
+    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
+    if (ctx_companion == nullptr) {
+        return 0;
+    }
+
+    common_speculative_seed_companion_hidden(spec, hidden);
+    return mtp_update_kv_cache(ctx_companion, batch, true);
+}
+
+int32_t common_speculative_on_accept_batch(common_speculative * spec, const llama_batch & batch, const float * hidden) {
+    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
+    if (ctx_companion == nullptr) {
+        return 0;
+    }
+
+    common_speculative_seed_companion_hidden(spec, hidden);
+    return mtp_update_kv_cache(ctx_companion, batch, false);
+}
+
+void common_speculative_accept_tokens(
+        common_speculative * spec,
+        const std::vector<llama_token> & ids,
+        int32_t n_past_base,
+        llama_seq_id seq_id,
+        const float * hidden) {
+    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
+    if (ctx_companion == nullptr) {
+        return;
+    }
+
+    common_speculative_seed_companion_hidden(spec, hidden);
+    mtp_accept_tokens(ctx_companion, ids, n_past_base, seq_id);
+}
+
+llama_context * common_speculative_get_mtp_ctx(common_speculative * spec) {
+    return common_speculative_get_companion_ctx(spec);
 }
 
 common_speculative_type common_speculative_current_type(const common_speculative * spec) {

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -6,6 +6,30 @@
 
 struct common_speculative;
 
+enum common_speculative_companion_kind {
+    COMMON_SPECULATIVE_COMPANION_NONE,
+    COMMON_SPECULATIVE_COMPANION_MODEL,
+};
+
+struct common_speculative_traits {
+    std::vector<common_speculative_type> configured_types;
+    common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
+    common_speculative_companion_kind companion_kind = COMMON_SPECULATIVE_COMPANION_NONE;
+};
+
+struct common_speculative_span {
+    common_speculative_type type = COMMON_SPECULATIVE_TYPE_NONE;
+    uint32_t stage_index = 0;
+    uint32_t token_offset = 0;
+    uint32_t n_tokens = 0;
+};
+
+struct common_speculative_draft_result {
+    llama_tokens tokens;
+    std::vector<common_speculative_span> spans;
+    common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
+};
+
 // comma separated list of all types
 std::string common_speculative_type_name_str();
 
@@ -30,6 +54,14 @@ void common_speculative_begin(common_speculative * spec, const llama_tokens & pr
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 // draft_base_pos/draft_seq_id override the MTP position for id_last
+common_speculative_draft_result common_speculative_draft_ex(
+            common_speculative * spec,
+            common_params_speculative & params,
+            const llama_tokens & prompt,
+                llama_token   id_last,
+                llama_pos     draft_base_pos = -1,
+                llama_seq_id  draft_seq_id = 0);
+
 llama_tokens common_speculative_draft(
                      common_speculative * spec,
                      common_params_speculative & params,
@@ -40,6 +72,19 @@ llama_tokens common_speculative_draft(
 
 // informs the speculative decoder that n_accepted tokens were accepted by the target model
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
+
+bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type);
+common_speculative_traits common_speculative_get_traits(const common_speculative * spec);
+llama_context * common_speculative_get_companion_ctx(common_speculative * spec);
+void common_speculative_seed_companion_hidden(common_speculative * spec, const float * hidden);
+int32_t common_speculative_on_prompt_batch(common_speculative * spec, const llama_batch & batch, const float * hidden);
+int32_t common_speculative_on_accept_batch(common_speculative * spec, const llama_batch & batch, const float * hidden);
+void common_speculative_accept_tokens(
+    common_speculative * spec,
+    const std::vector<llama_token> & ids,
+    int32_t n_past_base,
+    llama_seq_id seq_id,
+    const float * hidden = nullptr);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps = 0.0, int n_decoded = 0, int n_past = 0, common_params_speculative * active_params = nullptr);

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -52,7 +52,7 @@ static bool params_use_gemma4_external_mtp(const gpt_params & params_base) {
 }
 
 static llama_context * get_slot_mtp_ctx(server_slot & slot, llama_context * ctx) {
-    llama_context * mtp_ctx = common_speculative_get_mtp_ctx(slot.spec);
+    llama_context * mtp_ctx = common_speculative_get_companion_ctx(slot.spec);
     return mtp_ctx ? mtp_ctx : ctx;
 }
 
@@ -83,7 +83,7 @@ static void sync_slot_mtp_hidden(server_slot & slot, llama_context * ctx) {
     }
 
     const int n_hidden = slot.mtp_hidden_state.size() / n_embd;
-    llama_set_draft_input_hidden_state(get_slot_mtp_ctx(slot, ctx), slot.mtp_hidden_state.data() + (n_hidden - 1) * n_embd);
+    common_speculative_seed_companion_hidden(slot.spec, slot.mtp_hidden_state.data() + (n_hidden - 1) * n_embd);
 }
 
 static void cache_and_sync_slot_mtp_hidden(server_slot & slot, llama_context * ctx, const float * hidden, int n_embd) {
@@ -141,15 +141,13 @@ static void apply_slot_mtp_accept(
         return;
     }
 
-    llama_context * mtp_ctx = get_slot_mtp_ctx(slot, ctx);
     if (slot.use_gemma4_external_mtp) {
         cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, mtp_hidden_state, n_embd);
         return;
     }
 
     slot.mtp_hidden_state = mtp_hidden_state;
-    llama_set_draft_input_hidden_state(mtp_ctx, slot.mtp_hidden_state.data());
-    mtp_accept_tokens(mtp_ctx, ids, mtp_n_past_base, slot.id);
+    common_speculative_accept_tokens(slot.spec, ids, mtp_n_past_base, slot.id, slot.mtp_hidden_state.data());
 }
 
 static void set_external_mtp_hidden(server_slot & slot, llama_context * ctx, const float * hidden, int n_embd) {
@@ -196,8 +194,7 @@ static int32_t server_mtp_warmup_batch(
     }
 
     cache_slot_mtp_hidden(slot, last_hidden, n_embd_dst);
-    llama_set_draft_input_hidden_state(ctx_mtp, emb);
-    return mtp_update_kv_cache(ctx_mtp, *batch, true);
+    return common_speculative_on_prompt_batch(slot.spec, *batch, emb);
 }
 
 static int32_t server_mtp_media_warmup_callback(void * user_data, const llama_batch * batch) {
@@ -3658,7 +3655,14 @@ void server_context::add_sampled_tokens() {
                 }
             }
 
-            llama_tokens draft = common_speculative_draft(slot.spec, params_spec, cached_text_tokens, slot.sampled, draft_base_pos, slot.id);
+            common_speculative_draft_result draft_result = common_speculative_draft_ex(
+                slot.spec,
+                params_spec,
+                cached_text_tokens,
+                slot.sampled,
+                draft_base_pos,
+                slot.id);
+            llama_tokens draft = std::move(draft_result.tokens);
 
             const int n_draft_max = slot.get_n_draft_max();
 
@@ -4234,9 +4238,6 @@ static void restore_speculative_checkpoint(
 
         // Update MTP KV cache and hidden state using embeddings collected before checkpoint restore.
         if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
-            llama_context * mtp_ctx = common_speculative_get_mtp_ctx(slot.spec);
-            llama_context * mtp_target = mtp_ctx ? mtp_ctx : ctx;
-
             if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
                 const int n_embd = get_ctx_mtp_n_embd(ctx);
                 apply_slot_mtp_accept(slot, ctx, mtp_hidden_state_pre, ids, mtp_n_past_base, n_embd);
@@ -4256,8 +4257,7 @@ static void restore_speculative_checkpoint(
                             common_batch_add(accepted_batch, mtp_commit_tokens[i], mtp_n_past_base + i, { slot.id }, true);
                         }
 
-                        llama_set_draft_input_hidden_state(mtp_target, seed_hidden);
-                        mtp_update_kv_cache(mtp_target, accepted_batch, false);
+                        common_speculative_on_accept_batch(slot.spec, accepted_batch, seed_hidden);
                         llama_batch_free(accepted_batch);
 
                         slot.mtp_hidden_state.assign(mtp_commit_states.end() - n_embd, mtp_commit_states.end());
@@ -4311,9 +4311,7 @@ static void restore_speculative_checkpoint(
                 if (slot.use_gemma4_external_mtp) {
                     cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, slot.mtp_hidden_state, n_embd);
                 } else {
-                    llama_context * mtp_ctx = get_slot_mtp_ctx(slot, ctx);
-                    llama_set_draft_input_hidden_state(mtp_ctx, slot.mtp_hidden_state.data());
-                    mtp_accept_tokens(mtp_ctx, ids, slot.spec_ckpt.n_past, slot.id);
+                    common_speculative_accept_tokens(slot.spec, ids, slot.spec_ckpt.n_past, slot.id, slot.mtp_hidden_state.data());
 
                     if (n_accepted > 1) {
                         memmove(slot.mtp_hidden_state.data(),
@@ -4445,9 +4443,6 @@ void server_context::speculative_decoding_accept() {
             restore_speculative_checkpoint(slot, ctx, model, spec_type_used, ids, n_draft, mtp_commit_tokens, mtp_commit_states, mtp_hidden_state_seed, mtp_hidden_state_pre, mtp_n_past_base);
         } else {
             if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
-                llama_context * mtp_ctx = common_speculative_get_mtp_ctx(slot.spec);
-                llama_context * mtp_target = mtp_ctx ? mtp_ctx : ctx;
-
                 if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
                     const int n_embd = get_ctx_mtp_n_embd(ctx);
                     apply_slot_mtp_accept(slot, ctx, mtp_hidden_state_pre, ids, mtp_n_past_base, n_embd);
@@ -4467,8 +4462,7 @@ void server_context::speculative_decoding_accept() {
                                 common_batch_add(accepted_batch, mtp_commit_tokens[i], mtp_n_past_base + i, { slot.id }, true);
                             }
 
-                            llama_set_draft_input_hidden_state(mtp_target, seed_hidden);
-                            mtp_update_kv_cache(mtp_target, accepted_batch, false);
+                            common_speculative_on_accept_batch(slot.spec, accepted_batch, seed_hidden);
                             llama_batch_free(accepted_batch);
 
                             slot.mtp_hidden_state.assign(mtp_commit_states.end() - n_embd, mtp_commit_states.end());


### PR DESCRIPTION
Starting with the refactoring series I have in mind for speculative and especially for MTP, this PR keeps it simple by adding a layer to prevent server-context from stopping the internal directing of MTP, while adding some structures for the draft without touching the validation, embeddings, and recurrent steps too deeply.

I also fixed the issue in https://github.com/ikawrakow/ik_llama.cpp/pull/1789#issuecomment-4457469823 that was affecting those using the -mtp flag.

I performed tests with gemma 4 and qwen 3.6 to verify regression, and the results are within the margin of error of +/- 1%.