### PR TITLE
DRAFT: Fix mrope application across chunk boundaries (Fixes #993 and #1902 -- part 2)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -4012,14 +4012,7 @@ static std::pair<int, int> get_batch_ubatch(const gpt_params & params) {
     if (params.n_ctx > 0) {
         n_batch = std::min(n_batch, params.n_ctx);
     }
-    if (!params.mmproj.path.empty() && params.mmproj_use_gpu) {
-        // temporary fix for qwen mtmd (only when mmproj is on GPU)
-        n_batch = std::max(n_batch, n_ubatch);
-        n_ubatch = n_batch;
-        fprintf(stdout, "Adjust batch size for mtmd: u_batch = %d, batch = %d\n", n_ubatch, n_batch);
-    } else {
-        n_ubatch = std::min(n_batch, n_ubatch);
-    }
+    n_ubatch = std::min(n_batch, n_ubatch);
     return {n_batch, n_ubatch};
 }
 
@@ -4564,7 +4557,7 @@ void common_batch_add(
                                bool   logits) {
     GGML_ASSERT(batch.seq_id[batch.n_tokens] && "llama_batch size exceeded");
     batch.token   [batch.n_tokens] = id;
-    batch.pos     [batch.n_tokens] = pos;
+    batch.pos     [batch.n_tokens] = { pos, pos, pos, 0 };
     batch.n_seq_id[batch.n_tokens] = seq_ids.size();
     for (size_t i = 0; i < seq_ids.size(); ++i) {
         batch.seq_id[batch.n_tokens][i] = seq_ids[i];

--- a/common/log.h
+++ b/common/log.h
@@ -801,7 +801,7 @@ inline std::string LOG_BATCH_TOSTR_PRETTY(const C & ctx, const B & batch)
         buf
             << "\n" << std::to_string(i)
             << ":token '" << detokenized << "'"
-            << ":pos " << std::to_string(batch.pos[i])
+            << ":pos " << std::to_string(batch.pos[i].t)
             << ":n_seq_id  " << std::to_string(batch.n_seq_id[i])
             << ":seq_id " << std::to_string(batch.seq_id[i][0])
             << ":logits " << std::to_string(batch.logits[i]);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1529,7 +1529,7 @@ static int common_speculative_copy_seq_batch(
 
     seq_batch = llama_batch_init((int) token_indices.size(), 0, 1);
     for (const int i : token_indices) {
-        common_batch_add(seq_batch, batch.token[i], batch.pos[i], { seq_id }, batch.logits != nullptr && batch.logits[i]);
+        common_batch_add(seq_batch, batch.token[i], batch.pos[i].t, { seq_id }, batch.logits != nullptr && batch.logits[i]);
     }
 
     return (int) token_indices.size();
@@ -1555,7 +1555,7 @@ static bool common_speculative_feature_view_copy_batch_rows(
     hidden_rows->clear();
     hidden_rows->reserve((size_t) batch.n_tokens * view.width);
     for (int i = 0; i < batch.n_tokens; ++i) {
-        auto it = rows_by_pos.find(batch.pos[i]);
+        auto it = rows_by_pos.find(batch.pos[i].t);
         if (it == rows_by_pos.end()) {
             hidden_rows->clear();
             return false;
@@ -2203,7 +2203,7 @@ int32_t mtp_update_kv_cache(struct llama_context * ctx, const llama_batch& batch
     }
 
     llama_seq_id seq_id    = batch.seq_id[0][0];
-    llama_pos    start_pos = batch.pos[0];
+    llama_pos    start_pos = batch.pos[0].t;
 
     if (llama_kv_cache_seq_pos_max(ctx, seq_id) >= start_pos) {
         llama_kv_cache_seq_rm(ctx, seq_id, start_pos, -1);

--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -79,7 +79,7 @@ batch.n_tokens = Int32(tokens.count)
 
 for (i, token) in tokens.enumerated() {
     batch.token[i] = token
-    batch.pos[i] = Int32(i)
+    batch.pos[i] = llama_mrope_pos(t: Int32(i), h: Int32(i), w: Int32(i), extra: 0)
     batch.n_seq_id[i] = 1
     // batch.seq_id[i][0] = 0
     // TODO: is this the proper way to do this?
@@ -173,7 +173,7 @@ while n_cur <= n_len {
 
         // push this new token for next evaluation
         batch.token[Int(batch.n_tokens)] = new_token_id
-        batch.pos[Int(batch.n_tokens)] = n_cur
+        batch.pos[Int(batch.n_tokens)] = llama_mrope_pos(t: n_cur, h: n_cur, w: n_cur, extra: 0)
         batch.n_seq_id[Int(batch.n_tokens)] = 1
         if let seq_id = batch.seq_id[Int(batch.n_tokens)] {
             seq_id[0] = Int32(i)

--- a/examples/llama.android/llama/src/main/cpp/llama-android.cpp
+++ b/examples/llama.android/llama/src/main/cpp/llama-android.cpp
@@ -300,7 +300,7 @@ Java_android_llama_cpp_LLamaAndroid_new_1batch(JNIEnv *, jobject, jint n_tokens,
         batch->token = (llama_token *) malloc(sizeof(llama_token) * n_tokens);
     }
 
-    batch->pos      = (llama_pos *)     malloc(sizeof(llama_pos)      * n_tokens);
+    batch->pos      = (llama_mrope_pos *) malloc(sizeof(llama_mrope_pos) * n_tokens);
     batch->n_seq_id = (int32_t *)       malloc(sizeof(int32_t)        * n_tokens);
     batch->seq_id   = (llama_seq_id **) malloc(sizeof(llama_seq_id *) * n_tokens);
     for (int i = 0; i < n_tokens; ++i) {

--- a/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
+++ b/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
@@ -11,7 +11,7 @@ func llama_batch_clear(_ batch: inout llama_batch) {
 
 func llama_batch_add(_ batch: inout llama_batch, _ id: llama_token, _ pos: llama_pos, _ seq_ids: [llama_seq_id], _ logits: Bool) {
     batch.token   [Int(batch.n_tokens)] = id
-    batch.pos     [Int(batch.n_tokens)] = pos
+    batch.pos     [Int(batch.n_tokens)] = llama_mrope_pos(t: pos, h: pos, w: pos, extra: 0)
     batch.n_seq_id[Int(batch.n_tokens)] = Int32(seq_ids.count)
     for i in 0..<seq_ids.count {
         batch.seq_id[Int(batch.n_tokens)]![Int(i)] = seq_ids[i]

--- a/examples/mtmd/mtmd-helper.cpp
+++ b/examples/mtmd/mtmd-helper.cpp
@@ -58,15 +58,14 @@ llama_pos mtmd_helper_get_n_pos(const mtmd_input_chunks * chunks) {
 struct decode_embd_batch {
     int n_pos_per_embd;
     int n_mmproj_embd;
-    std::vector<llama_pos>      pos;
-    std::vector<llama_pos>      pos_view; // used by mrope
+    std::vector<llama_mrope_pos> pos;
     std::vector<int32_t>        n_seq_id;
     std::vector<llama_seq_id>   seq_id_0;
     std::vector<llama_seq_id *> seq_ids;
     std::vector<int8_t>         logits;
     llama_batch batch;
     decode_embd_batch(float * embd, int32_t n_tokens, int n_pos_per_embd, int n_mmproj_embd) : n_pos_per_embd(n_pos_per_embd), n_mmproj_embd(n_mmproj_embd) {
-        pos     .resize(n_tokens * n_pos_per_embd);
+        pos     .resize(n_tokens); // array-of-structs: one llama_mrope_pos per token
         n_seq_id.resize(n_tokens);
         seq_ids .resize(n_tokens + 1);
         logits  .resize(n_tokens);
@@ -86,7 +85,7 @@ struct decode_embd_batch {
     void set_position_normal(llama_pos pos_0, llama_seq_id seq_id) {
         seq_id_0[0] = seq_id;
         for (int i = 0; i < batch.n_tokens; i++) {
-            batch.pos     [i] = pos_0 + i;
+            batch.pos     [i] = { pos_0 + i, pos_0 + i, pos_0 + i, 0 };
             batch.n_seq_id[i] = 1;
             batch.seq_id  [i] = seq_id_0.data();
             batch.logits  [i] = false;
@@ -100,10 +99,7 @@ struct decode_embd_batch {
         for (int y = 0; y < ny; y++) {
             for (int x = 0; x < nx; x++) {
                 int i = y * nx + x;
-                pos[i                     ] = pos_0;
-                pos[i + batch.n_tokens    ] = pos_0 + y;
-                pos[i + batch.n_tokens * 2] = pos_0 + x;
-                pos[i + batch.n_tokens * 3] = 0; // last pos dim is unused
+                pos[i] = { pos_0, pos_0 + y, pos_0 + x, 0 }; // last pos dim is unused
             }
         }
         for (int i = 0; i < batch.n_tokens; i++) {
@@ -118,10 +114,7 @@ struct decode_embd_batch {
         GGML_ASSERT(n_pos_per_embd == 4);
         seq_id_0[0] = seq_id;
         for (int i = 0; i < batch.n_tokens; i++) {
-            pos[i                     ] = pos_0 + i;
-            pos[i + batch.n_tokens    ] = pos_0 + i;
-            pos[i + batch.n_tokens * 2] = pos_0 + i;
-            pos[i + batch.n_tokens * 3] = 0; // last pos dim is unused
+            pos[i] = { pos_0 + i, pos_0 + i, pos_0 + i, 0 }; // last pos dim is unused
         }
         for (int i = 0; i < batch.n_tokens; i++) {
             batch.n_seq_id[i] = 1;
@@ -131,32 +124,12 @@ struct decode_embd_batch {
     }
 
     llama_batch get_view(int offset, int n_tokens) {
-        llama_pos * pos_ptr;
-        pos_view.clear();
-        pos_view.reserve(n_tokens * n_pos_per_embd);
-        if (n_pos_per_embd > 1) {
-            // mrope
-            // for example, with layout of src: 1234...1234...1234...1234...
-            //       offset 2 will give us dst: 34...34...34...34...
-            for (int i = 0; i < n_pos_per_embd; i++) {
-                // assume n_tokens is less than or equal to batch.n_tokens
-                // batch.n_tokens is number of **total** tokens
-                // n_tokens is number of viewed token
-                size_t src_idx = i * batch.n_tokens + offset;
-                pos_view.insert(pos_view.end(),
-                    pos.data() + src_idx,
-                    pos.data() + src_idx + n_tokens);
-            }
-            pos_ptr = pos_view.data();
-        } else {
-            // normal
-            pos_ptr = pos.data() + offset;
-        }
+        // AoS positions: a sub-batch is just a contiguous slice, no re-striding.
         return {
             /*n_tokens       =*/ n_tokens,
             /*tokens         =*/ nullptr,
             /*embd           =*/ batch.embd     + offset * n_mmproj_embd,
-            /*pos            =*/ pos_ptr,
+            /*pos            =*/ pos.data()     + offset,
             /*n_seq_id       =*/ batch.n_seq_id + offset,
             /*seq_id         =*/ batch.seq_id   + offset,
             /*logits         =*/ batch.logits   + offset,
@@ -303,7 +276,8 @@ int32_t mtmd_helper_eval_chunk_single_with_callback(mtmd_context * ctx,
             for (; i < n_tokens && text_batch.n_tokens < n_batch; i++) {
                 int32_t j = text_batch.n_tokens;
                 text_batch.token   [j]    = tokens[i];
-                text_batch.pos     [j]    = n_past++;
+                text_batch.pos     [j]    = { n_past, n_past, n_past, 0 };
+                n_past++;
                 text_batch.n_seq_id[j]    = 1;
                 text_batch.seq_id  [j][0] = seq_id;
                 text_batch.logits  [j]    = false;

--- a/examples/mtmd/mtmd-helper.cpp
+++ b/examples/mtmd/mtmd-helper.cpp
@@ -183,7 +183,7 @@ static int32_t mtmd_helper_decode_image_chunk_impl(
     }
 
     const llama_model * model = llama_get_model(lctx);
-    int n_mmproj_embd = llama_model_n_embd_inp(model);
+    int n_mmproj_embd = llama_model_n_embd(model);
     int n_pos_per_embd = mtmd_decode_use_mrope(ctx) ? 4 : 1;
 
     int32_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk);

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -609,10 +609,10 @@ static results_perplexity perplexity(llama_context * ctx, const gpt_params & par
                 for (int k = 0; k < batch_size; ++k) {
                     const int idx = seq*n_ctx + k;
                     batch.token   [idx]    = tokens[seq_start + k];
-                    batch.pos     [idx]    = j*n_batch + k;
+                    batch.pos     [idx]    = { j*n_batch + k, j*n_batch + k, j*n_batch + k, 0 };
                     batch.n_seq_id[idx]    = 1;
                     batch.seq_id  [idx][0] = seq;
-                    batch.logits  [idx]    = batch.pos[idx] >= first ? 1 : 0;
+                    batch.logits  [idx]    = batch.pos[idx].t >= first ? 1 : 0;
 
                     n_outputs += batch.logits[idx] != 0;
                 }

--- a/include/llama.h
+++ b/include/llama.h
@@ -72,6 +72,20 @@ extern "C" {
     typedef int32_t llama_token;
     typedef int32_t llama_seq_id;
 
+    // Per-token position carrier. For normal RoPE only `t` (the sequence
+    // position) is meaningful. For m-rope (Qwen2VL/Qwen3VL) the four fields are
+    // the temporal, height and width components plus an unused 4th dimension:
+    //   text token : { t, t, t, 0 }
+    //   image patch: { base, base+y, base+x, 0 }
+    // This is an array-of-structs (one per token), so slicing a batch is plain
+    // element-wise pointer arithmetic - no section-major stride math required.
+    typedef struct llama_mrope_pos {
+        int32_t t;
+        int32_t h;
+        int32_t w;
+        int32_t extra;
+    } llama_mrope_pos;
+
     enum llama_vocab_type {
         LLAMA_VOCAB_TYPE_NONE   = 0, // For models without vocab
         LLAMA_VOCAB_TYPE_SPM    = 1, // LLaMA tokenizer based on byte-level BPE with byte fallback
@@ -320,7 +334,7 @@ extern "C" {
 
         llama_token  *  token;
         float        *  embd;
-        llama_pos    *  pos;
+        llama_mrope_pos * pos;
         int32_t      *  n_seq_id;
         llama_seq_id ** seq_id;
         int8_t       *  logits; // TODO: rename this to "output"

--- a/src/llama-delta-net.cpp
+++ b/src/llama-delta-net.cpp
@@ -623,7 +623,7 @@ ggml_tensor * delta_net::build_layer_attn_linear(ggml_context * ctx0, ggml_cgrap
     GGML_ASSERT(model.layers[il].wqkv_gate != nullptr || model.layers[il].ssm_in != nullptr);
 
     if (all_same_seq) {
-        bool reset_state = batch.pos != nullptr && batch.pos[0] == 0;
+        bool reset_state = batch.pos != nullptr && batch.pos[0].t == 0;
         return build_layer_attn_linear_core(ctx0, gf, cur, lctx.inp_s_seq_qnext, inp_out_ids, token_seq_ids.front(), reset_state, il, cb);
     }
 
@@ -634,7 +634,7 @@ ggml_tensor * delta_net::build_layer_attn_linear(ggml_context * ctx0, ggml_cgrap
         ggml_tensor * cur_i = ggml_view_2d(ctx0, cur, cur->ne[0], 1, cur->nb[1], (size_t) i * cur->nb[1]);
         ggml_tensor * inp_s_seq_qnext_i = ggml_view_2d(ctx0, lctx.inp_s_seq_qnext, 1, 1, lctx.inp_s_seq_qnext->nb[1], (size_t) i * lctx.inp_s_seq_qnext->nb[1]);
 
-        const bool reset_state_i = batch.pos != nullptr && batch.pos[i] == 0;
+        const bool reset_state_i = batch.pos != nullptr && batch.pos[i].t == 0;
         const uint32_t state_seq_id_i = (uint32_t) token_seq_ids[i];
         ggml_tensor * out_i = build_layer_attn_linear_core(ctx0, gf, cur_i, inp_s_seq_qnext_i, inp_out_ids, state_seq_id_i, reset_state_i, il, cb);
 

--- a/src/llama-spec-features.cpp
+++ b/src/llama-spec-features.cpp
@@ -80,7 +80,7 @@ bool llama_spec_get_hidden_feature_view(
 
         view.rows.push_back({
             /* .seq_id = */ batch.seq_id[i][0],
-            /* .pos    = */ batch.pos[i],
+            /* .pos    = */ batch.pos[i].t,
             /* .data   = */ ctx->embd + (size_t) i * view.width,
         });
     }
@@ -114,7 +114,7 @@ bool llama_spec_get_hidden_feature_view_for_seq(
 
             view.rows.push_back({
                 /* .seq_id = */ seq_id,
-                /* .pos    = */ batch.pos[i],
+                /* .pos    = */ batch.pos[i].t,
                 /* .data   = */ ctx->embd + (size_t) i * view.width,
             });
             break;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1201,16 +1201,16 @@ static bool llama_kv_cache_find_slot(
                         min = seq_id;
                     }
                     // Assuming the tokens are in-order
-                    if (batch.pos[i] != cache.cells[seq_id].pos + 1) {
+                    if (batch.pos[i].t != cache.cells[seq_id].pos + 1) {
                         // What should happen when the pos backtracks or skips a value?
                         // Clearing the state mid-batch would require special-casing which isn't done.
                         LLAMA_LOG_WARN("%s: non-consecutive token position %d after %d for sequence %d\n",
-                            __func__, batch.pos[i], cache.cells[seq_id].pos, seq_id);
+                            __func__, batch.pos[i].t, cache.cells[seq_id].pos, seq_id);
                     }
-                    if (cache.cells[seq_id].pos < 0 && 0 <= batch.pos[i]) {
+                    if (cache.cells[seq_id].pos < 0 && 0 <= batch.pos[i].t) {
                         cache.used += 1;
                     }
-                    cache.cells[seq_id].pos = batch.pos[i];
+                    cache.cells[seq_id].pos = batch.pos[i].t;
                     // NOTE: seq_ids are not inserted here; they are handled when the input tensors are set
                 } else {
                     // too big seq_id
@@ -1265,7 +1265,7 @@ static bool llama_kv_cache_find_slot(
     }
 
     for (uint32_t i = 0; i < n_tokens; i++) {
-        cache.cells[cache.head + i].pos = batch.pos[i];
+        cache.cells[cache.head + i].pos = batch.pos[i].t;
 
         for (int32_t j = 0; j < batch.n_seq_id[i]; j++) {
             cache.cells[cache.head + i].seq_id.insert(batch.seq_id[i][j]);
@@ -4234,18 +4234,19 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 #endif
         const int64_t n_tokens = batch.n_tokens;
         const int n_pos_per_embd =  hparams.rope_type == LLAMA_ROPE_TYPE_MROPE || hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE ? 4 : 1;
-        if (batch.token && n_pos_per_embd == 4) {
-            std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd);
-            for (int i = 0; i < n_tokens; ++i) {
-                pos_data[               i] = batch.pos[i];
-                pos_data[    n_tokens + i] = batch.pos[i];
-                pos_data[2 * n_tokens + i] = batch.pos[i];
-                pos_data[3 * n_tokens + i] = 0; // 4th dim is 0
+        // Scatter the AoS per-token positions into the section-major (SoA) layout
+        // the rope kernels expect for inp_pos: [all t][all h][all w][all extra].
+        // For normal rope (n_pos_per_embd == 1) only the temporal component is used.
+        std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd);
+        for (int i = 0; i < n_tokens; ++i) {
+            pos_data[i] = batch.pos[i].t;
+            if (n_pos_per_embd == 4) {
+                pos_data[    n_tokens + i] = batch.pos[i].h;
+                pos_data[2 * n_tokens + i] = batch.pos[i].w;
+                pos_data[3 * n_tokens + i] = batch.pos[i].extra;
             }
-            ggml_backend_tensor_set(lctx.inp_pos, pos_data.data(), 0, pos_data.size()*ggml_element_size(lctx.inp_pos));
-        } else {
-            ggml_backend_tensor_set(lctx.inp_pos, batch.pos, 0, n_tokens*n_pos_per_embd*ggml_element_size(lctx.inp_pos));
         }
+        ggml_backend_tensor_set(lctx.inp_pos, pos_data.data(), 0, pos_data.size()*ggml_element_size(lctx.inp_pos));
 #if IK_PRINT_TIMING == 2
         auto tim2 = ggml_time_us();
         printf("set_inputs(pos): %d us\n", int(tim2-tim1));
@@ -4261,7 +4262,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
         if (int(lctx.scale_data.size()) < n_tokens) lctx.scale_data.resize(n_tokens);
         int n_pos_per_token = 1;
         for (int i = 0; i < n_tokens; ++i) {
-            lctx.scale_data[i] = std::log(std::floor((batch.pos[i] + 1.0f) / hparams.n_attn_temp_floor_scale) + 1.0f) * hparams.f_attn_temp_scale + 1.0f;
+            lctx.scale_data[i] = std::log(std::floor((batch.pos[i].t + 1.0f) / hparams.n_attn_temp_floor_scale) + 1.0f) * hparams.f_attn_temp_scale + 1.0f;
         }
         ggml_backend_tensor_set(lctx.inp_scale, lctx.scale_data.data(), 0, n_tokens*n_pos_per_token*ggml_element_size(lctx.inp_scale));
 #if IK_PRINT_TIMING == 2
@@ -4385,7 +4386,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                     int last  = std::min(int(n_kv), first + npt);
                     if (last <= first) return;
                     for (int j = 0; j < n_tokens; ++j) {
-                        const llama_pos    pos    = batch.pos[j];
+                        const llama_pos    pos    = batch.pos[j].t;
                         const llama_seq_id seq_id = batch.seq_id[j][0];
 
                         if (!hparams.use_alibi && cparams.flash_attn) {
@@ -4466,7 +4467,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
             // It's assumed that if a token in the batch has multiple sequences, they are equivalent.
             for (int h = 0; h < 1; ++h) {
                 for (int j = 0; j < n_tokens; ++j) {
-                    const llama_pos    pos    = batch.pos[j];
+                    const llama_pos    pos    = batch.pos[j].t;
                     const llama_seq_id seq_id = batch.seq_id[j][0];
 
                     if (!hparams.use_alibi && cparams.flash_attn) {
@@ -4577,7 +4578,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                         for (int s = 0; s < batch.n_seq_id[i]; ++s) {
                             if (batch.seq_id[i][s] == seq_id) {
                                 if (hparams.use_alibi) {
-                                    f = -std::abs(batch.pos[i] - batch.pos[j]);
+                                    f = -std::abs(batch.pos[i].t - batch.pos[j].t);
                                 } else {
                                     f = 0.0f;
                                 }
@@ -4594,12 +4595,12 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 
                         if (data_swa || data_swa_f16) {
                             if (hparams.n_attn_chunk) {
-                                llama_pos pos_chunk_start = (batch.pos[i] / hparams.n_attn_chunk) * hparams.n_attn_chunk;
-                                if (lctx.kv_self.cells[i].pos < pos_chunk_start || batch.pos[i] < pos_chunk_start) {
+                                llama_pos pos_chunk_start = (batch.pos[i].t / hparams.n_attn_chunk) * hparams.n_attn_chunk;
+                                if (lctx.kv_self.cells[i].pos < pos_chunk_start || batch.pos[i].t < pos_chunk_start) {
                                     f = -INFINITY;
                                 }
                             } else {
-                                if (batch.pos[i] - kv_self.cells[i].pos >= (int32_t)hparams.n_swa) {
+                                if (batch.pos[i].t - kv_self.cells[i].pos >= (int32_t)hparams.n_swa) {
                                     f = -INFINITY;
                                 }
                             }
@@ -4675,7 +4676,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 
         for (int i = 0; i < n_tokens; ++i) {
             const llama_seq_id seq_id = batch.seq_id[i][0];
-            const llama_pos    pos    = batch.pos[i];
+            const llama_pos    pos    = batch.pos[i].t;
 
             GGML_ASSERT(seq_id < n_tokens && "seq_id cannot be larger than n_tokens with pooling_type == CLS");
 
@@ -4699,7 +4700,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 
         for (int i = 0; i < n_tokens; ++i) {
             const llama_seq_id seq_id = batch.seq_id[i][0];
-            const llama_pos    pos    = batch.pos[i];
+            const llama_pos    pos    = batch.pos[i].t;
 
             GGML_ASSERT(seq_id < n_tokens && "seq_id cannot be larger than n_tokens with pooling_type == LAST");
 
@@ -4787,7 +4788,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
             for (int h = 0; h < 1; ++h) {
                 for (int j = 0; j < n_tokens; ++j) {
                     for (int i = 0; i < n_kv; ++i) {
-                        data[h*(n_kv*n_tokens) + j*n_kv + i] = llama_relative_position_bucket(lctx.kv_self.cells[i].pos, batch.pos[j], hparams.n_rel_attn_bkts, lctx.is_encoding);
+                        data[h*(n_kv*n_tokens) + j*n_kv + i] = llama_relative_position_bucket(lctx.kv_self.cells[i].pos, batch.pos[j].t, hparams.n_rel_attn_bkts, lctx.is_encoding);
                     }
                 }
             }
@@ -4795,7 +4796,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
             for (int h = 0; h < 1; ++h) {
                 for (int j = 0; j < n_tokens; ++j) {
                     for (int i = 0; i < n_tokens; ++i) {
-                        data[h*(n_tokens*n_tokens) + j*n_tokens + i] = llama_relative_position_bucket(batch.pos[i], batch.pos[j], hparams.n_rel_attn_bkts, lctx.is_encoding);
+                        data[h*(n_tokens*n_tokens) + j*n_tokens + i] = llama_relative_position_bucket(batch.pos[i].t, batch.pos[j].t, hparams.n_rel_attn_bkts, lctx.is_encoding);
                     }
                 }
             }
@@ -5060,7 +5061,7 @@ static int llama_decode_internal(
     const auto n_ubatch = cparams.n_ubatch;
 
     // TODO: simplify or deprecate
-    std::vector<llama_pos> pos;
+    std::vector<llama_mrope_pos> pos;
     std::vector<int32_t>                   n_seq_id;
     std::vector<llama_seq_id *>            seq_id_arr;
     std::vector<std::vector<llama_seq_id>> seq_id;
@@ -5197,7 +5198,8 @@ static int llama_decode_internal(
         if (u_batch.pos == nullptr) {
             pos.resize(n_tokens);
             for (uint32_t i = 0; i < n_tokens; i++) {
-                pos[i] = u_batch.all_pos_0 + i*u_batch.all_pos_1;
+                const llama_pos v = u_batch.all_pos_0 + i*u_batch.all_pos_1;
+                pos[i] = { v, v, v, 0 };
             }
 
             u_batch.pos = pos.data();
@@ -5558,7 +5560,7 @@ static int llama_encode_internal(
     const int64_t n_embd = hparams.n_embd;
 
     // TODO: simplify or deprecate
-    std::vector<llama_pos> pos;
+    std::vector<llama_mrope_pos> pos;
     std::vector<int32_t>                   n_seq_id;
     std::vector<llama_seq_id *>            seq_id_arr;
     std::vector<std::vector<llama_seq_id>> seq_id;
@@ -5584,7 +5586,8 @@ static int llama_encode_internal(
     if (batch.pos == nullptr) {
         pos.resize(n_tokens);
         for (uint32_t i = 0; i < n_tokens; i++) {
-            pos[i] = batch.all_pos_0 + i*batch.all_pos_1;
+            const llama_pos v = batch.all_pos_0 + i*batch.all_pos_1;
+            pos[i] = { v, v, v, 0 };
         }
 
         batch.pos = pos.data();
@@ -8521,7 +8524,7 @@ struct llama_data_read {
                     return false;
                 }
 
-                batch.pos[i] = pos;
+                batch.pos[i] = { pos, pos, pos, 0 };
                 batch.n_seq_id[i] = 1;
                 batch.seq_id[i][0] = dest_seq_id;
             }
@@ -8534,8 +8537,8 @@ struct llama_data_read {
             // DEBUG CHECK: kv_self.head should be our first cell, kv_self.head + cell_count - 1 should be our last cell (verify seq_id and pos values)
             // Assume that this is one contiguous block of cells
             GGML_ASSERT(kv_self.head + cell_count <= kv_self.size);
-            GGML_ASSERT(kv_self.cells[kv_self.head].pos == batch.pos[0]);
-            GGML_ASSERT(kv_self.cells[kv_self.head + cell_count - 1].pos == batch.pos[cell_count - 1]);
+            GGML_ASSERT(kv_self.cells[kv_self.head].pos == batch.pos[0].t);
+            GGML_ASSERT(kv_self.cells[kv_self.head + cell_count - 1].pos == batch.pos[cell_count - 1].t);
             GGML_ASSERT(kv_self.cells[kv_self.head].has_seq_id(dest_seq_id));
             GGML_ASSERT(kv_self.cells[kv_self.head + cell_count - 1].has_seq_id(dest_seq_id));
 
@@ -9493,7 +9496,7 @@ struct llama_batch llama_batch_init(int32_t n_tokens_alloc, int32_t embd, int32_
         batch.token = (llama_token *) malloc(sizeof(llama_token) * n_tokens_alloc);
     }
 
-    batch.pos      = (llama_pos *)     malloc(sizeof(llama_pos)      * n_tokens_alloc);
+    batch.pos      = (llama_mrope_pos *) malloc(sizeof(llama_mrope_pos) * n_tokens_alloc);
     batch.n_seq_id = (int32_t *)       malloc(sizeof(int32_t)        * n_tokens_alloc);
     batch.seq_id   = (llama_seq_id **) malloc(sizeof(llama_seq_id *) * (n_tokens_alloc + 1));
     for (int i = 0; i < n_tokens_alloc; ++i) {


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] AI Slop
  - [x] Breaks libllama ABI 

Short description because this draft PR is low value. Raising the PR because it does embody the complete fix to qwen bbox issues in  #993  and #1202

Currently, for mrope models (qwen3vl, qwen3.5 etc), mrope is misapplied when an image crosses a chunk boundary.  This is almost definitely a trivial error that stems from the fact that normal positional rope is expressed as an array of integers, and m-rope is an expressed as the same array of integers. It is the programmer's responsibility to pack and unpack this data correctly in llama_decode depending on the model architecture.

I prompted Claude with "make (m)-rope into a struct and apply it everywhere". In doing so, it realized where the packing/unpacking was being done incorrectly for m-rope models and quietly fixed the problem.

I have created some synthetic tests that show the before and after state for qwen3vl on bbox2d tasks.
[Before](https://raw.githack.com/Farmadupe/ik_llama.cpp/report-snapshots/oob_fix.html)
[After](https://raw.githack.com/Farmadupe/ik_llama.cpp/report-snapshots/mrope_fix.html)

There is probably a 1 line change that will fix this issue.