### PR TITLE
Fix split mode graph with ngl < n_layer

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3693,6 +3693,15 @@ static bool llm_load_tensors(
                 split_buft,
                 llama_default_buffer_type_offload(model, model.devices[model.default_layer_device[n_layer]])
             };
+        } else if (n_gpu_layers > 0) {
+            // Under partial -ngl with -sm graph, route output to the GPU buffer
+            // to avoid synchronization issues between the GPU where the last
+            // REDUCE op is performed and the CPU, where the fused RMS norm and
+            // mul_mat with the output tensor would be performed if left on the CPU.
+            int last_gpu_layer = (int)n_layer - 1;
+            int dev = model.default_layer_device.empty() || last_gpu_layer < 0
+                    ? 0 : std::max(0, model.default_layer_device[last_gpu_layer]);
+            model.buft_output = llama_default_buffer_type_offload(model, dev);
         } else {
             model.buft_output = llama_default_buffer_type_cpu(true);
         }


### PR DESCRIPTION

This PR fixes split mode `graph` for MoE models with shared experts when using `-ngl N` with `N` less than the number of layers, except for MLA models (MoE models without shared experts work file without this fix).

The change was extracted from #1832, and it is the only change required when the model does not use MLA attention.

MLA models still do not work. The reason is that when a layer has not been uploaded to the GPU, the KV cache lives on the CPU and the back-end scheduler copies the cache to the main GPU to perform the flash attention computation there. But in the case of MLA models we only have K-cache, and the V-cache is a non-contiguous view of the `K-cache`. The back-end scheduler doesn't know this, so initiates a separate copy of the V-cache. The back-end scheduler assumes tensors are contiguous when handling copies between back-ends, so things go downhill from there.  

The fix in #1832 for MLA models via disabling GPU offload for 3D tensors (which disables offload of the matrix multiplications with the `attn_k_b` and `attn_v_b` tensors) works not because copying (contiguous) 3D tensors is bugged, but because in that case flash attention gets scheduled on the CPU, and hence the not working copy of the cache to the GPU is avoided. But such a fix makes split mode `graph` being much slower than split mode `layer`, so it is better to just use split mode `layer` when `ngl < n_layer`.     