### PR TITLE
Apply Hadamard to Gemma 4 MTP

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -482,6 +482,8 @@ bool server_context::load_model(const gpt_params& params_) {
         params_dft.cache_type_k = params_base.speculative.cache_type_k.empty() ? params_base.cache_type_k : params_base.speculative.cache_type_k;
         params_dft.cache_type_v = params_base.speculative.cache_type_v.empty() ? params_base.cache_type_v : params_base.speculative.cache_type_v;
         params_dft.flash_attn   = params_base.flash_attn;
+        params_dft.k_cache_hadamard = params_base.k_cache_hadamard;
+        params_dft.v_cache_hadamard = params_base.v_cache_hadamard;
         if (!params_base.speculative.params.empty()) {
             auto [argc, argv] = parse_command_line("llama-server " + params_base.speculative.params);
             if (!gpt_params_parse(argc, argv, params_dft)) {


### PR DESCRIPTION

Since Gemma MTP utilizes a separate model, it follows a path similar to the common draft mechanism. However, this path does not account for the `--k-cache-hadamard` and `--v-cache-hadamard` flags, which results in the accept rate dropping to 0%. This is a minor fix that should be applied to both Gemma and for those using `--model-draft`.

In preliminary tests with k+v Hadamard, we observed 55.1 +/- 8.4 t/s @ 70.7% compared to 56.8 +/- 9.6 t/s @ 71.8% without it. Other MTP-enabled models were not affected.