### PR TITLE
Insert image begin/end markers for kimi K2.5 and K2.6

### DIFF
--- a/examples/mtmd/mtmd.cpp
+++ b/examples/mtmd/mtmd.cpp
@@ -307,6 +307,11 @@ struct mtmd_context {
             img_end = "<image|>";
             //image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
         }
+        else if (proj == PROJECTOR_TYPE_KIMIK25) {
+            // template renders: <|media_begin|>image<|media_content|> <pad/embeddings> <|media_end|>
+            img_beg = "<|media_begin|>image<|media_content|>";
+            img_end = "<|media_end|>";
+        }
     }
 
     void init_audio() {


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low

Image begin/end markers were missing from kimi k2.5 and kimi k2.6