### PR TITLE
Fix Qwen3.5/3.6 MTP and -muge

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6013,6 +6013,9 @@ void llama_free_model(struct llama_model * model) {
 }
 
 static void llama_repack_up_gate_exps(llama_context & lctx) {
+    if (lctx.cparams.mtp_op_type != MTP_OP_NONE) {
+        return;
+    }
     auto & model = lctx.model;
     bool needs_repack = false;
     for (auto & l : model.layers) {


### PR DESCRIPTION

I notices that using MTP with Qwen3.5/3.6-MoE models alongside `-muge` (on-the-fly merged `ffn_up_exps` and `ffn_gate_exps`) results in gibberish output.

The issue is that with MTP there are two contexts created, but both contexts use the same model. As the function doing the repacking (merging) is called during context initialization, the repacking was done twice on the same model weights, resulting in broken merged `ffn_up_gate_exps` tensors.

This PR fixes the issue.