### PR TITLE
spec : disacard last drafted token with low prob

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -473,6 +473,9 @@ struct common_speculative_state_draft : public common_speculative_state {
 
             // only collect very high-confidence draft tokens
             if (cur_p->data[0].p < params.p_min) {
+                if (i == 0) {
+                    result.push_back(id);
+                }
                 break;
             }
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -471,16 +471,17 @@ struct common_speculative_state_draft : public common_speculative_state {
 
             common_sampler_accept(smpl, nullptr, id, true);
 
+            // only collect very high-confidence draft tokens
+            if (cur_p->data[0].p < params.p_min) {
+                break;
+            }
+
             result.push_back(id);
 
             if (params.n_max <= (int) result.size()) {
                 break;
             }
 
-            // only collect very high-confidence draft tokens
-            if (cur_p->data[0].p < params.p_min) {
-                break;
-            }
 
             common_batch_add(batch, id, n_past + i + 1, { 0 }, true);
 

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -5031,7 +5031,7 @@ void server_context::update_slots() {
     // start populating the batch for this iteration
     common_batch_clear(batch);
 
-    // frist, add sampled tokens from any ongoing sequences
+    // first, add sampled tokens from any ongoing sequences
     add_sampled_tokens(); // Prepare batch for inference
 
     // process in chunks of params.n_batch


### PR DESCRIPTION
In the majority of drafts, the last token is low-prob. For non-recurrent models, it's not a big issue to keep that token. But for recurrent models, this causes the logic to restore checkpoints and re-evaluate the same draft (minus the last token) quite often.

This PR simply discards the low-prob token from the draft. Should result in significant improvement for draft-based speculative decoding for recurrent models due to having to restore the speculative checkpoint less often.

Port from https://github.com/ggml-org/llama.cpp/pull/22506