### PR TITLE
CUDA : support head_dim 512 with gqa_ratio % 8 (unblocks Gemma 4 12B)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-new-mma.cu
+++ b/ggml/src/ggml-cuda/fattn-new-mma.cu
@@ -2255,10 +2255,15 @@ void ggml_cuda_flash_attn_ext_mma_new(ggml_backend_cuda_context & ctx, ggml_tens
         return;
     }
     if (Q->ne[0] == 512 && K->ne[0] == 512 && V->ne[0] == 512) {
-        if (gqa_ratio == 8) {
+        // head_dim 512: ncols2=16 exceeds the max dynamic shared memory on some GPUs (e.g. Ada,
+        // where cudaFuncSetAttribute returns invalid argument), so route gqa_ratio % 8 == 0
+        // (covers 8 and 16) through the ncols2=8 kernel. It iterates over Q-head groups
+        // (iter_z = ceil(gqa_ratio/ncols2)), so 16 heads run as two passes of 8. This unblocks
+        // head_dim-512 models with a 16:1 GQA ratio such as Gemma 4 12B's global layers.
+        if (gqa_ratio % 8 == 0) {
             ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<512, 512, 8>(ctx, dst);
         }
-        else if (gqa_ratio == 4) {
+        else if (gqa_ratio % 4 == 0) {
             ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<512, 512, 4>(ctx, dst);
         }
         else {


### PR DESCRIPTION
**Review Complexity : Low**

## Summary

The MMA flash-attention dispatcher in `fattn-new-mma.cu` only instantiates `ncols2 = 8` and `4` for `head_dim == 512`; any other GQA ratio hits `GGML_ABORT("Fatal error")`.

**Gemma 4 12B**'s global (full-attention) layers use **head_dim 512 with a 16:1 GQA ratio** (16 query heads / 1 KV head), so loading it with flash attention enabled aborts immediately. Since MTP speculative decoding requires FA, this also blocks the Gemma 4 12B MTP drafter entirely.

## Why not just instantiate `<512, 512, 16>`?

It compiles, but at launch `cudaFuncSetAttribute(..., cudaFuncAttributeMaxDynamicSharedMemorySize, ...)` returns `invalid argument` — `ncols2 = 16` at head_dim 512 exceeds the max dynamic shared memory on Ada (cc 8.9, ~100 KB).

## Fix

Route `gqa_ratio % 8 == 0` (covers 8 **and** 16) through the existing `ncols2 = 8` kernel, which already iterates over Q-head groups (`iter_z = ceil(gqa_ratio / ncols2)`). 16 heads simply run as two passes of 8 — no new kernel, no extra shared memory. This mirrors the divisor-based dispatch already used a few lines below for the 576×512 case.

- `gqa_ratio` 8 → ncols2 8 (unchanged)
- `gqa_ratio` 4 → ncols2 4 (unchanged)
- `gqa_ratio` 16 → ncols2 8, iter_z 2 (**new**)

Strictly a superset of prior behavior; existing models are unaffected.

## Testing

Note: `tests/test-backend-ops.cpp` is present in the tree but is **not wired into the build** and does not currently compile against this codebase (`test_flash_attn_ext` constructor arg-count drift, missing `test_pad_ext`), so the standard `tests/test-backend-ops` command could not be run as-is. Happy to wire it up / fix it in a separate PR if useful. Validation done here instead:

- **No-regression by construction:** the `gqa_ratio` 8 and 4 routes are unchanged — `% 8`/`% 4` select the same `ncols2` for 8 and 4 as the previous `== 8`/`== 4`. Only `gqa_ratio % 8` values that previously **aborted** (e.g. 16) gain a route, and through the existing, already-exercised `ncols2 = 8` kernel.
- **Correctness, end-to-end** (RTX 4070 Ti SUPER, Ada cc 8.9, Gemma 4 12B Q6_K, FA on): the patched 512×512 path runs on the model's global layers every token; known-answer prompts return correct output (broken attention would not) — "capital of France"→"Paris", "17+25"→"42", "…lazy"→"dog."
- **MTP drafter, FA on** (Gemma 4 12B + its assistant drafter, `--spec-type mtp`): draft acceptance 43–95% by workload — it is ~0% when attention is wrong — with 1.5–2.2× end-to-end speedup:

| workload | baseline | MTP | speedup | acceptance |
|---|--:|--:|--:|--:|
| structured / JSON | 46.7 | 104.4 t/s | 2.24× | 95% |
| code | 46.4 | 91.3 t/s | 1.97× | 78% |
| creative | 46.3 | 68.5 t/s | 1.48× | 43% |

- **26B-A4B drafter (gqa_ratio 8)** runs identically before and after — no regression.

Before this patch the server aborts at load in the 512×512 branch of `ggml_cuda_flash_attn_ext_mma_new`.
