### PR TITLE
server: preserve primary KV cache when MTP companion trim fails

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3953,8 +3953,23 @@ void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t 
                 auto * ctx_companion = slot.spec ? common_speculative_get_companion_ctx(slot.spec) : nullptr;
                 const bool target_trimmed = llama_kv_cache_seq_rm(ctx, slot.id, p0, -1);
                 const bool companion_trimmed = ctx_companion == nullptr || llama_kv_cache_seq_rm(ctx_companion, slot.id, p0, -1);
-                if (!target_trimmed || !companion_trimmed) {
-                    // could not partially delete (likely using a non-Transformer model)
+
+                // When MTP companion ctx fails partial trim at p0 (common after
+                // generation due to unvalidated draft tokens leaving companion
+                // KV positions out of sync with primary), wipe just the
+                // companion entirely so it re-populates on next prefill. The
+                // primary cache is intact and reusable; clearing it discards
+                // hard-won prefill state for an issue confined to the draft
+                // ctx. This restores prefix-cache reuse for recurrent / MTP
+                // models that would otherwise force a full re-prefill on every
+                // request.
+                if (target_trimmed && ctx_companion != nullptr && !companion_trimmed) {
+                    LLAMA_LOG_WARN("MTP companion ctx out-of-sync at p0=%d; wiping companion only, primary cache preserved\n", p0);
+                    llama_kv_cache_seq_rm(ctx_companion, slot.id, -1, -1);
+                }
+                else if (!target_trimmed) {
+                    // Primary trim failed (likely using a non-Transformer model
+                    // that cannot partially delete). Full reset.
                     llama_kv_cache_seq_rm(ctx, slot.id, -1, -1);
                     if (ctx_companion != nullptr) {
                         llama_kv_cache_seq_rm(ctx_companion, slot.id, -1, -1);


### PR DESCRIPTION
## Summary

The pre-batch reset path in `server_context` partially trims both the target ctx and (when MTP is enabled) its speculative companion ctx at `p0 = system + n_past`. The existing logic treats either trim failure as a reason to nuke `cache_tokens`, `slot.n_past`, `n_prompt_tokens_cache`, the checkpoint list, and reset the sampler.

Companion failures happen routinely after generation: unvalidated draft tokens leave the companion KV's position layout out of sync with primary. Sacrificing the primary cache for a recoverable mismatch confined to the draft ctx forces a full re-prefill on the next request, defeating the entire point of prefix caching when MTP is on.

## Change

Split the fallback into two paths:

- `target_trimmed && !companion_trimmed` → wipe only the companion (it repopulates during the next prefill); leave the primary cache + checkpoints + sampler state intact.
- `!target_trimmed` → unchanged conservative full reset (the original non-Transformer fall-through case that the existing comment alludes to).

## Validation

Tested on Qwen3.6-27B + `--multi-token-prediction --draft-max 3` + `--reasoning on`. Combined with #1888 (qwen3next checkpoint reuse), multi-pass synthesis goes from 0% prefix-cache reuse to 92% reuse on shared-prefix follow-up calls. Without this patch the companion-trim failure path still wiped the primary cache and undid the checkpoint fix.

## Note

This patch addresses the pre-batch reset site that exists in current `main`. PR #1877 (Fix prompt cache viability) introduces a similar trim-fallback at the second post-prefix-match site; the same split should be applied there when that PR lands.