### PR TITLE
Fix MTP token-generation performance regression

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4930,11 +4930,7 @@ static void llama_graph_compute(
     // fprintf(stderr, "splits: %d\n", ggml_backend_sched_get_n_splits(lctx.sched));
 }
 
-static bool prepare_mtp_graph_inputs(
-        struct llama_context & lctx,
-        uint32_t cur_token,
-        uint32_t n_tokens,
-        uint32_t n_tokens_all) {
+static bool prepare_mtp_graph_inputs(struct llama_context & lctx) {
     ggml_tensor * dst = lctx.inp_mtp_states;
     const size_t expected_floats = ggml_nbytes(dst) / sizeof(float);
     const size_t total_floats = lctx.draft_input_hidden_state_n_floats;
@@ -4945,30 +4941,8 @@ static bool prepare_mtp_graph_inputs(
         return false;
     }
 
-    if (total_floats != expected_floats) {
-        if (n_tokens_all == 0 || total_floats % n_tokens_all != 0) {
-            LLAMA_LOG_ERROR("%s: Source hidden state size mismatch (have %zu floats, need %zu)\n",
-                    __func__, total_floats, expected_floats);
-            return false;
-        }
-
-        const size_t row_width = total_floats / n_tokens_all;
-        const size_t slice_floats = row_width * n_tokens;
-        const size_t slice_offset = (size_t) cur_token * row_width;
-
-        if (slice_floats != expected_floats ||
-                slice_offset > total_floats ||
-                total_floats - slice_offset < expected_floats) {
-            LLAMA_LOG_ERROR("%s: Source hidden state size mismatch (have %zu floats, need %zu)\n",
-                    __func__, total_floats, expected_floats);
-            return false;
-        }
-
-        src += slice_offset;
-    }
-
-    if (src == nullptr) {
-        LLAMA_LOG_ERROR("%s: Source hidden state size mismatch (have %zu floats, need %zu)\n",
+    if (total_floats < expected_floats) {
+        LLAMA_LOG_ERROR("%s: Source hidden state size too small (have %zu floats, need at least %zu)\n",
                 __func__, total_floats, expected_floats);
         return false;
     }
@@ -5264,7 +5238,7 @@ static int llama_decode_internal(
         }
 
         if (cparams.mtp_op_type != MTP_OP_NONE) {
-            if (!prepare_mtp_graph_inputs(lctx, cur_token, n_tokens, n_tokens_all)) {
+            if (!prepare_mtp_graph_inputs(lctx)) {
                 return GGML_STATUS_FAILED;
             }
         }


### PR DESCRIPTION
First, revert 19e09e81 from #1866 which added a multi-ubatch slicer that silences the size-mismatch errors during prompt warmup, but also activates during the TG accept path, feeding garbage hidden states into the MTP model. This drops acceptance from ~78% to ~69% in my test, and didn't actually fix the TG regression from #1825 (from 85 to 75 tps).

Then, fix the original #1825 size check. #1825 stores the full batch of hidden rows via `llama_set_draft_input_hidden_state_copy` but `inp_mtp_states` is rebuilt per-operation with a different shape (1D for draft-gen, 2D for warmup/accept). The strict `!=` check rejects every case where those shapes differ, which kills the MTP decode. This leaves the MTP KV cache stale: without #1866 it stays empty, with #1866 it accumulates garbage. In both cases the draft model produces worse drafts, lowering acceptance and dragging down token-generation speed. Switching `!=` to `<` allows the source to be larger than the destination (the common case), while still catching truly undersized buffers. `ggml_backend_tensor_set` naturally copies only what fits, matching pre-#1825 behavior.

With these 2 changes, both acceptance and TG are now back to pre-#1825 level in my test (~87%, 85 tps)

(heavily assisted by DSV4 Pro)



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [x] High
