### PR TITLE
Move embedding management to speculative

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1951,11 +1951,17 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         }
 
         params.has_mtp = true;
+        if (params.speculative.type == COMMON_SPECULATIVE_TYPE_NONE) {
+            params.speculative.type = COMMON_SPECULATIVE_TYPE_MTP;
+        }
         return true;
     }
     if (arg == "-no-mtp" || arg == "--no-multi-token-prediction") {
         params.has_mtp = false;
         common_speculative_remove_explicit_stage(params.speculative, COMMON_SPECULATIVE_TYPE_MTP);
+        if (params.speculative.stages.empty() && params.speculative.type == COMMON_SPECULATIVE_TYPE_MTP) {
+            params.speculative.type = COMMON_SPECULATIVE_TYPE_NONE;
+        }
         return true;
     }
     if (arg == "-draft" || arg == "--draft-params") {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1951,17 +1951,11 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         }
 
         params.has_mtp = true;
-        if (params.speculative.type == COMMON_SPECULATIVE_TYPE_NONE) {
-            params.speculative.type = COMMON_SPECULATIVE_TYPE_MTP;
-        }
         return true;
     }
     if (arg == "-no-mtp" || arg == "--no-multi-token-prediction") {
         params.has_mtp = false;
         common_speculative_remove_explicit_stage(params.speculative, COMMON_SPECULATIVE_TYPE_MTP);
-        if (params.speculative.stages.empty() && params.speculative.type == COMMON_SPECULATIVE_TYPE_MTP) {
-            params.speculative.type = COMMON_SPECULATIVE_TYPE_NONE;
-        }
         return true;
     }
     if (arg == "-draft" || arg == "--draft-params") {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1454,7 +1454,7 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
     }
 }
 
-bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type) {
+static bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type) {
     if (spec == nullptr) {
         return false;
     }
@@ -1595,7 +1595,7 @@ static bool common_speculative_feature_view_from_hidden_rows(
     return true;
 }
 
-bool common_speculative_collect_target_batch_features(
+static bool common_speculative_collect_target_batch_features(
         const common_speculative * spec,
         llama_context * ctx,
         const llama_batch & batch,
@@ -1612,7 +1612,7 @@ bool common_speculative_collect_target_batch_features(
     return true;
 }
 
-bool common_speculative_collect_target_seq_batch_features(
+static bool common_speculative_collect_target_seq_batch_features(
         const common_speculative * spec,
         llama_context * ctx,
         const llama_batch & batch,

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -3,6 +3,7 @@
 #include "common.h"
 #include "ggml.h"
 #include "llama.h"
+#include "llama-context.h"
 #include "log.h"
 #include "ngram-cache.h"
 #include "ngram-map.h"
@@ -1575,6 +1576,105 @@ static bool common_speculative_feature_view_copy_batch_rows(
     }
 
     return hidden_rows->size() == (size_t) batch.n_tokens * view.width;
+}
+
+static common_speculative_feature_kind common_speculative_feature_kind_from_llama(llama_spec_feature_kind kind) {
+    switch (kind) {
+        case LLAMA_SPEC_FEATURE_HIDDEN_STATE:
+            return COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
+        case LLAMA_SPEC_FEATURE_NONE:
+        default:
+            return COMMON_SPECULATIVE_FEATURE_NONE;
+    }
+}
+
+static void common_speculative_feature_view_from_llama(
+        const llama_spec_feature_view & src,
+        common_speculative_feature_view & dst) {
+    dst.kind = common_speculative_feature_kind_from_llama(src.kind);
+    dst.width = src.width;
+    dst.rows.clear();
+    dst.rows.reserve(src.rows.size());
+
+    for (const auto & row : src.rows) {
+        dst.rows.push_back({
+            /* .seq_id = */ row.seq_id,
+            /* .pos    = */ row.pos,
+            /* .data   = */ row.data,
+        });
+    }
+}
+
+bool common_speculative_collect_target_batch_features(
+        const common_speculative * spec,
+        llama_context * ctx,
+        const llama_batch & batch,
+        common_speculative_feature_view & features) {
+    features = {};
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP)) {
+        return true;
+    }
+
+    llama_spec_feature_view llama_features;
+    if (!llama_spec_get_hidden_feature_view(ctx, batch, llama_features)) {
+        return false;
+    }
+
+    common_speculative_feature_view_from_llama(llama_features, features);
+    return true;
+}
+
+bool common_speculative_collect_target_seq_batch_features(
+        const common_speculative * spec,
+        llama_context * ctx,
+        const llama_batch & batch,
+        llama_seq_id seq_id,
+        common_speculative_feature_view & features) {
+    features = {};
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP)) {
+        return true;
+    }
+
+    llama_spec_feature_view llama_features;
+    if (!llama_spec_get_hidden_feature_view_for_seq(ctx, batch, seq_id, llama_features)) {
+        return false;
+    }
+
+    common_speculative_feature_view_from_llama(llama_features, features);
+    return true;
+}
+
+bool common_speculative_capture_output_hidden(
+        common_speculative * spec,
+        llama_context * ctx,
+        int32_t output_index,
+        llama_seq_id seq_id,
+        llama_pos pos) {
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP)) {
+        return true;
+    }
+
+    llama_spec_feature_view llama_features;
+    if (!llama_spec_get_hidden_feature_view_from_output_index(ctx, output_index, seq_id, pos, llama_features)) {
+        return false;
+    }
+
+    common_speculative_feature_view features;
+    common_speculative_feature_view_from_llama(llama_features, features);
+    return common_speculative_capture_target_features(spec, features);
+}
+
+bool common_speculative_copy_output_hidden_rows(
+        const common_speculative * spec,
+        llama_context * ctx,
+        const std::vector<int32_t> & output_indices,
+        std::vector<float> & hidden_rows) {
+    hidden_rows.clear();
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP)) {
+        return true;
+    }
+
+    return llama_spec_copy_hidden_rows_from_output_indices(ctx, output_indices, hidden_rows);
 }
 
 common_speculative_traits common_speculative_get_traits(const common_speculative * spec) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -168,7 +168,30 @@ struct common_speculative_state {
     virtual void accept(uint16_t n_accepted) = 0;
 };
 
-static void mtp_invalidate_cached_draft(const llama_context * ctx);
+struct common_speculative_state_mtp;
+
+static common_speculative_state_mtp * common_speculative_get_mtp_state(common_speculative * spec);
+static const common_speculative_state_mtp * common_speculative_get_mtp_state(const common_speculative * spec);
+static void mtp_invalidate_cached_drafts(common_speculative_state_mtp & state);
+
+static std::vector<llama_token> mtp_speculative_gen_draft(
+    common_speculative_state_mtp & state,
+    struct common_sampler * smpl,
+    struct llama_context * ctx,
+    int n_draft,
+    float p_min,
+    llama_token id_last,
+    llama_pos n_past,
+    llama_seq_id seq_id,
+    bool constant_draft_positions = false);
+
+static int32_t mtp_update_kv_cache(struct llama_context * ctx, const llama_batch & batch, bool is_prompt_warmup);
+
+struct mtp_last_embd {
+    std::vector<float> embd;
+    float prob = 0.0f;
+    int   last_id = -1;
+};
 
 struct common_speculative_state_mtp : public common_speculative_state {
     llama_context * ctx_tgt;
@@ -176,6 +199,9 @@ struct common_speculative_state_mtp : public common_speculative_state {
     common_sampler * smpl;
     // For Gemma 4 external MTP assistant: draft positions are held constant
     bool constant_draft_positions = false;
+    int n_embd = 0;
+    std::unordered_map<llama_seq_id, std::vector<float>> target_hidden_by_seq;
+    std::unordered_map<llama_seq_id, mtp_last_embd> draft_cache_by_seq;
 
     common_speculative_state_mtp(
             enum common_speculative_type type,
@@ -193,6 +219,7 @@ struct common_speculative_state_mtp : public common_speculative_state {
         };
         smpl = common_sampler_init(llama_get_model(ctx_mtp), sparams);
         llama_set_mtp_target_context(ctx_mtp, ctx_tgt);
+        n_embd = llama_mtp_state_n_embd(ctx_mtp);
 
         LOG_INF("%s: MTP context ready (n_ctx=%d, constant_draft_positions=%s)\n", __func__,
                 llama_n_ctx(ctx_mtp), constant_draft_positions ? "true" : "false");
@@ -207,7 +234,8 @@ struct common_speculative_state_mtp : public common_speculative_state {
 
     void begin(const llama_tokens & prompt) override {
         GGML_UNUSED(prompt);
-        mtp_invalidate_cached_draft(ctx_mtp);
+        target_hidden_by_seq.clear();
+        draft_cache_by_seq.clear();
     }
 
     void draft(
@@ -245,7 +273,17 @@ struct common_speculative_state_mtp : public common_speculative_state {
 
         llama_context * ctx = ctx_mtp;
 
+        const auto hidden_it = target_hidden_by_seq.find(seq_id);
+        if (hidden_it == target_hidden_by_seq.end() || (int) hidden_it->second.size() != n_embd) {
+            LOG_WRN("%s: missing target hidden state for seq_id %d\n", __func__, (int) seq_id);
+            result.clear();
+            return;
+        }
+
+        llama_set_draft_input_hidden_state(ctx, hidden_it->second.data());
+
         result = mtp_speculative_gen_draft(
+            *this,
             smpl,
             ctx,
             params.n_max,
@@ -1317,33 +1355,6 @@ void common_speculative_begin(common_speculative * spec, const llama_tokens & pr
     }
 }
 
-struct mtp_last_embd {
-    std::vector<float> embd;
-    float prob;
-    int   last_id = -1;
-};
-
-// Hopefully never called concurrently from multiple threads
-static mtp_last_embd & mtp_get_last_embd(const llama_context * ctx) {
-    static std::unordered_map<const llama_context *, mtp_last_embd> map;
-    auto & last = map[ctx];
-    if (last.embd.empty()) {
-        auto n_embd = llama_mtp_state_n_embd(ctx);
-        last.embd.resize(n_embd);
-    }
-    return last;
-}
-
-static void mtp_invalidate_cached_draft(const llama_context * ctx) {
-    if (ctx == nullptr) {
-        return;
-    }
-
-    auto & last = mtp_get_last_embd(ctx);
-    last.last_id = -1;
-    last.prob = 0.0f;
-}
-
 common_speculative_draft_result common_speculative_draft_ex(
         common_speculative * spec,
         common_params_speculative & params,
@@ -1456,8 +1467,8 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
     }
 
     if (impl->type != COMMON_SPECULATIVE_TYPE_MTP) {
-        if (auto * ctx_mtp = common_speculative_get_mtp_ctx(spec); ctx_mtp != nullptr) {
-            mtp_invalidate_cached_draft(ctx_mtp);
+        if (auto * mtp_state = common_speculative_get_mtp_state(spec); mtp_state != nullptr) {
+            mtp_invalidate_cached_drafts(*mtp_state);
         }
     }
 }
@@ -1470,6 +1481,100 @@ bool common_speculative_has_type(const common_speculative * spec, common_specula
     return std::any_of(spec->configs.begin(), spec->configs.end(), [type](const common_speculative_config & config) {
         return config.type == type;
     });
+}
+
+static bool common_speculative_feature_view_find_seq_rows(
+        const common_speculative_feature_view & view,
+        llama_seq_id seq_id,
+        const float ** first_row,
+        const float ** last_row) {
+    if (first_row != nullptr) {
+        *first_row = nullptr;
+    }
+    if (last_row != nullptr) {
+        *last_row = nullptr;
+    }
+
+    if (view.kind != COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE || view.width <= 0) {
+        return false;
+    }
+
+    const common_speculative_feature_row_view * first_row_view = nullptr;
+    const common_speculative_feature_row_view * last_row_view = nullptr;
+    for (const auto & row : view.rows) {
+        if (row.seq_id != seq_id || row.data == nullptr) {
+            continue;
+        }
+
+        if (first_row_view == nullptr || row.pos < first_row_view->pos) {
+            first_row_view = &row;
+        }
+        if (last_row_view == nullptr || row.pos > last_row_view->pos) {
+            last_row_view = &row;
+        }
+    }
+
+    if (first_row != nullptr) {
+        *first_row = first_row_view != nullptr ? first_row_view->data : nullptr;
+    }
+    if (last_row != nullptr) {
+        *last_row = last_row_view != nullptr ? last_row_view->data : nullptr;
+    }
+
+    return first_row_view != nullptr && last_row_view != nullptr;
+}
+
+bool common_speculative_feature_view_copy_seq_rows(
+        const common_speculative_feature_view & view,
+        llama_seq_id seq_id,
+        std::vector<float> * first_row,
+        std::vector<float> * last_row) {
+    const float * first_ptr = nullptr;
+    const float * last_ptr = nullptr;
+    if (!common_speculative_feature_view_find_seq_rows(view, seq_id, &first_ptr, &last_ptr)) {
+        return false;
+    }
+
+    if (first_row != nullptr) {
+        first_row->assign(first_ptr, first_ptr + view.width);
+    }
+    if (last_row != nullptr) {
+        last_row->assign(last_ptr, last_ptr + view.width);
+    }
+
+    return true;
+}
+
+static bool common_speculative_feature_view_copy_batch_rows(
+        const common_speculative_feature_view & view,
+        const llama_batch & batch,
+        llama_seq_id seq_id,
+        std::vector<float> * hidden_rows) {
+    if (hidden_rows == nullptr || view.kind != COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE || view.width <= 0 || batch.n_tokens <= 0 || batch.pos == nullptr) {
+        return false;
+    }
+
+    std::unordered_map<llama_pos, const float *> rows_by_pos;
+    rows_by_pos.reserve(view.rows.size());
+    for (const auto & row : view.rows) {
+        if (row.seq_id == seq_id && row.data != nullptr) {
+            rows_by_pos[row.pos] = row.data;
+        }
+    }
+
+    hidden_rows->clear();
+    hidden_rows->reserve((size_t) batch.n_tokens * view.width);
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        auto it = rows_by_pos.find(batch.pos[i]);
+        if (it == rows_by_pos.end()) {
+            hidden_rows->clear();
+            return false;
+        }
+
+        hidden_rows->insert(hidden_rows->end(), it->second, it->second + view.width);
+    }
+
+    return hidden_rows->size() == (size_t) batch.n_tokens * view.width;
 }
 
 common_speculative_traits common_speculative_get_traits(const common_speculative * spec) {
@@ -1553,6 +1658,132 @@ static common_speculative_state_mtp * common_speculative_get_mtp_state(common_sp
     return nullptr;
 }
 
+static const common_speculative_state_mtp * common_speculative_get_mtp_state(const common_speculative * spec) {
+    return common_speculative_get_mtp_state(const_cast<common_speculative *>(spec));
+}
+
+static mtp_last_embd & mtp_get_last_embd(common_speculative_state_mtp & state, llama_seq_id seq_id) {
+    auto & last = state.draft_cache_by_seq[seq_id];
+    if ((int) last.embd.size() != state.n_embd) {
+        last.embd.resize(state.n_embd);
+    }
+    return last;
+}
+
+static void mtp_invalidate_cached_draft(common_speculative_state_mtp & state, llama_seq_id seq_id) {
+    auto it = state.draft_cache_by_seq.find(seq_id);
+    if (it == state.draft_cache_by_seq.end()) {
+        return;
+    }
+
+    it->second.last_id = -1;
+    it->second.prob = 0.0f;
+}
+
+static void mtp_invalidate_cached_drafts(common_speculative_state_mtp & state) {
+    for (auto & entry : state.draft_cache_by_seq) {
+        entry.second.last_id = -1;
+        entry.second.prob = 0.0f;
+    }
+}
+
+static void mtp_store_target_hidden(
+        common_speculative_state_mtp & state,
+        llama_seq_id seq_id,
+        const float * hidden,
+        int32_t width) {
+    if (hidden == nullptr || width <= 0) {
+        return;
+    }
+
+    auto & stored = state.target_hidden_by_seq[seq_id];
+    stored.assign(hidden, hidden + width);
+}
+
+static bool mtp_copy_target_hidden(
+        const common_speculative_state_mtp & state,
+        llama_seq_id seq_id,
+        std::vector<float> & hidden) {
+    auto it = state.target_hidden_by_seq.find(seq_id);
+    if (it == state.target_hidden_by_seq.end()) {
+        return false;
+    }
+
+    hidden = it->second;
+    return !hidden.empty();
+}
+
+static void mtp_clear_target_hidden(common_speculative_state_mtp & state, llama_seq_id seq_id) {
+    state.target_hidden_by_seq.erase(seq_id);
+    state.draft_cache_by_seq.erase(seq_id);
+}
+
+std::vector<common_speculative_feature_request> common_speculative_get_feature_requests(const common_speculative * spec) {
+    std::vector<common_speculative_feature_request> requests;
+    if (common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP)) {
+        requests.push_back({ COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE });
+    }
+    return requests;
+}
+
+bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features) {
+    auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr || features.kind != COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE || features.width <= 0) {
+        return false;
+    }
+
+    bool captured = false;
+    for (const auto & row : features.rows) {
+        if (row.data == nullptr) {
+            continue;
+        }
+
+        mtp_store_target_hidden(*mtp_state, row.seq_id, row.data, features.width);
+        mtp_invalidate_cached_draft(*mtp_state, row.seq_id);
+        captured = true;
+    }
+
+    return captured;
+}
+
+bool common_speculative_has_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id) {
+    const auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr) {
+        return false;
+    }
+
+    auto it = mtp_state->target_hidden_by_seq.find(seq_id);
+    return it != mtp_state->target_hidden_by_seq.end() && !it->second.empty();
+}
+
+bool common_speculative_copy_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id, std::vector<float> & hidden) {
+    const auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr) {
+        return false;
+    }
+
+    return mtp_copy_target_hidden(*mtp_state, seq_id, hidden);
+}
+
+void common_speculative_restore_sequence_hidden(common_speculative * spec, llama_seq_id seq_id, const std::vector<float> & hidden) {
+    auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr || hidden.empty()) {
+        return;
+    }
+
+    mtp_store_target_hidden(*mtp_state, seq_id, hidden.data(), hidden.size());
+    mtp_invalidate_cached_draft(*mtp_state, seq_id);
+}
+
+void common_speculative_clear_sequence_hidden(common_speculative * spec, llama_seq_id seq_id) {
+    auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr) {
+        return;
+    }
+
+    mtp_clear_target_hidden(*mtp_state, seq_id);
+}
+
 llama_context * common_speculative_get_companion_ctx(common_speculative * spec) {
     if (auto * mtp_state = common_speculative_get_mtp_state(spec); mtp_state != nullptr) {
         return mtp_state->ctx_mtp;
@@ -1561,49 +1792,81 @@ llama_context * common_speculative_get_companion_ctx(common_speculative * spec) 
     return nullptr;
 }
 
-void common_speculative_seed_companion_hidden(common_speculative * spec, const float * hidden) {
-    if (hidden == nullptr) {
-        return;
-    }
-
-    if (auto * ctx_companion = common_speculative_get_companion_ctx(spec); ctx_companion != nullptr) {
-        llama_set_draft_input_hidden_state(ctx_companion, hidden);
-    }
-}
-
-int32_t common_speculative_on_prompt_batch(common_speculative * spec, const llama_batch & batch, const float * hidden) {
-    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
-    if (ctx_companion == nullptr) {
-        return 0;
-    }
-
-    common_speculative_seed_companion_hidden(spec, hidden);
-    return mtp_update_kv_cache(ctx_companion, batch, true);
-}
-
-int32_t common_speculative_on_accept_batch(common_speculative * spec, const llama_batch & batch, const float * hidden) {
-    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
-    if (ctx_companion == nullptr) {
-        return 0;
-    }
-
-    common_speculative_seed_companion_hidden(spec, hidden);
-    return mtp_update_kv_cache(ctx_companion, batch, false);
-}
-
-void common_speculative_accept_tokens(
-        common_speculative * spec,
-        const std::vector<llama_token> & ids,
-        int32_t n_past_base,
+static int32_t mtp_accept_batch(
+        common_speculative_state_mtp & state,
+        const llama_batch & accepted_batch,
         llama_seq_id seq_id,
-        const float * hidden) {
-    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
-    if (ctx_companion == nullptr) {
-        return;
+        const float * hidden_rows) {
+    if (accepted_batch.n_tokens == 0 || hidden_rows == nullptr) {
+        return 0;
     }
 
-    common_speculative_seed_companion_hidden(spec, hidden);
-    mtp_accept_tokens(ctx_companion, ids, n_past_base, seq_id);
+    llama_set_draft_input_hidden_state(state.ctx_mtp, hidden_rows);
+    if (mtp_update_kv_cache(state.ctx_mtp, accepted_batch, false) != 0) {
+        return -1;
+    }
+
+    auto & last = mtp_get_last_embd(state, seq_id);
+    const float * embd = llama_get_embeddings_ith(state.ctx_mtp, accepted_batch.n_tokens - 1);
+    if (embd != nullptr) {
+        std::memcpy(last.embd.data(), embd, last.embd.size() * sizeof(float));
+        llama_set_draft_input_hidden_state(state.ctx_mtp, last.embd.data());
+        last.last_id = common_sampler_sample_speculative(nullptr, state.ctx_mtp, accepted_batch.n_tokens - 1, &last.prob);
+    }
+
+    return 0;
+}
+
+int32_t common_speculative_on_target_batch(
+        common_speculative * spec,
+        const llama_batch & batch,
+        const common_speculative_feature_view & features,
+        bool is_prompt_warmup,
+        const float * seed_hidden) {
+    auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr) {
+        return 0;
+    }
+
+    if (features.kind != COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE || features.width <= 0 || batch.n_tokens <= 0) {
+        return 0;
+    }
+
+    if (batch.n_seq_id == nullptr || batch.seq_id == nullptr || batch.n_seq_id[0] <= 0 || batch.seq_id[0] == nullptr) {
+        return -1;
+    }
+
+    const llama_seq_id seq_id = batch.seq_id[0][0];
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] != 1 || batch.seq_id[i] == nullptr || batch.seq_id[i][0] != seq_id) {
+            return -1;
+        }
+    }
+
+    std::vector<float> hidden_rows_storage;
+    if (!common_speculative_feature_view_copy_batch_rows(features, batch, seq_id, &hidden_rows_storage)) {
+        return -1;
+    }
+
+    const float * first_hidden = hidden_rows_storage.data();
+    const float * last_hidden = hidden_rows_storage.data() + (size_t) (batch.n_tokens - 1) * features.width;
+    mtp_store_target_hidden(*mtp_state, seq_id, last_hidden, features.width);
+
+    if (mtp_state->constant_draft_positions) {
+        mtp_invalidate_cached_draft(*mtp_state, seq_id);
+        return 0;
+    }
+
+    GGML_UNUSED(seed_hidden);
+
+    if (is_prompt_warmup) {
+        llama_set_draft_input_hidden_state(mtp_state->ctx_mtp, hidden_rows_storage.data());
+        const int32_t ret = mtp_update_kv_cache(mtp_state->ctx_mtp, batch, true);
+        mtp_invalidate_cached_draft(*mtp_state, seq_id);
+        return ret;
+    }
+
+    return mtp_accept_batch(*mtp_state, batch, seq_id, first_hidden);
 }
 
 llama_context * common_speculative_get_mtp_ctx(common_speculative * spec) {
@@ -1631,6 +1894,7 @@ void common_speculative_context_shift(
 }
 
 std::vector<llama_token> mtp_speculative_gen_draft(
+    common_speculative_state_mtp & state,
     struct common_sampler * smpl,
     struct llama_context * ctx,
     int n_draft,
@@ -1646,7 +1910,7 @@ std::vector<llama_token> mtp_speculative_gen_draft(
     if (!smpl) return drafts;
 
     if (n_draft <= 0) {
-        mtp_invalidate_cached_draft(ctx);
+        mtp_invalidate_cached_draft(state, seq_id);
         return drafts;
     }
 
@@ -1662,7 +1926,7 @@ std::vector<llama_token> mtp_speculative_gen_draft(
     llama_pos current_n_past = n_past;
     const int n_embd = llama_mtp_state_n_embd(ctx);
 
-    auto & last = mtp_get_last_embd(ctx);
+    auto & last = mtp_get_last_embd(state, seq_id);
     int i0 = 0;
     if (last.last_id >= 0) {
         if (last.prob < p_min) {
@@ -1765,35 +2029,4 @@ int32_t mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch
     const int32_t ret = llama_decode(ctx, mtp_batch);
     llama_set_mtp_op_type(ctx, MTP_OP_NONE);
     return ret;
-}
-
-void mtp_accept_tokens(
-    struct llama_context * ctx,
-    const std::vector<llama_token> & ids,
-    int32_t n_past_base,
-    llama_seq_id seq_id) {
-    if (ids.empty()) {
-        return;
-    }
-
-    llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
-    for (size_t i = 0; i < ids.size(); ++i) {
-        common_batch_add(accepted_batch, ids[i], n_past_base + i, { seq_id }, true);
-    }
-
-    if (mtp_update_kv_cache(ctx, accepted_batch, false) != 0) {
-        LOG_ERR("failed to update MTP KV cache for accepted tokens\n");
-        llama_batch_free(accepted_batch);
-        return;
-    }
-
-    auto & last = mtp_get_last_embd(ctx);
-    auto embd = llama_get_embeddings_ith(ctx, ids.size() - 1);
-    if (embd) {
-        std::memcpy(last.embd.data(), embd, last.embd.size()*sizeof(float));
-        llama_set_draft_input_hidden_state(ctx, last.embd.data());
-        last.last_id = common_sampler_sample_speculative(nullptr, ctx, ids.size() - 1, &last.prob);
-    }
-
-    llama_batch_free(accepted_batch);
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1581,6 +1581,10 @@ static bool common_speculative_feature_view_copy_batch_rows(
     return hidden_rows->size() == (size_t) batch.n_tokens * view.width;
 }
 
+static bool common_speculative_capture_target_features(
+        common_speculative * spec,
+        const common_speculative_feature_view & features);
+
 static common_speculative_feature_kind common_speculative_feature_kind_from_llama(llama_spec_feature_kind kind) {
     switch (kind) {
         case LLAMA_SPEC_FEATURE_HIDDEN_STATE:
@@ -1829,7 +1833,7 @@ std::vector<common_speculative_feature_request> common_speculative_get_feature_r
     return requests;
 }
 
-bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features) {
+static bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features) {
     auto * mtp_state = common_speculative_get_mtp_state(spec);
     if (mtp_state == nullptr || features.kind != COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE || features.width <= 0) {
         return false;
@@ -1979,10 +1983,6 @@ int32_t common_speculative_on_target_batch(
     return mtp_accept_batch(*mtp_state, batch, seq_id, first_hidden);
 }
 
-llama_context * common_speculative_get_mtp_ctx(common_speculative * spec) {
-    return common_speculative_get_companion_ctx(spec);
-}
-
 common_speculative_type common_speculative_current_type(const common_speculative * spec) {
     if (spec == nullptr || spec->curr_impl == nullptr) {
         return COMMON_SPECULATIVE_TYPE_NONE;
@@ -1997,7 +1997,7 @@ void common_speculative_context_shift(
         llama_pos            kv_keep,
         llama_pos            kv_discard,
         llama_pos            kv_past) {
-    if (auto * ctx_mtp = common_speculative_get_mtp_ctx(spec); ctx_mtp != nullptr) {
+    if (auto * ctx_mtp = common_speculative_get_companion_ctx(spec); ctx_mtp != nullptr) {
         llama_kv_cache_seq_rm (ctx_mtp, seq_id, kv_keep, kv_keep + kv_discard);
         llama_kv_cache_seq_add(ctx_mtp, seq_id, kv_keep + kv_discard, kv_past, -kv_discard);
     }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -281,7 +281,10 @@ struct common_speculative_state_mtp : public common_speculative_state {
             return;
         }
 
-        llama_set_draft_input_hidden_state(ctx, hidden_it->second.data());
+        if (!llama_set_draft_input_hidden_state_copy(ctx, hidden_it->second.data(), hidden_it->second.size())) {
+            result.clear();
+            return;
+        }
 
         result = mtp_speculative_gen_draft(
             *this,
@@ -1901,7 +1904,10 @@ static int32_t mtp_accept_batch(
         return 0;
     }
 
-    llama_set_draft_input_hidden_state(state.ctx_mtp, hidden_rows);
+    const size_t hidden_rows_floats = (size_t) accepted_batch.n_tokens * state.n_embd;
+    if (!llama_set_draft_input_hidden_state_copy(state.ctx_mtp, hidden_rows, hidden_rows_floats)) {
+        return -1;
+    }
     if (mtp_update_kv_cache(state.ctx_mtp, accepted_batch, false) != 0) {
         return -1;
     }
@@ -1910,7 +1916,9 @@ static int32_t mtp_accept_batch(
     const float * embd = llama_get_embeddings_ith(state.ctx_mtp, accepted_batch.n_tokens - 1);
     if (embd != nullptr) {
         std::memcpy(last.embd.data(), embd, last.embd.size() * sizeof(float));
-        llama_set_draft_input_hidden_state(state.ctx_mtp, last.embd.data());
+        if (!llama_set_draft_input_hidden_state_copy(state.ctx_mtp, last.embd.data(), last.embd.size())) {
+            return -1;
+        }
         last.last_id = common_sampler_sample_speculative(nullptr, state.ctx_mtp, accepted_batch.n_tokens - 1, &last.prob);
     }
 
@@ -1960,7 +1968,9 @@ int32_t common_speculative_on_target_batch(
     GGML_UNUSED(seed_hidden);
 
     if (is_prompt_warmup) {
-        llama_set_draft_input_hidden_state(mtp_state->ctx_mtp, hidden_rows_storage.data());
+        if (!llama_set_draft_input_hidden_state_copy(mtp_state->ctx_mtp, hidden_rows_storage.data(), hidden_rows_storage.size())) {
+            return -1;
+        }
         const int32_t ret = mtp_update_kv_cache(mtp_state->ctx_mtp, batch, true);
         mtp_invalidate_cached_draft(*mtp_state, seq_id);
         return ret;
@@ -2036,7 +2046,11 @@ std::vector<llama_token> mtp_speculative_gen_draft(
         last.last_id = -1;
         drafts.push_back(current_input_id);
         current_n_past++;
-        llama_set_draft_input_hidden_state(ctx, last.embd.data());
+        if (!llama_set_draft_input_hidden_state_copy(ctx, last.embd.data(), last.embd.size())) {
+            llama_batch_free(mtp_batch);
+            llama_set_mtp_op_type(ctx, MTP_OP_NONE);
+            return drafts;
+        }
         i0 = 1;
     }
 
@@ -2066,7 +2080,9 @@ std::vector<llama_token> mtp_speculative_gen_draft(
 
         // Keep a stable copy because later decode steps reuse ctx->embd storage.
         memcpy(last.embd.data(), emb, n_embd * sizeof(float));
-        llama_set_draft_input_hidden_state(ctx, last.embd.data());
+        if (!llama_set_draft_input_hidden_state_copy(ctx, last.embd.data(), last.embd.size())) {
+            break;
+        }
 
         current_input_id = id_next;
         current_n_past++;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -961,6 +961,7 @@ struct common_speculative {
     std::vector<common_speculative_config> configs; // resolved stage config for each implementation
     std::vector<std::unique_ptr<common_speculative_state>> impls; // list of implementations to use and their states
     common_speculative_state * curr_impl = nullptr; // current implementation in use (for stats)
+    size_t curr_impl_index = SIZE_MAX;
     std::unique_ptr<spec_tuner> tuner;
     int last_n_drafted = 0;
     int64_t t_step_start_us = 0;
@@ -1343,14 +1344,14 @@ static void mtp_invalidate_cached_draft(const llama_context * ctx) {
     last.prob = 0.0f;
 }
 
-llama_tokens common_speculative_draft(
+common_speculative_draft_result common_speculative_draft_ex(
         common_speculative * spec,
         common_params_speculative & params,
         const llama_tokens & prompt_tgt, // specified in target model vocab
         llama_token id_last,
         llama_pos draft_base_pos,
         llama_seq_id draft_seq_id) {
-    llama_tokens result;
+    common_speculative_draft_result result;
 
     spec->t_step_start_us = ggml_time_us();
 
@@ -1363,46 +1364,68 @@ llama_tokens common_speculative_draft(
     const bool use_runtime_stage_overrides = common_speculative_stage_chain_matches(runtime_stages, spec->configs);
 
     spec->curr_impl = nullptr; // reset current implementation
+    spec->curr_impl_index = SIZE_MAX;
 
     for (size_t i = 0; i < spec->impls.size(); ++i) {
         auto & impl = spec->impls[i];
         const auto & runtime_stage = use_runtime_stage_overrides ? runtime_stages[i] : spec->configs[i].stage;
         common_params_speculative impl_params = common_speculative_get_runtime_params(spec->configs[i], params, runtime_stage);
-        result.clear();
+        result.tokens.clear();
+        result.spans.clear();
+        result.active_type = COMMON_SPECULATIVE_TYPE_NONE;
 
         {
             common_time_meas tm(impl->t_draft_us, !impl->gen_perf);
-            impl->draft(impl_params, prompt_tgt, id_last, draft_base_pos, draft_seq_id, result);
+            impl->draft(impl_params, prompt_tgt, id_last, draft_base_pos, draft_seq_id, result.tokens);
             impl->n_call_draft++;
         }
 
-        if (result.empty()) {
+        if (result.tokens.empty()) {
             continue;
         }
 
-        if (common_speculative_type_is_self_spec(impl->type) && impl_params.n_min > 0 && (int)result.size() < impl_params.n_min) {
+        if (common_speculative_type_is_self_spec(impl->type) && impl_params.n_min > 0 && (int)result.tokens.size() < impl_params.n_min) {
             LOG_DBG("%s: impl %s drafted %zu tokens, below fallback threshold %d - trying next implementation\n",
-                    __func__, common_speculative_type_to_str(impl->type).c_str(), result.size(), impl_params.n_min);
-            result.clear();
+                    __func__, common_speculative_type_to_str(impl->type).c_str(), result.tokens.size(), impl_params.n_min);
+            result.tokens.clear();
             continue;
         }
         LOG_DBG("%s: called impl %s, hist size = %zu, call_count = %zu, gen = %zu\n", __func__,
                 common_speculative_type_to_str(impl.get()->type).c_str(), prompt_tgt.size(),
-                impl.get()->n_call_draft, result.size());
+                impl.get()->n_call_draft, result.tokens.size());
 
         spec->curr_impl = impl.get();
+        spec->curr_impl_index = i;
         impl->n_gen_drafts++;
-        impl->n_gen_tokens += result.size();
+        impl->n_gen_tokens += result.tokens.size();
+        result.active_type = impl->type;
+        result.spans.push_back({
+            /* .type         = */ impl->type,
+            /* .stage_index  = */ (uint32_t) i,
+            /* .token_offset = */ 0,
+            /* .n_tokens     = */ (uint32_t) result.tokens.size(),
+        });
 
         break; // We have a draft, so break out of the loop and return it.
     }
 
     // store draft count for tuner feedback
     if (spec->tuner && spec->tuner->enabled) {
-        spec->last_n_drafted = (int)result.size();
+        spec->last_n_drafted = (int)result.tokens.size();
     }
 
     return result;
+}
+
+llama_tokens common_speculative_draft(
+        common_speculative * spec,
+        common_params_speculative & params,
+        const llama_tokens & prompt_tgt,
+        llama_token id_last,
+        llama_pos draft_base_pos,
+        llama_seq_id draft_seq_id) {
+    auto result = common_speculative_draft_ex(spec, params, prompt_tgt, id_last, draft_base_pos, draft_seq_id);
+    return result.tokens;
 }
 
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
@@ -1437,6 +1460,37 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
             mtp_invalidate_cached_draft(ctx_mtp);
         }
     }
+}
+
+bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type) {
+    if (spec == nullptr) {
+        return false;
+    }
+
+    return std::any_of(spec->configs.begin(), spec->configs.end(), [type](const common_speculative_config & config) {
+        return config.type == type;
+    });
+}
+
+common_speculative_traits common_speculative_get_traits(const common_speculative * spec) {
+    common_speculative_traits traits;
+    if (spec == nullptr) {
+        return traits;
+    }
+
+    traits.configured_types.reserve(spec->configs.size());
+    for (const auto & config : spec->configs) {
+        traits.configured_types.push_back(config.type);
+        if (config.type == COMMON_SPECULATIVE_TYPE_MTP || config.type == COMMON_SPECULATIVE_TYPE_DRAFT) {
+            traits.companion_kind = COMMON_SPECULATIVE_COMPANION_MODEL;
+        }
+    }
+
+    if (spec->curr_impl != nullptr) {
+        traits.active_type = spec->curr_impl->type;
+    }
+
+    return traits;
 }
 
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps, int n_decoded, int n_past, common_params_speculative * active_params) {
@@ -1481,18 +1535,79 @@ void common_speculative_print_stats(const common_speculative * spec, double slot
 // MTP
 // ----------------------------------------------------------------------------
 
-llama_context * common_speculative_get_mtp_ctx(common_speculative * spec) {
-    if (!spec) return nullptr;
+static common_speculative_state_mtp * common_speculative_get_mtp_state(common_speculative * spec) {
+    if (!spec) {
+        return nullptr;
+    }
 
     for (auto & impl : spec->impls) {
-        if (impl->type == COMMON_SPECULATIVE_TYPE_MTP) {
-            auto * mtp_state = dynamic_cast<common_speculative_state_mtp *>(impl.get());
-            if (mtp_state) {
-                return mtp_state->ctx_mtp;
-            }
+        if (impl->type != COMMON_SPECULATIVE_TYPE_MTP) {
+            continue;
+        }
+
+        if (auto * mtp_state = dynamic_cast<common_speculative_state_mtp *>(impl.get())) {
+            return mtp_state;
         }
     }
+
     return nullptr;
+}
+
+llama_context * common_speculative_get_companion_ctx(common_speculative * spec) {
+    if (auto * mtp_state = common_speculative_get_mtp_state(spec); mtp_state != nullptr) {
+        return mtp_state->ctx_mtp;
+    }
+
+    return nullptr;
+}
+
+void common_speculative_seed_companion_hidden(common_speculative * spec, const float * hidden) {
+    if (hidden == nullptr) {
+        return;
+    }
+
+    if (auto * ctx_companion = common_speculative_get_companion_ctx(spec); ctx_companion != nullptr) {
+        llama_set_draft_input_hidden_state(ctx_companion, hidden);
+    }
+}
+
+int32_t common_speculative_on_prompt_batch(common_speculative * spec, const llama_batch & batch, const float * hidden) {
+    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
+    if (ctx_companion == nullptr) {
+        return 0;
+    }
+
+    common_speculative_seed_companion_hidden(spec, hidden);
+    return mtp_update_kv_cache(ctx_companion, batch, true);
+}
+
+int32_t common_speculative_on_accept_batch(common_speculative * spec, const llama_batch & batch, const float * hidden) {
+    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
+    if (ctx_companion == nullptr) {
+        return 0;
+    }
+
+    common_speculative_seed_companion_hidden(spec, hidden);
+    return mtp_update_kv_cache(ctx_companion, batch, false);
+}
+
+void common_speculative_accept_tokens(
+        common_speculative * spec,
+        const std::vector<llama_token> & ids,
+        int32_t n_past_base,
+        llama_seq_id seq_id,
+        const float * hidden) {
+    auto * ctx_companion = common_speculative_get_companion_ctx(spec);
+    if (ctx_companion == nullptr) {
+        return;
+    }
+
+    common_speculative_seed_companion_hidden(spec, hidden);
+    mtp_accept_tokens(ctx_companion, ids, n_past_base, seq_id);
+}
+
+llama_context * common_speculative_get_mtp_ctx(common_speculative * spec) {
+    return common_speculative_get_companion_ctx(spec);
 }
 
 common_speculative_type common_speculative_current_type(const common_speculative * spec) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -3,7 +3,6 @@
 #include "common.h"
 #include "ggml.h"
 #include "llama.h"
-#include "llama-context.h"
 #include "log.h"
 #include "ngram-cache.h"
 #include "ngram-map.h"
@@ -21,7 +20,6 @@
 #define SPEC_VOCAB_CHECK_START_TOKEN_ID 5
 
 void llama_set_mtp_target_context(struct llama_context * ctx, struct llama_context * target_ctx);
-uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx);
 
 const std::vector<enum common_speculative_type> common_speculative_types = {
     COMMON_SPECULATIVE_TYPE_NONE,
@@ -1509,27 +1507,28 @@ static int common_speculative_copy_seq_batch(
         return -1;
     }
 
-    int n_seq_tokens = 0;
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        if (common_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
-            ++n_seq_tokens;
-        }
-    }
-
-    if (n_seq_tokens == 0) {
+    if (batch.n_tokens < 1) {
         return 0;
     }
 
-    seq_batch = llama_batch_init(n_seq_tokens, 0, 1);
+    std::vector<int> token_indices;
+    token_indices.reserve(batch.n_tokens);
     for (int i = 0; i < batch.n_tokens; ++i) {
-        if (!common_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
-            continue;
+        if (common_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
+            token_indices.push_back(i);
         }
+    }
 
+    if (token_indices.empty()) {
+        return 0;
+    }
+
+    seq_batch = llama_batch_init((int) token_indices.size(), 0, 1);
+    for (const int i : token_indices) {
         common_batch_add(seq_batch, batch.token[i], batch.pos[i], { seq_id }, batch.logits != nullptr && batch.logits[i]);
     }
 
-    return n_seq_tokens;
+    return (int) token_indices.size();
 }
 
 static bool common_speculative_feature_view_copy_batch_rows(

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1464,45 +1464,72 @@ bool common_speculative_has_type(const common_speculative * spec, common_specula
     });
 }
 
-static bool common_speculative_feature_view_find_seq_rows(
-        const common_speculative_feature_view & view,
-        llama_seq_id seq_id,
-        const float ** first_row,
-        const float ** last_row) {
-    if (first_row != nullptr) {
-        *first_row = nullptr;
-    }
-    if (last_row != nullptr) {
-        *last_row = nullptr;
-    }
+static int common_speculative_ctx_mtp_n_embd(llama_context * ctx) {
+    return ctx ? (int) llama_mtp_state_n_embd(ctx) : 0;
+}
 
-    if (view.kind != COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE || view.width <= 0) {
+static bool common_speculative_batch_token_has_seq_id(
+        const llama_batch & batch,
+        int token_index,
+        llama_seq_id seq_id) {
+    if (batch.n_seq_id == nullptr || batch.seq_id == nullptr || batch.n_seq_id[token_index] <= 0 || batch.seq_id[token_index] == nullptr) {
         return false;
     }
 
-    const common_speculative_feature_row_view * first_row_view = nullptr;
-    const common_speculative_feature_row_view * last_row_view = nullptr;
-    for (const auto & row : view.rows) {
-        if (row.seq_id != seq_id || row.data == nullptr) {
+    for (int i = 0; i < batch.n_seq_id[token_index]; ++i) {
+        if (batch.seq_id[token_index][i] == seq_id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool common_speculative_batch_is_exact_single_seq(
+        const llama_batch & batch,
+        llama_seq_id seq_id) {
+    if (batch.n_tokens <= 0 || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
+        return false;
+    }
+
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] != 1 || batch.seq_id[i] == nullptr || batch.seq_id[i][0] != seq_id) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static int common_speculative_copy_seq_batch(
+        const llama_batch & batch,
+        llama_seq_id seq_id,
+        llama_batch & seq_batch) {
+    if (batch.token == nullptr || batch.pos == nullptr) {
+        return -1;
+    }
+
+    int n_seq_tokens = 0;
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (common_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
+            ++n_seq_tokens;
+        }
+    }
+
+    if (n_seq_tokens == 0) {
+        return 0;
+    }
+
+    seq_batch = llama_batch_init(n_seq_tokens, 0, 1);
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (!common_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
             continue;
         }
 
-        if (first_row_view == nullptr || row.pos < first_row_view->pos) {
-            first_row_view = &row;
-        }
-        if (last_row_view == nullptr || row.pos > last_row_view->pos) {
-            last_row_view = &row;
-        }
+        common_batch_add(seq_batch, batch.token[i], batch.pos[i], { seq_id }, batch.logits != nullptr && batch.logits[i]);
     }
 
-    if (first_row != nullptr) {
-        *first_row = first_row_view != nullptr ? first_row_view->data : nullptr;
-    }
-    if (last_row != nullptr) {
-        *last_row = last_row_view != nullptr ? last_row_view->data : nullptr;
-    }
-
-    return first_row_view != nullptr && last_row_view != nullptr;
+    return n_seq_tokens;
 }
 
 static bool common_speculative_feature_view_copy_batch_rows(
@@ -1541,33 +1568,6 @@ static bool common_speculative_capture_target_features(
         common_speculative * spec,
         const common_speculative_feature_view & features);
 
-static common_speculative_feature_kind common_speculative_feature_kind_from_llama(llama_spec_feature_kind kind) {
-    switch (kind) {
-        case LLAMA_SPEC_FEATURE_HIDDEN_STATE:
-            return COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
-        case LLAMA_SPEC_FEATURE_NONE:
-        default:
-            return COMMON_SPECULATIVE_FEATURE_NONE;
-    }
-}
-
-static void common_speculative_feature_view_from_llama(
-        const llama_spec_feature_view & src,
-        common_speculative_feature_view & dst) {
-    dst.kind = common_speculative_feature_kind_from_llama(src.kind);
-    dst.width = src.width;
-    dst.rows.clear();
-    dst.rows.reserve(src.rows.size());
-
-    for (const auto & row : src.rows) {
-        dst.rows.push_back({
-            /* .seq_id = */ row.seq_id,
-            /* .pos    = */ row.pos,
-            /* .data   = */ row.data,
-        });
-    }
-}
-
 static bool common_speculative_feature_view_from_hidden_rows(
         const std::vector<float> & hidden_rows,
         int32_t width,
@@ -1605,12 +1605,10 @@ bool common_speculative_collect_target_batch_features(
         return true;
     }
 
-    llama_spec_feature_view llama_features;
-    if (!llama_spec_get_hidden_feature_view(ctx, batch, llama_features)) {
+    if (!llama_spec_get_hidden_feature_view(ctx, batch, features)) {
         return false;
     }
 
-    common_speculative_feature_view_from_llama(llama_features, features);
     return true;
 }
 
@@ -1625,12 +1623,10 @@ bool common_speculative_collect_target_seq_batch_features(
         return true;
     }
 
-    llama_spec_feature_view llama_features;
-    if (!llama_spec_get_hidden_feature_view_for_seq(ctx, batch, seq_id, llama_features)) {
+    if (!llama_spec_get_hidden_feature_view_for_seq(ctx, batch, seq_id, features)) {
         return false;
     }
 
-    common_speculative_feature_view_from_llama(llama_features, features);
     return true;
 }
 
@@ -1644,14 +1640,78 @@ bool common_speculative_capture_output_hidden(
         return true;
     }
 
-    llama_spec_feature_view llama_features;
-    if (!llama_spec_get_hidden_feature_view_from_output_index(ctx, output_index, seq_id, pos, llama_features)) {
+    common_speculative_feature_view features;
+    if (!llama_spec_get_hidden_feature_view_from_output_index(ctx, output_index, seq_id, pos, features)) {
         return false;
     }
 
-    common_speculative_feature_view features;
-    common_speculative_feature_view_from_llama(llama_features, features);
     return common_speculative_capture_target_features(spec, features);
+}
+
+bool common_speculative_ensure_sequence_hidden(
+        common_speculative * spec,
+        llama_context * ctx,
+        llama_seq_id seq_id,
+        llama_pos pos) {
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP) || common_speculative_has_sequence_hidden(spec, seq_id)) {
+        return true;
+    }
+
+    return common_speculative_capture_output_hidden(spec, ctx, -1, seq_id, pos);
+}
+
+int32_t common_speculative_on_target_seq_batch(
+        common_speculative * spec,
+        llama_context * ctx_tgt,
+        const llama_batch & batch,
+        llama_seq_id seq_id,
+        bool is_prompt_warmup) {
+    llama_context * ctx_mtp = common_speculative_get_companion_ctx(spec);
+    ctx_mtp = ctx_mtp ? ctx_mtp : ctx_tgt;
+    if (ctx_tgt == nullptr || ctx_mtp == nullptr || batch.n_tokens <= 0) {
+        return 0;
+    }
+
+    const int n_embd_src = common_speculative_ctx_mtp_n_embd(ctx_tgt);
+    const int n_embd_dst = common_speculative_ctx_mtp_n_embd(ctx_mtp);
+    if (n_embd_src <= 0 || n_embd_dst <= 0) {
+        return -1;
+    }
+
+    if (n_embd_src != n_embd_dst) {
+        LOG_ERR("MTP warmup hidden state width mismatch: n_embd_src = %d, n_embd_dst = %d\n", n_embd_src, n_embd_dst);
+        return -1;
+    }
+
+    common_speculative_feature_view feature_view;
+    const llama_batch * batch_for_spec = &batch;
+    llama_batch seq_batch = {};
+    const bool needs_seq_split = is_prompt_warmup && !common_speculative_batch_is_exact_single_seq(batch, seq_id);
+
+    if (needs_seq_split) {
+        const int n_seq_tokens = common_speculative_copy_seq_batch(batch, seq_id, seq_batch);
+        if (n_seq_tokens <= 0) {
+            return n_seq_tokens < 0 ? -1 : 0;
+        }
+
+        if (!common_speculative_collect_target_seq_batch_features(spec, ctx_tgt, batch, seq_id, feature_view)) {
+            llama_batch_free(seq_batch);
+            return -1;
+        }
+
+        batch_for_spec = &seq_batch;
+    } else {
+        if (!common_speculative_collect_target_batch_features(spec, ctx_tgt, batch, feature_view)) {
+            return -1;
+        }
+    }
+
+    const int32_t ret = common_speculative_on_target_batch(spec, *batch_for_spec, feature_view, is_prompt_warmup);
+    if (needs_seq_split) {
+        llama_batch_free(seq_batch);
+    }
+
+    return ret;
 }
 
 bool common_speculative_copy_output_hidden_rows(

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1003,7 +1003,6 @@ struct common_speculative {
     std::vector<common_speculative_config> configs; // resolved stage config for each implementation
     std::vector<std::unique_ptr<common_speculative_state>> impls; // list of implementations to use and their states
     common_speculative_state * curr_impl = nullptr; // current implementation in use (for stats)
-    size_t curr_impl_index = SIZE_MAX;
     std::unique_ptr<spec_tuner> tuner;
     int last_n_drafted = 0;
     int64_t t_step_start_us = 0;
@@ -1359,14 +1358,14 @@ void common_speculative_begin(common_speculative * spec, const llama_tokens & pr
     }
 }
 
-common_speculative_draft_result common_speculative_draft_ex(
+llama_tokens common_speculative_draft(
         common_speculative * spec,
         common_params_speculative & params,
         const llama_tokens & prompt_tgt, // specified in target model vocab
         llama_token id_last,
         llama_pos draft_base_pos,
         llama_seq_id draft_seq_id) {
-    common_speculative_draft_result result;
+    llama_tokens result;
 
     spec->t_step_start_us = ggml_time_us();
 
@@ -1379,68 +1378,46 @@ common_speculative_draft_result common_speculative_draft_ex(
     const bool use_runtime_stage_overrides = common_speculative_stage_chain_matches(runtime_stages, spec->configs);
 
     spec->curr_impl = nullptr; // reset current implementation
-    spec->curr_impl_index = SIZE_MAX;
 
     for (size_t i = 0; i < spec->impls.size(); ++i) {
         auto & impl = spec->impls[i];
         const auto & runtime_stage = use_runtime_stage_overrides ? runtime_stages[i] : spec->configs[i].stage;
         common_params_speculative impl_params = common_speculative_get_runtime_params(spec->configs[i], params, runtime_stage);
-        result.tokens.clear();
-        result.spans.clear();
-        result.active_type = COMMON_SPECULATIVE_TYPE_NONE;
+        result.clear();
 
         {
             common_time_meas tm(impl->t_draft_us, !impl->gen_perf);
-            impl->draft(impl_params, prompt_tgt, id_last, draft_base_pos, draft_seq_id, result.tokens);
+            impl->draft(impl_params, prompt_tgt, id_last, draft_base_pos, draft_seq_id, result);
             impl->n_call_draft++;
         }
 
-        if (result.tokens.empty()) {
+        if (result.empty()) {
             continue;
         }
 
-        if (common_speculative_type_is_self_spec(impl->type) && impl_params.n_min > 0 && (int)result.tokens.size() < impl_params.n_min) {
+        if (common_speculative_type_is_self_spec(impl->type) && impl_params.n_min > 0 && (int)result.size() < impl_params.n_min) {
             LOG_DBG("%s: impl %s drafted %zu tokens, below fallback threshold %d - trying next implementation\n",
-                    __func__, common_speculative_type_to_str(impl->type).c_str(), result.tokens.size(), impl_params.n_min);
-            result.tokens.clear();
+                    __func__, common_speculative_type_to_str(impl->type).c_str(), result.size(), impl_params.n_min);
+            result.clear();
             continue;
         }
         LOG_DBG("%s: called impl %s, hist size = %zu, call_count = %zu, gen = %zu\n", __func__,
                 common_speculative_type_to_str(impl.get()->type).c_str(), prompt_tgt.size(),
-                impl.get()->n_call_draft, result.tokens.size());
+                impl.get()->n_call_draft, result.size());
 
         spec->curr_impl = impl.get();
-        spec->curr_impl_index = i;
         impl->n_gen_drafts++;
-        impl->n_gen_tokens += result.tokens.size();
-        result.active_type = impl->type;
-        result.spans.push_back({
-            /* .type         = */ impl->type,
-            /* .stage_index  = */ (uint32_t) i,
-            /* .token_offset = */ 0,
-            /* .n_tokens     = */ (uint32_t) result.tokens.size(),
-        });
+        impl->n_gen_tokens += result.size();
 
         break; // We have a draft, so break out of the loop and return it.
     }
 
     // store draft count for tuner feedback
     if (spec->tuner && spec->tuner->enabled) {
-        spec->last_n_drafted = (int)result.tokens.size();
+        spec->last_n_drafted = (int)result.size();
     }
 
     return result;
-}
-
-llama_tokens common_speculative_draft(
-        common_speculative * spec,
-        common_params_speculative & params,
-        const llama_tokens & prompt_tgt,
-        llama_token id_last,
-        llama_pos draft_base_pos,
-        llama_seq_id draft_seq_id) {
-    auto result = common_speculative_draft_ex(spec, params, prompt_tgt, id_last, draft_base_pos, draft_seq_id);
-    return result.tokens;
 }
 
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted) {
@@ -1528,27 +1505,6 @@ static bool common_speculative_feature_view_find_seq_rows(
     return first_row_view != nullptr && last_row_view != nullptr;
 }
 
-bool common_speculative_feature_view_copy_seq_rows(
-        const common_speculative_feature_view & view,
-        llama_seq_id seq_id,
-        std::vector<float> * first_row,
-        std::vector<float> * last_row) {
-    const float * first_ptr = nullptr;
-    const float * last_ptr = nullptr;
-    if (!common_speculative_feature_view_find_seq_rows(view, seq_id, &first_ptr, &last_ptr)) {
-        return false;
-    }
-
-    if (first_row != nullptr) {
-        first_row->assign(first_ptr, first_ptr + view.width);
-    }
-    if (last_row != nullptr) {
-        last_row->assign(last_ptr, last_ptr + view.width);
-    }
-
-    return true;
-}
-
 static bool common_speculative_feature_view_copy_batch_rows(
         const common_speculative_feature_view & view,
         const llama_batch & batch,
@@ -1610,6 +1566,33 @@ static void common_speculative_feature_view_from_llama(
             /* .data   = */ row.data,
         });
     }
+}
+
+static bool common_speculative_feature_view_from_hidden_rows(
+        const std::vector<float> & hidden_rows,
+        int32_t width,
+        llama_seq_id seq_id,
+        llama_pos pos_base,
+        common_speculative_feature_view & view) {
+    view = {};
+    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
+    view.width = width;
+
+    if (width <= 0 || hidden_rows.empty() || hidden_rows.size() % (size_t) width != 0) {
+        return false;
+    }
+
+    const size_t n_rows = hidden_rows.size() / (size_t) width;
+    view.rows.reserve(n_rows);
+    for (size_t i = 0; i < n_rows; ++i) {
+        view.rows.push_back({
+            /* .seq_id = */ seq_id,
+            /* .pos    = */ pos_base + (llama_pos) i,
+            /* .data   = */ hidden_rows.data() + i * (size_t) width,
+        });
+    }
+
+    return true;
 }
 
 bool common_speculative_collect_target_batch_features(
@@ -1684,25 +1667,108 @@ bool common_speculative_copy_output_hidden_rows(
     return llama_spec_copy_hidden_rows_from_output_indices(ctx, output_indices, hidden_rows);
 }
 
-common_speculative_traits common_speculative_get_traits(const common_speculative * spec) {
-    common_speculative_traits traits;
-    if (spec == nullptr) {
-        return traits;
+static bool common_speculative_build_commit_tokens(
+        common_speculative_type spec_type_used,
+        llama_token sampled_before,
+        const std::vector<llama_token> & ids,
+        std::vector<llama_token> & commit_tokens) {
+    commit_tokens.clear();
+    if (ids.empty()) {
+        return true;
     }
 
-    traits.configured_types.reserve(spec->configs.size());
-    for (const auto & config : spec->configs) {
-        traits.configured_types.push_back(config.type);
-        if (config.type == COMMON_SPECULATIVE_TYPE_MTP || config.type == COMMON_SPECULATIVE_TYPE_DRAFT) {
-            traits.companion_kind = COMMON_SPECULATIVE_COMPANION_MODEL;
-        }
+    if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
+        commit_tokens = ids;
+        return true;
     }
 
-    if (spec->curr_impl != nullptr) {
-        traits.active_type = spec->curr_impl->type;
+    commit_tokens.reserve(ids.size());
+    commit_tokens.push_back(sampled_before);
+    if (ids.size() > 1) {
+        commit_tokens.insert(commit_tokens.end(), ids.begin(), ids.end() - 1);
     }
 
-    return traits;
+    return commit_tokens.size() == ids.size();
+}
+
+static bool common_speculative_apply_hidden_rows(
+        common_speculative * spec,
+        llama_seq_id seq_id,
+        llama_pos pos_base,
+        const std::vector<llama_token> & ids,
+        const std::vector<float> & hidden_rows) {
+    auto * mtp_state = common_speculative_get_mtp_state(spec);
+    if (mtp_state == nullptr || ids.empty()) {
+        return true;
+    }
+
+    const size_t expected_floats = ids.size() * (size_t) mtp_state->n_embd;
+    if (mtp_state->n_embd <= 0 || hidden_rows.size() != expected_floats) {
+        return false;
+    }
+
+    llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
+    for (size_t i = 0; i < ids.size(); ++i) {
+        common_batch_add(accepted_batch, ids[i], pos_base + (llama_pos) i, { seq_id }, true);
+    }
+
+    common_speculative_feature_view feature_view;
+    const bool have_feature_view = common_speculative_feature_view_from_hidden_rows(
+        hidden_rows, mtp_state->n_embd, seq_id, pos_base, feature_view);
+    const int32_t ret = have_feature_view
+        ? common_speculative_on_target_batch(spec, accepted_batch, feature_view, false)
+        : -1;
+
+    llama_batch_free(accepted_batch);
+    return ret == 0;
+}
+
+bool common_speculative_commit_accepted_hidden_rows(
+        common_speculative * spec,
+        common_speculative_type spec_type_used,
+        llama_seq_id seq_id,
+        llama_pos pos_base,
+        llama_token sampled_before,
+        const std::vector<llama_token> & ids,
+        const std::vector<float> & hidden_rows) {
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP) || ids.empty()) {
+        return true;
+    }
+
+    std::vector<llama_token> commit_tokens;
+    if (!common_speculative_build_commit_tokens(spec_type_used, sampled_before, ids, commit_tokens)) {
+        return false;
+    }
+
+    return common_speculative_apply_hidden_rows(spec, seq_id, pos_base, commit_tokens, hidden_rows);
+}
+
+bool common_speculative_commit_accepted_output(
+        common_speculative * spec,
+        llama_context * ctx,
+        common_speculative_type spec_type_used,
+        llama_seq_id seq_id,
+        llama_pos pos_base,
+        llama_token sampled_before,
+        const std::vector<llama_token> & ids,
+        const std::vector<int32_t> & output_indices) {
+    if (!common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP) || ids.empty()) {
+        return true;
+    }
+
+    std::vector<float> hidden_rows;
+    if (!common_speculative_copy_output_hidden_rows(spec, ctx, output_indices, hidden_rows)) {
+        return false;
+    }
+
+    return common_speculative_commit_accepted_hidden_rows(
+        spec,
+        spec_type_used,
+        seq_id,
+        pos_base,
+        sampled_before,
+        ids,
+        hidden_rows);
 }
 
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps, int n_decoded, int n_past, common_params_speculative * active_params) {
@@ -1807,30 +1873,9 @@ static void mtp_store_target_hidden(
     stored.assign(hidden, hidden + width);
 }
 
-static bool mtp_copy_target_hidden(
-        const common_speculative_state_mtp & state,
-        llama_seq_id seq_id,
-        std::vector<float> & hidden) {
-    auto it = state.target_hidden_by_seq.find(seq_id);
-    if (it == state.target_hidden_by_seq.end()) {
-        return false;
-    }
-
-    hidden = it->second;
-    return !hidden.empty();
-}
-
 static void mtp_clear_target_hidden(common_speculative_state_mtp & state, llama_seq_id seq_id) {
     state.target_hidden_by_seq.erase(seq_id);
     state.draft_cache_by_seq.erase(seq_id);
-}
-
-std::vector<common_speculative_feature_request> common_speculative_get_feature_requests(const common_speculative * spec) {
-    std::vector<common_speculative_feature_request> requests;
-    if (common_speculative_has_type(spec, COMMON_SPECULATIVE_TYPE_MTP)) {
-        requests.push_back({ COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE });
-    }
-    return requests;
 }
 
 static bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features) {
@@ -1861,25 +1906,6 @@ bool common_speculative_has_sequence_hidden(const common_speculative * spec, lla
 
     auto it = mtp_state->target_hidden_by_seq.find(seq_id);
     return it != mtp_state->target_hidden_by_seq.end() && !it->second.empty();
-}
-
-bool common_speculative_copy_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id, std::vector<float> & hidden) {
-    const auto * mtp_state = common_speculative_get_mtp_state(spec);
-    if (mtp_state == nullptr) {
-        return false;
-    }
-
-    return mtp_copy_target_hidden(*mtp_state, seq_id, hidden);
-}
-
-void common_speculative_restore_sequence_hidden(common_speculative * spec, llama_seq_id seq_id, const std::vector<float> & hidden) {
-    auto * mtp_state = common_speculative_get_mtp_state(spec);
-    if (mtp_state == nullptr || hidden.empty()) {
-        return;
-    }
-
-    mtp_store_target_hidden(*mtp_state, seq_id, hidden.data(), hidden.size());
-    mtp_invalidate_cached_draft(*mtp_state, seq_id);
 }
 
 void common_speculative_clear_sequence_hidden(common_speculative * spec, llama_seq_id seq_id) {
@@ -1933,8 +1959,7 @@ int32_t common_speculative_on_target_batch(
         common_speculative * spec,
         const llama_batch & batch,
         const common_speculative_feature_view & features,
-        bool is_prompt_warmup,
-        const float * seed_hidden) {
+    bool is_prompt_warmup) {
     auto * mtp_state = common_speculative_get_mtp_state(spec);
     if (mtp_state == nullptr) {
         return 0;
@@ -1968,8 +1993,6 @@ int32_t common_speculative_on_target_batch(
         mtp_invalidate_cached_draft(*mtp_state, seq_id);
         return 0;
     }
-
-    GGML_UNUSED(seed_hidden);
 
     if (is_prompt_warmup) {
         if (!llama_set_draft_input_hidden_state_copy(mtp_state->ctx_mtp, hidden_rows_storage.data(), hidden_rows_storage.size())) {

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -6,6 +6,30 @@
 
 struct common_speculative;
 
+enum common_speculative_companion_kind {
+    COMMON_SPECULATIVE_COMPANION_NONE,
+    COMMON_SPECULATIVE_COMPANION_MODEL,
+};
+
+struct common_speculative_traits {
+    std::vector<common_speculative_type> configured_types;
+    common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
+    common_speculative_companion_kind companion_kind = COMMON_SPECULATIVE_COMPANION_NONE;
+};
+
+struct common_speculative_span {
+    common_speculative_type type = COMMON_SPECULATIVE_TYPE_NONE;
+    uint32_t stage_index = 0;
+    uint32_t token_offset = 0;
+    uint32_t n_tokens = 0;
+};
+
+struct common_speculative_draft_result {
+    llama_tokens tokens;
+    std::vector<common_speculative_span> spans;
+    common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
+};
+
 // comma separated list of all types
 std::string common_speculative_type_name_str();
 
@@ -30,6 +54,14 @@ void common_speculative_begin(common_speculative * spec, const llama_tokens & pr
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 // draft_base_pos/draft_seq_id override the MTP position for id_last
+common_speculative_draft_result common_speculative_draft_ex(
+            common_speculative * spec,
+            common_params_speculative & params,
+            const llama_tokens & prompt,
+                llama_token   id_last,
+                llama_pos     draft_base_pos = -1,
+                llama_seq_id  draft_seq_id = 0);
+
 llama_tokens common_speculative_draft(
                      common_speculative * spec,
                      common_params_speculative & params,
@@ -40,6 +72,19 @@ llama_tokens common_speculative_draft(
 
 // informs the speculative decoder that n_accepted tokens were accepted by the target model
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
+
+bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type);
+common_speculative_traits common_speculative_get_traits(const common_speculative * spec);
+llama_context * common_speculative_get_companion_ctx(common_speculative * spec);
+void common_speculative_seed_companion_hidden(common_speculative * spec, const float * hidden);
+int32_t common_speculative_on_prompt_batch(common_speculative * spec, const llama_batch & batch, const float * hidden);
+int32_t common_speculative_on_accept_batch(common_speculative * spec, const llama_batch & batch, const float * hidden);
+void common_speculative_accept_tokens(
+    common_speculative * spec,
+    const std::vector<llama_token> & ids,
+    int32_t n_past_base,
+    llama_seq_id seq_id,
+    const float * hidden = nullptr);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps = 0.0, int n_decoded = 0, int n_past = 0, common_params_speculative * active_params = nullptr);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -6,24 +6,9 @@
 
 struct common_speculative;
 
-enum common_speculative_companion_kind {
-    COMMON_SPECULATIVE_COMPANION_NONE,
-    COMMON_SPECULATIVE_COMPANION_MODEL,
-};
-
 enum common_speculative_feature_kind {
     COMMON_SPECULATIVE_FEATURE_NONE,
     COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE,
-};
-
-struct common_speculative_traits {
-    std::vector<common_speculative_type> configured_types;
-    common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
-    common_speculative_companion_kind companion_kind = COMMON_SPECULATIVE_COMPANION_NONE;
-};
-
-struct common_speculative_feature_request {
-    common_speculative_feature_kind kind = COMMON_SPECULATIVE_FEATURE_NONE;
 };
 
 struct common_speculative_feature_row_view {
@@ -36,19 +21,6 @@ struct common_speculative_feature_view {
     common_speculative_feature_kind kind = COMMON_SPECULATIVE_FEATURE_NONE;
     int32_t width = 0;
     std::vector<common_speculative_feature_row_view> rows;
-};
-
-struct common_speculative_span {
-    common_speculative_type type = COMMON_SPECULATIVE_TYPE_NONE;
-    uint32_t stage_index = 0;
-    uint32_t token_offset = 0;
-    uint32_t n_tokens = 0;
-};
-
-struct common_speculative_draft_result {
-    llama_tokens tokens;
-    std::vector<common_speculative_span> spans;
-    common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
 };
 
 // comma separated list of all types
@@ -75,14 +47,6 @@ void common_speculative_begin(common_speculative * spec, const llama_tokens & pr
 
 // sample up to n_draft tokens and add them to the batch using the draft model
 // draft_base_pos/draft_seq_id override the MTP position for id_last
-common_speculative_draft_result common_speculative_draft_ex(
-            common_speculative * spec,
-            common_params_speculative & params,
-            const llama_tokens & prompt,
-                llama_token   id_last,
-                llama_pos     draft_base_pos = -1,
-                llama_seq_id  draft_seq_id = 0);
-
 llama_tokens common_speculative_draft(
                      common_speculative * spec,
                      common_params_speculative & params,
@@ -95,13 +59,6 @@ llama_tokens common_speculative_draft(
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
 
 bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type);
-common_speculative_traits common_speculative_get_traits(const common_speculative * spec);
-std::vector<common_speculative_feature_request> common_speculative_get_feature_requests(const common_speculative * spec);
-bool common_speculative_feature_view_copy_seq_rows(
-    const common_speculative_feature_view & view,
-    llama_seq_id seq_id,
-    std::vector<float> * first_row,
-    std::vector<float> * last_row);
 bool common_speculative_collect_target_batch_features(
     const common_speculative * spec,
     llama_context * ctx,
@@ -124,17 +81,31 @@ bool common_speculative_copy_output_hidden_rows(
     llama_context * ctx,
     const std::vector<int32_t> & output_indices,
     std::vector<float> & hidden_rows);
+bool common_speculative_commit_accepted_hidden_rows(
+    common_speculative * spec,
+    common_speculative_type spec_type_used,
+    llama_seq_id seq_id,
+    llama_pos pos_base,
+    llama_token sampled_before,
+    const std::vector<llama_token> & ids,
+    const std::vector<float> & hidden_rows);
+bool common_speculative_commit_accepted_output(
+    common_speculative * spec,
+    llama_context * ctx,
+    common_speculative_type spec_type_used,
+    llama_seq_id seq_id,
+    llama_pos pos_base,
+    llama_token sampled_before,
+    const std::vector<llama_token> & ids,
+    const std::vector<int32_t> & output_indices);
 bool common_speculative_has_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id);
-bool common_speculative_copy_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id, std::vector<float> & hidden);
-void common_speculative_restore_sequence_hidden(common_speculative * spec, llama_seq_id seq_id, const std::vector<float> & hidden);
 void common_speculative_clear_sequence_hidden(common_speculative * spec, llama_seq_id seq_id);
 llama_context * common_speculative_get_companion_ctx(common_speculative * spec);
 int32_t common_speculative_on_target_batch(
     common_speculative * spec,
     const llama_batch & batch,
     const common_speculative_feature_view & features,
-    bool is_prompt_warmup,
-    const float * seed_hidden = nullptr);
+    bool is_prompt_warmup);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps = 0.0, int n_decoded = 0, int n_past = 0, common_params_speculative * active_params = nullptr);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -102,6 +102,28 @@ bool common_speculative_feature_view_copy_seq_rows(
     llama_seq_id seq_id,
     std::vector<float> * first_row,
     std::vector<float> * last_row);
+bool common_speculative_collect_target_batch_features(
+    const common_speculative * spec,
+    llama_context * ctx,
+    const llama_batch & batch,
+    common_speculative_feature_view & features);
+bool common_speculative_collect_target_seq_batch_features(
+    const common_speculative * spec,
+    llama_context * ctx,
+    const llama_batch & batch,
+    llama_seq_id seq_id,
+    common_speculative_feature_view & features);
+bool common_speculative_capture_output_hidden(
+    common_speculative * spec,
+    llama_context * ctx,
+    int32_t output_index,
+    llama_seq_id seq_id,
+    llama_pos pos);
+bool common_speculative_copy_output_hidden_rows(
+    const common_speculative * spec,
+    llama_context * ctx,
+    const std::vector<int32_t> & output_indices,
+    std::vector<float> & hidden_rows);
 bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features);
 bool common_speculative_has_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id);
 bool common_speculative_copy_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id, std::vector<float> & hidden);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -51,26 +51,11 @@ llama_tokens common_speculative_draft(
 // informs the speculative decoder that n_accepted tokens were accepted by the target model
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
 
-bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type);
-
 bool common_speculative_ensure_sequence_hidden(
     common_speculative * spec,
     llama_context * ctx,
     llama_seq_id seq_id,
     llama_pos pos);
-
-bool common_speculative_collect_target_batch_features(
-    const common_speculative * spec,
-    llama_context * ctx,
-    const llama_batch & batch,
-    common_speculative_feature_view & features);
-
-bool common_speculative_collect_target_seq_batch_features(
-    const common_speculative * spec,
-    llama_context * ctx,
-    const llama_batch & batch,
-    llama_seq_id seq_id,
-    common_speculative_feature_view & features);
 
 bool common_speculative_capture_output_hidden(
     common_speculative * spec,

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -1,27 +1,20 @@
 #pragma once
 
+#include <random>
+
 #include "llama.h"
+#include "llama-context.h"
 #include "common.h"
 #include "spec-tuner.h"
 
 struct common_speculative;
 
-enum common_speculative_feature_kind {
-    COMMON_SPECULATIVE_FEATURE_NONE,
-    COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE,
-};
+using common_speculative_feature_kind = llama_spec_feature_kind;
+using common_speculative_feature_row_view = llama_spec_feature_row_view;
+using common_speculative_feature_view = llama_spec_feature_view;
 
-struct common_speculative_feature_row_view {
-    llama_seq_id seq_id = 0;
-    llama_pos pos = -1;
-    const float * data = nullptr;
-};
-
-struct common_speculative_feature_view {
-    common_speculative_feature_kind kind = COMMON_SPECULATIVE_FEATURE_NONE;
-    int32_t width = 0;
-    std::vector<common_speculative_feature_row_view> rows;
-};
+static constexpr common_speculative_feature_kind COMMON_SPECULATIVE_FEATURE_NONE = LLAMA_SPEC_FEATURE_NONE;
+static constexpr common_speculative_feature_kind COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE = LLAMA_SPEC_FEATURE_HIDDEN_STATE;
 
 // comma separated list of all types
 std::string common_speculative_type_name_str();
@@ -59,28 +52,39 @@ llama_tokens common_speculative_draft(
 void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
 
 bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type);
+
+bool common_speculative_ensure_sequence_hidden(
+    common_speculative * spec,
+    llama_context * ctx,
+    llama_seq_id seq_id,
+    llama_pos pos);
+
 bool common_speculative_collect_target_batch_features(
     const common_speculative * spec,
     llama_context * ctx,
     const llama_batch & batch,
     common_speculative_feature_view & features);
+
 bool common_speculative_collect_target_seq_batch_features(
     const common_speculative * spec,
     llama_context * ctx,
     const llama_batch & batch,
     llama_seq_id seq_id,
     common_speculative_feature_view & features);
+
 bool common_speculative_capture_output_hidden(
     common_speculative * spec,
     llama_context * ctx,
     int32_t output_index,
     llama_seq_id seq_id,
     llama_pos pos);
+
 bool common_speculative_copy_output_hidden_rows(
     const common_speculative * spec,
     llama_context * ctx,
     const std::vector<int32_t> & output_indices,
     std::vector<float> & hidden_rows);
+
 bool common_speculative_commit_accepted_hidden_rows(
     common_speculative * spec,
     common_speculative_type spec_type_used,
@@ -89,6 +93,7 @@ bool common_speculative_commit_accepted_hidden_rows(
     llama_token sampled_before,
     const std::vector<llama_token> & ids,
     const std::vector<float> & hidden_rows);
+
 bool common_speculative_commit_accepted_output(
     common_speculative * spec,
     llama_context * ctx,
@@ -98,9 +103,20 @@ bool common_speculative_commit_accepted_output(
     llama_token sampled_before,
     const std::vector<llama_token> & ids,
     const std::vector<int32_t> & output_indices);
+
 bool common_speculative_has_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id);
+
 void common_speculative_clear_sequence_hidden(common_speculative * spec, llama_seq_id seq_id);
+
 llama_context * common_speculative_get_companion_ctx(common_speculative * spec);
+
+int32_t common_speculative_on_target_seq_batch(
+    common_speculative * spec,
+    llama_context * ctx,
+    const llama_batch & batch,
+    llama_seq_id seq_id,
+    bool is_prompt_warmup);
+
 int32_t common_speculative_on_target_batch(
     common_speculative * spec,
     const llama_batch & batch,

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <random>
-
 #include "llama.h"
-#include "llama-context.h"
+#include "llama-spec-features.h"
 #include "common.h"
 #include "spec-tuner.h"
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -124,7 +124,6 @@ bool common_speculative_copy_output_hidden_rows(
     llama_context * ctx,
     const std::vector<int32_t> & output_indices,
     std::vector<float> & hidden_rows);
-bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features);
 bool common_speculative_has_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id);
 bool common_speculative_copy_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id, std::vector<float> & hidden);
 void common_speculative_restore_sequence_hidden(common_speculative * spec, llama_seq_id seq_id, const std::vector<float> & hidden);
@@ -140,8 +139,6 @@ int32_t common_speculative_on_target_batch(
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps = 0.0, int n_decoded = 0, int n_past = 0, common_params_speculative * active_params = nullptr);
 
-// get the MTP context from the speculative object (nullptr if not MTP type)
-llama_context * common_speculative_get_mtp_ctx(common_speculative * spec);
 common_speculative_type common_speculative_current_type(const common_speculative * spec);
 
 // Context shift for MTP to match how server handle main model

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -11,10 +11,31 @@ enum common_speculative_companion_kind {
     COMMON_SPECULATIVE_COMPANION_MODEL,
 };
 
+enum common_speculative_feature_kind {
+    COMMON_SPECULATIVE_FEATURE_NONE,
+    COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE,
+};
+
 struct common_speculative_traits {
     std::vector<common_speculative_type> configured_types;
     common_speculative_type active_type = COMMON_SPECULATIVE_TYPE_NONE;
     common_speculative_companion_kind companion_kind = COMMON_SPECULATIVE_COMPANION_NONE;
+};
+
+struct common_speculative_feature_request {
+    common_speculative_feature_kind kind = COMMON_SPECULATIVE_FEATURE_NONE;
+};
+
+struct common_speculative_feature_row_view {
+    llama_seq_id seq_id = 0;
+    llama_pos pos = -1;
+    const float * data = nullptr;
+};
+
+struct common_speculative_feature_view {
+    common_speculative_feature_kind kind = COMMON_SPECULATIVE_FEATURE_NONE;
+    int32_t width = 0;
+    std::vector<common_speculative_feature_row_view> rows;
 };
 
 struct common_speculative_span {
@@ -75,16 +96,24 @@ void common_speculative_accept(common_speculative * spec, uint16_t n_accepted);
 
 bool common_speculative_has_type(const common_speculative * spec, common_speculative_type type);
 common_speculative_traits common_speculative_get_traits(const common_speculative * spec);
-llama_context * common_speculative_get_companion_ctx(common_speculative * spec);
-void common_speculative_seed_companion_hidden(common_speculative * spec, const float * hidden);
-int32_t common_speculative_on_prompt_batch(common_speculative * spec, const llama_batch & batch, const float * hidden);
-int32_t common_speculative_on_accept_batch(common_speculative * spec, const llama_batch & batch, const float * hidden);
-void common_speculative_accept_tokens(
-    common_speculative * spec,
-    const std::vector<llama_token> & ids,
-    int32_t n_past_base,
+std::vector<common_speculative_feature_request> common_speculative_get_feature_requests(const common_speculative * spec);
+bool common_speculative_feature_view_copy_seq_rows(
+    const common_speculative_feature_view & view,
     llama_seq_id seq_id,
-    const float * hidden = nullptr);
+    std::vector<float> * first_row,
+    std::vector<float> * last_row);
+bool common_speculative_capture_target_features(common_speculative * spec, const common_speculative_feature_view & features);
+bool common_speculative_has_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id);
+bool common_speculative_copy_sequence_hidden(const common_speculative * spec, llama_seq_id seq_id, std::vector<float> & hidden);
+void common_speculative_restore_sequence_hidden(common_speculative * spec, llama_seq_id seq_id, const std::vector<float> & hidden);
+void common_speculative_clear_sequence_hidden(common_speculative * spec, llama_seq_id seq_id);
+llama_context * common_speculative_get_companion_ctx(common_speculative * spec);
+int32_t common_speculative_on_target_batch(
+    common_speculative * spec,
+    const llama_batch & batch,
+    const common_speculative_feature_view & features,
+    bool is_prompt_warmup,
+    const float * seed_hidden = nullptr);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec, double slot_tps = 0.0, int n_decoded = 0, int n_past = 0, common_params_speculative * active_params = nullptr);
@@ -100,23 +129,3 @@ void common_speculative_context_shift(
         llama_pos            kv_keep,
         llama_pos            kv_discard,
         llama_pos            kv_past);
-
-// Generates speculative draft tokens using the Multi-Token Prediction (MTP) architecture.
-std::vector<llama_token> mtp_speculative_gen_draft(
-    struct common_sampler * smpl,
-    struct llama_context * ctx,
-    int n_draft,
-    float p_min,
-    llama_token id_last,
-    llama_pos n_past,
-    llama_seq_id seq_id,
-    bool constant_draft_positions = false);
-
-int32_t mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch, bool is_prompt_warmup);
-
-void mtp_accept_tokens(
-    struct llama_context * ctx,
-    const std::vector<llama_token> & ids,
-    int32_t n_past_base,
-    llama_seq_id seq_id
-);

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -7,7 +7,7 @@
 
 #include "common.h"
 #include "llama.h"
-#include "llama-context.h"
+#include "llama-spec-features.h"
 
 #include <cmath>
 #include <cstdio>
@@ -99,8 +99,6 @@ static bool add_and_check_nans(int n, const float * x, float * y, int * counts) 
     return add_and_check_nans_scalar(n, x, y, counts);
 }
 
-
-uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx);
 void llama_set_mtp_target_context(struct llama_context * ctx, struct llama_context * target_ctx);
 
 static llama_model * ik_load_model_from_params(const gpt_params & params, const llama_model_params & mparams) {

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -7,6 +7,7 @@
 
 #include "common.h"
 #include "llama.h"
+#include "llama-context.h"
 
 #include <cmath>
 #include <cstdio>
@@ -927,7 +928,11 @@ static bool compute_draft_imatrix_batch(
     }
 
     llama_set_mtp_op_type(ctx_dft, MTP_OP_DRAFT_GEN);
-    llama_set_draft_input_hidden_state(ctx_dft, hidden);
+    if (!llama_set_draft_input_hidden_state_copy(ctx_dft, hidden, (size_t) batch_size * n_embd_dft)) {
+        llama_set_mtp_op_type(ctx_dft, MTP_OP_NONE);
+        fprintf(stderr, "%s: failed to stage paired draft hidden snapshot\n", __func__);
+        return false;
+    }
     const int ret = llama_decode(ctx_dft, llama_batch_get_one(draft_tokens + batch_start, batch_size, batch_pos, 0));
     llama_set_mtp_op_type(ctx_dft, MTP_OP_NONE);
 

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -105,46 +105,6 @@ static bool server_speculative_batch_is_exact_single_seq(const llama_batch & bat
     return true;
 }
 
-static void server_speculative_add_hidden_row(
-        common_speculative_feature_view & view,
-        llama_seq_id seq_id,
-        llama_pos pos,
-        const float * hidden) {
-    if (hidden == nullptr) {
-        return;
-    }
-
-    view.rows.push_back({
-        /* .seq_id = */ seq_id,
-        /* .pos    = */ pos,
-        /* .data   = */ hidden,
-    });
-}
-
-static common_speculative_feature_view server_speculative_hidden_feature_view_from_batch(
-        const llama_batch & batch,
-        const float * hidden_rows,
-        int n_embd) {
-    common_speculative_feature_view view;
-    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
-    view.width = n_embd;
-
-    if (hidden_rows == nullptr || n_embd <= 0) {
-        return view;
-    }
-
-    view.rows.reserve(batch.n_tokens);
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        if (batch.n_seq_id == nullptr || batch.seq_id == nullptr || batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
-            continue;
-        }
-
-        server_speculative_add_hidden_row(view, batch.seq_id[i][0], batch.pos[i], hidden_rows + (size_t) i * n_embd);
-    }
-
-    return view;
-}
-
 static common_speculative_feature_view server_speculative_hidden_feature_view_from_rows(
         const std::vector<float> & rows,
         int n_embd,
@@ -161,32 +121,21 @@ static common_speculative_feature_view server_speculative_hidden_feature_view_fr
     const size_t n_rows = rows.size() / n_embd;
     view.rows.reserve(n_rows);
     for (size_t i = 0; i < n_rows; ++i) {
-        server_speculative_add_hidden_row(view, seq_id, pos_base + i, rows.data() + i * n_embd);
+        view.rows.push_back({
+            /* .seq_id = */ seq_id,
+            /* .pos    = */ pos_base + (llama_pos) i,
+            /* .data   = */ rows.data() + i * n_embd,
+        });
     }
 
     return view;
 }
 
-static common_speculative_feature_view server_speculative_hidden_feature_view_single(
-        llama_seq_id seq_id,
-        llama_pos pos,
-        const float * hidden,
-        int n_embd) {
-    common_speculative_feature_view view;
-    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
-    view.width = n_embd;
-    server_speculative_add_hidden_row(view, seq_id, pos, hidden);
-    return view;
-}
-
 static int server_speculative_copy_seq_batch(
         const llama_batch & batch,
-        const float * hidden_rows,
-        int n_embd,
         llama_seq_id seq_id,
-        llama_batch & seq_batch,
-        common_speculative_feature_view & feature_view) {
-    if (batch.token == nullptr || batch.pos == nullptr || hidden_rows == nullptr || n_embd <= 0) {
+        llama_batch & seq_batch) {
+    if (batch.token == nullptr || batch.pos == nullptr) {
         return -1;
     }
 
@@ -202,9 +151,6 @@ static int server_speculative_copy_seq_batch(
     }
 
     seq_batch = llama_batch_init(n_seq_tokens, 0, 1);
-    feature_view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
-    feature_view.width = n_embd;
-    feature_view.rows.reserve(n_seq_tokens);
 
     for (int i = 0; i < batch.n_tokens; ++i) {
         if (!server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
@@ -212,25 +158,17 @@ static int server_speculative_copy_seq_batch(
         }
 
         common_batch_add(seq_batch, batch.token[i], batch.pos[i], { seq_id }, batch.logits != nullptr && batch.logits[i]);
-        server_speculative_add_hidden_row(feature_view, seq_id, batch.pos[i], hidden_rows + (size_t) i * n_embd);
     }
 
     return n_seq_tokens;
 }
 
-static void server_speculative_capture_hidden(server_slot & slot, llama_context * ctx, const float * hidden, llama_pos pos) {
-    if (!slot.has_mtp || !slot.spec || hidden == nullptr) {
+static void server_speculative_capture_hidden(server_slot & slot, llama_context * ctx, int32_t output_index, llama_pos pos) {
+    if (!slot.has_mtp || !slot.spec) {
         return;
     }
 
-    const int n_embd = get_slot_mtp_n_embd(slot, ctx);
-    if (n_embd <= 0) {
-        return;
-    }
-
-    common_speculative_capture_target_features(
-        slot.spec,
-        server_speculative_hidden_feature_view_single(slot.id, pos, hidden, n_embd));
+    (void) common_speculative_capture_output_hidden(slot.spec, ctx, output_index, slot.id, pos);
 }
 
 static bool server_speculative_apply_target_batch(
@@ -276,10 +214,9 @@ static int32_t server_speculative_target_batch(
         return 0;
     }
 
-    const float * emb = llama_get_embeddings(ctx_tgt);
     const int n_embd_src = get_ctx_mtp_n_embd(ctx_tgt);
     const int n_embd_dst = get_ctx_mtp_n_embd(ctx_mtp);
-    if (emb == nullptr || n_embd_src <= 0 || n_embd_dst <= 0) {
+    if (n_embd_src <= 0 || n_embd_dst <= 0) {
         return -1;
     }
 
@@ -297,14 +234,21 @@ static int32_t server_speculative_target_batch(
     const bool needs_seq_split = is_prompt_warmup && !server_speculative_batch_is_exact_single_seq(*batch, slot.id);
 
     if (needs_seq_split) {
-        const int n_seq_tokens = server_speculative_copy_seq_batch(*batch, emb, n_embd_src, slot.id, seq_batch, feature_view);
+        const int n_seq_tokens = server_speculative_copy_seq_batch(*batch, slot.id, seq_batch);
         if (n_seq_tokens <= 0) {
             return n_seq_tokens < 0 ? -1 : 0;
         }
 
+        if (!common_speculative_collect_target_seq_batch_features(slot.spec, ctx_tgt, *batch, slot.id, feature_view)) {
+            llama_batch_free(seq_batch);
+            return -1;
+        }
+
         batch_for_spec = &seq_batch;
     } else {
-        feature_view = server_speculative_hidden_feature_view_from_batch(*batch, emb, n_embd_src);
+        if (!common_speculative_collect_target_batch_features(slot.spec, ctx_tgt, *batch, feature_view)) {
+            return -1;
+        }
     }
 
     const int32_t ret = common_speculative_on_target_batch(slot.spec, *batch_for_spec, feature_view, is_prompt_warmup, seed_hidden);
@@ -867,6 +811,7 @@ void server_slot::reset() {
     n_past_prompt = 0;
     n_sent_text = 0;
     drafted.clear();
+    drafted_spec_type = COMMON_SPECULATIVE_TYPE_NONE;
     i_batch_dft.clear();
     spec_ckpt.clear();
     n_sent_token_probs = 0;
@@ -3765,10 +3710,7 @@ void server_context::add_sampled_tokens() {
             if (slot.has_mtp) {
                 if (!common_speculative_has_sequence_hidden(slot.spec, slot.id)) {
                     LOG_ERROR("MTP hidden state is empty during speculation", {});
-                    const float* emb_neg1 = llama_get_embeddings_ith(ctx, -1);
-                    if (emb_neg1) {
-                        server_speculative_capture_hidden(slot, ctx, emb_neg1, draft_base_pos - 1);
-                    }
+                    server_speculative_capture_hidden(slot, ctx, -1, draft_base_pos - 1);
                 }
             }
 
@@ -3780,6 +3722,7 @@ void server_context::add_sampled_tokens() {
                 draft_base_pos,
                 slot.id);
             llama_tokens draft = std::move(draft_result.tokens);
+            slot.drafted_spec_type = draft_result.active_type;
 
             const int n_draft_max = slot.get_n_draft_max();
 
@@ -3804,6 +3747,7 @@ void server_context::add_sampled_tokens() {
                 // fallback to normal decoding
                 slot.i_batch = slot.i_batch_dft[0];
                 slot.drafted.clear();
+                slot.drafted_spec_type = COMMON_SPECULATIVE_TYPE_NONE;
                 slot.i_batch_dft.clear();
             } else {
                 // keep track of total number of drafted tokens tested
@@ -3820,6 +3764,7 @@ void server_context::add_sampled_tokens() {
         }
         else {
             // no speculative decoding
+            slot.drafted_spec_type = COMMON_SPECULATIVE_TYPE_NONE;
             slot.i_batch = batch.n_tokens;
 
             common_batch_add(batch, slot.sampled, slot.cache_tokens.pos_next(), { slot.id }, true);
@@ -4402,15 +4347,14 @@ static void restore_speculative_checkpoint(
                 SLT_ERR(slot, "failed to re-decode accepted tokens after checkpoint restore: %d\n", ret);
             }
             if (slot.has_mtp) {
-                const int n_embd = get_ctx_mtp_n_embd(ctx);
                 const int n_accepted = (int)ids.size();
-                std::vector<float> mtp_redecoded_states(n_accepted * n_embd);
-                for (int j = 0; j < n_accepted; j++) {
-                    const float * emb_j = llama_get_embeddings_ith(ctx, j);
-                    if (emb_j) {
-                        memcpy(mtp_redecoded_states.data() + j * n_embd, emb_j, n_embd * sizeof(float));
-                    }
+                std::vector<int32_t> redecoded_indices(n_accepted);
+                for (int j = 0; j < n_accepted; ++j) {
+                    redecoded_indices[j] = j;
                 }
+
+                std::vector<float> mtp_redecoded_states;
+                (void) common_speculative_copy_output_hidden_rows(slot.spec, ctx, redecoded_indices, mtp_redecoded_states);
 
                 if (!server_speculative_apply_target_batch(slot, ids, slot.spec_ckpt.n_past, mtp_redecoded_states)) {
                     common_speculative_clear_sequence_hidden(slot.spec, slot.id);
@@ -4437,7 +4381,7 @@ void server_context::speculative_decoding_accept() {
         }
 
         const llama_token sampled_before = slot.sampled;
-        const common_speculative_type spec_type_used = common_speculative_current_type(slot.spec);
+        const common_speculative_type spec_type_used = slot.drafted_spec_type;
         size_t n_draft = slot.drafted.size();
         std::vector<float> mtp_hidden_state_seed;
         if (slot.has_mtp) {
@@ -4479,14 +4423,10 @@ void server_context::speculative_decoding_accept() {
             const int32_t n_pre_spec_tokens = slot.cache_tokens.n_tokens() - (int32_t)(slot.drafted.size() + 1);
             mtp_n_past_base = slot.cache_tokens.pos_next(n_pre_spec_tokens);
 
-            const int n_embd = get_ctx_mtp_n_embd(ctx);
             if (!ids.empty()) {
-                mtp_hidden_state_pre.resize(ids.size() * n_embd);
-                for (size_t i = 0; i < ids.size(); i++) {
-                    const float* emb_i = llama_get_embeddings_ith(ctx, slot.i_batch_dft[i]);
-                    if (emb_i) {
-                        memcpy(mtp_hidden_state_pre.data() + i * n_embd, emb_i, n_embd * sizeof(float));
-                    }
+                std::vector<int32_t> accepted_indices(slot.i_batch_dft.begin(), slot.i_batch_dft.begin() + ids.size());
+                if (!common_speculative_copy_output_hidden_rows(slot.spec, ctx, accepted_indices, mtp_hidden_state_pre)) {
+                    mtp_hidden_state_pre.clear();
                 }
 
                 if (spec_type_used != COMMON_SPECULATIVE_TYPE_MTP) {
@@ -4494,25 +4434,18 @@ void server_context::speculative_decoding_accept() {
                     mtp_commit_tokens.push_back(sampled_before);
                     mtp_commit_tokens.insert(mtp_commit_tokens.end(), ids.begin(), ids.end() - 1);
 
-                    mtp_commit_states.resize(ids.size() * n_embd);
-                    for (size_t i = 0; i < ids.size(); ++i) {
-                        const float * emb_i = llama_get_embeddings_ith(ctx, slot.i_batch_dft[i]);
-                        if (emb_i) {
-                            memcpy(mtp_commit_states.data() + i * n_embd, emb_i, n_embd * sizeof(float));
-                        }
+                    if (!common_speculative_copy_output_hidden_rows(slot.spec, ctx, accepted_indices, mtp_commit_states)) {
+                        mtp_commit_states.clear();
                     }
                 }
             } else {
-                const float* emb0 = llama_get_embeddings_ith(ctx, 0);
-                if (emb0) {
-                    mtp_hidden_state_pre.resize(n_embd);
-                    memcpy(mtp_hidden_state_pre.data(), emb0, n_embd * sizeof(float));
-                }
+                (void) common_speculative_copy_output_hidden_rows(slot.spec, ctx, std::vector<int32_t>{ 0 }, mtp_hidden_state_pre);
             }
         }
 
         slot.i_batch_dft.clear();
         slot.drafted.clear();
+        slot.drafted_spec_type = COMMON_SPECULATIVE_TYPE_NONE;
 
         slot.n_past += ids.size();
         slot.n_decoded += ids.size();
@@ -5003,10 +4936,7 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
             const int tok_idx = slot.i_batch - i;
 
             if (slot.has_mtp && slot.n_decoded == 0) {
-                const float* emb_i = llama_get_embeddings_ith(ctx, tok_idx);
-                if (emb_i) {
-                    server_speculative_capture_hidden(slot, ctx, emb_i, slot.n_past);
-                }
+                server_speculative_capture_hidden(slot, ctx, tok_idx, slot.n_past);
             }
 
             apply_server_biases(slot);

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -105,32 +105,6 @@ static bool server_speculative_batch_is_exact_single_seq(const llama_batch & bat
     return true;
 }
 
-static common_speculative_feature_view server_speculative_hidden_feature_view_from_rows(
-        const std::vector<float> & rows,
-        int n_embd,
-        llama_seq_id seq_id,
-        llama_pos pos_base) {
-    common_speculative_feature_view view;
-    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
-    view.width = n_embd;
-
-    if (n_embd <= 0 || rows.size() < (size_t) n_embd) {
-        return view;
-    }
-
-    const size_t n_rows = rows.size() / n_embd;
-    view.rows.reserve(n_rows);
-    for (size_t i = 0; i < n_rows; ++i) {
-        view.rows.push_back({
-            /* .seq_id = */ seq_id,
-            /* .pos    = */ pos_base + (llama_pos) i,
-            /* .data   = */ rows.data() + i * n_embd,
-        });
-    }
-
-    return view;
-}
-
 static int server_speculative_copy_seq_batch(
         const llama_batch & batch,
         llama_seq_id seq_id,
@@ -171,33 +145,6 @@ static void server_speculative_capture_hidden(server_slot & slot, llama_context 
     (void) common_speculative_capture_output_hidden(slot.spec, ctx, output_index, slot.id, pos);
 }
 
-static bool server_speculative_apply_target_batch(
-        server_slot & slot,
-        const std::vector<llama_token> & ids,
-        llama_pos pos_base,
-        const std::vector<float> & hidden_rows,
-        const float * seed_hidden = nullptr) {
-    if (!slot.has_mtp || !slot.spec || ids.empty()) {
-        return true;
-    }
-
-    const int n_embd = get_ctx_mtp_n_embd(get_slot_mtp_ctx(slot, slot.ctx));
-    if (n_embd <= 0 || hidden_rows.size() < (size_t) n_embd) {
-        return false;
-    }
-
-    llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
-    for (size_t i = 0; i < ids.size(); ++i) {
-        common_batch_add(accepted_batch, ids[i], pos_base + i, { slot.id }, true);
-    }
-
-    const auto feature_view = server_speculative_hidden_feature_view_from_rows(hidden_rows, n_embd, slot.id, pos_base);
-    const int32_t ret = common_speculative_on_target_batch(slot.spec, accepted_batch, feature_view, false, seed_hidden);
-    llama_batch_free(accepted_batch);
-
-    return ret == 0;
-}
-
 struct server_mtp_warmup {
     llama_context * ctx_tgt;
     server_slot   * slot;
@@ -207,8 +154,7 @@ static int32_t server_speculative_target_batch(
         llama_context * ctx_tgt,
         const llama_batch * batch,
         server_slot & slot,
-        bool is_prompt_warmup,
-        const float * seed_hidden = nullptr) {
+    bool is_prompt_warmup) {
     llama_context * ctx_mtp = get_slot_mtp_ctx(slot, ctx_tgt);
     if (!ctx_tgt || !ctx_mtp || !batch || batch->n_tokens <= 0) {
         return 0;
@@ -251,7 +197,7 @@ static int32_t server_speculative_target_batch(
         }
     }
 
-    const int32_t ret = common_speculative_on_target_batch(slot.spec, *batch_for_spec, feature_view, is_prompt_warmup, seed_hidden);
+    const int32_t ret = common_speculative_on_target_batch(slot.spec, *batch_for_spec, feature_view, is_prompt_warmup);
     if (needs_seq_split) {
         llama_batch_free(seq_batch);
     }
@@ -3714,15 +3660,14 @@ void server_context::add_sampled_tokens() {
                 }
             }
 
-            common_speculative_draft_result draft_result = common_speculative_draft_ex(
+            llama_tokens draft = common_speculative_draft(
                 slot.spec,
                 params_spec,
                 cached_text_tokens,
                 slot.sampled,
                 draft_base_pos,
                 slot.id);
-            llama_tokens draft = std::move(draft_result.tokens);
-            slot.drafted_spec_type = draft_result.active_type;
+            slot.drafted_spec_type = common_speculative_current_type(slot.spec);
 
             const int n_draft_max = slot.get_n_draft_max();
 
@@ -4282,10 +4227,8 @@ void server_context::extend_context(const int32_t n_tokens) {
 static void restore_speculative_checkpoint(
         server_slot & slot, llama_context * ctx, llama_model * model,
         common_speculative_type spec_type_used,
-        const std::vector<llama_token> & ids, int n_draft,
-        const std::vector<llama_token> & mtp_commit_tokens,
-        const std::vector<float> & mtp_commit_states,
-        const std::vector<float> & mtp_hidden_state_seed,
+    llama_token sampled_before,
+    const std::vector<llama_token> & ids, int n_draft,
         const std::vector<float> & mtp_hidden_state_pre, int32_t mtp_n_past_base) {
     if (slot.spec_ckpt.per_step_enabled) {
         const int step = (int)ids.size() - 1;
@@ -4300,19 +4243,17 @@ static void restore_speculative_checkpoint(
 
         // Update MTP KV cache and hidden state using embeddings collected before checkpoint restore.
         if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
-            if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
-                if (!server_speculative_apply_target_batch(slot, ids, mtp_n_past_base, mtp_hidden_state_pre)) {
-                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
-                }
-            } else if (!mtp_commit_tokens.empty() && !mtp_commit_states.empty()) {
-                if (mtp_hidden_state_seed.empty()) {
-                    SLT_WRN(slot, "%s", "missing MTP seed hidden state for accepted-prefix replay after per-step restore");
-                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
-                } else if (!server_speculative_apply_target_batch(slot, mtp_commit_tokens, mtp_n_past_base, mtp_commit_states, mtp_hidden_state_seed.data())) {
-                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
-                } else {
-                    SLT_DBG(slot, "%s", "synced MTP target hidden state from accepted-prefix rows after per-step restore");
-                }
+            if (!common_speculative_commit_accepted_hidden_rows(
+                    slot.spec,
+                    spec_type_used,
+                    slot.id,
+                    mtp_n_past_base,
+                    sampled_before,
+                    ids,
+                    mtp_hidden_state_pre)) {
+                common_speculative_clear_sequence_hidden(slot.spec, slot.id);
+            } else if (spec_type_used != COMMON_SPECULATIVE_TYPE_MTP) {
+                SLT_DBG(slot, "%s", "synced MTP target hidden state from accepted-prefix rows after per-step restore");
             }
         }
 
@@ -4353,10 +4294,15 @@ static void restore_speculative_checkpoint(
                     redecoded_indices[j] = j;
                 }
 
-                std::vector<float> mtp_redecoded_states;
-                (void) common_speculative_copy_output_hidden_rows(slot.spec, ctx, redecoded_indices, mtp_redecoded_states);
-
-                if (!server_speculative_apply_target_batch(slot, ids, slot.spec_ckpt.n_past, mtp_redecoded_states)) {
+                if (!common_speculative_commit_accepted_output(
+                        slot.spec,
+                        ctx,
+                        spec_type_used,
+                        slot.id,
+                        slot.spec_ckpt.n_past,
+                        sampled_before,
+                        ids,
+                        redecoded_indices)) {
                     common_speculative_clear_sequence_hidden(slot.spec, slot.id);
                 }
             }
@@ -4383,10 +4329,6 @@ void server_context::speculative_decoding_accept() {
         const llama_token sampled_before = slot.sampled;
         const common_speculative_type spec_type_used = slot.drafted_spec_type;
         size_t n_draft = slot.drafted.size();
-        std::vector<float> mtp_hidden_state_seed;
-        if (slot.has_mtp) {
-            common_speculative_copy_sequence_hidden(slot.spec, slot.id, mtp_hidden_state_seed);
-        }
 
         slot.ctx_sampling->to_generated_text = &slot.generated_text;
         if (n_draft > 0) {
@@ -4415,31 +4357,22 @@ void server_context::speculative_decoding_accept() {
             continue;
         }
 
+        const bool any_rejected = (ids.size() - 1) < n_draft;
         int32_t mtp_n_past_base = 0;
         std::vector<float> mtp_hidden_state_pre;
-        std::vector<llama_token> mtp_commit_tokens;
-        std::vector<float> mtp_commit_states;
+        std::vector<int32_t> accepted_output_indices;
         if (slot.has_mtp) {
             const int32_t n_pre_spec_tokens = slot.cache_tokens.n_tokens() - (int32_t)(slot.drafted.size() + 1);
             mtp_n_past_base = slot.cache_tokens.pos_next(n_pre_spec_tokens);
 
             if (!ids.empty()) {
-                std::vector<int32_t> accepted_indices(slot.i_batch_dft.begin(), slot.i_batch_dft.begin() + ids.size());
-                if (!common_speculative_copy_output_hidden_rows(slot.spec, ctx, accepted_indices, mtp_hidden_state_pre)) {
+                accepted_output_indices.assign(slot.i_batch_dft.begin(), slot.i_batch_dft.begin() + ids.size());
+            }
+
+            if (any_rejected && slot.spec_ckpt.valid && !accepted_output_indices.empty()) {
+                if (!common_speculative_copy_output_hidden_rows(slot.spec, ctx, accepted_output_indices, mtp_hidden_state_pre)) {
                     mtp_hidden_state_pre.clear();
                 }
-
-                if (spec_type_used != COMMON_SPECULATIVE_TYPE_MTP) {
-                    mtp_commit_tokens.reserve(ids.size());
-                    mtp_commit_tokens.push_back(sampled_before);
-                    mtp_commit_tokens.insert(mtp_commit_tokens.end(), ids.begin(), ids.end() - 1);
-
-                    if (!common_speculative_copy_output_hidden_rows(slot.spec, ctx, accepted_indices, mtp_commit_states)) {
-                        mtp_commit_states.clear();
-                    }
-                }
-            } else {
-                (void) common_speculative_copy_output_hidden_rows(slot.spec, ctx, std::vector<int32_t>{ 0 }, mtp_hidden_state_pre);
             }
         }
 
@@ -4469,24 +4402,22 @@ void server_context::speculative_decoding_accept() {
         slot.n_past = slot.cache_tokens.n_tokens();
 
         // for recurrent/hybrid models: if any drafts were rejected, restore recurrent state
-        const bool any_rejected = (ids.size() - 1) < n_draft;
         if (any_rejected && slot.spec_ckpt.valid) {
-            restore_speculative_checkpoint(slot, ctx, model, spec_type_used, ids, n_draft, mtp_commit_tokens, mtp_commit_states, mtp_hidden_state_seed, mtp_hidden_state_pre, mtp_n_past_base);
+            restore_speculative_checkpoint(slot, ctx, model, spec_type_used, sampled_before, ids, n_draft, mtp_hidden_state_pre, mtp_n_past_base);
         } else {
-            if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
-                if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
-                    if (!server_speculative_apply_target_batch(slot, ids, mtp_n_past_base, mtp_hidden_state_pre)) {
-                        common_speculative_clear_sequence_hidden(slot.spec, slot.id);
-                    }
-                } else if (!mtp_commit_tokens.empty() && !mtp_commit_states.empty()) {
-                    if (mtp_hidden_state_seed.empty()) {
-                        SLT_WRN(slot, "%s", "missing MTP seed hidden state for accepted-prefix replay");
-                        common_speculative_clear_sequence_hidden(slot.spec, slot.id);
-                    } else if (!server_speculative_apply_target_batch(slot, mtp_commit_tokens, mtp_n_past_base, mtp_commit_states, mtp_hidden_state_seed.data())) {
-                        common_speculative_clear_sequence_hidden(slot.spec, slot.id);
-                    } else {
-                        SLT_DBG(slot, "%s", "synced MTP target hidden state from accepted-prefix rows");
-                    }
+            if (slot.has_mtp && !accepted_output_indices.empty()) {
+                if (!common_speculative_commit_accepted_output(
+                        slot.spec,
+                        ctx,
+                        spec_type_used,
+                        slot.id,
+                        mtp_n_past_base,
+                        sampled_before,
+                        ids,
+                        accepted_output_indices)) {
+                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
+                } else if (spec_type_used != COMMON_SPECULATIVE_TYPE_MTP) {
+                    SLT_DBG(slot, "%s", "synced MTP target hidden state from accepted-prefix rows");
                 }
             }
             llama_kv_cache_seq_rm(ctx, slot.id, slot.cache_tokens.pos_next(slot.n_past), -1);

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -445,7 +445,6 @@ void server_context::init() {
                 params_base.speculative.cparams_dft.embeddings   = true;
 
                 slot.has_mtp = true;
-                slot.use_gemma4_external_mtp = has_external_mtp;
                 slot.params.speculative.cparams_dft = params_base.speculative.cparams_dft;
 
                 slot.batch_spec = llama_batch_init(slot.params.speculative.get_max_stage_n_max() + 1, 0, 1);

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -16,8 +16,6 @@
 #include <regex>
 #include <exception>
 
-uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx);
-
 static void server_prompt_checkpoint_update(server_prompt_checkpoint & ckpt, llama_context * ctx, int id, int64_t n_tokens, llama_pos pos_min = -1, llama_pos pos_max = -1, int32_t offset = 0) {
     if (pos_min == -1) {
         pos_min = llama_kv_cache_seq_pos_min(ctx, id);
@@ -51,159 +49,10 @@ static bool params_use_gemma4_external_mtp(const gpt_params & params_base) {
         llama_model_is_gemma4_mtp_assistant(params_base.speculative.model_dft);
 }
 
-static llama_context * get_slot_mtp_ctx(server_slot & slot, llama_context * ctx) {
-    llama_context * mtp_ctx = common_speculative_get_companion_ctx(slot.spec);
-    return mtp_ctx ? mtp_ctx : ctx;
-}
-
-static int get_ctx_mtp_n_embd(llama_context * ctx) {
-    return ctx ? (int) llama_mtp_state_n_embd(ctx) : 0;
-}
-
-static int get_slot_mtp_n_embd(server_slot & slot, llama_context * ctx) {
-    return get_ctx_mtp_n_embd(get_slot_mtp_ctx(slot, ctx));
-}
-
-static bool server_speculative_batch_token_has_seq_id(
-        const llama_batch & batch,
-        int token_index,
-        llama_seq_id seq_id) {
-    if (batch.n_seq_id == nullptr || batch.seq_id == nullptr || batch.n_seq_id[token_index] <= 0 || batch.seq_id[token_index] == nullptr) {
-        return false;
-    }
-
-    for (int i = 0; i < batch.n_seq_id[token_index]; ++i) {
-        if (batch.seq_id[token_index][i] == seq_id) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-static bool server_speculative_batch_has_seq_id(const llama_batch & batch, llama_seq_id seq_id) {
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        if (server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-static bool server_speculative_batch_is_exact_single_seq(const llama_batch & batch, llama_seq_id seq_id) {
-    if (batch.n_tokens <= 0 || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
-        return false;
-    }
-
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        if (batch.n_seq_id[i] != 1 || batch.seq_id[i] == nullptr || batch.seq_id[i][0] != seq_id) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-static int server_speculative_copy_seq_batch(
-        const llama_batch & batch,
-        llama_seq_id seq_id,
-        llama_batch & seq_batch) {
-    if (batch.token == nullptr || batch.pos == nullptr) {
-        return -1;
-    }
-
-    int n_seq_tokens = 0;
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        if (server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
-            ++n_seq_tokens;
-        }
-    }
-
-    if (n_seq_tokens == 0) {
-        return 0;
-    }
-
-    seq_batch = llama_batch_init(n_seq_tokens, 0, 1);
-
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        if (!server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
-            continue;
-        }
-
-        common_batch_add(seq_batch, batch.token[i], batch.pos[i], { seq_id }, batch.logits != nullptr && batch.logits[i]);
-    }
-
-    return n_seq_tokens;
-}
-
-static void server_speculative_capture_hidden(server_slot & slot, llama_context * ctx, int32_t output_index, llama_pos pos) {
-    if (!slot.has_mtp || !slot.spec) {
-        return;
-    }
-
-    (void) common_speculative_capture_output_hidden(slot.spec, ctx, output_index, slot.id, pos);
-}
-
 struct server_mtp_warmup {
     llama_context * ctx_tgt;
     server_slot   * slot;
 };
-
-static int32_t server_speculative_target_batch(
-        llama_context * ctx_tgt,
-        const llama_batch * batch,
-        server_slot & slot,
-    bool is_prompt_warmup) {
-    llama_context * ctx_mtp = get_slot_mtp_ctx(slot, ctx_tgt);
-    if (!ctx_tgt || !ctx_mtp || !batch || batch->n_tokens <= 0) {
-        return 0;
-    }
-
-    const int n_embd_src = get_ctx_mtp_n_embd(ctx_tgt);
-    const int n_embd_dst = get_ctx_mtp_n_embd(ctx_mtp);
-    if (n_embd_src <= 0 || n_embd_dst <= 0) {
-        return -1;
-    }
-
-    if (n_embd_src != n_embd_dst) {
-        LOG_ERROR("MTP warmup hidden state width mismatch", {
-            {"n_embd_src", n_embd_src},
-            {"n_embd_dst", n_embd_dst},
-        });
-        return -1;
-    }
-
-    common_speculative_feature_view feature_view;
-    const llama_batch * batch_for_spec = batch;
-    llama_batch seq_batch = {};
-    const bool needs_seq_split = is_prompt_warmup && !server_speculative_batch_is_exact_single_seq(*batch, slot.id);
-
-    if (needs_seq_split) {
-        const int n_seq_tokens = server_speculative_copy_seq_batch(*batch, slot.id, seq_batch);
-        if (n_seq_tokens <= 0) {
-            return n_seq_tokens < 0 ? -1 : 0;
-        }
-
-        if (!common_speculative_collect_target_seq_batch_features(slot.spec, ctx_tgt, *batch, slot.id, feature_view)) {
-            llama_batch_free(seq_batch);
-            return -1;
-        }
-
-        batch_for_spec = &seq_batch;
-    } else {
-        if (!common_speculative_collect_target_batch_features(slot.spec, ctx_tgt, *batch, feature_view)) {
-            return -1;
-        }
-    }
-
-    const int32_t ret = common_speculative_on_target_batch(slot.spec, *batch_for_spec, feature_view, is_prompt_warmup);
-    if (needs_seq_split) {
-        llama_batch_free(seq_batch);
-    }
-
-    return ret;
-}
 
 static int32_t server_mtp_media_warmup_callback(void * user_data, const llama_batch * batch) {
     auto * data = static_cast<server_mtp_warmup *>(user_data);
@@ -211,7 +60,9 @@ static int32_t server_mtp_media_warmup_callback(void * user_data, const llama_ba
         return 0;
     }
 
-    return server_speculative_target_batch(data->ctx_tgt, batch, *data->slot, true);
+    return batch != nullptr
+        ? common_speculative_on_target_seq_batch(data->slot->spec, data->ctx_tgt, *batch, data->slot->id, true)
+        : 0;
 }
 
 static bool server_response_needs_chat_parse(oaicompat_type oaicompat) {
@@ -3654,9 +3505,8 @@ void server_context::add_sampled_tokens() {
             const llama_pos draft_base_pos = slot.has_mtp ? slot.cache_tokens.pos_next() : -1;
 
             if (slot.has_mtp) {
-                if (!common_speculative_has_sequence_hidden(slot.spec, slot.id)) {
+                if (!common_speculative_ensure_sequence_hidden(slot.spec, ctx, slot.id, draft_base_pos - 1)) {
                     LOG_ERROR("MTP hidden state is empty during speculation", {});
-                    server_speculative_capture_hidden(slot, ctx, -1, draft_base_pos - 1);
                 }
             }
 
@@ -4807,11 +4657,7 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
                 continue;
             }
 
-            if (!server_speculative_batch_has_seq_id(batch_view, slot.id)) {
-                continue;
-            }
-
-            if (server_speculative_target_batch(ctx, &batch_view, slot, true) != 0) {
+            if (common_speculative_on_target_seq_batch(slot.spec, ctx, batch_view, slot.id, true) != 0) {
                 LOG_ERROR("failed to warm up MTP state from prompt batch for slot %d\n", slot.id);
             }
         }
@@ -4867,7 +4713,7 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
             const int tok_idx = slot.i_batch - i;
 
             if (slot.has_mtp && slot.n_decoded == 0) {
-                server_speculative_capture_hidden(slot, ctx, tok_idx, slot.n_past);
+                (void) common_speculative_capture_output_hidden(slot.spec, ctx, tok_idx, slot.id, slot.n_past);
             }
 
             apply_server_biases(slot);

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -52,7 +52,7 @@ static bool params_use_gemma4_external_mtp(const gpt_params & params_base) {
 }
 
 static llama_context * get_slot_mtp_ctx(server_slot & slot, llama_context * ctx) {
-    llama_context * mtp_ctx = common_speculative_get_mtp_ctx(slot.spec);
+    llama_context * mtp_ctx = common_speculative_get_companion_ctx(slot.spec);
     return mtp_ctx ? mtp_ctx : ctx;
 }
 
@@ -83,7 +83,7 @@ static void sync_slot_mtp_hidden(server_slot & slot, llama_context * ctx) {
     }
 
     const int n_hidden = slot.mtp_hidden_state.size() / n_embd;
-    llama_set_draft_input_hidden_state(get_slot_mtp_ctx(slot, ctx), slot.mtp_hidden_state.data() + (n_hidden - 1) * n_embd);
+    common_speculative_seed_companion_hidden(slot.spec, slot.mtp_hidden_state.data() + (n_hidden - 1) * n_embd);
 }
 
 static void cache_and_sync_slot_mtp_hidden(server_slot & slot, llama_context * ctx, const float * hidden, int n_embd) {
@@ -141,15 +141,13 @@ static void apply_slot_mtp_accept(
         return;
     }
 
-    llama_context * mtp_ctx = get_slot_mtp_ctx(slot, ctx);
     if (slot.use_gemma4_external_mtp) {
         cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, mtp_hidden_state, n_embd);
         return;
     }
 
     slot.mtp_hidden_state = mtp_hidden_state;
-    llama_set_draft_input_hidden_state(mtp_ctx, slot.mtp_hidden_state.data());
-    mtp_accept_tokens(mtp_ctx, ids, mtp_n_past_base, slot.id);
+    common_speculative_accept_tokens(slot.spec, ids, mtp_n_past_base, slot.id, slot.mtp_hidden_state.data());
 }
 
 static void set_external_mtp_hidden(server_slot & slot, llama_context * ctx, const float * hidden, int n_embd) {
@@ -196,8 +194,7 @@ static int32_t server_mtp_warmup_batch(
     }
 
     cache_slot_mtp_hidden(slot, last_hidden, n_embd_dst);
-    llama_set_draft_input_hidden_state(ctx_mtp, emb);
-    return mtp_update_kv_cache(ctx_mtp, *batch, true);
+    return common_speculative_on_prompt_batch(slot.spec, *batch, emb);
 }
 
 static int32_t server_mtp_media_warmup_callback(void * user_data, const llama_batch * batch) {
@@ -3658,7 +3655,14 @@ void server_context::add_sampled_tokens() {
                 }
             }
 
-            llama_tokens draft = common_speculative_draft(slot.spec, params_spec, cached_text_tokens, slot.sampled, draft_base_pos, slot.id);
+            common_speculative_draft_result draft_result = common_speculative_draft_ex(
+                slot.spec,
+                params_spec,
+                cached_text_tokens,
+                slot.sampled,
+                draft_base_pos,
+                slot.id);
+            llama_tokens draft = std::move(draft_result.tokens);
 
             const int n_draft_max = slot.get_n_draft_max();
 
@@ -4234,9 +4238,6 @@ static void restore_speculative_checkpoint(
 
         // Update MTP KV cache and hidden state using embeddings collected before checkpoint restore.
         if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
-            llama_context * mtp_ctx = common_speculative_get_mtp_ctx(slot.spec);
-            llama_context * mtp_target = mtp_ctx ? mtp_ctx : ctx;
-
             if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
                 const int n_embd = get_ctx_mtp_n_embd(ctx);
                 apply_slot_mtp_accept(slot, ctx, mtp_hidden_state_pre, ids, mtp_n_past_base, n_embd);
@@ -4256,8 +4257,7 @@ static void restore_speculative_checkpoint(
                             common_batch_add(accepted_batch, mtp_commit_tokens[i], mtp_n_past_base + i, { slot.id }, true);
                         }
 
-                        llama_set_draft_input_hidden_state(mtp_target, seed_hidden);
-                        mtp_update_kv_cache(mtp_target, accepted_batch, false);
+                        common_speculative_on_accept_batch(slot.spec, accepted_batch, seed_hidden);
                         llama_batch_free(accepted_batch);
 
                         slot.mtp_hidden_state.assign(mtp_commit_states.end() - n_embd, mtp_commit_states.end());
@@ -4311,9 +4311,7 @@ static void restore_speculative_checkpoint(
                 if (slot.use_gemma4_external_mtp) {
                     cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, slot.mtp_hidden_state, n_embd);
                 } else {
-                    llama_context * mtp_ctx = get_slot_mtp_ctx(slot, ctx);
-                    llama_set_draft_input_hidden_state(mtp_ctx, slot.mtp_hidden_state.data());
-                    mtp_accept_tokens(mtp_ctx, ids, slot.spec_ckpt.n_past, slot.id);
+                    common_speculative_accept_tokens(slot.spec, ids, slot.spec_ckpt.n_past, slot.id, slot.mtp_hidden_state.data());
 
                     if (n_accepted > 1) {
                         memmove(slot.mtp_hidden_state.data(),
@@ -4445,9 +4443,6 @@ void server_context::speculative_decoding_accept() {
             restore_speculative_checkpoint(slot, ctx, model, spec_type_used, ids, n_draft, mtp_commit_tokens, mtp_commit_states, mtp_hidden_state_seed, mtp_hidden_state_pre, mtp_n_past_base);
         } else {
             if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
-                llama_context * mtp_ctx = common_speculative_get_mtp_ctx(slot.spec);
-                llama_context * mtp_target = mtp_ctx ? mtp_ctx : ctx;
-
                 if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
                     const int n_embd = get_ctx_mtp_n_embd(ctx);
                     apply_slot_mtp_accept(slot, ctx, mtp_hidden_state_pre, ids, mtp_n_past_base, n_embd);
@@ -4467,8 +4462,7 @@ void server_context::speculative_decoding_accept() {
                                 common_batch_add(accepted_batch, mtp_commit_tokens[i], mtp_n_past_base + i, { slot.id }, true);
                             }
 
-                            llama_set_draft_input_hidden_state(mtp_target, seed_hidden);
-                            mtp_update_kv_cache(mtp_target, accepted_batch, false);
+                            common_speculative_on_accept_batch(slot.spec, accepted_batch, seed_hidden);
                             llama_batch_free(accepted_batch);
 
                             slot.mtp_hidden_state.assign(mtp_commit_states.end() - n_embd, mtp_commit_states.end());

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -64,98 +64,200 @@ static int get_slot_mtp_n_embd(server_slot & slot, llama_context * ctx) {
     return get_ctx_mtp_n_embd(get_slot_mtp_ctx(slot, ctx));
 }
 
-static void cache_slot_mtp_hidden(server_slot & slot, const float * hidden, int n_embd) {
-    if (hidden == nullptr || n_embd <= 0) {
+static bool server_speculative_batch_token_has_seq_id(
+        const llama_batch & batch,
+        int token_index,
+        llama_seq_id seq_id) {
+    if (batch.n_seq_id == nullptr || batch.seq_id == nullptr || batch.n_seq_id[token_index] <= 0 || batch.seq_id[token_index] == nullptr) {
+        return false;
+    }
+
+    for (int i = 0; i < batch.n_seq_id[token_index]; ++i) {
+        if (batch.seq_id[token_index][i] == seq_id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool server_speculative_batch_has_seq_id(const llama_batch & batch, llama_seq_id seq_id) {
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool server_speculative_batch_is_exact_single_seq(const llama_batch & batch, llama_seq_id seq_id) {
+    if (batch.n_tokens <= 0 || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
+        return false;
+    }
+
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] != 1 || batch.seq_id[i] == nullptr || batch.seq_id[i][0] != seq_id) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void server_speculative_add_hidden_row(
+        common_speculative_feature_view & view,
+        llama_seq_id seq_id,
+        llama_pos pos,
+        const float * hidden) {
+    if (hidden == nullptr) {
         return;
     }
 
-    slot.mtp_hidden_state.assign(hidden, hidden + n_embd);
+    view.rows.push_back({
+        /* .seq_id = */ seq_id,
+        /* .pos    = */ pos,
+        /* .data   = */ hidden,
+    });
 }
 
-static void sync_slot_mtp_hidden(server_slot & slot, llama_context * ctx) {
-    if (!slot.has_mtp || !slot.spec || slot.mtp_hidden_state.empty()) {
+static common_speculative_feature_view server_speculative_hidden_feature_view_from_batch(
+        const llama_batch & batch,
+        const float * hidden_rows,
+        int n_embd) {
+    common_speculative_feature_view view;
+    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
+    view.width = n_embd;
+
+    if (hidden_rows == nullptr || n_embd <= 0) {
+        return view;
+    }
+
+    view.rows.reserve(batch.n_tokens);
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id == nullptr || batch.seq_id == nullptr || batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
+            continue;
+        }
+
+        server_speculative_add_hidden_row(view, batch.seq_id[i][0], batch.pos[i], hidden_rows + (size_t) i * n_embd);
+    }
+
+    return view;
+}
+
+static common_speculative_feature_view server_speculative_hidden_feature_view_from_rows(
+        const std::vector<float> & rows,
+        int n_embd,
+        llama_seq_id seq_id,
+        llama_pos pos_base) {
+    common_speculative_feature_view view;
+    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
+    view.width = n_embd;
+
+    if (n_embd <= 0 || rows.size() < (size_t) n_embd) {
+        return view;
+    }
+
+    const size_t n_rows = rows.size() / n_embd;
+    view.rows.reserve(n_rows);
+    for (size_t i = 0; i < n_rows; ++i) {
+        server_speculative_add_hidden_row(view, seq_id, pos_base + i, rows.data() + i * n_embd);
+    }
+
+    return view;
+}
+
+static common_speculative_feature_view server_speculative_hidden_feature_view_single(
+        llama_seq_id seq_id,
+        llama_pos pos,
+        const float * hidden,
+        int n_embd) {
+    common_speculative_feature_view view;
+    view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
+    view.width = n_embd;
+    server_speculative_add_hidden_row(view, seq_id, pos, hidden);
+    return view;
+}
+
+static int server_speculative_copy_seq_batch(
+        const llama_batch & batch,
+        const float * hidden_rows,
+        int n_embd,
+        llama_seq_id seq_id,
+        llama_batch & seq_batch,
+        common_speculative_feature_view & feature_view) {
+    if (batch.token == nullptr || batch.pos == nullptr || hidden_rows == nullptr || n_embd <= 0) {
+        return -1;
+    }
+
+    int n_seq_tokens = 0;
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
+            ++n_seq_tokens;
+        }
+    }
+
+    if (n_seq_tokens == 0) {
+        return 0;
+    }
+
+    seq_batch = llama_batch_init(n_seq_tokens, 0, 1);
+    feature_view.kind = COMMON_SPECULATIVE_FEATURE_HIDDEN_STATE;
+    feature_view.width = n_embd;
+    feature_view.rows.reserve(n_seq_tokens);
+
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        if (!server_speculative_batch_token_has_seq_id(batch, i, seq_id)) {
+            continue;
+        }
+
+        common_batch_add(seq_batch, batch.token[i], batch.pos[i], { seq_id }, batch.logits != nullptr && batch.logits[i]);
+        server_speculative_add_hidden_row(feature_view, seq_id, batch.pos[i], hidden_rows + (size_t) i * n_embd);
+    }
+
+    return n_seq_tokens;
+}
+
+static void server_speculative_capture_hidden(server_slot & slot, llama_context * ctx, const float * hidden, llama_pos pos) {
+    if (!slot.has_mtp || !slot.spec || hidden == nullptr) {
         return;
     }
 
     const int n_embd = get_slot_mtp_n_embd(slot, ctx);
-    if (n_embd <= 0 || slot.mtp_hidden_state.size() < (size_t) n_embd) {
+    if (n_embd <= 0) {
         return;
     }
 
-    const int n_hidden = slot.mtp_hidden_state.size() / n_embd;
-    common_speculative_seed_companion_hidden(slot.spec, slot.mtp_hidden_state.data() + (n_hidden - 1) * n_embd);
+    common_speculative_capture_target_features(
+        slot.spec,
+        server_speculative_hidden_feature_view_single(slot.id, pos, hidden, n_embd));
 }
 
-static void cache_and_sync_slot_mtp_hidden(server_slot & slot, llama_context * ctx, const float * hidden, int n_embd) {
-    cache_slot_mtp_hidden(slot, hidden, n_embd);
-    sync_slot_mtp_hidden(slot, ctx);
-}
-
-static void cache_and_sync_slot_mtp_hidden_from_rows(server_slot & slot, llama_context * ctx, const std::vector<float> & rows, int n_embd) {
-    if (rows.empty() || n_embd <= 0) {
-        return;
-    }
-
-    const size_t n_rows = rows.size() / n_embd;
-    if (n_rows == 0) {
-        return;
-    }
-
-    cache_and_sync_slot_mtp_hidden(slot, ctx, rows.data() + (n_rows - 1) * n_embd, n_embd);
-}
-
-static const float * mtp_hidden_last_row(const std::vector<float> & rows, int n_embd) {
-    if (n_embd <= 0 || rows.size() < (size_t) n_embd) {
-        return nullptr;
-    }
-
-    const size_t n_rows = rows.size() / n_embd;
-    if (n_rows == 0) {
-        return nullptr;
-    }
-
-    return rows.data() + (n_rows - 1) * n_embd;
-}
-
-static bool sync_external_mtp_after_non_mtp_accept(
+static bool server_speculative_apply_target_batch(
         server_slot & slot,
-        llama_context * ctx,
-        const std::vector<float> & mtp_commit_states,
-        int n_embd) {
-    if (!slot.use_gemma4_external_mtp || mtp_commit_states.empty() || n_embd <= 0) {
+        const std::vector<llama_token> & ids,
+        llama_pos pos_base,
+        const std::vector<float> & hidden_rows,
+        const float * seed_hidden = nullptr) {
+    if (!slot.has_mtp || !slot.spec || ids.empty()) {
+        return true;
+    }
+
+    const int n_embd = get_ctx_mtp_n_embd(get_slot_mtp_ctx(slot, slot.ctx));
+    if (n_embd <= 0 || hidden_rows.size() < (size_t) n_embd) {
         return false;
     }
 
-    cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, mtp_commit_states, n_embd);
-    return true;
-}
-
-static void apply_slot_mtp_accept(
-        server_slot & slot,
-        llama_context * ctx,
-        const std::vector<float> & mtp_hidden_state,
-        const std::vector<llama_token> & ids,
-        int32_t mtp_n_past_base,
-        int n_embd) {
-    if (!slot.has_mtp || mtp_hidden_state.empty() || n_embd <= 0) {
-        return;
+    llama_batch accepted_batch = llama_batch_init(ids.size(), 0, 1);
+    for (size_t i = 0; i < ids.size(); ++i) {
+        common_batch_add(accepted_batch, ids[i], pos_base + i, { slot.id }, true);
     }
 
-    if (slot.use_gemma4_external_mtp) {
-        cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, mtp_hidden_state, n_embd);
-        return;
-    }
+    const auto feature_view = server_speculative_hidden_feature_view_from_rows(hidden_rows, n_embd, slot.id, pos_base);
+    const int32_t ret = common_speculative_on_target_batch(slot.spec, accepted_batch, feature_view, false, seed_hidden);
+    llama_batch_free(accepted_batch);
 
-    slot.mtp_hidden_state = mtp_hidden_state;
-    common_speculative_accept_tokens(slot.spec, ids, mtp_n_past_base, slot.id, slot.mtp_hidden_state.data());
-}
-
-static void set_external_mtp_hidden(server_slot & slot, llama_context * ctx, const float * hidden, int n_embd) {
-    if (!slot.has_mtp || !slot.spec || hidden == nullptr || n_embd <= 0) {
-        return;
-    }
-
-    cache_and_sync_slot_mtp_hidden(slot, ctx, hidden, n_embd);
+    return ret == 0;
 }
 
 struct server_mtp_warmup {
@@ -163,11 +265,13 @@ struct server_mtp_warmup {
     server_slot   * slot;
 };
 
-static int32_t server_mtp_warmup_batch(
+static int32_t server_speculative_target_batch(
         llama_context * ctx_tgt,
-        llama_context * ctx_mtp,
         const llama_batch * batch,
-        server_slot & slot) {
+        server_slot & slot,
+        bool is_prompt_warmup,
+        const float * seed_hidden = nullptr) {
+    llama_context * ctx_mtp = get_slot_mtp_ctx(slot, ctx_tgt);
     if (!ctx_tgt || !ctx_mtp || !batch || batch->n_tokens <= 0) {
         return 0;
     }
@@ -187,14 +291,28 @@ static int32_t server_mtp_warmup_batch(
         return -1;
     }
 
-    const float * last_hidden = emb + (batch->n_tokens - 1) * n_embd_src;
-    if (slot.use_gemma4_external_mtp) {
-        cache_and_sync_slot_mtp_hidden(slot, ctx_tgt, last_hidden, n_embd_dst);
-        return 0;
+    common_speculative_feature_view feature_view;
+    const llama_batch * batch_for_spec = batch;
+    llama_batch seq_batch = {};
+    const bool needs_seq_split = is_prompt_warmup && !server_speculative_batch_is_exact_single_seq(*batch, slot.id);
+
+    if (needs_seq_split) {
+        const int n_seq_tokens = server_speculative_copy_seq_batch(*batch, emb, n_embd_src, slot.id, seq_batch, feature_view);
+        if (n_seq_tokens <= 0) {
+            return n_seq_tokens < 0 ? -1 : 0;
+        }
+
+        batch_for_spec = &seq_batch;
+    } else {
+        feature_view = server_speculative_hidden_feature_view_from_batch(*batch, emb, n_embd_src);
     }
 
-    cache_slot_mtp_hidden(slot, last_hidden, n_embd_dst);
-    return common_speculative_on_prompt_batch(slot.spec, *batch, emb);
+    const int32_t ret = common_speculative_on_target_batch(slot.spec, *batch_for_spec, feature_view, is_prompt_warmup, seed_hidden);
+    if (needs_seq_split) {
+        llama_batch_free(seq_batch);
+    }
+
+    return ret;
 }
 
 static int32_t server_mtp_media_warmup_callback(void * user_data, const llama_batch * batch) {
@@ -203,7 +321,7 @@ static int32_t server_mtp_media_warmup_callback(void * user_data, const llama_ba
         return 0;
     }
 
-    return server_mtp_warmup_batch(data->ctx_tgt, get_slot_mtp_ctx(*data->slot, data->ctx_tgt), batch, *data->slot);
+    return server_speculative_target_batch(data->ctx_tgt, batch, *data->slot, true);
 }
 
 static bool server_response_needs_chat_parse(oaicompat_type oaicompat) {
@@ -767,7 +885,9 @@ void server_slot::reset() {
     checkpoint_pos = 0;
     image_just_processed = false;
     do_checkpoint = false;
-    mtp_hidden_state.clear();
+    if (spec != nullptr) {
+        common_speculative_clear_sequence_hidden(spec, id);
+    }
 
     positional_bans.clear();
     ban_phrases.clear();
@@ -3643,14 +3763,11 @@ void server_context::add_sampled_tokens() {
             const llama_pos draft_base_pos = slot.has_mtp ? slot.cache_tokens.pos_next() : -1;
 
             if (slot.has_mtp) {
-                if (!slot.mtp_hidden_state.empty()) {
-                    sync_slot_mtp_hidden(slot, ctx);
-                } else {
+                if (!common_speculative_has_sequence_hidden(slot.spec, slot.id)) {
                     LOG_ERROR("MTP hidden state is empty during speculation", {});
                     const float* emb_neg1 = llama_get_embeddings_ith(ctx, -1);
                     if (emb_neg1) {
-                        const int n_embd = get_ctx_mtp_n_embd(ctx);
-                        cache_and_sync_slot_mtp_hidden(slot, ctx, emb_neg1, n_embd);
+                        server_speculative_capture_hidden(slot, ctx, emb_neg1, draft_base_pos - 1);
                     }
                 }
             }
@@ -4239,29 +4356,17 @@ static void restore_speculative_checkpoint(
         // Update MTP KV cache and hidden state using embeddings collected before checkpoint restore.
         if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
             if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
-                const int n_embd = get_ctx_mtp_n_embd(ctx);
-                apply_slot_mtp_accept(slot, ctx, mtp_hidden_state_pre, ids, mtp_n_past_base, n_embd);
+                if (!server_speculative_apply_target_batch(slot, ids, mtp_n_past_base, mtp_hidden_state_pre)) {
+                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
+                }
             } else if (!mtp_commit_tokens.empty() && !mtp_commit_states.empty()) {
-                const int n_embd = get_ctx_mtp_n_embd(ctx);
-                if (sync_external_mtp_after_non_mtp_accept(slot, ctx, mtp_commit_states, n_embd)) {
-                    SLT_DBG(slot, "%s", "synced external MTP hidden state from accepted-prefix rows after per-step restore");
+                if (mtp_hidden_state_seed.empty()) {
+                    SLT_WRN(slot, "%s", "missing MTP seed hidden state for accepted-prefix replay after per-step restore");
+                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
+                } else if (!server_speculative_apply_target_batch(slot, mtp_commit_tokens, mtp_n_past_base, mtp_commit_states, mtp_hidden_state_seed.data())) {
+                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
                 } else {
-                    const float * seed_hidden = mtp_hidden_last_row(mtp_hidden_state_seed, n_embd);
-
-                    if (seed_hidden == nullptr) {
-                        SLT_WRN(slot, "%s", "missing MTP seed hidden state for accepted-prefix replay after per-step restore");
-                        slot.mtp_hidden_state.clear();
-                    } else {
-                        llama_batch accepted_batch = llama_batch_init(mtp_commit_tokens.size(), 0, 1);
-                        for (size_t i = 0; i < mtp_commit_tokens.size(); ++i) {
-                            common_batch_add(accepted_batch, mtp_commit_tokens[i], mtp_n_past_base + i, { slot.id }, true);
-                        }
-
-                        common_speculative_on_accept_batch(slot.spec, accepted_batch, seed_hidden);
-                        llama_batch_free(accepted_batch);
-
-                        slot.mtp_hidden_state.assign(mtp_commit_states.end() - n_embd, mtp_commit_states.end());
-                    }
+                    SLT_DBG(slot, "%s", "synced MTP target hidden state from accepted-prefix rows after per-step restore");
                 }
             }
         }
@@ -4298,28 +4403,18 @@ static void restore_speculative_checkpoint(
             }
             if (slot.has_mtp) {
                 const int n_embd = get_ctx_mtp_n_embd(ctx);
-
                 const int n_accepted = (int)ids.size();
-                slot.mtp_hidden_state.resize(n_accepted * n_embd);
+                std::vector<float> mtp_redecoded_states(n_accepted * n_embd);
                 for (int j = 0; j < n_accepted; j++) {
                     const float * emb_j = llama_get_embeddings_ith(ctx, j);
                     if (emb_j) {
-                        memcpy(slot.mtp_hidden_state.data() + j * n_embd, emb_j, n_embd * sizeof(float));
+                        memcpy(mtp_redecoded_states.data() + j * n_embd, emb_j, n_embd * sizeof(float));
                     }
                 }
 
-                if (slot.use_gemma4_external_mtp) {
-                    cache_and_sync_slot_mtp_hidden_from_rows(slot, ctx, slot.mtp_hidden_state, n_embd);
-                } else {
-                    common_speculative_accept_tokens(slot.spec, ids, slot.spec_ckpt.n_past, slot.id, slot.mtp_hidden_state.data());
-
-                    if (n_accepted > 1) {
-                        memmove(slot.mtp_hidden_state.data(),
-                                slot.mtp_hidden_state.data() + (n_accepted - 1) * n_embd,
-                                n_embd * sizeof(float));
-                    }
+                if (!server_speculative_apply_target_batch(slot, ids, slot.spec_ckpt.n_past, mtp_redecoded_states)) {
+                    common_speculative_clear_sequence_hidden(slot.spec, slot.id);
                 }
-                slot.mtp_hidden_state.resize(n_embd);
             }
 
             for (llama_token id : ids) {
@@ -4344,7 +4439,10 @@ void server_context::speculative_decoding_accept() {
         const llama_token sampled_before = slot.sampled;
         const common_speculative_type spec_type_used = common_speculative_current_type(slot.spec);
         size_t n_draft = slot.drafted.size();
-        const std::vector<float> mtp_hidden_state_seed = slot.has_mtp ? slot.mtp_hidden_state : std::vector<float>{};
+        std::vector<float> mtp_hidden_state_seed;
+        if (slot.has_mtp) {
+            common_speculative_copy_sequence_hidden(slot.spec, slot.id, mtp_hidden_state_seed);
+        }
 
         slot.ctx_sampling->to_generated_text = &slot.generated_text;
         if (n_draft > 0) {
@@ -4444,29 +4542,17 @@ void server_context::speculative_decoding_accept() {
         } else {
             if (slot.has_mtp && !mtp_hidden_state_pre.empty()) {
                 if (spec_type_used == COMMON_SPECULATIVE_TYPE_MTP) {
-                    const int n_embd = get_ctx_mtp_n_embd(ctx);
-                    apply_slot_mtp_accept(slot, ctx, mtp_hidden_state_pre, ids, mtp_n_past_base, n_embd);
+                    if (!server_speculative_apply_target_batch(slot, ids, mtp_n_past_base, mtp_hidden_state_pre)) {
+                        common_speculative_clear_sequence_hidden(slot.spec, slot.id);
+                    }
                 } else if (!mtp_commit_tokens.empty() && !mtp_commit_states.empty()) {
-                    const int n_embd = get_ctx_mtp_n_embd(ctx);
-                    if (sync_external_mtp_after_non_mtp_accept(slot, ctx, mtp_commit_states, n_embd)) {
-                        SLT_DBG(slot, "%s", "synced external MTP hidden state from accepted-prefix rows");
+                    if (mtp_hidden_state_seed.empty()) {
+                        SLT_WRN(slot, "%s", "missing MTP seed hidden state for accepted-prefix replay");
+                        common_speculative_clear_sequence_hidden(slot.spec, slot.id);
+                    } else if (!server_speculative_apply_target_batch(slot, mtp_commit_tokens, mtp_n_past_base, mtp_commit_states, mtp_hidden_state_seed.data())) {
+                        common_speculative_clear_sequence_hidden(slot.spec, slot.id);
                     } else {
-                        const float * seed_hidden = mtp_hidden_last_row(mtp_hidden_state_seed, n_embd);
-
-                        if (seed_hidden == nullptr) {
-                            SLT_WRN(slot, "%s", "missing MTP seed hidden state for accepted-prefix replay");
-                            slot.mtp_hidden_state.clear();
-                        } else {
-                            llama_batch accepted_batch = llama_batch_init(mtp_commit_tokens.size(), 0, 1);
-                            for (size_t i = 0; i < mtp_commit_tokens.size(); ++i) {
-                                common_batch_add(accepted_batch, mtp_commit_tokens[i], mtp_n_past_base + i, { slot.id }, true);
-                            }
-
-                            common_speculative_on_accept_batch(slot.spec, accepted_batch, seed_hidden);
-                            llama_batch_free(accepted_batch);
-
-                            slot.mtp_hidden_state.assign(mtp_commit_states.end() - n_embd, mtp_commit_states.end());
-                        }
+                        SLT_DBG(slot, "%s", "synced MTP target hidden state from accepted-prefix rows");
                     }
                 }
             }
@@ -4846,26 +4932,26 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
             continue; // continue loop of n_batch
         }
 
-    server_slot * mtp_warmup_slot = nullptr;
     if (server_speculative_has_mtp(params_base.speculative)) {
-            for (auto& slot : slots) {
-                if ((slot.state == SLOT_STATE_PROCESSING && slot.n_decoded == 0) ||
-                    (slot.state == SLOT_STATE_IDLE && slot.command == SLOT_COMMAND_LOAD_PROMPT)) {
-                    bool has_tokens_for_slot = (batch_view.n_tokens > 0 && batch_view.n_seq_id[0] > 0 && batch_view.seq_id[0][0] == slot.id);
-                    if (has_tokens_for_slot) {
-                        mtp_warmup_slot = &slot;
-                        break;
-                    }
-                }
+        for (auto & slot : slots) {
+            if (!slot.spec || !slot.has_mtp) {
+                continue;
             }
-        }
 
-        if (mtp_warmup_slot && mtp_warmup_slot->spec && mtp_warmup_slot->has_mtp) {
-            llama_context * mtp_ctx = get_slot_mtp_ctx(*mtp_warmup_slot, ctx);
-            if (server_mtp_warmup_batch(ctx, mtp_ctx, &batch_view, *mtp_warmup_slot) != 0) {
-                LOG_ERROR("%s\n", "failed to warm up MTP state from prompt batch");
+            if ((slot.state != SLOT_STATE_PROCESSING || slot.n_decoded != 0) &&
+                (slot.state != SLOT_STATE_IDLE || slot.command != SLOT_COMMAND_LOAD_PROMPT)) {
+                continue;
+            }
+
+            if (!server_speculative_batch_has_seq_id(batch_view, slot.id)) {
+                continue;
+            }
+
+            if (server_speculative_target_batch(ctx, &batch_view, slot, true) != 0) {
+                LOG_ERROR("failed to warm up MTP state from prompt batch for slot %d\n", slot.id);
             }
         }
+    }
 
         for (auto& slot : slots) {
             bool is_active_slot = (slot.state == SLOT_STATE_PROCESSING);
@@ -4919,12 +5005,7 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
             if (slot.has_mtp && slot.n_decoded == 0) {
                 const float* emb_i = llama_get_embeddings_ith(ctx, tok_idx);
                 if (emb_i) {
-                    const int n_embd = get_ctx_mtp_n_embd(ctx);
-                    if (slot.use_gemma4_external_mtp) {
-                        set_external_mtp_hidden(slot, ctx, emb_i, n_embd);
-                    } else {
-                        cache_slot_mtp_hidden(slot, emb_i, n_embd);
-                    }
+                    server_speculative_capture_hidden(slot, ctx, emb_i, slot.n_past);
                 }
             }
 

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -172,7 +172,6 @@ struct server_slot {
     decltype(ctx_sampling->elb_states) elb_prev_states;
 
     bool has_mtp = false;
-    bool use_gemma4_external_mtp = false;
 
     // saves recurrent state before a speculative batch so it can be restored on rejection
     server_speculative_checkpoint spec_ckpt;

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -136,6 +136,7 @@ struct server_slot {
     // sampling
     llama_token sampled; // in speculative mode, this is the last accepted token
     llama_tokens drafted;
+    common_speculative_type drafted_spec_type = COMMON_SPECULATIVE_TYPE_NONE;
 
     json json_schema;
 

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -172,7 +172,6 @@ struct server_slot {
 
     bool has_mtp = false;
     bool use_gemma4_external_mtp = false;
-    std::vector<float> mtp_hidden_state;
 
     // saves recurrent state before a speculative batch so it can be restored on rejection
     server_speculative_checkpoint spec_ckpt;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 add_library(llama
             ../include/llama.h
             llama.cpp
+            llama-spec-features.cpp
             llama-vocab.cpp
             llama-grammar.cpp
             llama-sampling.cpp

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -287,6 +287,8 @@ struct llama_context {
     void *              abort_callback_data = nullptr;
 
     const float * draft_input_hidden_state = nullptr;
+    size_t draft_input_hidden_state_n_floats = 0;
+    std::vector<float> draft_input_hidden_state_owned;
 
     // input tensors
     struct ggml_tensor * inp_tokens;      // I32 [n_batch]
@@ -353,3 +355,8 @@ struct llama_context {
         struct llama_context * ctx,
         const std::vector<int32_t> & output_indices,
         std::vector<float>         & hidden_rows);
+
+    bool llama_set_draft_input_hidden_state_copy(
+        struct llama_context * ctx,
+        const float * hidden_state,
+        size_t n_floats);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -4,29 +4,14 @@
 #include "llama-cparams.h"
 #include "llama-sampling.h"
 
+#include "llama-spec-features.h"
+
 struct llama_model;
 
 #include <vector>
 #include <map>
 #include <set>
 #include <memory>
-
-enum llama_spec_feature_kind {
-    LLAMA_SPEC_FEATURE_NONE,
-    LLAMA_SPEC_FEATURE_HIDDEN_STATE,
-};
-
-struct llama_spec_feature_row_view {
-    llama_seq_id seq_id = 0;
-    llama_pos pos = -1;
-    const float * data = nullptr;
-};
-
-struct llama_spec_feature_view {
-    llama_spec_feature_kind kind = LLAMA_SPEC_FEATURE_NONE;
-    int32_t width = 0;
-    std::vector<llama_spec_feature_row_view> rows;
-};
 
 struct llama_kv_cell {
     llama_pos pos   = -1;
@@ -333,30 +318,3 @@ struct llama_context {
 
 };
 
-    bool llama_spec_get_hidden_feature_view(
-        struct llama_context * ctx,
-        const llama_batch    & batch,
-        llama_spec_feature_view & view);
-
-    bool llama_spec_get_hidden_feature_view_for_seq(
-        struct llama_context * ctx,
-        const llama_batch    & batch,
-        llama_seq_id           seq_id,
-        llama_spec_feature_view & view);
-
-    bool llama_spec_get_hidden_feature_view_from_output_index(
-        struct llama_context * ctx,
-        int32_t                output_index,
-        llama_seq_id           seq_id,
-        llama_pos              pos,
-        llama_spec_feature_view & view);
-
-    bool llama_spec_copy_hidden_rows_from_output_indices(
-        struct llama_context * ctx,
-        const std::vector<int32_t> & output_indices,
-        std::vector<float>         & hidden_rows);
-
-    bool llama_set_draft_input_hidden_state_copy(
-        struct llama_context * ctx,
-        const float * hidden_state,
-        size_t n_floats);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -11,6 +11,23 @@ struct llama_model;
 #include <set>
 #include <memory>
 
+enum llama_spec_feature_kind {
+    LLAMA_SPEC_FEATURE_NONE,
+    LLAMA_SPEC_FEATURE_HIDDEN_STATE,
+};
+
+struct llama_spec_feature_row_view {
+    llama_seq_id seq_id = 0;
+    llama_pos pos = -1;
+    const float * data = nullptr;
+};
+
+struct llama_spec_feature_view {
+    llama_spec_feature_kind kind = LLAMA_SPEC_FEATURE_NONE;
+    int32_t width = 0;
+    std::vector<llama_spec_feature_row_view> rows;
+};
+
 struct llama_kv_cell {
     llama_pos pos   = -1;
     llama_pos delta = 0;
@@ -242,6 +259,7 @@ struct llama_context {
     std::vector<int32_t> output_ids; // map batch token positions to ids of the logits and embd buffers
     size_t  output_size = 0; // capacity (of tokens positions) for the output buffers
     int32_t n_outputs   = 0; // number of actually-used outputs in the current ubatch or last logical batch
+    int32_t n_outputs_embd = 0; // number of embedding rows produced for the current logical batch
 
     bool logits_all = false;
 
@@ -312,3 +330,26 @@ struct llama_context {
     void set_mtp_op_type(llama_mtp_op_type value);
 
 };
+
+    bool llama_spec_get_hidden_feature_view(
+        struct llama_context * ctx,
+        const llama_batch    & batch,
+        llama_spec_feature_view & view);
+
+    bool llama_spec_get_hidden_feature_view_for_seq(
+        struct llama_context * ctx,
+        const llama_batch    & batch,
+        llama_seq_id           seq_id,
+        llama_spec_feature_view & view);
+
+    bool llama_spec_get_hidden_feature_view_from_output_index(
+        struct llama_context * ctx,
+        int32_t                output_index,
+        llama_seq_id           seq_id,
+        llama_pos              pos,
+        llama_spec_feature_view & view);
+
+    bool llama_spec_copy_hidden_rows_from_output_indices(
+        struct llama_context * ctx,
+        const std::vector<int32_t> & output_indices,
+        std::vector<float>         & hidden_rows);

--- a/src/llama-spec-features.cpp
+++ b/src/llama-spec-features.cpp
@@ -1,0 +1,182 @@
+#include "llama-spec-features.h"
+
+#include <random>
+
+#include "llama-model.h"
+#include "llama-context.h"
+
+uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx) {
+    if (ctx == nullptr) {
+        return 0;
+    }
+
+    const auto & hparams = ctx->model.hparams;
+    if (ctx->cparams.mtp && ctx->model.arch == LLM_ARCH_GEMMA4_MTP && hparams.mtp_backbone_n_embd > 0) {
+        return hparams.mtp_backbone_n_embd;
+    }
+
+    return hparams.n_embd;
+}
+
+bool llama_set_draft_input_hidden_state_copy(
+        struct llama_context * ctx,
+        const float * hidden_state,
+        size_t n_floats) {
+    if (ctx == nullptr || hidden_state == nullptr || n_floats == 0) {
+        return false;
+    }
+
+    ctx->draft_input_hidden_state_owned.assign(hidden_state, hidden_state + n_floats);
+    ctx->draft_input_hidden_state = ctx->draft_input_hidden_state_owned.data();
+    ctx->draft_input_hidden_state_n_floats = n_floats;
+    return true;
+}
+
+static bool llama_spec_prepare_hidden_feature_view(
+        struct llama_context   * ctx,
+        int32_t                  n_rows,
+        llama_spec_feature_view & view) {
+    view.kind = LLAMA_SPEC_FEATURE_HIDDEN_STATE;
+    view.width = 0;
+    view.rows.clear();
+
+    if (ctx == nullptr || n_rows < 0) {
+        return false;
+    }
+
+    llama_synchronize(ctx);
+
+    if (ctx->embd == nullptr) {
+        return false;
+    }
+
+    view.width = (int32_t) llama_mtp_state_n_embd(ctx);
+    if (view.width <= 0 || ctx->n_outputs_embd < n_rows) {
+        view.width = 0;
+        return false;
+    }
+
+    view.rows.reserve(n_rows);
+    return true;
+}
+
+bool llama_spec_get_hidden_feature_view(
+        struct llama_context   * ctx,
+        const llama_batch      & batch,
+        llama_spec_feature_view & view) {
+    if (batch.n_tokens <= 0 || batch.pos == nullptr || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
+        return false;
+    }
+
+    if (!llama_spec_prepare_hidden_feature_view(ctx, batch.n_tokens, view)) {
+        return false;
+    }
+
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
+            view.rows.clear();
+            return false;
+        }
+
+        view.rows.push_back({
+            /* .seq_id = */ batch.seq_id[i][0],
+            /* .pos    = */ batch.pos[i],
+            /* .data   = */ ctx->embd + (size_t) i * view.width,
+        });
+    }
+
+    return true;
+}
+
+bool llama_spec_get_hidden_feature_view_for_seq(
+        struct llama_context   * ctx,
+        const llama_batch      & batch,
+        llama_seq_id             seq_id,
+        llama_spec_feature_view & view) {
+    if (batch.n_tokens <= 0 || batch.pos == nullptr || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
+        return false;
+    }
+
+    if (!llama_spec_prepare_hidden_feature_view(ctx, batch.n_tokens, view)) {
+        return false;
+    }
+
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
+            view.rows.clear();
+            return false;
+        }
+
+        for (int32_t j = 0; j < batch.n_seq_id[i]; ++j) {
+            if (batch.seq_id[i][j] != seq_id) {
+                continue;
+            }
+
+            view.rows.push_back({
+                /* .seq_id = */ seq_id,
+                /* .pos    = */ batch.pos[i],
+                /* .data   = */ ctx->embd + (size_t) i * view.width,
+            });
+            break;
+        }
+    }
+
+    return !view.rows.empty();
+}
+
+bool llama_spec_get_hidden_feature_view_from_output_index(
+        struct llama_context   * ctx,
+        int32_t                  output_index,
+        llama_seq_id             seq_id,
+        llama_pos                pos,
+        llama_spec_feature_view & view) {
+    if (!llama_spec_prepare_hidden_feature_view(ctx, 1, view)) {
+        return false;
+    }
+
+    if (output_index < 0) {
+        output_index += ctx->n_outputs_embd;
+    }
+    if (output_index < 0 || output_index >= ctx->n_outputs_embd) {
+        view.rows.clear();
+        return false;
+    }
+
+    view.rows.push_back({
+        /* .seq_id = */ seq_id,
+        /* .pos    = */ pos,
+        /* .data   = */ ctx->embd + (size_t) output_index * view.width,
+    });
+    return true;
+}
+
+bool llama_spec_copy_hidden_rows_from_output_indices(
+        struct llama_context * ctx,
+        const std::vector<int32_t> & output_indices,
+        std::vector<float> & hidden_rows) {
+    hidden_rows.clear();
+    if (output_indices.empty()) {
+        return false;
+    }
+
+    llama_spec_feature_view view;
+    if (!llama_spec_prepare_hidden_feature_view(ctx, (int32_t) output_indices.size(), view)) {
+        return false;
+    }
+
+    hidden_rows.reserve((size_t) output_indices.size() * view.width);
+    for (int32_t output_index : output_indices) {
+        if (output_index < 0) {
+            output_index += ctx->n_outputs_embd;
+        }
+        if (output_index < 0 || output_index >= ctx->n_outputs_embd) {
+            hidden_rows.clear();
+            return false;
+        }
+
+        const float * row = ctx->embd + (size_t) output_index * view.width;
+        hidden_rows.insert(hidden_rows.end(), row, row + view.width);
+    }
+
+    return hidden_rows.size() == (size_t) output_indices.size() * view.width;
+}

--- a/src/llama-spec-features.h
+++ b/src/llama-spec-features.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "llama.h"
+
+#include <vector>
+
+struct llama_context;
+
+enum llama_spec_feature_kind {
+    LLAMA_SPEC_FEATURE_NONE,
+    LLAMA_SPEC_FEATURE_HIDDEN_STATE,
+};
+
+struct llama_spec_feature_row_view {
+    llama_seq_id seq_id = 0;
+    llama_pos pos = -1;
+    const float * data = nullptr;
+};
+
+struct llama_spec_feature_view {
+    llama_spec_feature_kind kind = LLAMA_SPEC_FEATURE_NONE;
+    int32_t width = 0;
+    std::vector<llama_spec_feature_row_view> rows;
+};
+
+uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx);
+
+bool llama_set_draft_input_hidden_state_copy(
+        struct llama_context * ctx,
+        const float * hidden_state,
+        size_t n_floats);
+
+bool llama_spec_get_hidden_feature_view(
+        struct llama_context   * ctx,
+        const llama_batch      & batch,
+        llama_spec_feature_view & view);
+
+bool llama_spec_get_hidden_feature_view_for_seq(
+        struct llama_context   * ctx,
+        const llama_batch      & batch,
+        llama_seq_id             seq_id,
+        llama_spec_feature_view & view);
+
+bool llama_spec_get_hidden_feature_view_from_output_index(
+        struct llama_context   * ctx,
+        int32_t                  output_index,
+        llama_seq_id             seq_id,
+        llama_pos                pos,
+        llama_spec_feature_view & view);
+
+bool llama_spec_copy_hidden_rows_from_output_indices(
+        struct llama_context * ctx,
+        const std::vector<int32_t> & output_indices,
+        std::vector<float> & hidden_rows);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -17,6 +17,7 @@
 #include "llama-cparams.h"
 #include "llama-hparams.h"
 #include "llama-context.h"
+#include "llama-spec-features.h"
 #include "llama-quantize.h"
 
 #include "unicode.h"
@@ -25,7 +26,6 @@
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
 
-uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx);
 void llama_set_mtp_target_context(struct llama_context * ctx, struct llama_context * target_ctx);
 
 // TODO: fix these includes
@@ -4239,11 +4239,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 // Make sure enough space is available for outputs.
 // Returns max number of outputs for which space was reserved.
 static uint32_t llama_output_embd_width(const llama_context & lctx) {
-    const auto & hparams = lctx.model.hparams;
-    if (lctx.cparams.mtp && lctx.model.arch == LLM_ARCH_GEMMA4_MTP && hparams.mtp_backbone_n_embd > 0) {
-        return hparams.mtp_backbone_n_embd;
-    }
-    return hparams.n_embd;
+    return llama_mtp_state_n_embd(&lctx);
 }
 
 static bool llama_context_has_mtp_outputs(const llama_context & lctx) {
@@ -8900,169 +8896,6 @@ float * llama_get_embeddings(struct llama_context * ctx) {
     return ctx->embd;
 }
 
-static bool llama_spec_prepare_hidden_feature_view(
-        struct llama_context   * ctx,
-        int32_t                  n_rows,
-        llama_spec_feature_view & view) {
-    view.kind = LLAMA_SPEC_FEATURE_HIDDEN_STATE;
-    view.width = 0;
-    view.rows.clear();
-
-    if (ctx == nullptr || n_rows < 0) {
-        return false;
-    }
-
-    llama_synchronize(ctx);
-
-    if (ctx->embd == nullptr) {
-        return false;
-    }
-
-    view.width = (int32_t) llama_output_embd_width(*ctx);
-    if (view.width <= 0 || ctx->n_outputs_embd < n_rows) {
-        view.width = 0;
-        return false;
-    }
-
-    view.rows.reserve(n_rows);
-    return true;
-}
-
-bool llama_spec_get_hidden_feature_view(
-        struct llama_context   * ctx,
-        const llama_batch      & batch,
-        llama_spec_feature_view & view) {
-    if (batch.n_tokens <= 0 || batch.pos == nullptr || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
-        return false;
-    }
-
-    if (!llama_spec_prepare_hidden_feature_view(ctx, batch.n_tokens, view)) {
-        return false;
-    }
-
-    for (int32_t i = 0; i < batch.n_tokens; ++i) {
-        if (batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
-            view.rows.clear();
-            return false;
-        }
-
-        view.rows.push_back({
-            /* .seq_id = */ batch.seq_id[i][0],
-            /* .pos    = */ batch.pos[i],
-            /* .data   = */ ctx->embd + (size_t) i * view.width,
-        });
-    }
-
-    return true;
-}
-
-bool llama_spec_get_hidden_feature_view_for_seq(
-        struct llama_context   * ctx,
-        const llama_batch      & batch,
-        llama_seq_id             seq_id,
-        llama_spec_feature_view & view) {
-    if (batch.n_tokens <= 0 || batch.pos == nullptr || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
-        return false;
-    }
-
-    if (!llama_spec_prepare_hidden_feature_view(ctx, batch.n_tokens, view)) {
-        return false;
-    }
-
-    for (int32_t i = 0; i < batch.n_tokens; ++i) {
-        if (batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
-            view.rows.clear();
-            return false;
-        }
-
-        for (int32_t j = 0; j < batch.n_seq_id[i]; ++j) {
-            if (batch.seq_id[i][j] != seq_id) {
-                continue;
-            }
-
-            view.rows.push_back({
-                /* .seq_id = */ seq_id,
-                /* .pos    = */ batch.pos[i],
-                /* .data   = */ ctx->embd + (size_t) i * view.width,
-            });
-            break;
-        }
-    }
-
-    return !view.rows.empty();
-}
-
-bool llama_spec_get_hidden_feature_view_from_output_index(
-        struct llama_context   * ctx,
-        int32_t                  output_index,
-        llama_seq_id             seq_id,
-        llama_pos                pos,
-        llama_spec_feature_view & view) {
-    if (!llama_spec_prepare_hidden_feature_view(ctx, 1, view)) {
-        return false;
-    }
-
-    if (output_index < 0) {
-        output_index += ctx->n_outputs_embd;
-    }
-    if (output_index < 0 || output_index >= ctx->n_outputs_embd) {
-        view.rows.clear();
-        return false;
-    }
-
-    view.rows.push_back({
-        /* .seq_id = */ seq_id,
-        /* .pos    = */ pos,
-        /* .data   = */ ctx->embd + (size_t) output_index * view.width,
-    });
-    return true;
-}
-
-bool llama_spec_copy_hidden_rows_from_output_indices(
-        struct llama_context * ctx,
-        const std::vector<int32_t> & output_indices,
-        std::vector<float> & hidden_rows) {
-    hidden_rows.clear();
-    if (output_indices.empty()) {
-        return false;
-    }
-
-    llama_spec_feature_view view;
-    if (!llama_spec_prepare_hidden_feature_view(ctx, (int32_t) output_indices.size(), view)) {
-        return false;
-    }
-
-    hidden_rows.reserve((size_t) output_indices.size() * view.width);
-    for (int32_t output_index : output_indices) {
-        if (output_index < 0) {
-            output_index += ctx->n_outputs_embd;
-        }
-        if (output_index < 0 || output_index >= ctx->n_outputs_embd) {
-            hidden_rows.clear();
-            return false;
-        }
-
-        const float * row = ctx->embd + (size_t) output_index * view.width;
-        hidden_rows.insert(hidden_rows.end(), row, row + view.width);
-    }
-
-    return hidden_rows.size() == (size_t) output_indices.size() * view.width;
-}
-
-bool llama_set_draft_input_hidden_state_copy(
-        struct llama_context * ctx,
-        const float * hidden_state,
-        size_t n_floats) {
-    if (ctx == nullptr || hidden_state == nullptr || n_floats == 0) {
-        return false;
-    }
-
-    ctx->draft_input_hidden_state_owned.assign(hidden_state, hidden_state + n_floats);
-    ctx->draft_input_hidden_state = ctx->draft_input_hidden_state_owned.data();
-    ctx->draft_input_hidden_state_n_floats = n_floats;
-    return true;
-}
-
 float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i) {
     int32_t j = -1;
 
@@ -10325,10 +10158,6 @@ void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float 
     ctx->draft_input_hidden_state_n_floats = ctx->inp_mtp_states
         ? ggml_nbytes(ctx->inp_mtp_states) / sizeof(float)
         : 0;
-}
-
-uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx) {
-    return llama_output_embd_width(*ctx);
 }
 
 void llama_set_mtp_target_context(struct llama_context * ctx, struct llama_context * target_ctx) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4364,9 +4364,16 @@ static void llama_graph_compute(
 static bool prepare_mtp_graph_inputs(struct llama_context & lctx) {
     ggml_tensor * dst = lctx.inp_mtp_states;
     const float * src = lctx.draft_input_hidden_state;
+    const size_t expected_floats = ggml_nbytes(dst) / sizeof(float);
 
     if (!src) {
         LLAMA_LOG_ERROR("%s: Source hidden state is null\n", __func__);
+        return false;
+    }
+
+    if (lctx.draft_input_hidden_state_n_floats != expected_floats) {
+        LLAMA_LOG_ERROR("%s: Source hidden state size mismatch (have %zu floats, need %zu)\n",
+                __func__, lctx.draft_input_hidden_state_n_floats, expected_floats);
         return false;
     }
 
@@ -9042,6 +9049,20 @@ bool llama_spec_copy_hidden_rows_from_output_indices(
     return hidden_rows.size() == (size_t) output_indices.size() * view.width;
 }
 
+bool llama_set_draft_input_hidden_state_copy(
+        struct llama_context * ctx,
+        const float * hidden_state,
+        size_t n_floats) {
+    if (ctx == nullptr || hidden_state == nullptr || n_floats == 0) {
+        return false;
+    }
+
+    ctx->draft_input_hidden_state_owned.assign(hidden_state, hidden_state + n_floats);
+    ctx->draft_input_hidden_state = ctx->draft_input_hidden_state_owned.data();
+    ctx->draft_input_hidden_state_n_floats = n_floats;
+    return true;
+}
+
 float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i) {
     int32_t j = -1;
 
@@ -10299,7 +10320,11 @@ void llama_set_offload_policy(struct llama_context * lctx, int op, bool on_or_of
 }
 
 void llama_set_draft_input_hidden_state(struct llama_context * ctx, const float * hidden_state) {
+    ctx->draft_input_hidden_state_owned.clear();
     ctx->draft_input_hidden_state = hidden_state;
+    ctx->draft_input_hidden_state_n_floats = ctx->inp_mtp_states
+        ? ggml_nbytes(ctx->inp_mtp_states) / sizeof(float)
+        : 0;
 }
 
 uint32_t llama_mtp_state_n_embd(const struct llama_context * ctx) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4848,6 +4848,7 @@ static int llama_decode_internal(
 
     // set to total number of outputs in the batch, for use in llama_get_logits_ith
     lctx.n_outputs = n_outputs;
+    lctx.n_outputs_embd = n_outputs_embd;
 
     // wait for the computation to finish (automatically done when obtaining the model output)
     //llama_synchronize(&lctx);
@@ -7493,7 +7494,8 @@ struct llama_data_write {
     }
 
     void write_embeddings(const struct llama_context * ctx) {
-        const uint64_t embeddings_size = std::min((uint64_t) ctx->embd_size, (uint64_t) ctx->n_outputs * ctx->model.hparams.n_embd);
+        const uint64_t row_width = llama_output_embd_width(*ctx);
+        const uint64_t embeddings_size = std::min((uint64_t) ctx->embd_size, (uint64_t) ctx->n_outputs_embd * row_width);
 
         write(&embeddings_size, sizeof(embeddings_size));
 
@@ -7788,6 +7790,13 @@ struct llama_data_read {
         if (ctx->embd_size < embeddings_size) {
             throw std::runtime_error("embeddings buffer too small");
         }
+
+        const uint64_t row_width = llama_output_embd_width(*ctx);
+        if (row_width == 0 || (embeddings_size % row_width) != 0) {
+            throw std::runtime_error("invalid embeddings payload size");
+        }
+
+        ctx->n_outputs_embd = embeddings_size / row_width;
 
         if (embeddings_size) {
             read_to(ctx->embd, embeddings_size * sizeof(float));
@@ -8884,6 +8893,155 @@ float * llama_get_embeddings(struct llama_context * ctx) {
     return ctx->embd;
 }
 
+static bool llama_spec_prepare_hidden_feature_view(
+        struct llama_context   * ctx,
+        int32_t                  n_rows,
+        llama_spec_feature_view & view) {
+    view.kind = LLAMA_SPEC_FEATURE_HIDDEN_STATE;
+    view.width = 0;
+    view.rows.clear();
+
+    if (ctx == nullptr || n_rows < 0) {
+        return false;
+    }
+
+    llama_synchronize(ctx);
+
+    if (ctx->embd == nullptr) {
+        return false;
+    }
+
+    view.width = (int32_t) llama_output_embd_width(*ctx);
+    if (view.width <= 0 || ctx->n_outputs_embd < n_rows) {
+        view.width = 0;
+        return false;
+    }
+
+    view.rows.reserve(n_rows);
+    return true;
+}
+
+bool llama_spec_get_hidden_feature_view(
+        struct llama_context   * ctx,
+        const llama_batch      & batch,
+        llama_spec_feature_view & view) {
+    if (batch.n_tokens <= 0 || batch.pos == nullptr || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
+        return false;
+    }
+
+    if (!llama_spec_prepare_hidden_feature_view(ctx, batch.n_tokens, view)) {
+        return false;
+    }
+
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
+            view.rows.clear();
+            return false;
+        }
+
+        view.rows.push_back({
+            /* .seq_id = */ batch.seq_id[i][0],
+            /* .pos    = */ batch.pos[i],
+            /* .data   = */ ctx->embd + (size_t) i * view.width,
+        });
+    }
+
+    return true;
+}
+
+bool llama_spec_get_hidden_feature_view_for_seq(
+        struct llama_context   * ctx,
+        const llama_batch      & batch,
+        llama_seq_id             seq_id,
+        llama_spec_feature_view & view) {
+    if (batch.n_tokens <= 0 || batch.pos == nullptr || batch.n_seq_id == nullptr || batch.seq_id == nullptr) {
+        return false;
+    }
+
+    if (!llama_spec_prepare_hidden_feature_view(ctx, batch.n_tokens, view)) {
+        return false;
+    }
+
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        if (batch.n_seq_id[i] <= 0 || batch.seq_id[i] == nullptr) {
+            view.rows.clear();
+            return false;
+        }
+
+        for (int32_t j = 0; j < batch.n_seq_id[i]; ++j) {
+            if (batch.seq_id[i][j] != seq_id) {
+                continue;
+            }
+
+            view.rows.push_back({
+                /* .seq_id = */ seq_id,
+                /* .pos    = */ batch.pos[i],
+                /* .data   = */ ctx->embd + (size_t) i * view.width,
+            });
+            break;
+        }
+    }
+
+    return !view.rows.empty();
+}
+
+bool llama_spec_get_hidden_feature_view_from_output_index(
+        struct llama_context   * ctx,
+        int32_t                  output_index,
+        llama_seq_id             seq_id,
+        llama_pos                pos,
+        llama_spec_feature_view & view) {
+    if (!llama_spec_prepare_hidden_feature_view(ctx, 1, view)) {
+        return false;
+    }
+
+    if (output_index < 0) {
+        output_index += ctx->n_outputs_embd;
+    }
+    if (output_index < 0 || output_index >= ctx->n_outputs_embd) {
+        view.rows.clear();
+        return false;
+    }
+
+    view.rows.push_back({
+        /* .seq_id = */ seq_id,
+        /* .pos    = */ pos,
+        /* .data   = */ ctx->embd + (size_t) output_index * view.width,
+    });
+    return true;
+}
+
+bool llama_spec_copy_hidden_rows_from_output_indices(
+        struct llama_context * ctx,
+        const std::vector<int32_t> & output_indices,
+        std::vector<float> & hidden_rows) {
+    hidden_rows.clear();
+    if (output_indices.empty()) {
+        return false;
+    }
+
+    llama_spec_feature_view view;
+    if (!llama_spec_prepare_hidden_feature_view(ctx, (int32_t) output_indices.size(), view)) {
+        return false;
+    }
+
+    hidden_rows.reserve((size_t) output_indices.size() * view.width);
+    for (int32_t output_index : output_indices) {
+        if (output_index < 0) {
+            output_index += ctx->n_outputs_embd;
+        }
+        if (output_index < 0 || output_index >= ctx->n_outputs_embd) {
+            hidden_rows.clear();
+            return false;
+        }
+
+        const float * row = ctx->embd + (size_t) output_index * view.width;
+        hidden_rows.insert(hidden_rows.end(), row, row + view.width);
+    }
+
+    return hidden_rows.size() == (size_t) output_indices.size() * view.width;
+}
+
 float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i) {
     int32_t j = -1;
 
@@ -8895,9 +9053,9 @@ float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i) {
         }
 
         if (i < 0) {
-            j = ctx->n_outputs + i;
+            j = ctx->n_outputs_embd + i;
             if (j < 0) {
-                throw std::runtime_error(format("negative index out of range [0, %d)", ctx->n_outputs));
+                throw std::runtime_error(format("negative index out of range [0, %d)", ctx->n_outputs_embd));
             }
         } else if ((size_t) i >= ctx->output_ids.size()) {
             throw std::runtime_error(format("out of range [0, %lu)", ctx->output_ids.size()));
@@ -8908,12 +9066,12 @@ float * llama_get_embeddings_ith(struct llama_context * ctx, int32_t i) {
         if (j < 0) {
             throw std::runtime_error(format("batch.logits[%d] != true", i));
         }
-        if (j >= ctx->n_outputs) {
+        if (j >= ctx->n_outputs_embd) {
             // This should not happen
-            throw std::runtime_error(format("corrupt output buffer (j=%d, n_outputs=%d)", j, ctx->n_outputs));
+            throw std::runtime_error(format("corrupt output buffer (j=%d, n_outputs_embd=%d)", j, ctx->n_outputs_embd));
         }
 
-        return ctx->embd + j*ctx->model.hparams.n_embd;
+        return ctx->embd + (size_t) j * llama_output_embd_width(*ctx);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: invalid embeddings id %d, reason: %s\n", __func__, i, err.what());
 #ifndef NDEBUG


### PR DESCRIPTION
Initially, this branch was only intended to better encapsulate the logic without diving too deep into moving all embedding management from the server to speculative. However, to make the ideas in #1727 viable, I moved everything explicitly related to it. As a result, this PR ended up being much more extensive, but at least it's no longer necessary to manage all embedding logic on the server side.

My tests focused primarily on Qwen 27B to verify benchmarks, output consistency, and the hashes of logits and embeddings. I found no regressions in either case. Additionally, I briefly tested GLM 4.5 Air and Gemma 4 31B to ensure compatibility.