### PR TITLE
Gemma4: allow missing shared-KV edge tensors

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2125,13 +2125,16 @@ bool create_tensors_helper::create_gemma4_tensors(const LLM_TN & tn) {
         layer.attn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
 
         // note: use_alternative_attention (v_proj is optional, if it's not present, use k_proj)
+        // Gemma 4 shared-KV layers omit fresh K/K-norm tensors.
+        const int kv_required = hparams.has_kv(i) ? 0 : llama_model_loader::TENSOR_NOT_REQUIRED;
+
         layer.wq = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head * n_head}, 0);
-        layer.wk = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k}, 0);
+        layer.wk = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k}, kv_required);
         layer.wv = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_v}, llama_model_loader::TENSOR_NOT_REQUIRED);
         layer.wo = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head * n_head, n_embd}, 0);
 
         layer.attn_q_norm    = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q_NORM,    "weight", i), {n_embd_head}, 0);
-        layer.attn_k_norm    = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K_NORM,    "weight", i), {n_embd_head}, 0);
+        layer.attn_k_norm    = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K_NORM,    "weight", i), {n_embd_head}, kv_required);
         layer.attn_post_norm = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_POST_NORM, "weight", i), {n_embd}, 0);
 
         layer.out_scale = create_tensor(ctx_split, tn(LLM_TENSOR_LAYER_OUT_SCALE, "weight", i), {1u}, llama_model_loader::TENSOR_NOT_REQUIRED);


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Gemma 4 already reads `gemma4.attention.shared_kv_layers` into `hparams.n_layer_kv_from_start`, and the Gemma 4 graph already uses `hparams.has_kv(il)` when building attention for shared-KV layers.

The Gemma 4 target tensor loader did not use the same predicate. It required `blk.N.attn_k.weight` and `blk.N.attn_k_norm.weight` for every layer, including shared-KV tail layers that intentionally omit fresh K/K-norm tensors.

This blocks the official Google Gemma 4 QAT E2B/E4B target GGUFs before draft loading is relevant, for example:

```text
E2B: missing blk.15.attn_k.weight
E4B: missing blk.24.attn_k.weight
```

This PR applies the existing `hparams.has_kv(i)` predicate in `create_gemma4_tensors()` so Gemma 4 shared-KV tail layers can omit K and K-norm tensors, while layers that do have KV continue to require them exactly as before.

Scope:

- Gemma 4 loader path only
- no converter changes; this does not include or depend on #1925's converter diff
- Gemma 4 models without shared-KV tail layers should be behavior-identical because `hparams.has_kv(i)` remains true for every layer

Validation performed locally:

```bash
cmake --build build-cuda --target llama-cli llama-server
```

Runtime smoke, CPU-only, with matched official QAT targets and Q4_0 MTP assistants:

```text
E4B QAT target + E4B Q4_0 assistant: MTP context ready; completion generated; 33/116 draft tokens accepted
E2B QAT target + E2B Q4_0 assistant: MTP context ready; completion generated; 37/92 draft tokens accepted
```

I also searched current public PRs/issues/history for an existing shared-KV loader fix and did not find one. The closest related Gemma 4 work appears to be graph, CUDA, converter, and assistant-MTP handling rather than target-side optional K/K-norm loading.
