### PR TITLE
Fix mrope application across chunk boundaries (Fixes #993 and #1902 -- part 2)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -4012,14 +4012,7 @@ static std::pair<int, int> get_batch_ubatch(const gpt_params & params) {
     if (params.n_ctx > 0) {
         n_batch = std::min(n_batch, params.n_ctx);
     }
-    if (!params.mmproj.path.empty() && params.mmproj_use_gpu) {
-        // temporary fix for qwen mtmd (only when mmproj is on GPU)
-        n_batch = std::max(n_batch, n_ubatch);
-        n_ubatch = n_batch;
-        fprintf(stdout, "Adjust batch size for mtmd: u_batch = %d, batch = %d\n", n_ubatch, n_batch);
-    } else {
-        n_ubatch = std::min(n_batch, n_ubatch);
-    }
+    n_ubatch = std::min(n_batch, n_ubatch);
     return {n_batch, n_ubatch};
 }
 

--- a/examples/mtmd/mtmd-helper.cpp
+++ b/examples/mtmd/mtmd-helper.cpp
@@ -183,7 +183,7 @@ static int32_t mtmd_helper_decode_image_chunk_impl(
     }
 
     const llama_model * model = llama_get_model(lctx);
-    int n_mmproj_embd = llama_model_n_embd_inp(model);
+    int n_mmproj_embd = llama_model_n_embd(model);
     int n_pos_per_embd = mtmd_decode_use_mrope(ctx) ? 4 : 1;
 
     int32_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5155,11 +5155,31 @@ static int llama_decode_internal(
             }
         }
 
+
+        // Repack the rope buffer for the ubatch depending on type.
+        // * mrope:  (section-major array of rope fields) [t; n][h; n][w; n][extra; n]
+        // * others: (flat array )                        [t; n]
+        const uint8_t rope_params_per_token = (hparams.rope_type == LLAMA_ROPE_TYPE_MROPE ||
+            hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE) ? 4 : 1;
+        llama_pos * u_batch_pos;
+        if (batch_all.pos && batch_all.embd && rope_params_per_token == 4) {
+            pos.resize((size_t) n_tokens * rope_params_per_token);
+            for (uint32_t i = 0; i < n_tokens; ++i) {
+                pos[0*n_tokens + i] = batch_all.pos[0*n_tokens_all + cur_token + i]; // t
+                pos[1*n_tokens + i] = batch_all.pos[1*n_tokens_all + cur_token + i]; // h
+                pos[2*n_tokens + i] = batch_all.pos[2*n_tokens_all + cur_token + i]; // w
+                pos[3*n_tokens + i] = batch_all.pos[3*n_tokens_all + cur_token + i]; // extra
+            }
+            u_batch_pos = pos.data();
+        } else {
+            u_batch_pos = batch_all.pos ? batch_all.pos + cur_token : nullptr;
+        }
+
         llama_batch u_batch = {
             /* .n_tokens   = */ (int32_t) n_tokens,
             /* .token      = */ batch_all.token     ? batch_all.token    + cur_token        : nullptr,
             /* .embd       = */ batch_all.embd      ? batch_all.embd     + cur_token*n_embd : nullptr,
-            /* .pos        = */ batch_all.pos       ? batch_all.pos      + cur_token        : nullptr,
+            /* .pos        = */ u_batch_pos,
             /* .n_seq_id   = */ batch_all.n_seq_id  ? batch_all.n_seq_id + cur_token        : nullptr,
             /* .seq_id     = */ batch_all.seq_id    ? batch_all.seq_id   + cur_token        : nullptr,
             /* .logits     = */ batch_all.logits    ? batch_all.logits   + cur_token        : nullptr,


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  
Context:
  * Replaces previous vibeslop PR #1907 
  * Still using AI. Standard psychosis warnings apply.
  
Changes:
  * Repack rope buffer correctly during ubatch setup inside llama_decode. Fixes m-rope corruption issue caused by ubatch splitting. 
  * Re-enable pipeline parallelism when mmproj is loaded.

For the last 6 moths, pipeline parallelism has been disabled whenever an mmproj has been loaded due to corruptions in Qwen M-Rope. I submitted an AI guided slop PR for this last week.

I have since realized [full disclosure: the same AI agent told me] that the ABI change was never necessary, so here is the resulting PR. The solution is simply to repack the rope array to fit the layout requirements of the ubatch.

Notes:
* This PR contains two commits, the first of which is the deepstack fix for qwen3vl and is technically unrelated. It's been left in place because this patch was tested using the same qwen3vl model I tested the prior patch with. If the other PR is rejected, [0cb9ef5](https://github.com/ikawrakow/ik_llama.cpp/pull/1918/commits/0cb9ef5a4b1269024d437b5a5c66d7d073803e3f) can be cherrypicked.
* Honestly, if it wasn't for the ABI change, I actually prefer the vibeslop patch that turned rope into a struct. By my count, by the time we're repacking rope inside llama-decode for ubatching, we're at the **4th** manual repacking of the token sequence:  [0: token sequence] -> [1: modality chunk] -> [2: batch-window] -> [3: ubatch-window] -> [4: repack rope for ubatch-window (but only for Qwen models!)] -- Using a struct allowed the compiler to bear the weight of that repacking.

bbox2d test results:
Using vibed synthetic bbox2d test from the following commit https://github.com/Farmadupe/ik_llama.cpp/commit/cec3d609a7be87d35dcbaab2b0512c13c29a90a9 
**Before this patch** (note: guard in server-common.cpp needs to be removed to re-expose the bug)
(https://raw.githack.com/Farmadupe/ik_llama.cpp/report-snapshots/oob_fix.html)
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/b7b3b404-e307-47e3-b841-1538a296a9ee" />

**After this patch**
https://raw.githack.com/Farmadupe/ik_llama.cpp/report-snapshots/fix-mrope-pipeline-parallel.html
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/1fe03ed9-0f57-4552-801d-d019c2b47549" />
