### PR TITLE
server: enable checkpoint reuse for recurrent/hybrid models (qwen3next, Mamba)

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3650,7 +3650,15 @@ void server_context::apply_checkpoint(server_slot & slot) {
                 slot.server_cached_prompt.checkpoints.rbegin(),
                 slot.server_cached_prompt.checkpoints.rend(),
                 [&](const auto & cur) {
-                    return cur.pos_min < pos_min_thold || cur.pos_min == 0;
+                    // For recurrent/hybrid models (Gated DeltaNet, qwen3next, Mamba),
+                    // llama_kv_cache_seq_pos_min returns the full sequence length, so
+                    // `cur.pos_min < pos_min_thold` is always false. Add a second
+                    // condition matching ggml-org/llama.cpp PR for this case: a
+                    // checkpoint is usable if its captured KV range ends at or before
+                    // the rewind target (pos_next). For dense transformer models the
+                    // original conditions still trip first, so no regression.
+                    return cur.pos_min < pos_min_thold || cur.pos_min == 0
+                        || cur.pos_max <= pos_next;
                 }
             );
 
@@ -3711,7 +3719,13 @@ bool server_context::create_checkpoint(server_slot & slot) {
     const auto pos_max = llama_kv_cache_seq_pos_max(slot.ctx, slot.id);
 
     // no need for empty or small checkpoints
-    do_checkpoint = do_checkpoint && (pos_min >= 0 && slot.cache_tokens.n_tokens() >= 64);
+    // For recurrent/hybrid architectures, follow-up prompts after a short prior
+    // turn can have very few new tokens, but a checkpoint is still required to
+    // avoid full re-processing on the next request. Lower the threshold for
+    // those architectures so checkpoints survive short turns.
+    const bool is_recurrent = llama_model_has_recurrent(llama_get_model(slot.ctx));
+    const int min_ckpt_tokens = is_recurrent ? 4 : 64;
+    do_checkpoint = do_checkpoint && (pos_min >= 0 && slot.cache_tokens.n_tokens() >= min_ckpt_tokens);
 
     // no need to create checkpoints that are too close together
     do_checkpoint = do_checkpoint && (slot.server_cached_prompt.checkpoints.empty() || slot.cache_tokens.n_tokens() > slot.server_cached_prompt.checkpoints.back().n_tokens);


### PR DESCRIPTION
## Summary

Fixes #1762. Ports the fix from ggml-org/llama.cpp PR for the same root cause.

For Gated DeltaNet, qwen3next, and Mamba architectures, `llama_kv_cache_seq_pos_min` returns the full sequence length, so the existing `apply_checkpoint` validity check (`cur.pos_min < pos_min_thold`) always evaluates **false**. Consequence: no saved checkpoint is ever considered usable, the slot is force-reset, and every follow-up request re-processes the entire prompt from scratch.

A second small bug compounds it: `create_checkpoint` requires the slot to hold at least 64 tokens before saving. For recurrent models a short follow-up prompt commonly adds far fewer than 64 new tokens, so the checkpoint that would have rescued the next turn never gets created.

## Changes

- `apply_checkpoint`: extend the lambda's validity check to also accept `cur.pos_max <= pos_next`. Dense transformer paths still trip the original conditions first, so no behavior change for them.
- `create_checkpoint`: split the minimum-tokens gate by architecture. Recurrent/hybrid models now create a checkpoint at >= 4 tokens; everything else still requires >= 64.

## Validation

Tested on Qwen3.6-27B (qwen3next arch) with `--multi-token-prediction --draft-max 3` + `--reasoning on`:

Before this patch:
- Direct identical-prompt probe: `cached_tokens: 0` every call
- Multi-pass synthesis (12-section research report): every section paid full prefill, ~50s per section

After this patch:
- Direct identical-prompt probe: `cached_tokens: 1713 / 1718` (99.7% reuse)
- Multi-pass synthesis: 92% prefix-cache reuse on shared-prefix calls

## Reference

- Issue: #1762
- Upstream port reference: ggml-org/llama.cpp PR #22384