### PR TITLE
Fix FA shape for Gemma 4 E4B

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -343,6 +343,12 @@ bool server_context::load_model(const gpt_params& params_) {
         params_dft.main_gpu     = params_base.main_gpu;
         params_dft.n_gpu_layers = params_base.speculative.n_gpu_layers;
         params_dft.rpc_servers  = params_base.rpc_servers;
+        params_dft.n_threads    = params_base.speculative.n_threads == -1
+            ? params_base.n_threads
+            : params_base.speculative.n_threads;
+        params_dft.n_threads_batch = params_base.speculative.n_threads_batch == -1
+            ? params_dft.n_threads
+            : params_base.speculative.n_threads_batch;
         params_dft.cache_type_k = params_base.speculative.cache_type_k.empty() ? params_base.cache_type_k : params_base.speculative.cache_type_k;
         params_dft.cache_type_v = params_base.speculative.cache_type_v.empty() ? params_base.cache_type_v : params_base.speculative.cache_type_v;
         params_dft.flash_attn   = params_base.flash_attn;

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -10,8 +10,21 @@ static int gemma4_mtp_target_kv_layer(const llama_hparams & mtp_hparams, const l
         ? std::min<int>((int) target_hparams.n_layer, target_hparams.n_layer_kv_from_start)
         : (int) target_hparams.n_layer;
 
+    if (target_hparams.n_layer_kv_from_start > 0 &&
+            target_hparams.n_layer_kv_from_start < (int32_t) target_hparams.n_layer) {
+        const int owner_il = is_sliding ? target_n_kv_layer - 2 : target_n_kv_layer - 1;
+        if (owner_il >= 0 &&
+                target_hparams.has_kv(owner_il) &&
+                (target_hparams.swa_layers[owner_il] != 0) == is_sliding) {
+            return owner_il;
+        }
+    }
+
     int target_il = target_n_kv_layer - 1;
     for (; target_il >= 0; --target_il) {
+        if (!target_hparams.has_kv(target_il)) {
+            continue;
+        }
         if ((target_hparams.swa_layers[target_il] != 0) == is_sliding) {
             break;
         }
@@ -40,6 +53,12 @@ static void gemma4_mtp_prepare_frozen_kv_views(
         return;
     }
 
+    const llama_model & target_model = lctx.mtp_target_ctx->model;
+    if (target_model.split_mode != LLAMA_SPLIT_MODE_GRAPH &&
+            target_model.split_mode != LLAMA_SPLIT_MODE_ATTN) {
+        return;
+    }
+
     GGML_ASSERT(target_il >= 0 && target_il < (int) target_kv.k_l.size() && target_il < (int) target_kv.v_l.size());
 
     ggml_tensor * k_cache = target_kv.k_l[target_il];
@@ -55,8 +74,13 @@ static void gemma4_mtp_prepare_frozen_kv_views(
     GGML_ASSERT(split_k->n_device == split_v->n_device);
 
     const llama_hparams & assistant_hparams = lctx.model.hparams;
-    const int64_t n_embd_head_k = assistant_hparams.n_embd_head_k(assistant_il);
-    const int64_t n_embd_head_v = assistant_hparams.n_embd_head_v(assistant_il);
+    const llama_hparams & target_hparams    = lctx.mtp_target_ctx->model.hparams;
+    const int64_t n_embd_head_k = target_hparams.n_embd_head_k(target_il);
+    const int64_t n_embd_head_v = target_hparams.n_embd_head_v(target_il);
+
+    GGML_ASSERT(assistant_hparams.n_embd_head_k(assistant_il) == n_embd_head_k);
+    GGML_ASSERT(assistant_hparams.n_embd_head_v(assistant_il) == n_embd_head_v);
+    GGML_ASSERT(target_n_kv <= (int32_t) target_kv.size);
 
     std::vector<ggml_tensor *> k_parts;
     std::vector<ggml_tensor *> v_parts;
@@ -78,9 +102,14 @@ static void gemma4_mtp_prepare_frozen_kv_views(
         }
 
         GGML_ASSERT(target_kv.size > 0);
+        GGML_ASSERT(split_kl->ne[0] == n_embd_head_k);
         GGML_ASSERT(split_kl->ne[1] % target_kv.size == 0);
+        GGML_ASSERT(split_vl->ne[0] % target_kv.size == 0);
 
         const int64_t split_n_head_kv = split_kl->ne[1] / target_kv.size;
+        const int64_t split_n_head_v  = (split_vl->ne[0] / target_kv.size) / n_embd_head_v;
+        GGML_ASSERT((split_vl->ne[0] / target_kv.size) % n_embd_head_v == 0);
+        GGML_ASSERT(split_n_head_v == split_n_head_kv);
 
         ggml_tensor * k_part = ggml_view_3d(ctx0, split_kl,
                 n_embd_head_k, target_n_kv, split_n_head_kv,
@@ -99,7 +128,7 @@ static void gemma4_mtp_prepare_frozen_kv_views(
 
         ggml_tensor * v_part = ggml_view_3d(ctx0, split_vl,
                 n_embd_head_v, target_n_kv, split_n_head_kv,
-            ggml_row_size(split_vl->type, split_n_head_kv * n_embd_head_v),
+                ggml_row_size(split_vl->type, split_n_head_kv * n_embd_head_v),
                 ggml_row_size(split_vl->type, n_embd_head_v),
                 0);
         if (auto row_size = ggml_row_size(v_part->type, v_part->ne[0]); row_size % sizeof(float) == 0) {
@@ -610,13 +639,17 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
         ggml_tensor * inpL = cur;
 
         const bool is_sliding    = hparams.swa_layers[il] ? true : false;
+        const int   n_embd_head  = hparams.n_embd_head_k(il);
+        const int   n_head       = hparams.n_head(il);
+        const int target_il      = gemma4_mtp_target_kv_layer(hparams, target_hparams, il);
+        const bool target_is_sliding = target_hparams.swa_layers[target_il] != 0;
+        GGML_ASSERT(target_is_sliding == is_sliding);
+
         const float freq_base_l  = is_sliding ? target_hparams.rope_freq_base_train_swa  : target_cparams.rope_freq_base;
         const float freq_scale_l = is_sliding ? target_hparams.rope_freq_scale_train_swa : target_cparams.rope_freq_scale;
         const int   n_rot_l      = is_sliding ? target_hparams.n_rot_swa : target_hparams.n_rot;
-        const int   n_swa        = is_sliding ? target_hparams.n_swa : 0;
-        const int   n_embd_head  = hparams.n_embd_head_k(il);
-        const int   n_head       = hparams.n_head(il);
-        ggml_tensor * KQ_mask_l  = is_sliding ? KQ_mask_swa : KQ_mask;
+        const int   n_swa        = target_is_sliding ? target_hparams.n_swa : 0;
+        ggml_tensor * KQ_mask_l  = target_is_sliding ? KQ_mask_swa : KQ_mask;
 
         cur = llm_build_norm(ctx0, inpL, hparams, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, cb, il);
         cb(cur, "attn_norm", il);
@@ -630,13 +663,23 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
                 ext_factor, attn_factor, beta_fast, beta_slow);
         cb(Qcur, "Qcur_rope", il);
 
-        const int target_il = gemma4_mtp_target_kv_layer(hparams, target_hparams, il);
         ggml_tensor *& frozen_k = is_sliding ? frozen_k_swa : frozen_k_full;
         ggml_tensor *& frozen_v = is_sliding ? frozen_v_swa : frozen_v_full;
-        gemma4_mtp_prepare_frozen_kv_views(ctx0, lctx, target_kv, il, target_il, target_n_kv, &frozen_k, &frozen_v, cb);
+        const bool force_nonflash_attn =
+            target_cparams.flash_attn &&
+            !target_is_sliding &&
+            n_embd_head > 256 &&
+            hparams.n_gqa(il) == 2;
+
+        int32_t target_n_kv_l = target_n_kv;
+        if (force_nonflash_attn && target_n_kv > target_n_kv_l) {
+            target_n_kv_l = target_n_kv;
+        }
+
+        gemma4_mtp_prepare_frozen_kv_views(ctx0, lctx, target_kv, il, target_il, target_n_kv_l, &frozen_k, &frozen_v, cb);
         cur = llm_build_kv(ctx0, lctx, target_kv, gf, model.layers[il].wo, model.layers[il].bo,
-            nullptr, nullptr, Qcur, KQ_mask_l, n_tokens, target_kv_head, target_n_kv, hparams.f_attention_scale, cb, il, nullptr, n_swa, target_il,
-            &frozen_k, &frozen_v);
+            nullptr, nullptr, Qcur, KQ_mask_l, n_tokens, target_kv_head, target_n_kv_l, hparams.f_attention_scale, cb, il, nullptr, n_swa, target_il,
+            &frozen_k, &frozen_v, force_nonflash_attn);
 
         cur = llm_build_norm(ctx0, cur, hparams, model.layers[il].attn_post_norm, nullptr, LLM_NORM_RMS, cb, il);
         cb(cur, "attn_post_norm", il);

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -1540,7 +1540,7 @@ static ggml_tensor * llm_build_kqv(
          const llm_build_cb & cb,
                     int       il,
                 ggml_tensor * sinks = nullptr, int n_swa = 0, int kv_il = -1,
-                ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr) {
+                ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr, bool force_nonflash = false) {
     const llama_model   & model   = lctx.model;
     const llama_hparams & hparams = lctx.model.hparams;
     const llama_cparams & cparams = lctx.cparams;
@@ -1600,7 +1600,7 @@ static ggml_tensor * llm_build_kqv(
 
     struct ggml_tensor * cur;
 
-    if (cparams.flash_attn) {
+    if (cparams.flash_attn && !force_nonflash) {
         GGML_UNUSED(model);
         GGML_UNUSED(n_ctx);
 
@@ -1799,7 +1799,7 @@ ggml_tensor * llm_build_context::llm_build_kv(
                     int32_t   n_kv,
                     float     kq_scale,
          const llm_build_cb & cb, int il, ggml_tensor * sinks, int n_swa, int kv_il,
-         ggml_tensor ** k_cache_view, ggml_tensor ** v_cache_view) {
+                ggml_tensor ** k_cache_view, ggml_tensor ** v_cache_view, bool force_nonflash) {
     const llama_hparams & hparams = lctx.model.hparams;
     const llama_cparams & cparams = lctx.cparams;
 
@@ -1834,7 +1834,7 @@ ggml_tensor * llm_build_context::llm_build_kv(
     }
 
     auto cur = llm_build_kqv(ctx, lctx, kv, graph, wo, wo_b, q_cur, kq_mask, n_tokens, n_kv, kq_scale, cb, il, sinks, n_swa, kv_il,
-            k_cache_view, v_cache_view);
+            k_cache_view, v_cache_view, force_nonflash);
     cb(cur, "kqv_out", il);
 
     return cur;

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -361,8 +361,8 @@ struct llm_build_context {
                     int32_t   kv_head,
                     int32_t   n_kv,
                     float     kq_scale,
-         const llm_build_cb & cb, int il, ggml_tensor * sinks = nullptr, int n_swa = 0, int kv_il = -1,
-         ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr);
+        const llm_build_cb & cb, int il, ggml_tensor * sinks = nullptr, int n_swa = 0, int kv_il = -1,
+        ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr, bool force_nonflash = false);
 
     static ggml_tensor * llm_build_ffn(ggml_context * ctx, llama_context & lctx, ggml_tensor * ffn_norm,
          ggml_tensor * cur,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4322,12 +4322,38 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 #endif
         // NOTE: hparams.causal_attn indicates the model is capable of generation and uses the kv cache.
         if (cparams.causal_attn && !lctx.is_encoding) {
+            const bool use_gemma4_target_kv =
+                lctx.model.arch == LLM_ARCH_GEMMA4_MTP &&
+                lctx.mtp_target_ctx != nullptr;
+
             const llama_kv_cache & mask_kv_self =
-                (lctx.model.arch == LLM_ARCH_GEMMA4_MTP && lctx.mtp_target_ctx != nullptr)
+                use_gemma4_target_kv
                     ? lctx.mtp_target_ctx->kv_self
                     : kv_self;
             const int64_t n_kv     = mask_kv_self.n;
             const int64_t n_tokens = batch.n_tokens;
+
+            if (n_kv < 0 || (uint64_t) n_kv > mask_kv_self.cells.size()) {
+                LLAMA_LOG_ERROR("%s: invalid KV metadata for mask build: n_kv=%" PRId64 ", cells.size()=%zu, model_arch=%d, mtp_target_ctx=%p\n",
+                        __func__, n_kv, mask_kv_self.cells.size(), (int) lctx.model.arch, (void *) lctx.mtp_target_ctx);
+                GGML_ABORT("invalid KV metadata during llama_set_inputs");
+            }
+
+            const bool use_target_pos_only = use_gemma4_target_kv;
+
+            auto cell_visible_for_seq = [&mask_kv_self, use_target_pos_only] (int i, llama_pos pos, llama_seq_id seq_id) {
+                const llama_kv_cell & cell = mask_kv_self.cells[i];
+
+                if (cell.pos < 0 || cell.pos > pos) {
+                    return false;
+                }
+
+                if (use_target_pos_only) {
+                    return true;
+                }
+
+                return cell.has_seq_id(seq_id);
+            };
 
 
             float * data     = nullptr;
@@ -4353,12 +4379,52 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                 }
             }
 
-            auto noalibi_f16 = [&mask_kv_self, &hparams, n_kv, data_f16, data_swa_f16] (int j, llama_pos pos, llama_seq_id seq_id, int first, int last) {
+            const int64_t n_kv_stride = use_gemma4_target_kv && lctx.inp_KQ_mask
+                ? lctx.inp_KQ_mask->ne[0]
+                : n_kv;
+
+            GGML_ASSERT(use_gemma4_target_kv || n_kv_stride == n_kv);
+
+            // initialise the extra columns to -INFINITY so flash attention does not read
+            // uninitialised memory.
+            if (use_gemma4_target_kv && n_kv_stride > n_kv) {
+                const int64_t n_tokens_pad = lctx.inp_KQ_mask
+                    ? lctx.inp_KQ_mask->ne[1]
+                    : GGML_PAD(n_tokens, GGML_KQ_MASK_PAD);
+
+                const ggml_half h_inf = ggml_fp32_to_fp16(-INFINITY);
+                if (data_f16) {
+                    for (int64_t j = 0; j < n_tokens_pad; ++j) {
+                        std::fill(data_f16 + j*n_kv_stride + n_kv,
+                                  data_f16 + (j+1)*n_kv_stride, h_inf);
+                    }
+                }
+                if (data) {
+                    for (int64_t j = 0; j < n_tokens_pad; ++j) {
+                        std::fill(data + j*n_kv_stride + n_kv,
+                                  data + (j+1)*n_kv_stride, -INFINITY);
+                    }
+                }
+                if (data_swa_f16) {
+                    for (int64_t j = 0; j < n_tokens_pad; ++j) {
+                        std::fill(data_swa_f16 + j*n_kv_stride + n_kv,
+                                  data_swa_f16 + (j+1)*n_kv_stride, h_inf);
+                    }
+                }
+                if (data_swa) {
+                    for (int64_t j = 0; j < n_tokens_pad; ++j) {
+                        std::fill(data_swa + j*n_kv_stride + n_kv,
+                                  data_swa + (j+1)*n_kv_stride, -INFINITY);
+                    }
+                }
+            }
+
+            auto noalibi_f16 = [&mask_kv_self, &hparams, &cell_visible_for_seq, n_kv, n_kv_stride, data_f16, data_swa_f16] (int j, llama_pos pos, llama_seq_id seq_id, int first, int last) {
                 ggml_half h_inf  = ggml_fp32_to_fp16(-INFINITY);
                 ggml_half h_zero = ggml_fp32_to_fp16(0.f);
                 for (int i = first; i < last; ++i) {
-                    ggml_half h = !mask_kv_self.cells[i].has_seq_id(seq_id) || mask_kv_self.cells[i].pos > pos ? h_inf : h_zero;
-                    if (data_f16) data_f16[j*n_kv + i] = h;
+                    ggml_half h = !cell_visible_for_seq(i, pos, seq_id) ? h_inf : h_zero;
+                    if (data_f16) data_f16[j*n_kv_stride + i] = h;
                     if (data_swa_f16) {
                         if (h != h_inf) {
                             if (hparams.n_attn_chunk) {
@@ -4372,7 +4438,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                                 }
                             }
                         }
-                        data_swa_f16[j*n_kv + i] = h;
+                        data_swa_f16[j*n_kv_stride + i] = h;
                     }
                 }
             };
@@ -4380,7 +4446,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
             if (n_kv >= 1024 && n_tokens >= 32) {
                 int n_thread = std::max(1, int(std::thread::hardware_concurrency()/2));
                 int npt = (n_kv + n_thread - 1)/n_thread;
-                auto compute = [&batch, &mask_kv_self, &hparams, &cparams, &noalibi_f16, n_tokens, n_kv, npt, data, data_swa, data_f16, data_swa_f16] (int ith) {
+                auto compute = [&batch, &mask_kv_self, &hparams, &cparams, &noalibi_f16, &cell_visible_for_seq, n_tokens, n_kv, n_kv_stride, npt, data, data_swa, data_f16, data_swa_f16] (int ith) {
                     int first = ith * npt;
                     int last  = std::min(int(n_kv), first + npt);
                     if (last <= first) return;
@@ -4395,7 +4461,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 
                         for (int i = first; i < last; ++i) {
                             float f;
-                            if (!mask_kv_self.cells[i].has_seq_id(seq_id) || mask_kv_self.cells[i].pos > pos) {
+                            if (!cell_visible_for_seq(i, pos, seq_id)) {
                                 f = -INFINITY;
                             } else {
                                 if (hparams.use_alibi) {
@@ -4406,10 +4472,10 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                             }
 
                             if (data) {
-                                data[j*n_kv + i] = f;
+                                data[j*n_kv_stride + i] = f;
                             }
                             if (data_f16) {
-                                data_f16[j*n_kv + i] = ggml_fp32_to_fp16(f);
+                                data_f16[j*n_kv_stride + i] = ggml_fp32_to_fp16(f);
                             }
 
                             // may need to cut off old tokens for sliding window
@@ -4427,10 +4493,10 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                                     }
                                 }
                                 if (data_swa) {
-                                    data_swa[j*n_kv + i] = f;
+                                    data_swa[j*n_kv_stride + i] = f;
                                 }
                                 if (data_swa_f16) {
-                                    data_swa_f16[j*n_kv + i] = ggml_fp32_to_fp16(f);
+                                    data_swa_f16[j*n_kv_stride + i] = ggml_fp32_to_fp16(f);
                                 }
                             }
                         }
@@ -4444,18 +4510,18 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                 int64_t n_tokens_padded = GGML_PAD(n_tokens, GGML_KQ_MASK_PAD);
                 if (n_tokens_padded > n_tokens) {
                     if (data) {
-                        std::fill(data + int64_t(n_tokens)*n_kv, data + n_tokens_padded*n_kv, -INFINITY);
+                        std::fill(data + int64_t(n_tokens)*n_kv_stride, data + n_tokens_padded*n_kv_stride, -INFINITY);
                     }
                     if (data_f16) {
                         ggml_half h_inf = ggml_fp32_to_fp16(-INFINITY);
-                        std::fill(data_f16 + int64_t(n_tokens)*n_kv, data_f16 + n_tokens_padded*n_kv, h_inf);
+                        std::fill(data_f16 + int64_t(n_tokens)*n_kv_stride, data_f16 + n_tokens_padded*n_kv_stride, h_inf);
                     }
                     if (data_swa) {
-                        std::fill(data_swa + int64_t(n_tokens)*n_kv, data_swa + n_tokens_padded*n_kv, -INFINITY);
+                        std::fill(data_swa + int64_t(n_tokens)*n_kv_stride, data_swa + n_tokens_padded*n_kv_stride, -INFINITY);
                     }
                     if (data_swa_f16) {
                         ggml_half h_inf = ggml_fp32_to_fp16(-INFINITY);
-                        std::fill(data_swa_f16 + int64_t(n_tokens)*n_kv, data_swa_f16 + n_tokens_padded*n_kv, h_inf);
+                        std::fill(data_swa_f16 + int64_t(n_tokens)*n_kv_stride, data_swa_f16 + n_tokens_padded*n_kv_stride, h_inf);
                     }
                 }
             }
@@ -4476,7 +4542,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
 
                     for (int i = 0; i < n_kv; ++i) {
                         float f;
-                        if (!mask_kv_self.cells[i].has_seq_id(seq_id) || mask_kv_self.cells[i].pos > pos) {
+                        if (!cell_visible_for_seq(i, pos, seq_id)) {
                             f = -INFINITY;
                         } else {
                             if (hparams.use_alibi) {
@@ -4487,10 +4553,10 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                         }
 
                         if (data) {
-                            data[h*(n_kv*n_tokens) + j*n_kv + i] = f;
+                            data[h*(n_kv_stride*n_tokens) + j*n_kv_stride + i] = f;
                         }
                         if (data_f16) {
-                            data_f16[h*(n_kv*n_tokens) + j*n_kv + i] = ggml_fp32_to_fp16(f);
+                            data_f16[h*(n_kv_stride*n_tokens) + j*n_kv_stride + i] = ggml_fp32_to_fp16(f);
                         }
 
                         // may need to cut off old tokens for sliding window
@@ -4506,10 +4572,10 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                                 }
                             }
                             if (data_swa) {
-                                data_swa[h*(n_kv*n_tokens) + j*n_kv + i] = f;
+                                data_swa[h*(n_kv_stride*n_tokens) + j*n_kv_stride + i] = f;
                             }
                             if (data_swa_f16) {
-                                data_swa_f16[h*(n_kv*n_tokens) + j*n_kv + i] = ggml_fp32_to_fp16(f);
+                                data_swa_f16[h*(n_kv_stride*n_tokens) + j*n_kv_stride + i] = ggml_fp32_to_fp16(f);
                             }
                         }
                     }
@@ -4518,18 +4584,18 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
                 int64_t n_tokens_padded = GGML_PAD(n_tokens, GGML_KQ_MASK_PAD);
                 if (n_tokens_padded > n_tokens) {
                     if (data) {
-                        std::fill(data + int64_t(n_tokens)*n_kv, data + n_tokens_padded*n_kv, -INFINITY);
+                        std::fill(data + int64_t(n_tokens)*n_kv_stride, data + n_tokens_padded*n_kv_stride, -INFINITY);
                     }
                     if (data_f16) {
                         ggml_half h_inf = ggml_fp32_to_fp16(-INFINITY);
-                        std::fill(data_f16 + int64_t(n_tokens)*n_kv, data_f16 + n_tokens_padded*n_kv, h_inf);
+                        std::fill(data_f16 + int64_t(n_tokens)*n_kv_stride, data_f16 + n_tokens_padded*n_kv_stride, h_inf);
                     }
                     if (data_swa) {
-                        std::fill(data_swa + int64_t(n_tokens)*n_kv, data_swa + n_tokens_padded*n_kv, -INFINITY);
+                        std::fill(data_swa + int64_t(n_tokens)*n_kv_stride, data_swa + n_tokens_padded*n_kv_stride, -INFINITY);
                     }
                     if (data_swa_f16) {
                         ggml_half h_inf = ggml_fp32_to_fp16(-INFINITY);
-                        std::fill(data_swa_f16 + int64_t(n_tokens)*n_kv, data_swa_f16 + n_tokens_padded*n_kv, h_inf);
+                        std::fill(data_swa_f16 + int64_t(n_tokens)*n_kv_stride, data_swa_f16 + n_tokens_padded*n_kv_stride, h_inf);
                     }
                 }
             }


### PR DESCRIPTION
Gemma 4 E4B with MTP and flash-attn was hitting an unsupported shape: non-sliding, `n_embd_head = 512`, `n_gqa = 2`. This path was failing on the CPU flash fallback, which breaks when the KV padded bucket crosses 256/512. I couldn't find an elegant solution, so I'm forcing the non-flash path for this dimension, which at least avoids the problem in Main where it would hang indefinitely during decode.