### PR TITLE
ggml: clean up MoE active expert input handling

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1972,7 +1972,7 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
 }
 
 static void ggml_backend_sched_copy_inputs(ggml_backend_sched_t sched, ggml_backend_sched_split * split, std::array<bool, GGML_SCHED_MAX_BACKENDS> & needs_sync,
-        std::vector<int32_t> & ids, std::vector<uint32_t> & unique_ids, ggml_tensor * last_ids_tensor) {
+        std::vector<int32_t> & ids, std::vector<uint32_t> & unique_ids, ggml_tensor *& last_ids_tensor) {
     if (split->n_inputs < 1) return;
     constexpr bool k_set_sync = false;
     int split_backend_id = split->backend_id;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2007,8 +2007,8 @@ static void ggml_backend_sched_copy_inputs(ggml_backend_sched_t sched, ggml_back
                 needs_sync[split_backend_id] = k_set_sync;
             }
 
-            ggml_tensor * node = split->graph.nodes[0];
-            if (sched->only_active_experts && split->graph.n_nodes > 0 &&
+            ggml_tensor * node = split->graph.n_nodes > 0 ? split->graph.nodes[0] : nullptr;
+            if (sched->only_active_experts && node != nullptr &&
                     ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
                     ggml_backend_buffer_is_host(input->buffer) &&
                     (node->op == GGML_OP_MUL_MAT_ID || node->op == GGML_OP_MOE_FUSED_UP_GATE)) {
@@ -2046,6 +2046,9 @@ static void ggml_backend_sched_copy_inputs(ggml_backend_sched_t sched, ggml_back
                     for (int64_t i1 = 0; i1 < ids_tensor->ne[1]; i1++) {
                         for (int64_t i0 = 0; i0 < ids_tensor->ne[0]; i0++) {
                             int32_t id = ids[i1 * ids_tensor->nb[1]/sizeof(int32_t) + i0 * ids_tensor->nb[0]/sizeof(int32_t)];
+                            if (id < 0 || id >= n_expert) {
+                                continue;
+                            }
                             unique_ids[id >> 5] |= (1u << (id & 31));
                         }
                     }


### PR DESCRIPTION
Summary
- Reuse the last MoE ids tensor across split-copy calls in the same scheduler compute pass.
- Avoid reading the first split node before confirming the split graph is non-empty.
- Skip inactive/out-of-range MoE ids when building the active expert bitset, matching the compute path behavior used by SER.

Scope
- Scheduler hygiene for the active-expert CPU-to-backend copy path.
- This is not a resident expert cache or larger performance feature.

Validation
- cmake -S . -B build-hygiene -DGGML_CUDA=OFF -DGGML_VULKAN=OFF -DLLAMA_CURL=OFF
- cmake --build build-hygiene --target llama-server -j 8
- git diff --check
- ./build-hygiene/bin/llama-server --help

Note
- The generic CTest target was not useful in this fresh local build tree because the test executables were not built, so no test cases actually ran.
