### PR TITLE
Fix Gemma4-E4B compute graph

### DIFF
--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -720,10 +720,18 @@ ggml_cgraph * llm_build_context::build_gemma4() {
 
     auto inp_out_ids = n_tokens > 1 ? build_inp_out_ids() : nullptr;
 
+    if (model.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+        return build_gemma4_graph_parallel(*this, lctx, ctx0, inpL, inp_pos, inp_out_ids,
+                                     KQ_mask, KQ_mask_swa, n_tokens,  cb);
+    }
+
+    auto gf = ggml_new_graph_custom(ctx0, model.max_nodes(n_tokens), false);
+
     ggml_tensor * inp_per_layer = nullptr;
     if (model.tok_embd_per_layer) {
         if (batch.token) {
             inp_per_layer = ggml_get_rows(ctx0, model.tok_embd_per_layer, lctx.inp_tokens);
+            ggml_build_forward_expand(gf, inp_per_layer);
             inp_per_layer = ggml_reshape_3d(ctx0, inp_per_layer, hparams.n_embd_per_layer, n_layer, n_tokens);
             inp_per_layer = ggml_scale(ctx0, inp_per_layer, sqrtf((float) hparams.n_embd_per_layer));
             cb(inp_per_layer, "inp_per_layer_selected", -1);
@@ -735,6 +743,7 @@ ggml_cgraph * llm_build_context::build_gemma4() {
             // Extract and dequantize padding token embedding (row 0)
             auto padding = ggml_view_1d(ctx0, model.tok_embd_per_layer, embd_size, 0);
             inp_per_layer = ggml_cast(ctx0, padding, GGML_TYPE_F32);
+            ggml_build_forward_expand(gf, inp_per_layer);
 
             // Reshape to [n_embd_per_layer, n_layer, 1]
             inp_per_layer = ggml_reshape_3d(ctx0, inp_per_layer, hparams.n_embd_per_layer, n_layer, 1);
@@ -744,13 +753,6 @@ ggml_cgraph * llm_build_context::build_gemma4() {
                 model.hparams.n_embd_per_layer, n_layer, n_tokens, inpL, inp_per_layer);
 
     }
-
-    if (model.split_mode == LLAMA_SPLIT_MODE_GRAPH) {
-        return build_gemma4_graph_parallel(*this, lctx, ctx0, inpL, inp_pos, inp_out_ids,
-                                     KQ_mask, KQ_mask_swa, n_tokens,  cb);
-    }
-
-    auto gf = ggml_new_graph_custom(ctx0, model.max_nodes(n_tokens), false);
 
     // "5-to-1 interleaved attention"
     // 5 layers of local attention followed by 1 layer of global attention

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2060,7 +2060,7 @@ bool create_tensors_helper::create_gemma4_tensors(const LLM_TN & tn) {
     model.tok_embd = create_tensor(ctx_input, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
 
     if (n_embd_per_layer > 0) {
-        model.tok_embd_per_layer   = create_tensor(ctx_output, tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"), {n_embd_per_layer * n_layer, n_vocab}, 0);
+        model.tok_embd_per_layer   = create_tensor(ctx_input, tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight"), {n_embd_per_layer * n_layer, n_vocab}, 0);
         model.per_layer_model_proj = create_tensor(ctx_output, tn(LLM_TENSOR_PER_LAYER_MODEL_PROJ, "weight"), {n_embd, n_embd_per_layer * n_layer}, 0);
         model.per_layer_proj_norm  = create_tensor(ctx_output, tn(LLM_TENSOR_PER_LAYER_PROJ_NORM,  "weight"), {n_embd_per_layer}, 0);
     }


### PR DESCRIPTION

The issue was that the per layer token embedding tensor was loaded into the output context, so onto a GPU when present. But if this tensor was quantized with a type that does not have CUDA support for `ggml_get_rows` on CUDA (i.e., all quants except `Q4_0, Q4_1, Q5_0, Q5_1, Q8_0`), this required a copy of the per layer embedding tensor to the CPU, computing `ggml_get_rows` there, and copying back the result to the GPU. As the per layer embedding tensor is giant (2.8 billion elements!), this totally kills performance.

There is PR #1830, which adds CUDA support for `ggml_get_rows` for some k-quants. But this does not solve the actual root cause of the per layer embedding tensor being loaded into the wrong context.

With this PR CUDA performance for Gemma4-E4B is recovered to expected levels independently of the quantization type of the per layer embedding tensor.

 