### PR TITLE
(qwen3vl) Correct calculation for injection point of deepstack image embeddings  (Fixes #993 and #1902 -- part 1)

### DIFF
--- a/examples/mtmd/mtmd-helper.cpp
+++ b/examples/mtmd/mtmd-helper.cpp
@@ -183,7 +183,7 @@ static int32_t mtmd_helper_decode_image_chunk_impl(
     }
 
     const llama_model * model = llama_get_model(lctx);
-    int n_mmproj_embd = llama_model_n_embd_inp(model);
+    int n_mmproj_embd = llama_model_n_embd(model);
     int n_pos_per_embd = mtmd_decode_use_mrope(ctx) ? 4 : 1;
 
     int32_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk);


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  
Warning: AI/LLM assisted work.

Separating a fix into two PRs because I think this one is uncontroversial, and it fixes a segfault.

This is part 1 of a fix for #1902 (enabling mmproj disables pipeline paralellism and ignoes -ub flag) and for #993  The goal of both PRs is to fix groundings issues for m-rope models, and to reenable pipeline parallism with an mmproj is used.

The fix is split into two PRs, because this part is trivial, and the other part is in PoC state.

## Current state
When launching ik_llama.cpp with an mmproj, pipeline paralleism is disabled (#1902). This was done as a workaround for image grounding issues in qwen3vl, and m-rope models in general. Without the guard, llama-server will crash when an image spans a ubatch boundary.

## Root causes.
* Specifically for qwen3vl (the only model family that uses deepstack), there was a bug in an attribute accessor that calculates what point in the hidden state to inject residual image embeddings. This caused an OOB memory access and a segfault. **This PR fixes the OOB memory access**
* For m-rope models in general, image m-rope is incorrectly applied when an image spans two llama_decode calls. The next PR will address this.

## Testing.
Currently, image processing with mrope models only works because of the temporary guard condition taht disables PP and microbatching. [I vibed a set of e2e tests](https://github.com/Farmadupe/ik_llama.cpp/commit/cec3d609a7be87d35dcbaab2b0512c13c29a90a9) that checks qwen3vl's bbox2d performance after that guard has been removed.
 * Current state: If the guard is removed, llama-server crashes when an image is supplied
 * After part 1 (**THIS PR)**: llama-server does not crash, but mrope is non-functional when images span chunk boundaries: [See results here](https://raw.githack.com/Farmadupe/ik_llama.cpp/report-snapshots/oob_fix.html) 
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/b9f37619-1389-412b-98ba-a8183349c7e5" />

 * After part 2 (**NEXT PR**)) [mrope works and bbox2d works with qwen models](https://raw.githack.com/Farmadupe/ik_llama.cpp/report-snapshots/mrope_fix.html)
 
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/aa51b4a1-529a-4680-8abd-4464cd78adef" />
