### PR TITLE
convert: support Gemma4UnifiedAssistantForCausalLM

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3474,7 +3474,7 @@ class Gemma4Model(Gemma4BaseModel):
         return [(self.map_tensor_name(name), data_torch)]
 
 
-@Model.register("Gemma4AssistantForCausalLM")
+@Model.register("Gemma4AssistantForCausalLM", "Gemma4UnifiedAssistantForCausalLM")
 class Gemma4AssistantModel(Gemma4BaseModel):
     model_arch = gguf.MODEL_ARCH.GEMMA4_MTP
 


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

This adds `Gemma4UnifiedAssistantForCausalLM` as an alias for the existing Gemma 4 assistant converter.

Google's new Gemma 4 QAT assistant checkpoints, for example:

`google/gemma-4-12B-it-qat-q4_0-unquantized-assistant`

declare:

```json
"architectures": ["Gemma4UnifiedAssistantForCausalLM"],
"model_type": "gemma4_unified_assistant"
```

The tensor layout matches the existing `Gemma4AssistantModel` converter path:

- `pre_projection.weight` -> `mtp_pre_proj.weight`
- `post_projection.weight` -> `mtp_post_proj.weight`
- `model.layers.N.*` tensors map to the existing `blk.N.*` Gemma 4 MTP assistant names

No runtime changes are needed.

Using this converter change, I converted Google's QAT assistant checkpoints for
the 12B, 26B-A4B, and 31B models and published the resulting `ik_llama`
assistant GGUFs here:

https://huggingface.co/ji-farthing/gemma-4-qat-q4_0-MTP-assistants-ik-llama-GGUF

That repo contains Q4_0 and Q8_0 draft/assistant GGUFs for:

- `google/gemma-4-12B-it-qat-q4_0-unquantized-assistant`
- `google/gemma-4-26B-A4B-it-qat-q4_0-unquantized-assistant`
- `google/gemma-4-31B-it-qat-q4_0-unquantized-assistant`

Validation performed locally:

```bash
python -m py_compile convert_hf_to_gguf.py
```

Dry-run conversion:

```bash
python convert_hf_to_gguf.py \
  /path/to/google-gemma4-12b-qat-q4_0-unquantized-assistant \
  --outtype bf16 \
  --dry-run \
  --outfile gemma-4-12B-it-qat-q4_0-MTP-ik_llama-BF16.gguf
```

The dry run mapped all 48 tensors and emitted a `gemma4_mtp` GGUF plan.

I also tested real conversion and quantization locally:

- BF16 assistant GGUFs: `arch=gemma4_mtp`, `48` tensors
- Q4_0 assistant GGUFs via `llama-quantize`
- Q8_0 assistant GGUFs via `llama-quantize`

The published HF files were produced from those converted GGUFs. The remote
`x-linked-etag` values match the local SHA256 hashes for all six published
assistant files.

Runtime smoke with current `origin/main`:

```bash
llama-server \
  -m gemma-4-12b-it-qat-q4_0.gguf \
  --model-draft gemma-4-12B-it-qat-q4_0-MTP-ik_llama-Q4_0.gguf \
  --spec-type mtp:n_max=4,p_min=0.0 \
  -c 4096
```

Result:

- Target model loaded successfully
- Draft model loaded as `gemma4_mtp`
- `MTP context ready`
- Raw completion succeeded
- Chat completion also succeeded with `--jinja`

Small local smoke result on RTX 4070:

```text
draft acceptance rate = 0.90741 (49 accepted / 54 generated)
```

Additional Q4_0 draft smoke tests:

```text
12B:      MTP context ready; raw completion generated; 23/28 draft tokens accepted
26B-A4B:  MTP context ready; raw completion generated; 19/48 draft tokens accepted
31B:      MTP context ready; raw completion generated; 19/40 draft tokens accepted
```

One note: these Google assistant configs advertise centroid metadata, but the
12B, 26B-A4B, and 31B safetensors files I tested do not include
centroid/token-ordering tensors. The current Gemma 4 MTP runtime treats those
tensors as optional and uses the full-vocab output path, so this does not block
conversion or inference.
