### PR TITLE
Disable split mode graph for Qwen35-MoE when MTP is enabled

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3319,6 +3319,12 @@ static bool llm_load_tensors(
             LLAMA_LOG_WARN("  => changing split mode to 'layer'\n");
             LLAMA_LOG_WARN("===========================================================\n\n");
             split_mode = LLAMA_SPLIT_MODE_LAYER;
+        } else if (model.arch == LLM_ARCH_QWEN35MOE && mtp) {
+            LLAMA_LOG_WARN("\n=========================================================\n");
+            LLAMA_LOG_WARN("Split mode 'graph' curently does not work with MTP for Qwen35-MoE\n");
+            LLAMA_LOG_WARN("  => changing split mode to 'layer'\n");
+            LLAMA_LOG_WARN("=======================================================\n\n");
+            split_mode = LLAMA_SPLIT_MODE_LAYER;
         } else if (!is_model_split_supported(model)) {
             LLAMA_LOG_WARN("\n=======================================================\n");
             LLAMA_LOG_WARN("Split mode 'graph' is not supported for this model\n");


### PR DESCRIPTION

Ref #1850 

Split mode `graph` + MTP currently does not work, so it is better to disable it when MTP is enabled. Hopefully the warning is prominent enough so the user will see it so they can change their command to split mode `graph` without MTP if that's what they prefer.