### PR TITLE
Cleanup: Unify location of m-rope repacking for token and embd 

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5147,9 +5147,9 @@ static int llama_decode_internal(
 
 
         // Repack the rope buffer for the ubatch depending on whether the model uses mrope.
-        // * standard rope:  (flat array )                        [t; n]
+        // * standard rope:  (flat array)                         [t; n]
         // * mrope (token):  (section-major array of rope fields) [t; n][t; n][t; n][0;     n]
-        // * mrope (embd):   (section-major array of rope fields) [t; n][h; n][w; n][extra; n] 
+        // * mrope (embd):   (section-major array of rope fields) [t; n][h; n][w; n][extra; n]
         const uint8_t rope_params_per_token = (hparams.rope_type == LLAMA_ROPE_TYPE_MROPE ||
             hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE) ? 4 : 1;
             
@@ -5163,15 +5163,15 @@ static int llama_decode_internal(
             u_batch_pos = pos.data();
             for (uint32_t i = 0; i < n_tokens; ++i) {
                 if (batch_all.token) {
-                    pos[0*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
-                    pos[1*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
-                    pos[2*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
-                    pos[3*n_tokens + i] = 0;
+                    pos[               i] = batch_all.pos[cur_token + i]; // t
+                    pos[    n_tokens + i] = batch_all.pos[cur_token + i]; // t
+                    pos[2 * n_tokens + i] = batch_all.pos[cur_token + i]; // t
+                    pos[3 * n_tokens + i] = 0;
                 } else { //embd
-                    pos[0*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
-                    pos[1*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*1]; // h
-                    pos[2*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*2]; // w
-                    pos[3*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*3]; // extra (this field is supplied but unused)
+                    pos[               i] = batch_all.pos[                   cur_token + i]; // t
+                    pos[    n_tokens + i] = batch_all.pos[    n_tokens_all + cur_token + i]; // h
+                    pos[2 * n_tokens + i] = batch_all.pos[2 * n_tokens_all + cur_token + i]; // w
+                    pos[3 * n_tokens + i] = batch_all.pos[3 * n_tokens_all + cur_token + i]; // extra (this field is supplied but unused)
                 }
             }
         }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4235,18 +4235,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 #endif
         const int64_t n_tokens = batch.n_tokens;
         const int n_pos_per_embd =  hparams.rope_type == LLAMA_ROPE_TYPE_MROPE || hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE ? 4 : 1;
-        if (batch.token && n_pos_per_embd == 4) {
-            std::vector<llama_pos> pos_data(n_tokens*n_pos_per_embd);
-            for (int i = 0; i < n_tokens; ++i) {
-                pos_data[               i] = batch.pos[i];
-                pos_data[    n_tokens + i] = batch.pos[i];
-                pos_data[2 * n_tokens + i] = batch.pos[i];
-                pos_data[3 * n_tokens + i] = 0; // 4th dim is 0
-            }
-            ggml_backend_tensor_set(lctx.inp_pos, pos_data.data(), 0, pos_data.size()*ggml_element_size(lctx.inp_pos));
-        } else {
-            ggml_backend_tensor_set(lctx.inp_pos, batch.pos, 0, n_tokens*n_pos_per_embd*ggml_element_size(lctx.inp_pos));
-        }
+        ggml_backend_tensor_set(lctx.inp_pos, batch.pos, 0, n_tokens*n_pos_per_embd*ggml_element_size(lctx.inp_pos));
 #if IK_PRINT_TIMING == 2
         auto tim2 = ggml_time_us();
         printf("set_inputs(pos): %d us\n", int(tim2-tim1));
@@ -5157,23 +5146,34 @@ static int llama_decode_internal(
         }
 
 
-        // Repack the rope buffer for the ubatch depending on type.
-        // * mrope:  (section-major array of rope fields) [t; n][h; n][w; n][extra; n]
-        // * others: (flat array )                        [t; n]
+        // Repack the rope buffer for the ubatch depending on whether the model uses mrope.
+        // * standard rope:  (flat array )                        [t; n]
+        // * mrope (token):  (section-major array of rope fields) [t; n][t; n][t; n][0;     n]
+        // * mrope (embd):   (section-major array of rope fields) [t; n][h; n][w; n][extra; n] 
         const uint8_t rope_params_per_token = (hparams.rope_type == LLAMA_ROPE_TYPE_MROPE ||
             hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE) ? 4 : 1;
+            
         llama_pos * u_batch_pos;
-        if (batch_all.pos && batch_all.embd && rope_params_per_token == 4) {
-            pos.resize((size_t) n_tokens * rope_params_per_token);
-            for (uint32_t i = 0; i < n_tokens; ++i) {
-                pos[0*n_tokens + i] = batch_all.pos[0*n_tokens_all + cur_token + i]; // t
-                pos[1*n_tokens + i] = batch_all.pos[1*n_tokens_all + cur_token + i]; // h
-                pos[2*n_tokens + i] = batch_all.pos[2*n_tokens_all + cur_token + i]; // w
-                pos[3*n_tokens + i] = batch_all.pos[3*n_tokens_all + cur_token + i]; // extra
-            }
-            u_batch_pos = pos.data();
+        if (!batch_all.pos) {
+            u_batch_pos = nullptr;
+        } else if (rope_params_per_token == 1) {
+            u_batch_pos = batch_all.pos + cur_token;
         } else {
-            u_batch_pos = batch_all.pos ? batch_all.pos + cur_token : nullptr;
+            pos.resize((size_t) n_tokens * rope_params_per_token);
+            u_batch_pos = pos.data();
+            for (uint32_t i = 0; i < n_tokens; ++i) {
+                if (batch_all.token) {
+                    pos[0*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
+                    pos[1*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
+                    pos[2*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
+                    pos[3*n_tokens + i] = 0;
+                } else { //embd
+                    pos[0*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*0]; // t
+                    pos[1*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*1]; // h
+                    pos[2*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*2]; // w
+                    pos[3*n_tokens + i] = batch_all.pos[cur_token + i + n_tokens_all*3]; // extra (this field is supplied but unused)
+                }
+            }
         }
 
         llama_batch u_batch = {


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  
Sorry for the PR spam. I'd nearly finished prepping this change as part of  #1918 at the moment it got merged.

I figured that for m-rope models, repacking `pos` inside the ubatch for `token` but repacking outside the ubatch for `embed` is a footgun of my own making. 

`embed` can't go down so I've hoisted `token` up.

The reorganizaiton also give an obvious place to hang the next set of edits to the code if a new kind of positional encoding gets invented.