### PR TITLE
Check for output_extra.weight when loading Gemma4 assistant models

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2150,6 +2150,10 @@ bool create_tensors_helper::create_gemma4_mtp_tensors(const LLM_TN & tn) {
     model.tok_embd    = create_tensor(ctx_input,  tn(LLM_TENSOR_TOKEN_EMBD,  "weight"), {n_embd, n_vocab}, 0);
     model.output_norm = create_tensor(ctx_output, tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd}, 0);
     model.output      = create_tensor(ctx_output, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_NOT_REQUIRED);
+    auto output_extra = create_tensor(ctx_output, "output_extra.weight", {n_embd, n_vocab}, llama_model_loader::TENSOR_NOT_REQUIRED);
+    if (output_extra) {
+        model.output = output_extra;
+    }
     if (model.output == NULL) {
         model.output = create_tensor(ctx_output, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_DUPLICATED);
     }


### PR DESCRIPTION

PR #1810 added the ability to add an extra output tensor quantized with fewer bits per weight by adding `--extra-output-tensor` to the `llama-quantize` command.

This creates the opportunity for some clever user to do so for the Gemma4 assistant models. But then loading this model will fail because no attempt is made to load this additional tensor.

This PR fixes the loading failure of such a hypothetical model.

How do I know that this issue might occur? Well, after observing performance improvement when using MTP with the Qwen3.6 models by creating such an additional output tensor (see #1809, #1810), I went ahead to see if this will do something for Gemma4 MTP. With Gemma4 the MTP part is a separate "assistant model". This model does not have an `output.weight` tensor (as usual for Gemma models the token embedding tensor is uses also as output tensor), so quantizing a Gemma4 assistant model with `--extra-output-tensor`  does create `output_extra.weight`, but the resulting model fails to load. So, to try, I had to fix it.

The bad news is that this does not improve Gemma4 MTP performance. But at least we avoid having an issue filed. 