### PR TITLE
Fix crash with split mode graph and partial offload

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -133,7 +133,7 @@ void ggml_backend_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
 }
 
 bool ggml_backend_buffer_is_host(ggml_backend_buffer_t buffer) {
-    return ggml_backend_buft_is_host(ggml_backend_buffer_get_type(buffer));
+    return buffer && ggml_backend_buft_is_host(ggml_backend_buffer_get_type(buffer));
 }
 
 void ggml_backend_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage) {


### PR DESCRIPTION

In that case we may have the situation of the tensor buffer being `NULL` (because split). If `mmap` is disabled we go on to check all tensors if they are on the host and if so, modify (e.g., repack, etc.) or validate. The check if the tenor is on the host crashes in the back-end if the buffer is NULL.

The PR fixes that.  