### PR TITLE
llama-quantize: enable --extra-output-tensor with COPY

### DIFF
--- a/src/llama-quantize.cpp
+++ b/src/llama-quantize.cpp
@@ -1446,6 +1446,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
         // do not quantize relative position bias (T5)
         quantize &= name.find("attn_rel_b.weight") == std::string::npos;
 
+        // quantize the extra output tensor
+        quantize = tensor == output_tensor || quantize;
+
         enum ggml_type new_type;
         void * new_data = nullptr;
         size_t new_size = 0;
@@ -1515,6 +1518,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
             }
             if (params->output_tensor_type < GGML_TYPE_COUNT && strcmp(tensor->name, "output.weight") == 0) {
                 new_type = params->output_tensor_type;
+            }
+            else if (params->only_copy && tensor == output_tensor) {
+                new_type = tensor->type;
             }
             if (params->ffn_gate_inp_type < GGML_TYPE_COUNT && name.find("ffn_gate_inp.weight") != std::string::npos) {
                 new_type = params->ffn_gate_inp_type;


### PR DESCRIPTION
Allow COPY for `--extra-output-tensor` by quantizing the `output_tensor` (added in 1810) when present.

The following llama-quantize command creates an invalid GGUF on the main branch when adding the `--extra-output-tensor` to an existing GGUF: 
`llama-quantize --allow-requantize --extra-output-tensor iq4_ks input.gguf output.gguf COPY`

The error was `llama_model_load: error loading model: tensor 'blk.40.ffn_gate_exps.weight' data is not within the file bounds, model is corrupted or incomplete`

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High
