### PR TITLE
Fix GLM MTP crash in accepted tokens

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2006,7 +2006,7 @@ static int32_t mtp_accept_batch(
     }
 
     auto & last = mtp_get_last_embd(state, seq_id);
-    const float * embd = llama_get_embeddings_ith(state.ctx_mtp, accepted_batch.n_tokens - 1);
+    const float * embd = llama_get_embeddings_ith(state.ctx_mtp, -1);
     if (embd != nullptr) {
         std::memcpy(last.embd.data(), embd, last.embd.size() * sizeof(float));
         if (!llama_set_draft_input_hidden_state_copy(state.ctx_mtp, last.embd.data(), last.embd.size())) {

--- a/src/graphs/build_glm4.cpp
+++ b/src/graphs/build_glm4.cpp
@@ -347,6 +347,13 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
                         n_tokens, kv_head, n_kv,
                         kq_scale, cb, il);
         ffn_inp = ggml_add(ctx0, cur, inpSA);
+    }
+
+    if (inp_out_ids) {
+        ffn_inp = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
+    }
+
+    if (rope_cache != nullptr) {
         cb(ffn_inp, "mtp_ffn_inp", il);
     }
 
@@ -369,10 +376,6 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
     cb(cur, "ffn_out", il);
 
     cur = llm_build_norm(ctx0, cur, hparams, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, cb, il);
-
-    if (inp_out_ids) {
-        cur = ggml_get_rows(ctx0, cur, inp_out_ids);
-    }
     cb(cur, "result_norm", -1);
 
     // If nextn.shared_head_head is missing (GLM-4.6), use model.output (Main LM Head)

--- a/src/graphs/build_glm4.cpp
+++ b/src/graphs/build_glm4.cpp
@@ -369,11 +369,11 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
     cb(cur, "ffn_out", il);
 
     cur = llm_build_norm(ctx0, cur, hparams, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, cb, il);
-    cb(cur, "result_norm", -1);
 
     if (inp_out_ids) {
         cur = ggml_get_rows(ctx0, cur, inp_out_ids);
     }
+    cb(cur, "result_norm", -1);
 
     // If nextn.shared_head_head is missing (GLM-4.6), use model.output (Main LM Head)
     ggml_tensor * mtp_head_weights = mtp_layer.nextn.shared_head_head;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5048,8 +5048,7 @@ static int llama_decode_internal(
     }
 
     // reserve output buffer
-    const bool reserve_all_mtp_embd = has_mtp && cparams.mtp_op_type != MTP_OP_WARMUP;
-    n_outputs_embd = reserve_all_mtp_embd ? n_tokens_all : n_outputs;
+    n_outputs_embd = has_mtp && cparams.mtp_op_type == MTP_OP_NONE ? n_tokens_all : n_outputs;
     if (llama_output_reserve(lctx, std::max<size_t>(n_outputs, n_outputs_embd)) < std::max<size_t>(n_outputs, n_outputs_embd)) {
         LLAMA_LOG_ERROR("%s: could not reserve space for batch with %zu outputs\n", __func__, std::max<size_t>(n_outputs, n_outputs_embd));
         return -2;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5048,7 +5048,8 @@ static int llama_decode_internal(
     }
 
     // reserve output buffer
-    n_outputs_embd = has_mtp && cparams.mtp_op_type == MTP_OP_NONE ? n_tokens_all : n_outputs;
+    const bool reserve_all_mtp_embd = has_mtp && cparams.mtp_op_type != MTP_OP_WARMUP;
+    n_outputs_embd = reserve_all_mtp_embd ? n_tokens_all : n_outputs;
     if (llama_output_reserve(lctx, std::max<size_t>(n_outputs, n_outputs_embd)) < std::max<size_t>(n_outputs, n_outputs_embd)) {
         LLAMA_LOG_ERROR("%s: could not reserve space for batch with %zu outputs\n", __func__, std::max<size_t>(n_outputs, n_outputs_embd));
         return -2;
@@ -5450,7 +5451,7 @@ static int llama_decode_internal(
 
     // set to total number of outputs in the batch, for use in llama_get_logits_ith
     lctx.n_outputs = n_outputs;
-    lctx.n_outputs_embd = n_outputs_embd;
+    lctx.n_outputs_embd = n_outputs_prev_embd;
 
     // wait for the computation to finish (automatically done when obtaining the model output)
     //llama_synchronize(&lctx);


### PR DESCRIPTION
This fixes an assertion error involving `(n_outputs_prev_embd + n_outputs_new_embd <= n_outputs_embd)` that occurs with the GLM MTP family. Although there was a mismatch in the embedding rows for accepted tokens that could potentially affect all MTP models, only GLM was affected. This is because GLM's `inp_out_ids` are cropped only after the embeddings are extracted, whereas in Qwen and Gemma, this happens beforehand, which prevents the mismatch from triggering the assertion.