### PR TITLE
Fix reasoning-budget prefill and checkpoint replay logging

### DIFF
--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -56,7 +56,7 @@ static const char * common_reasoning_budget_name(const common_reasoning_budget_c
     return "reasoning-budget";
 }
 
-static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, llama_token token) {
+static void common_reasoning_budget_accept_impl(common_reasoning_budget_ctx * smpl, llama_token token, bool emit_logs) {
     auto * ctx = (common_reasoning_budget_ctx *)smpl;
 
     switch (ctx->state) {
@@ -65,12 +65,16 @@ static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, l
         if (ctx->start_matcher.advance(token)) {
             ctx->state = REASONING_BUDGET_COUNTING;
             ctx->remaining = ctx->budget;
-            LOG_INF("reasoning-budget: activated, budget=%d tokens\n", ctx->budget);
+            if (emit_logs) {
+                LOG_INF("reasoning-budget: activated, budget=%d tokens\n", ctx->budget);
+            }
 
             if (ctx->remaining <= 0) {
                 ctx->state = REASONING_BUDGET_FORCING;
                 ctx->force_pos = 0;
-                LOG_INF("reasoning-budget: budget=0, forcing immediately\n");
+                if (emit_logs) {
+                    LOG_INF("reasoning-budget: budget=0, forcing immediately\n");
+                }
             }
         }
         break;
@@ -80,7 +84,9 @@ static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, l
     {
         if (ctx->end_matcher.advance(token)) {
             ctx->state = REASONING_BUDGET_DONE;
-            LOG_INF("reasoning-budget: deactivated (natural end)\n");
+            if (emit_logs) {
+                LOG_INF("reasoning-budget: deactivated (natural end)\n");
+            }
             break;
         }
 
@@ -95,7 +101,9 @@ static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, l
                 ctx->state = REASONING_BUDGET_FORCING;
                 ctx->force_pos = 0;
                 ctx->end_matcher.reset();
-                LOG_INF("reasoning-budget: UTF-8 complete, now forcing end sequence\n");
+                if (emit_logs) {
+                    LOG_INF("reasoning-budget: UTF-8 complete, now forcing end sequence\n");
+                }
             }
         } else if (ctx->state == REASONING_BUDGET_COUNTING) {
             ctx->remaining--;
@@ -104,11 +112,15 @@ static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, l
                     ctx->state = REASONING_BUDGET_FORCING;
                     ctx->force_pos = 0;
                     ctx->end_matcher.reset();
-                    LOG_INF("reasoning-budget: budget exhausted, forcing end sequence\n");
+                    if (emit_logs) {
+                        LOG_INF("reasoning-budget: budget exhausted, forcing end sequence\n");
+                    }
                 } else {
                     ctx->state = REASONING_BUDGET_WAITING_UTF8;
                     ctx->end_matcher.reset();
-                    LOG_INF("reasoning-budget: budget exhausted, waiting for UTF-8 completion\n");
+                    if (emit_logs) {
+                        LOG_INF("reasoning-budget: budget exhausted, waiting for UTF-8 completion\n");
+                    }
                 }
             }
         }
@@ -118,7 +130,9 @@ static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, l
         ctx->force_pos++;
         if (ctx->force_pos >= ctx->forced_tokens.size()) {
             ctx->state = REASONING_BUDGET_DONE;
-            LOG_INF("reasoning-budget: forced sequence complete, done\n");
+            if (emit_logs) {
+                LOG_INF("reasoning-budget: forced sequence complete, done\n");
+            }
         }
         break;
     case REASONING_BUDGET_DONE:
@@ -128,19 +142,57 @@ static void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, l
             ctx->state = REASONING_BUDGET_COUNTING;
             ctx->remaining = ctx->budget;
             ctx->end_matcher.reset();
-            LOG_INF("reasoning-budget: re-activated on new start tag, budget=%d tokens\n", ctx->budget);
+            if (emit_logs) {
+                LOG_INF("reasoning-budget: re-activated on new start tag, budget=%d tokens\n", ctx->budget);
+            }
 
             if (ctx->remaining <= 0) {
                 ctx->state = REASONING_BUDGET_FORCING;
                 ctx->force_pos = 0;
-                LOG_INF("reasoning-budget: budget=0, forcing immediately\n");
+                if (emit_logs) {
+                    LOG_INF("reasoning-budget: budget=0, forcing immediately\n");
+                }
             }
         }
         break;
     }
 }
 
-static void common_reasoning_budget_apply(struct common_reasoning_budget_ctx * smpl, llama_token_data_array * cur_p) {
+void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, llama_token token) {
+    common_reasoning_budget_accept_impl(smpl, token, true);
+}
+
+void common_reasoning_budget_accept_silent(common_reasoning_budget_ctx * smpl, llama_token token) {
+    common_reasoning_budget_accept_impl(smpl, token, false);
+}
+
+void common_reasoning_budget_accept_prefill(common_reasoning_budget_ctx * smpl, llama_token token) {
+    common_reasoning_budget_accept_silent(smpl, token);
+}
+
+void common_reasoning_budget_log_prefill_state(const common_reasoning_budget_ctx * smpl) {
+    const auto * ctx = (const common_reasoning_budget_ctx *)smpl;
+    if (!ctx) {
+        return;
+    }
+
+    switch (ctx->state) {
+    case REASONING_BUDGET_COUNTING:
+        LOG_INF("reasoning-budget: activated by generation prompt, budget=%d tokens\n", ctx->budget);
+        break;
+    case REASONING_BUDGET_WAITING_UTF8:
+        LOG_INF("reasoning-budget: budget exhausted in generation prompt, waiting for UTF-8 completion\n");
+        break;
+    case REASONING_BUDGET_FORCING:
+        LOG_INF("reasoning-budget: budget exhausted in generation prompt, forcing end sequence\n");
+        break;
+    case REASONING_BUDGET_IDLE:
+    case REASONING_BUDGET_DONE:
+        break;
+    }
+}
+
+void common_reasoning_budget_apply(struct common_reasoning_budget_ctx * smpl, llama_token_data_array * cur_p) {
     auto * ctx = (common_reasoning_budget_ctx *)smpl;
     if (!ctx) {
         return;
@@ -164,7 +216,7 @@ static void common_reasoning_budget_apply(struct common_reasoning_budget_ctx * s
     }
 }
 
-static void common_reasoning_budget_reset(common_reasoning_budget_ctx * smpl) {
+void common_reasoning_budget_reset(common_reasoning_budget_ctx * smpl) {
     auto * ctx = (common_reasoning_budget_ctx *)smpl;
     ctx->state = REASONING_BUDGET_IDLE;
     ctx->remaining = ctx->budget;
@@ -179,12 +231,12 @@ static struct common_reasoning_budget_ctx * common_reasoning_budget_init_state(
     const std::vector<llama_token> & end_tokens, const std::vector<llama_token> & forced_tokens,
     int32_t budget, common_reasoning_budget_state initial_state);
 
-static struct common_reasoning_budget_ctx * common_reasoning_budget_clone(const struct common_reasoning_budget_ctx * smpl) {
+struct common_reasoning_budget_ctx * common_reasoning_budget_clone(const struct common_reasoning_budget_ctx * smpl) {
     const auto * ctx = (const common_reasoning_budget_ctx *)smpl;
     return new common_reasoning_budget_ctx(*ctx);
 }
 
-static void common_reasoning_budget_free(struct common_reasoning_budget_ctx * smpl) {
+void common_reasoning_budget_free(struct common_reasoning_budget_ctx * smpl) {
     delete (common_reasoning_budget_ctx *)smpl;
 }
 

--- a/common/reasoning-budget.h
+++ b/common/reasoning-budget.h
@@ -41,3 +41,12 @@ struct common_reasoning_budget_ctx * common_reasoning_budget_init(
     common_reasoning_budget_state    initial_state = REASONING_BUDGET_IDLE);
 
 common_reasoning_budget_state common_reasoning_budget_get_state(const common_reasoning_budget_ctx * smpl);
+
+void common_reasoning_budget_accept(common_reasoning_budget_ctx * smpl, llama_token token);
+void common_reasoning_budget_accept_silent(common_reasoning_budget_ctx * smpl, llama_token token);
+void common_reasoning_budget_accept_prefill(common_reasoning_budget_ctx * smpl, llama_token token);
+void common_reasoning_budget_log_prefill_state(const common_reasoning_budget_ctx * smpl);
+void common_reasoning_budget_apply(common_reasoning_budget_ctx * smpl, llama_token_data_array * cur_p);
+void common_reasoning_budget_reset(common_reasoning_budget_ctx * smpl);
+common_reasoning_budget_ctx * common_reasoning_budget_clone(const common_reasoning_budget_ctx * smpl);
+void common_reasoning_budget_free(common_reasoning_budget_ctx * smpl);

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -2,7 +2,6 @@
 #include "sampling.h"
 #include "llama-vocab.h"
 #include "common.h"
-#include "reasoning-budget.cpp"
 
 #include <limits>
 #include <random>
@@ -21,7 +20,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, co
     result->grammar = nullptr;
     result->rbudget = nullptr;
 
-    struct llama_grammar* grmr;
+    struct llama_grammar* grmr = nullptr;
     const std::string & grammar_str = common_grammar_value(params.grammar);
     if (grammar_str.compare(0, 11, "%llguidance") == 0) {
 #ifdef LLAMA_USE_LLGUIDANCE
@@ -136,9 +135,10 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, co
             params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens);
 
         for (const auto & token : prefill_tokens) {
-            common_reasoning_budget_accept(result->rbudget, token);
+            common_reasoning_budget_accept_prefill(result->rbudget, token);
             LOG_DBG("%s: reasoning-budget accepted prefill token (%d)\n", __func__, token);
         }
+        common_reasoning_budget_log_prefill_state(result->rbudget);
     }
 
     llama_sampling_set_rng_seed(result, params.seed);
@@ -174,6 +174,10 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, co
     result->elb_search_pos = 0;
 
     return result;
+}
+
+struct common_sampler * common_sampler_clone_init() {
+    return new common_sampler();
 }
 
 void common_sampler_free(struct common_sampler * ctx) {
@@ -696,7 +700,8 @@ void common_sampler_accept(
         struct common_sampler * ctx_sampling,
         struct llama_context * ctx_main,
         llama_token token,
-        bool is_generated) {
+        bool is_generated,
+        bool emit_rbudget_logs) {
     if (ctx_sampling->prev.size() > 0) {
         ctx_sampling->prev.erase(ctx_sampling->prev.begin());
     }
@@ -705,7 +710,11 @@ void common_sampler_accept(
     // grammar_should_apply() checks the reasoning budget state, so calculate this before we accept
     const auto accept_grammar = is_generated && grammar_should_apply(ctx_sampling);
     if (ctx_sampling->rbudget && is_generated) {
-        common_reasoning_budget_accept(ctx_sampling->rbudget, token);
+        if (emit_rbudget_logs) {
+            common_reasoning_budget_accept(ctx_sampling->rbudget, token);
+        } else {
+            common_reasoning_budget_accept_silent(ctx_sampling->rbudget, token);
+        }
     }
 
     if (ctx_sampling->grammar && accept_grammar) {

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -244,6 +244,9 @@ struct common_sampler {
 // Create a new sampling context instance.
 struct common_sampler * common_sampler_init(const struct llama_model * model, const struct common_params_sampling & params);
 
+// Create an empty sampling context suitable as a common_sampler_clone() destination.
+struct common_sampler * common_sampler_clone_init();
+
 void common_sampler_free(struct common_sampler * ctx);
 
 // Reset the sampler context
@@ -321,7 +324,8 @@ void common_sampler_accept(
         struct common_sampler * ctx_sampling,
         struct llama_context * ctx_main,
         llama_token id,
-        bool is_generated);
+        bool is_generated,
+        bool emit_rbudget_logs = true);
 
 // returns at least 1 token, up to draft.size()
 // access the internal list of current candidate tokens

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -234,6 +234,8 @@ static void discard_speculative_checkpoint(server_slot & slot, llama_context * c
 }
 
 static bool save_speculative_checkpoint(server_slot & slot, llama_model * model, llama_context * ctx, int ckpt_mode) {
+    (void) model;
+
     slot.spec_ckpt.clear();
     const int32_t n_pre_spec_tokens = slot.cache_tokens.n_tokens() - (int32_t)(slot.drafted.size() + 1);
     slot.spec_ckpt.n_past = slot.cache_tokens.pos_next(n_pre_spec_tokens);
@@ -252,7 +254,7 @@ static bool save_speculative_checkpoint(server_slot & slot, llama_model * model,
         return false;
     }
 
-    slot.spec_ckpt.sampler = common_sampler_init(model, slot.sparams);
+    slot.spec_ckpt.sampler = common_sampler_clone_init();
     if (slot.spec_ckpt.sampler == nullptr) {
         discard_speculative_checkpoint(slot, ctx);
         return false;
@@ -4235,7 +4237,7 @@ static void restore_speculative_checkpoint(
             common_sampler_clone(slot.spec_ckpt.sampler, slot.ctx_sampling);
         }
         for (llama_token id : ids) {
-            common_sampler_accept(slot.ctx_sampling, ctx, id, true);
+            common_sampler_accept(slot.ctx_sampling, ctx, id, true, false);
         }
 
         // Update MTP KV cache and hidden state using embeddings collected before checkpoint restore.
@@ -4331,7 +4333,7 @@ static void restore_speculative_checkpoint(
             }
 
             for (llama_token id : ids) {
-                common_sampler_accept(slot.ctx_sampling, ctx, id, true);
+                common_sampler_accept(slot.ctx_sampling, ctx, id, true, false);
             }
 
             llama_batch_free(re_batch);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,7 @@ llama_test(test-jinja NAME test-jinja-py ARGS -py LABEL python)
 llama_build_and_test(test-chat-auto-parser.cpp WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 llama_build_and_test(test-chat-template.cpp )
 llama_build_and_test(test-json-partial.cpp )
+llama_build_and_test(test-reasoning-budget.cpp )
 #llama_build_and_test(test-log.cpp)
 llama_build_and_test(
     test-peg-parser.cpp
@@ -212,5 +213,4 @@ llama_target_and_test(test-autorelease.cpp        LABEL "model")
 get_filename_component(TEST_TARGET test-c.c NAME_WE)
 add_executable(${TEST_TARGET} test-c.c)
 target_link_libraries(${TEST_TARGET} PRIVATE llama)
-
 

--- a/tests/test-reasoning-budget.cpp
+++ b/tests/test-reasoning-budget.cpp
@@ -8,6 +8,7 @@
 #undef NDEBUG
 #endif
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
@@ -67,7 +68,7 @@ static void test_reasoning_budget(
             cur[j].logit = logf((float)(j+1));  // reset logits
         }
 
-        llama_sampler_apply(sampler, &cur_p);
+        common_reasoning_budget_apply(sampler, &cur_p);
 
         // Check if forcing is active (all logits except one should be -INFINITY)
         size_t finite_count = 0;
@@ -79,7 +80,7 @@ static void test_reasoning_budget(
             }
         }
 
-        llama_sampler_accept(sampler, sequence[i]);
+        common_reasoning_budget_accept(sampler, sequence[i]);
 
         fprintf(stderr, "    i=%zu: token=%d, finite_count=%zu, finite_token=%d\n", i, (int)sequence[i], finite_count, (int)finite_token);
 
@@ -94,7 +95,7 @@ static void test_reasoning_budget(
         }
     }
 
-    llama_sampler_free(sampler);
+    common_reasoning_budget_free(sampler);
 
     // Verify forcing occurred at expected positions
     if (expected_force_start == SIZE_MAX) {
@@ -147,6 +148,55 @@ static void test_utf8_boundary_detection() {
     // Mixed: ASCII followed by start of multi-byte
     GGML_ASSERT(!common_utf8_is_complete(std::string("hello\xC3", 6)));       // ASCII + incomplete 2-byte
     GGML_ASSERT(common_utf8_is_complete(std::string("hello\xC3\xA9", 7)));    // ASCII + complete 2-byte
+}
+
+static void accept_sequence(
+    common_reasoning_budget_ctx * sampler,
+    const std::vector<llama_token> & sequence,
+    bool prefill) {
+    for (const auto token : sequence) {
+        if (prefill) {
+            common_reasoning_budget_accept_prefill(sampler, token);
+        } else {
+            common_reasoning_budget_accept(sampler, token);
+        }
+    }
+}
+
+static void test_prefill_start_tag_enters_counting() {
+    const std::vector<llama_token> start = {100, 101};
+    const std::vector<llama_token> end = {102};
+    const std::vector<llama_token> forced = {103, 102};
+
+    auto * sampler = common_reasoning_budget_init(nullptr, start, end, forced, 5);
+    accept_sequence(sampler, start, true);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+    common_reasoning_budget_free(sampler);
+}
+
+static void test_prefill_closed_reasoning_reaches_done() {
+    const std::vector<llama_token> start = {100};
+    const std::vector<llama_token> end = {101};
+    const std::vector<llama_token> forced = {102, 101};
+
+    auto * sampler = common_reasoning_budget_init(nullptr, start, end, forced, 5);
+    accept_sequence(sampler, {100, 50, 101}, true);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_DONE);
+    common_reasoning_budget_free(sampler);
+}
+
+static void test_generated_start_after_done_rearms() {
+    const std::vector<llama_token> start = {100};
+    const std::vector<llama_token> end = {101};
+    const std::vector<llama_token> forced = {102, 101};
+
+    auto * sampler = common_reasoning_budget_init(nullptr, start, end, forced, 5);
+    accept_sequence(sampler, {100, 50, 101}, true);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_DONE);
+
+    accept_sequence(sampler, start, false);
+    GGML_ASSERT(common_reasoning_budget_get_state(sampler) == REASONING_BUDGET_COUNTING);
+    common_reasoning_budget_free(sampler);
 }
 
 int main(void) {
@@ -227,7 +277,11 @@ int main(void) {
             3);     // forcing continues through i=3
     }
 
-    printf("OK (5 tests passed)\n");
+    test_prefill_start_tag_enters_counting();
+    test_prefill_closed_reasoning_reaches_done();
+    test_generated_start_after_done_rearms();
+
+    printf("OK (8 tests passed)\n");
 
     printf("Testing UTF-8 boundary detection... ");
     test_utf8_boundary_detection();


### PR DESCRIPTION
## Summary

Fix reasoning-budget side effects introduced by replaying `generation_prompt` during sampler initialization.

This keeps the correctness behavior we want: if the chat template's generation prompt already contains the thinking start tag, the reasoning-budget state machine is advanced before generation begins. That is required so lazy grammar suppression and budget accounting start from the right state.

At the same time, it removes two unwanted side effects:

- repeated `reasoning-budget: activated` log spam from speculative checkpoint clone destinations
- duplicate lifecycle logs when recurrent/MTP speculative checkpoint restore replays already-verified tokens

## What changed

### Silent prefill replay

`common_sampler_init()` still tokenizes and replays `generation_prompt` into the reasoning-budget state machine, but now uses a silent prefill accept path.

After prefill completes, the sampler emits a single summary log only if prefill leaves the reasoning budget active or forcing, for example:

```text
reasoning-budget: activated by generation prompt, budget=8192 tokens
```

Generated-token transitions still use the normal logging path, so natural end, forced end, budget exhaustion, and re-activation on a later generated start tag remain visible.

### Clone destination sampler initialization

Speculative checkpoint save previously created a checkpoint sampler with `common_sampler_init(model, slot.sparams)` and immediately overwrote its state with `common_sampler_clone()`.

That meant checkpoint clone destinations performed request-start side effects before being overwritten, including tokenizing/replaying `generation_prompt` and logging reasoning-budget activation.

This PR adds `common_sampler_clone_init()`, which creates an empty sampler object suitable as a clone destination, and uses it in `save_speculative_checkpoint()`.

### Silent checkpoint replay accepts

For recurrent/hybrid speculative restore, accepted tokens are first verified through the sampler and then replayed after restoring the checkpointed sampler state.

The verification accept is the real observable generation path and should log. The restore replay is internal state reconstruction and should not emit duplicate reasoning-budget lifecycle logs. The restore path now accepts replayed tokens with reasoning-budget logging disabled.

## Why

Reasoning-budget state needs to see generation-prompt tokens because several thinking templates force-open a reasoning block in the assistant prefix. Without prefill replay, the sampler would think it is still outside reasoning even though generation starts inside `<think>`.

However, sampler initialization is also used in places that are not real request starts, especially speculative checkpoint clone destinations. Replaying the generation prompt there caused misleading repeated activation logs and unnecessary prefill work.

This PR separates the two cases:

- real request sampler init still preloads reasoning-budget state
- clone destinations do not run sampler init side effects
- internal speculative restore replays do not duplicate lifecycle logs

## Manual validation

Tested with recurrent/MTP speculative decoding and reasoning budget enabled.

Before:

```text
reasoning-budget: activated, budget=8192 tokens
reasoning-budget: activated, budget=8192 tokens
...
reasoning-budget: deactivated (natural end)
reasoning-budget: deactivated (natural end)
```

After:

```text
reasoning-budget: activated by generation prompt, budget=8192 tokens
...
reasoning-budget: deactivated (natural end)
```

Also validated the case where generation stops before `</think>`: activation is logged and no deactivation is logged, which correctly reflects that neither natural end nor budget-forced end occurred.

## Tests

- `cmake --build /tmp/ikllama-build --target test-reasoning-budget llama-server -j$(nproc)`
- `ctest --test-dir /tmp/ikllama-build -R test-reasoning-budget --output-on-failure -j$(nproc)`
- `git diff --check`

Added/wired focused reasoning-budget coverage for:

- prefill start tag enters `COUNTING`
- prefill start/end tag reaches `DONE`
- generated start tag after `DONE` re-arms the budget
- existing budget exhaustion / forced-token behavior remains covered
