### PR TITLE
fix: add deepseek2/GLM-DSA to max_nodes, NULL-check ggml_new_object

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -5403,6 +5403,11 @@ static struct ggml_tensor * ggml_new_tensor_impl(
 
     struct ggml_object * const obj_new = ggml_new_object(ctx, GGML_OBJECT_TYPE_TENSOR, GGML_TENSOR_SIZE + obj_alloc_size);
 
+    if (!obj_new) {
+        GGML_PRINT("%s: failed to create new object (context memory exhausted)\n", __func__);
+        return NULL;
+    }
+
     // TODO: for recoverable errors, we would need to free the data allocated from the scratch buffer here
 
     struct ggml_tensor * const result = (struct ggml_tensor *)((char *)ctx->mem_buffer + obj_new->offs);

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -504,7 +504,8 @@ struct llama_model {
     size_t max_nodes(int n_tokens) const {
         auto n_tensors = tensors_by_name.size();
         if (split_mode == LLAMA_SPLIT_MODE_GRAPH && !devices.empty()) n_tensors *= devices.size();
-        if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_QWEN35MOE || arch == LLM_ARCH_QWEN35) {
+        if (arch == LLM_ARCH_QWEN3NEXT || arch == LLM_ARCH_QWEN35MOE || arch == LLM_ARCH_QWEN35
+                || arch == LLM_ARCH_DEEPSEEK2 || arch == LLM_ARCH_GLM_DSA) {
             return std::max<size_t>(n_tokens * 40, 32u * n_tensors);
         }
         //return std::max<size_t>(1024, 8*n_tensors);


### PR DESCRIPTION
## Problem

DeepSeek-V3.1 (deepseek2 arch, 61 layers, 685B MoE) segfaults during context initialization (graph reservation) when `--ubatch-size 4096` with `-ngl 0`. The `buf_compute_meta` pool is sized by `max_nodes()` = 65536, but ik_llama's per-expert graph expansion for deepseek2 exceeds this at ubatch ≥ 4096.

The failure path:

1. `n_tokens = min(n_ctx, n_ubatch)` → at ubatch 4096, n_tokens=4096
2. `max_nodes()` returns 65536 (deepseek2 not in the override list)
3. `buf_compute_meta` sized for 65536 tensor metadata slots (nodes + leafs + views all allocate from this pool)
4. deepseek2 graph with `fused_moe=1` creates 45521 final nodes — total tensor allocations exceed 65536
5. `ggml_new_object()` → "not enough space" → returns NULL → SEGV in `ggml_new_tensor_impl`

At default ubatch=512, total allocations fit within 65536 — the crash only manifests at ubatch ≥ 4096.

## Fix

**Patch 1 — `src/llama-model.h`**: Add `LLM_ARCH_DEEPSEEK2` and `LLM_ARCH_GLM_DSA` to the existing Qwen arch override in `max_nodes()`. These MLA architectures (already grouped together in `is_mla_model()`) need the same dynamic node limit: `max(n_tokens * 40, 32 * n_tensors)`.

**Patch 2 — `ggml/src/ggml.c`**: Add NULL check after `ggml_new_object()` in `ggml_new_tensor_impl()`. If context memory is exhausted, return NULL with a diagnostic message instead of dereferencing a NULL pointer. This is a safety net — any future node-limit miss becomes a clean error instead of a crash.

## Reproduction

```
llama-server \
  --model DeepSeek-V3.1-Terminus-UD-Q4_K_XL-00001-of-00008.gguf \
  --batch-size 4096 --ubatch-size 4096 \
  --ctx-size 8192 --parallel 4 \
  -ngl 0
```

- **Before**: SEGV at startup (exit 139)
- **After**: loads successfully, `graph nodes = 45521`, runs correctly

Tested on top of d2da6da (current `main`).