### PR TITLE
delta-net: fix np>1 hybrid recurrent-state corruption (batched multi-seq)

### DIFF
--- a/ggml/src/ggml-cuda/ssm-conv.cu
+++ b/ggml/src/ggml-cuda/ssm-conv.cu
@@ -574,10 +574,15 @@ void ggml_cuda_op_ssm_conv(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
         // Fast path for multi-sequence decode-like batches:
         // one token per unique sequence, no copy-to-multiple-sequences routing.
-        ggml_cuda_pool_alloc<int32_t> seq_ids(ctx.pool(), n_t);
-        ggml_cuda_pool_alloc<int32_t> seq_seen(ctx.pool(), n_kv);
+        // PXA_LLAMA_FIX_v4: the VMM cuda pool requires deallocations in REVERSE order of allocation. fast_path_ok_d is
+        // declared at function scope (freed LAST), so it must also be ALLOCATED FIRST among these three, otherwise when
+        // seq_ids/seq_seen (block-scoped) are freed at the end of this block while fast_path_ok_d is still live, the free
+        // order violates LIFO -> GGML_ASSERT(ptr == pool_addr + pool_used). Previously latent: the n_kv>1 path was never
+        // hit (decode batches were single-token-chunked); the batched mixed-seq delta-net now exercises it.
         int32_t fast_path_ok = 1;
         fast_path_ok_d.alloc(1);
+        ggml_cuda_pool_alloc<int32_t> seq_ids(ctx.pool(), n_t);
+        ggml_cuda_pool_alloc<int32_t> seq_seen(ctx.pool(), n_kv);
 
         CUDA_CHECK(cudaMemsetAsync(seq_seen.get(), 0, n_kv * sizeof(int32_t), ctx.stream()));
         CUDA_CHECK(cudaMemcpyAsync(fast_path_ok_d.get(), &fast_path_ok, sizeof(int32_t), cudaMemcpyHostToDevice, ctx.stream()));

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -19012,8 +19012,16 @@ static void ggml_compute_forward_set_rows_f32(
 
                     GGML_ASSERT(i1 >= 0 && i1 < ne1);
 
-                    from_float((const float *) ((char *) src0->data +  i*nb01 + i02*nb02 + i03*nb03),
-                            ((char *)  dst->data + i1*nb1  + i02*nb2  + i03*nb3), nc);
+                    if (dst->type == GGML_TYPE_F32) {
+                        // PXA: CPU set_rows into an F32 dst -- type_traits[F32].from_float is NULL,
+                        // so copy floats directly (mirrors the CUDA set_rows F32 path). This is what
+                        // the batched delta-net recurrent-state scatter needs on the CPU backend.
+                        memcpy(((char *) dst->data + i1*nb1 + i02*nb2 + i03*nb3),
+                               ((const char *) src0->data + i*nb01 + i02*nb02 + i03*nb03), nc*sizeof(float));
+                    } else {
+                        from_float((const float *) ((char *) src0->data +  i*nb01 + i02*nb02 + i03*nb03),
+                                ((char *)  dst->data + i1*nb1  + i02*nb2  + i03*nb3), nc);
+                    }
                 }
             }
         }
@@ -19030,8 +19038,16 @@ static void ggml_compute_forward_set_rows_f32(
 
                     GGML_ASSERT(i1 >= 0 && i1 < ne1);
 
-                    from_float((const float *) ((char *) src0->data +  i*nb01 + i02*nb02 + i03*nb03),
-                            ((char *)  dst->data + i1*nb1  + i02*nb2  + i03*nb3), nc);
+                    if (dst->type == GGML_TYPE_F32) {
+                        // PXA: CPU set_rows into an F32 dst -- type_traits[F32].from_float is NULL,
+                        // so copy floats directly (mirrors the CUDA set_rows F32 path). This is what
+                        // the batched delta-net recurrent-state scatter needs on the CPU backend.
+                        memcpy(((char *) dst->data + i1*nb1 + i02*nb2 + i03*nb3),
+                               ((const char *) src0->data + i*nb01 + i02*nb02 + i03*nb03), nc*sizeof(float));
+                    } else {
+                        from_float((const float *) ((char *) src0->data +  i*nb01 + i02*nb02 + i03*nb03),
+                                ((char *)  dst->data + i1*nb1  + i02*nb2  + i03*nb3), nc);
+                    }
                 }
             }
         }

--- a/src/graphs/build_qwen35.cpp
+++ b/src/graphs/build_qwen35.cpp
@@ -40,6 +40,16 @@ ggml_cgraph * llm_build_context::build_qwen35moe() {
         cb(lctx.inp_s_seq_qnext, "inp_s_seq_qnext", -1);
         ggml_set_input(lctx.inp_s_seq_qnext);
 
+        // PXA_LLAMA_FIX_v4: conv seq-map [n_kv=n_tokens, n_tokens] for the ONE-batched mixed-seq delta-net path.
+        lctx.inp_conv_seq_map = ggml_new_tensor_2d(ctx0, GGML_TYPE_I32, n_tokens, n_tokens);
+        cb(lctx.inp_conv_seq_map, "inp_conv_seq_map", -1);
+        ggml_set_input(lctx.inp_conv_seq_map);
+
+        // PXA_LLAMA_FIX_v4: per-seq recurrent-state reset mask (0=reset to zero, 1=keep).
+        lctx.inp_qnext_state_mask = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, 1, n_tokens);
+        cb(lctx.inp_qnext_state_mask, "inp_qnext_state_mask", -1);
+        ggml_set_input(lctx.inp_qnext_state_mask);
+
         float KQ_scale = hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
 
         const int n_transformer_layers = n_layer - hparams.nextn_predict_layers;
@@ -123,6 +133,16 @@ ggml_cgraph * llm_build_context::build_qwen35() {
         lctx.inp_s_seq_qnext = ggml_new_tensor_2d(ctx0, GGML_TYPE_I32, 1, n_tokens);
         cb(lctx.inp_s_seq_qnext, "inp_s_seq_qnext", -1);
         ggml_set_input(lctx.inp_s_seq_qnext);
+
+        // PXA_LLAMA_FIX_v4: conv seq-map [n_kv=n_tokens, n_tokens] for the ONE-batched mixed-seq delta-net path.
+        lctx.inp_conv_seq_map = ggml_new_tensor_2d(ctx0, GGML_TYPE_I32, n_tokens, n_tokens);
+        cb(lctx.inp_conv_seq_map, "inp_conv_seq_map", -1);
+        ggml_set_input(lctx.inp_conv_seq_map);
+
+        // PXA_LLAMA_FIX_v4: per-seq recurrent-state reset mask (0=reset to zero, 1=keep).
+        lctx.inp_qnext_state_mask = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, 1, n_tokens);
+        cb(lctx.inp_qnext_state_mask, "inp_qnext_state_mask", -1);
+        ggml_set_input(lctx.inp_qnext_state_mask);
 
         float KQ_scale = hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
 

--- a/src/graphs/build_qwen3next.cpp
+++ b/src/graphs/build_qwen3next.cpp
@@ -21,6 +21,17 @@ ggml_cgraph * llm_build_context::build_qwen3next() {
     cb(lctx.inp_s_seq_qnext, "inp_s_seq_qnext", -1);
     ggml_set_input(lctx.inp_s_seq_qnext);
 
+    // PXA_LLAMA_FIX_v4: conv seq-map [n_kv=n_tokens, n_tokens] for the ONE-batched mixed-seq delta-net path.
+    // Row 0 of column t = state column for token t (identity, since states are gathered in token order); rows >=1 = -1.
+    lctx.inp_conv_seq_map = ggml_new_tensor_2d(ctx0, GGML_TYPE_I32, n_tokens, n_tokens);
+    cb(lctx.inp_conv_seq_map, "inp_conv_seq_map", -1);
+    ggml_set_input(lctx.inp_conv_seq_map);
+
+    // PXA_LLAMA_FIX_v4: per-seq recurrent-state reset mask (0=reset to zero, 1=keep). One column per token/seq.
+    lctx.inp_qnext_state_mask = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, 1, n_tokens);
+    cb(lctx.inp_qnext_state_mask, "inp_qnext_state_mask", -1);
+    ggml_set_input(lctx.inp_qnext_state_mask);
+
     float KQ_scale = hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
 
     ggml_tensor * cur = nullptr;

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -109,6 +109,8 @@ void llm_build_context::init() {
     lctx.inp_s_mask      = nullptr;
     lctx.inp_s_seq       = nullptr;
     lctx.inp_s_seq_qnext = nullptr;
+    lctx.inp_conv_seq_map  = nullptr; // PXA_LLAMA_FIX_v4
+    lctx.inp_qnext_state_mask = nullptr; // PXA_LLAMA_FIX_v4
     lctx.inp_pos_bucket    = nullptr;
     lctx.inp_embd_enc      = nullptr;
     lctx.inp_KQ_mask_cross = nullptr;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -292,6 +292,8 @@ struct llama_context {
     struct ggml_tensor * inp_s_mask;      // F32 [1, n_kv]
     struct ggml_tensor * inp_s_seq;       // I32 [n_kv, n_batch]
     struct ggml_tensor * inp_s_seq_qnext; // I32 [1, n_batch]
+    struct ggml_tensor * inp_conv_seq_map;  // PXA_LLAMA_FIX_v4: I32 [n_batch, n_batch] conv seq-map for batched mixed-seq delta-net
+    struct ggml_tensor * inp_qnext_state_mask; // PXA_LLAMA_FIX_v4: F32 [1, n_batch] per-seq recurrent-state reset mask (0=reset)
     struct ggml_tensor * inp_pos_bucket;    // I32 [n_batch|n_kv, n_batch]
     struct ggml_tensor * inp_embd_enc;      // F32 [n_embd, n_outputs_enc]
     struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]

--- a/src/llama-delta-net.cpp
+++ b/src/llama-delta-net.cpp
@@ -256,12 +256,14 @@ std::pair<ggml_tensor *, ggml_tensor *> delta_net::build_beta_gate(llama_context
                 split_sizes_ba[0] * ggml_element_size(mixed_ba_reshaped));
         cb(a, "a", il);
 
-        beta  = ggml_cont_4d(ctx0, b, num_v_heads, 1, n_tok, 1);
-        alpha = ggml_cont_3d(ctx0, a, num_v_heads, n_tok, 1);
+        // PXA_LLAMA_FIX_v4: split the token axis into (n_seq_tokens, n_seqs) so beta/gate carry the per-seq batch dim
+        // that build_fused_delta_net expects (beta [H_v,1,n_seq_tokens,n_seqs], gate [H_v,n_seq_tokens,n_seqs]).
+        beta  = ggml_cont_4d(ctx0, b, num_v_heads, 1, n_seq_tokens, n_seqs);
+        alpha = ggml_cont_3d(ctx0, a, num_v_heads, n_seq_tokens, n_seqs);
     } else {
         beta = llm_build_context::llm_build_lora_mm(lctx, ctx0, ssm_beta, cur);
         cb(beta, "beta", il);
-        beta = ggml_reshape_4d(ctx0, beta, num_v_heads, 1, n_tok, 1);
+        beta = ggml_reshape_4d(ctx0, beta, num_v_heads, 1, n_seq_tokens, n_seqs);
         cb(beta, "beta_reshaped", il);
         alpha = llm_build_context::llm_build_lora_mm(lctx, ctx0, ssm_alpha, cur);
         cb(alpha, "alpha", il);
@@ -284,9 +286,9 @@ std::pair<ggml_tensor *, ggml_tensor *> delta_net::build_beta_gate(llama_context
 }
 
 ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_storage, ggml_tensor * ssm_conv1d,
-        ggml_tensor * qkv_mixed, ggml_tensor * inp_s_seq_qnext, ggml_tensor * beta, ggml_tensor * gate,
+        ggml_tensor * qkv_mixed, ggml_tensor * state_row_idx, ggml_tensor * conv_seq_map, ggml_tensor * state_mask, ggml_tensor * beta, ggml_tensor * gate,
         int64_t head_k_dim, int64_t num_k_heads, int64_t head_v_dim, int64_t num_v_heads, int64_t ssm_d_conv,
-        int64_t state_seq_id_local, uint32_t qnext_state_slots, bool reset_state_local,
+        int64_t n_seqs_in, uint32_t qnext_state_slots, bool reset_state_local,
         float eps_norm, int repeat_type, int il, const llm_build_cb & cb, ggml_cgraph * gf,
         ggml_tensor * per_step_ckpt, ggml_tensor * per_step_conv) {
     const int64_t key_dim        = head_k_dim * num_k_heads;
@@ -297,9 +299,15 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
     const int64_t state_dim      = conv_state_dim + ssm_state_dim;
     GGML_ASSERT(qnext_state_slots > 0);
 
-    const int64_t n_seq_tokens = qkv_mixed->ne[1];
-    const int64_t n_seqs       = qkv_mixed->ne[2];
-    const int64_t n_tok        = n_seq_tokens * n_seqs;
+    // PXA_LLAMA_FIX_v4: n_seqs is passed explicitly. The mixed (concurrent) path calls this ONCE with
+    // n_seqs = batch.n_tokens, n_seq_tokens = 1 (each token its own seq) -- a single batched delta-net,
+    // NOT a per-token loop of N subgraphs (that interleave was the recurrent-state corruption at np>=3).
+    // qkv_mixed is [conv_dim, n_tok] (or [conv_dim, n_tok, 1]); the conv consumes it token-major as a matrix.
+    const int64_t n_tok        = qkv_mixed->ne[1];
+    const int64_t n_seqs       = n_seqs_in;
+    GGML_ASSERT(n_seqs > 0 && n_tok % n_seqs == 0);
+    const int64_t n_seq_tokens = n_tok / n_seqs;
+    GGML_ASSERT(ggml_is_matrix(qkv_mixed)); // [conv_dim, n_tok] (ne[2]==1) -- consumed token-major by ssm_conv
 
     size_t state_row_size = 0;
     ggml_tensor * state_all = nullptr;
@@ -311,27 +319,49 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
 
     state_all = ggml_view_2d(ctx0, state_storage, state_dim, qnext_state_slots, state_row_size, 0);
 
-    ggml_tensor * state_dst = ggml_view_2d(ctx0, state_all, state_dim, 1, state_row_size, state_seq_id_local * state_row_size);
+    // PXA_LLAMA_FIX_v4: gather ALL participating sequences' recurrent rows ONCE, in token order, via state_row_idx
+    // (absolute seq_id per seq). all_same -> [n_seqs=1]; mixed -> [n_seqs=n_tok]. ONE get_rows -> [state_dim, n_seqs],
+    // ONE set_rows at the end => a SINGLE subgraph (the per-token N-subgraph interleave was the allocator-corruption bug).
+    GGML_ASSERT(state_row_idx != nullptr);
+    GGML_ASSERT(state_row_idx->ne[0] == n_seqs);
+    ggml_tensor * pxa_row_idx = state_row_idx;
+    ggml_tensor * state_dst = ggml_get_rows(ctx0, state_all, pxa_row_idx); // [state_dim, n_seqs]
     ggml_tensor * state_f32 = state_dst;
     if (state_f32->type != GGML_TYPE_F32) {
         state_f32 = ggml_cast(ctx0, state_f32, GGML_TYPE_F32);
     }
-    if (reset_state_local) {
+    // PXA_LLAMA_FIX_v4: per-seq reset via mask multiply ([1,n_seqs] broadcast over state_dim): 0 zeros a fresh seq's
+    // carried state, 1 keeps it. Handles mixed batches where some seqs start (pos 0) and others continue. Falls back to
+    // the scalar reset_state_local only if no mask is supplied (keeps non-qwen3next callers, if any, working).
+    if (state_mask != nullptr) {
+        GGML_ASSERT(state_mask->ne[1] == n_seqs);
+        state_f32 = ggml_mul(ctx0, state_f32, state_mask);
+        cb(state_f32, "state_reset_masked", il);
+    } else if (reset_state_local) {
         state_f32 = ggml_scale(ctx0, state_f32, 0.0f);
         cb(state_f32, "state_reset", il);
     }
 
-    ggml_tensor * conv_state_flat = ggml_view_2d(ctx0, state_f32, conv_state_dim, 1, state_f32->nb[1], 0);
-    ggml_tensor * ssm_state_flat  = ggml_view_2d(ctx0, state_f32, ssm_state_dim, 1, state_f32->nb[1],
+    // [state_dim, n_seqs] -> conv part [conv_state_dim, n_seqs] and ssm part [ssm_state_dim, n_seqs]
+    ggml_tensor * conv_state_flat = ggml_view_2d(ctx0, state_f32, conv_state_dim, n_seqs, state_f32->nb[1], 0);
+    ggml_tensor * ssm_state_flat  = ggml_view_2d(ctx0, state_f32, ssm_state_dim, n_seqs, state_f32->nb[1],
             conv_state_dim * ggml_element_size(state_f32));
+    if (n_seqs > 1) {
+        // ssm_conv requires a contiguous 3d conv_states; the views above are strided across seqs when n_seqs>1.
+        conv_state_flat = ggml_cont(ctx0, conv_state_flat);
+        ssm_state_flat  = ggml_cont(ctx0, ssm_state_flat);
+    }
 
-    ggml_tensor * conv_states = ggml_reshape_3d(ctx0, conv_state_flat, ssm_d_conv - 1, conv_dim, 1);
-    ggml_tensor * state       = ggml_reshape_4d(ctx0, ssm_state_flat, head_v_dim, head_v_dim, num_v_heads, 1);
+    ggml_tensor * conv_states = ggml_reshape_3d(ctx0, conv_state_flat, ssm_d_conv - 1, conv_dim, n_seqs);
+    ggml_tensor * state       = ggml_reshape_4d(ctx0, ssm_state_flat, head_v_dim, head_v_dim, num_v_heads, n_seqs);
     cb(conv_states, "conv_states", il);
     cb(state, "state_predelta", il);
     ggml_build_forward_expand(gf, state);
 
-    ggml_tensor * conv_output_raw = ggml_ssm_conv(ctx0, conv_states, qkv_mixed, ssm_conv1d, inp_s_seq_qnext, per_step_conv);
+    // PXA_LLAMA_FIX_v4: conv_seq_map is the [n_kv=n_seqs, n_tok] seq->state-column map. States are gathered in token
+    // order so it is identity in row 0 (sq[0][t]=t) with rows>=1 out-of-range -> hits ik's multi-seq-UNIQUE conv fast
+    // path. all_same passes a [1,n_tok] view (n_kv=1 -> single-seq fast path, content ignored).
+    ggml_tensor * conv_output_raw = ggml_ssm_conv(ctx0, conv_states, qkv_mixed, ssm_conv1d, conv_seq_map, per_step_conv);
     cb(conv_output_raw, "conv_output_raw", il);
 
     ggml_tensor * conv_output = ggml_view_2d(ctx0, conv_output_raw, conv_dim, n_tok, conv_dim * ggml_element_size(conv_output_raw), 0);
@@ -343,16 +373,20 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
     int64_t qkv_dim = head_k_dim * num_k_heads * 2 + head_v_dim * num_v_heads;
     int64_t nb1_qkv = ggml_row_size(conv_output_silu->type, qkv_dim);
 
+    // PXA_LLAMA_FIX_v4: seq stride is nb1_qkv * n_seq_tokens (tokens of a seq are contiguous in token order).
+    // all_same: n_seq_tokens=n_tok,n_seqs=1 (== old nb1_qkv*n_tok). mixed: n_seq_tokens=1,n_seqs=n_tok -> nb1_qkv.
+    const size_t nb3_qkv = (size_t) nb1_qkv * n_seq_tokens;
+
     // Extract the convolved Q, K, V from conv_output
     ggml_tensor * q_conv = ggml_view_4d(ctx0, conv_output_silu, head_k_dim, num_k_heads, n_seq_tokens, n_seqs,
-            ggml_row_size(conv_output_silu->type, head_k_dim), nb1_qkv, nb1_qkv * n_tok, 0);
+            ggml_row_size(conv_output_silu->type, head_k_dim), nb1_qkv, nb3_qkv, 0);
 
     ggml_tensor * k_conv = ggml_view_4d(ctx0, conv_output_silu, head_k_dim, num_k_heads, n_seq_tokens, n_seqs,
-            ggml_row_size(conv_output_silu->type, head_k_dim), nb1_qkv, nb1_qkv * n_tok,
+            ggml_row_size(conv_output_silu->type, head_k_dim), nb1_qkv, nb3_qkv,
             head_k_dim * num_k_heads * ggml_element_size(conv_output_silu));
 
     ggml_tensor * v_conv = ggml_view_4d(ctx0, conv_output_silu, head_v_dim, num_v_heads, n_seq_tokens, n_seqs,
-            ggml_row_size(conv_output_silu->type, head_v_dim), nb1_qkv, nb1_qkv * n_tok,
+            ggml_row_size(conv_output_silu->type, head_v_dim), nb1_qkv, nb3_qkv,
             ggml_row_size(conv_output_silu->type, 2 * head_k_dim * num_k_heads));
 
     cb(q_conv, "q_conv", il);
@@ -379,14 +413,20 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
     cb(output, "attn_output", il);
     cb(new_state, "new_state", il);
 
-    ggml_tensor * new_conv_states = ggml_view_2d(ctx0, conv_output_raw, ssm_d_conv - 1, conv_dim,
+    // PXA_LLAMA_FIX_v4: the new conv state lives in conv_output_raw's state region [d_conv, conv_dim, n_seqs] at flat
+    // offset conv_dim*n_tok; the next-step state is the LAST (d_conv-1) columns of each. View it generalized over n_seqs.
+    ggml_tensor * new_conv_states = ggml_view_3d(ctx0, conv_output_raw, ssm_d_conv - 1, conv_dim, n_seqs,
             ssm_d_conv * ggml_element_size(conv_output_raw),
-            (1 + conv_dim * n_tok) * ggml_element_size(conv_output_raw));
+            ssm_d_conv * conv_dim * ggml_element_size(conv_output_raw),
+            (conv_dim * n_tok + 1) * ggml_element_size(conv_output_raw));
     auto new_conv_states_cont = ggml_cont(ctx0, new_conv_states);
     cb(new_conv_states_cont, "new_conv_states_cont", il);
-    ggml_tensor * new_conv_flat = ggml_reshape_2d(ctx0, new_conv_states_cont, conv_state_dim, 1);
-    ggml_tensor * new_ssm_flat  = ggml_reshape_2d(ctx0, new_state, ssm_state_dim, 1);
-    auto state_cpy = ggml_concat_inplace(ctx0, new_conv_flat, new_ssm_flat, state_dst, 0);
+    ggml_tensor * new_conv_flat = ggml_reshape_2d(ctx0, new_conv_states_cont, conv_state_dim, n_seqs);
+    ggml_tensor * new_ssm_flat  = ggml_reshape_2d(ctx0, new_state, ssm_state_dim, n_seqs);
+    // PXA_LLAMA_FIX_v4: pack the new rows [state_dim, n_seqs] and SCATTER them back to their absolute seq rows with ONE
+    // ggml_set_rows. Single producer + single scatter => no per-token in-place aliasing => allocator-safe at any np.
+    ggml_tensor * pxa_new_row = ggml_concat(ctx0, new_conv_flat, new_ssm_flat, 0); // [state_dim, n_seqs]
+    auto state_cpy = ggml_set_rows(ctx0, state_storage, pxa_new_row, pxa_row_idx);
     cb(state_cpy, "state_cpy", il);
     ggml_build_forward_expand(gf, state_cpy);
 
@@ -433,12 +473,12 @@ static ggml_tensor * get_input_tensor_sm_graph(ggml_context * ctx, ggml_tensor *
 }
 
 ggml_tensor * delta_net::build_layer_attn_linear_core(ggml_context * ctx0, ggml_cgraph * gf,
-            ggml_tensor * delta_input, ggml_tensor * inp_s_seq_qnext, ggml_tensor * inp_out_ids,
-            uint32_t state_seq_id_local, bool reset_state_local, int il, const llm_build_cb & cb) const {
+            ggml_tensor * delta_input, ggml_tensor * state_row_idx, ggml_tensor * conv_seq_map, ggml_tensor * state_mask, ggml_tensor * inp_out_ids,
+            int64_t n_seqs, bool reset_state_local, int il, const llm_build_cb & cb) const {
 
     const int64_t n_tok = delta_input->ne[1];
-    const int64_t n_seqs = 1;
-    //const int64_t n_seq_tokens = n_tok;
+    GGML_ASSERT(n_seqs > 0 && n_tok % n_seqs == 0);
+    // PXA_LLAMA_FIX_v4: state routing is now by the runtime state_row_idx tensor (state_seq_id_local removed).
 
     auto & model   = lctx.model;
     auto & hparams = model.hparams;
@@ -526,9 +566,9 @@ ggml_tensor * delta_net::build_layer_attn_linear_core(ggml_context * ctx0, ggml_
                                  id < (int)kv_self.ckpt.per_step_conv[il].size()
                                ? kv_self.ckpt.per_step_conv[il][id] : nullptr;
 
-            auto output = build_qkv(ctx0, split_s_l->splits[id], split_ssm_conv1d->splits[id], qkv_mixed, inp_s_seq_qnext, beta, gate,
+            auto output = build_qkv(ctx0, split_s_l->splits[id], split_ssm_conv1d->splits[id], qkv_mixed, state_row_idx, conv_seq_map, state_mask, beta, gate,
                                head_k_dim, num_k_heads_id, head_v_dim, num_v_heads_id, hparams.ssm_d_conv,
-                               state_seq_id_local, qnext_state_slots, reset_state_local, hparams.f_norm_rms_eps,
+                               n_seqs, qnext_state_slots, reset_state_local, hparams.f_norm_rms_eps,
                                l.ssm_beta_alpha ? 0 : 1, il, cb, gf, per_step_ckpt, per_step_conv);
             split_norm = (ggml_split_tensor_t *)l.ssm_norm->extra;
             GGML_ASSERT(split_norm && split_norm->splits[id]);
@@ -589,9 +629,9 @@ ggml_tensor * delta_net::build_layer_attn_linear_core(ggml_context * ctx0, ggml_
                        ? kv_self.ckpt.per_step_conv[il].front() : nullptr;
 
     auto output = build_qkv(ctx0, kv_self.s_l[il], model.layers[il].ssm_conv1d,
-        qkv_mixed, inp_s_seq_qnext, beta, gate,
+        qkv_mixed, state_row_idx, conv_seq_map, state_mask, beta, gate,
         head_k_dim, num_k_heads, head_v_dim, num_v_heads, hparams.ssm_d_conv,
-        state_seq_id_local, qnext_state_slots, reset_state_local, hparams.f_norm_rms_eps,
+        n_seqs, qnext_state_slots, reset_state_local, hparams.f_norm_rms_eps,
         model.layers[il].ssm_beta_alpha ? 0 : 1, il, cb, gf, per_step_ckpt, per_step_conv);
 
     auto gated_output = build_gated_output(lctx, ctx0, model.layers[il].ssm_norm, model.layers[il].ssm_out, output, z, head_v_dim, num_v_heads, n_tok, il, cb);
@@ -622,26 +662,40 @@ ggml_tensor * delta_net::build_layer_attn_linear(ggml_context * ctx0, ggml_cgrap
     GGML_ASSERT(model.layers[il].wqkv != nullptr || model.layers[il].ssm_in != nullptr);
     GGML_ASSERT(model.layers[il].wqkv_gate != nullptr || model.layers[il].ssm_in != nullptr);
 
+    GGML_ASSERT(lctx.inp_conv_seq_map != nullptr);
+    GGML_ASSERT(lctx.inp_qnext_state_mask != nullptr);
+    const int64_t n_tok = batch.n_tokens;
+
+    // PXA_LLAMA_FIX_v4: state-reset mask [1, n_seqs] (per-seq), broadcast over state_dim inside build_qkv.
+    auto make_state_mask = [&](int64_t n_seqs) {
+        return ggml_view_2d(ctx0, lctx.inp_qnext_state_mask, 1, n_seqs,
+                lctx.inp_qnext_state_mask->nb[1], 0);
+    };
+
     if (all_same_seq) {
+        // SINGLE sequence: n_seqs = 1. state_row_idx = [1] (this seq's absolute row), conv map = [1, n_tok] view
+        // (n_kv=1 -> conv single-seq fast path). One batched call over all n_tok tokens (unchanged prompt/decode path).
+        ggml_tensor * state_row_idx = ggml_view_1d(ctx0, lctx.inp_s_seq_qnext, 1, 0);
+        ggml_tensor * conv_seq_map  = ggml_view_2d(ctx0, lctx.inp_conv_seq_map, 1, n_tok,
+                lctx.inp_conv_seq_map->nb[1], 0);
+        ggml_tensor * state_mask = make_state_mask(1);
         bool reset_state = batch.pos != nullptr && batch.pos[0] == 0;
-        return build_layer_attn_linear_core(ctx0, gf, cur, lctx.inp_s_seq_qnext, inp_out_ids, token_seq_ids.front(), reset_state, il, cb);
+        return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, 1, reset_state, il, cb);
     }
 
     GGML_ASSERT(has_unique_seq_ids && "qwen3next mixed-sequence batches require unique sequence IDs per token");
 
-    ggml_tensor * out = nullptr;
-    for (int64_t i = 0; i < batch.n_tokens; ++i) {
-        ggml_tensor * cur_i = ggml_view_2d(ctx0, cur, cur->ne[0], 1, cur->nb[1], (size_t) i * cur->nb[1]);
-        ggml_tensor * inp_s_seq_qnext_i = ggml_view_2d(ctx0, lctx.inp_s_seq_qnext, 1, 1, lctx.inp_s_seq_qnext->nb[1], (size_t) i * lctx.inp_s_seq_qnext->nb[1]);
+    // PXA_LLAMA_FIX_v4: THE FIX. Mixed (concurrent) batch -> ONE batched delta-net with n_seqs = n_tok, n_seq_tokens = 1
+    // (each token is its own sequence). state_row_idx = [n_tok] absolute seq rows in token order; conv_seq_map = the full
+    // [n_kv=n_tok, n_tok] identity map (row 0 = t, rows>=1 = -1) since states are gathered in token order. This replaces
+    // the previous per-token loop of N independent subgraphs, whose interleaved get_rows/conv/delta_net/set_rows scratch
+    // let ggml-alloc reuse a still-live recurrent buffer at np>=3 -> cross-conversation state bleed. A SINGLE subgraph
+    // (one get_rows, one ssm_conv, one ggml_delta_net over n_seqs, one set_rows) is allocator-safe at any concurrency.
+    ggml_tensor * state_row_idx = ggml_view_1d(ctx0, lctx.inp_s_seq_qnext, n_tok, 0);
+    ggml_tensor * conv_seq_map  = lctx.inp_conv_seq_map; // [n_tok, n_tok]
+    GGML_ASSERT(conv_seq_map->ne[0] == n_tok && conv_seq_map->ne[1] == n_tok);
+    ggml_tensor * state_mask = make_state_mask(n_tok);
 
-        const bool reset_state_i = batch.pos != nullptr && batch.pos[i] == 0;
-        const uint32_t state_seq_id_i = (uint32_t) token_seq_ids[i];
-        ggml_tensor * out_i = build_layer_attn_linear_core(ctx0, gf, cur_i, inp_s_seq_qnext_i, inp_out_ids, state_seq_id_i, reset_state_i, il, cb);
-
-        out = out == nullptr ? out_i : ggml_concat(ctx0, out, out_i, 1);
-    }
-
-    return out;
-
+    return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, n_tok, /*reset_state_local*/ false, il, cb);
 }
 

--- a/src/llama-delta-net.cpp
+++ b/src/llama-delta-net.cpp
@@ -60,6 +60,14 @@ delta_net::delta_net(llama_context & _lctx, const llama_batch & _batch) : lctx(_
         }
     }
 
+    // PXA_LLAMA_MTP_FIX: distinct-sequence decomposition. Generalizes the v4 "n_seqs == n_tok"
+    // (one token per seq) assumption. For an MTP verify batch each seq carries (n_max+1) tokens
+    // with the SAME seq_id on consecutive positions; this routes one recurrent row per *sequence*
+    // (gathered/scattered once) while the conv/delta-net scan iterates n_seq_tokens per seq.
+    // pxa_decompose_seqs requires per-seq contiguity + position-monotonicity (true for plain
+    // decode AND slot-major MTP verify) and rejects genuinely interleaved batches.
+    seq_decomp = pxa_decompose_seqs(batch);
+
     const uint32_t qnext_state_slots = llm_build_context::llama_kv_qnext_state_slots(lctx.kv_self);
     GGML_ASSERT(qnext_state_slots > 0);
 
@@ -683,19 +691,28 @@ ggml_tensor * delta_net::build_layer_attn_linear(ggml_context * ctx0, ggml_cgrap
         return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, 1, reset_state, il, cb);
     }
 
-    GGML_ASSERT(has_unique_seq_ids && "qwen3next mixed-sequence batches require unique sequence IDs per token");
+    // PXA_LLAMA_MTP_FIX: generalized mixed/MTP path. The batch is decomposed into n_seqs DISTINCT
+    // sequences (first-seen order), each with n_seq_tokens contiguous, position-monotonic tokens.
+    //   - plain concurrent decode: n_seqs == n_tok, n_seq_tokens == 1 (the old v4 behavior).
+    //   - MTP verify (np>1): n_seqs == #slots, n_seq_tokens == n_max+1 (same seq_id repeated).
+    // ONE recurrent row is gathered/scattered PER SEQUENCE (no duplicate get_rows/set_rows on the
+    // same row -> no racing writes). conv_seq_map is the [n_kv=n_seqs, n_tok] map (row 0 = seq_slot(t),
+    // rest -1); the general ssm_conv kernel scans tokens in order, carrying each seq's conv window.
+    GGML_ASSERT(seq_decomp.ok && "qwen3next mixed batch is not decomposable (interleaved sequences)");
+    GGML_ASSERT(seq_decomp.uniform_tok &&
+        "qwen3next batched delta-net requires a uniform tokens-per-sequence count (decode or MTP verify)");
+    const int64_t n_seqs = seq_decomp.n_seqs;
+    GGML_ASSERT(n_seqs >= 1 && n_tok % n_seqs == 0);
 
-    // PXA_LLAMA_FIX_v4: THE FIX. Mixed (concurrent) batch -> ONE batched delta-net with n_seqs = n_tok, n_seq_tokens = 1
-    // (each token is its own sequence). state_row_idx = [n_tok] absolute seq rows in token order; conv_seq_map = the full
-    // [n_kv=n_tok, n_tok] identity map (row 0 = t, rows>=1 = -1) since states are gathered in token order. This replaces
-    // the previous per-token loop of N independent subgraphs, whose interleaved get_rows/conv/delta_net/set_rows scratch
-    // let ggml-alloc reuse a still-live recurrent buffer at np>=3 -> cross-conversation state bleed. A SINGLE subgraph
-    // (one get_rows, one ssm_conv, one ggml_delta_net over n_seqs, one set_rows) is allocator-safe at any concurrency.
-    ggml_tensor * state_row_idx = ggml_view_1d(ctx0, lctx.inp_s_seq_qnext, n_tok, 0);
-    ggml_tensor * conv_seq_map  = lctx.inp_conv_seq_map; // [n_tok, n_tok]
-    GGML_ASSERT(conv_seq_map->ne[0] == n_tok && conv_seq_map->ne[1] == n_tok);
-    ggml_tensor * state_mask = make_state_mask(n_tok);
+    // state_row_idx: first n_seqs entries of inp_s_seq_qnext hold the DISTINCT absolute seq rows.
+    ggml_tensor * state_row_idx = ggml_view_1d(ctx0, lctx.inp_s_seq_qnext, n_seqs, 0);
+    // conv_seq_map: view the first n_seqs rows (n_kv) of the full [n_tok, n_tok] map, keeping the
+    // full per-token row stride (nb[1]) so the host-filled rows line up. -> [n_kv=n_seqs, n_tok].
+    ggml_tensor * conv_seq_map  = ggml_view_2d(ctx0, lctx.inp_conv_seq_map, n_seqs, n_tok,
+            lctx.inp_conv_seq_map->nb[1], 0);
+    GGML_ASSERT(conv_seq_map->ne[0] == n_seqs && conv_seq_map->ne[1] == n_tok);
+    ggml_tensor * state_mask = make_state_mask(n_seqs);
 
-    return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, n_tok, /*reset_state_local*/ false, il, cb);
+    return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, n_seqs, /*reset_state_local*/ false, il, cb);
 }
 

--- a/src/llama-delta-net.cpp
+++ b/src/llama-delta-net.cpp
@@ -298,7 +298,7 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
         int64_t head_k_dim, int64_t num_k_heads, int64_t head_v_dim, int64_t num_v_heads, int64_t ssm_d_conv,
         int64_t n_seqs_in, uint32_t qnext_state_slots, bool reset_state_local,
         float eps_norm, int repeat_type, int il, const llm_build_cb & cb, ggml_cgraph * gf,
-        ggml_tensor * per_step_ckpt, ggml_tensor * per_step_conv) {
+        ggml_tensor * per_step_ckpt, ggml_tensor * per_step_conv, int64_t pxa_static_slot) {
     const int64_t key_dim        = head_k_dim * num_k_heads;
     const int64_t value_dim      = head_v_dim * num_v_heads;
     const int64_t conv_dim       = key_dim * 2 + value_dim;
@@ -333,21 +333,44 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
     GGML_ASSERT(state_row_idx != nullptr);
     GGML_ASSERT(state_row_idx->ne[0] == n_seqs);
     ggml_tensor * pxa_row_idx = state_row_idx;
-    ggml_tensor * state_dst = ggml_get_rows(ctx0, state_all, pxa_row_idx); // [state_dim, n_seqs]
-    ggml_tensor * state_f32 = state_dst;
-    if (state_f32->type != GGML_TYPE_F32) {
-        state_f32 = ggml_cast(ctx0, state_f32, GGML_TYPE_F32);
-    }
-    // PXA_LLAMA_FIX_v4: per-seq reset via mask multiply ([1,n_seqs] broadcast over state_dim): 0 zeros a fresh seq's
-    // carried state, 1 keeps it. Handles mixed batches where some seqs start (pos 0) and others continue. Falls back to
-    // the scalar reset_state_local only if no mask is supplied (keeps non-qwen3next callers, if any, working).
-    if (state_mask != nullptr) {
-        GGML_ASSERT(state_mask->ne[1] == n_seqs);
-        state_f32 = ggml_mul(ctx0, state_f32, state_mask);
-        cb(state_f32, "state_reset_masked", il);
-    } else if (reset_state_local) {
-        state_f32 = ggml_scale(ctx0, state_f32, 0.0f);
-        cb(state_f32, "state_reset", il);
+
+    // PXA_PERF_NP1_FASTPATH: for a single sequence (n_seqs==1) whose state row is known at graph-build time
+    // (pxa_static_slot>=0), access the recurrent row IN PLACE via a static-offset view -- the pre-PR (main)
+    // path -- instead of get_rows/set_rows. The state row is ~state_dim floats (MBs) per layer; the
+    // gather+mask+scatter copies it ~3x/layer/token and cost ~10% TG / ~4% PP. Graph reuse stays correct
+    // because pxa_seq_sig() encodes the slot for the all_same case, so any slot change rebuilds the graph
+    // (a reused graph never keeps a stale static offset). The batched n_seqs>1 path is unchanged.
+    const bool pxa_fast = (pxa_static_slot >= 0);
+    GGML_ASSERT(!pxa_fast || n_seqs == 1);
+    ggml_tensor * state_dst = nullptr;
+    ggml_tensor * state_f32 = nullptr;
+    if (pxa_fast) {
+        state_dst = ggml_view_2d(ctx0, state_all, state_dim, 1, state_row_size, (size_t) pxa_static_slot * state_row_size);
+        state_f32 = state_dst;
+        if (state_f32->type != GGML_TYPE_F32) {
+            state_f32 = ggml_cast(ctx0, state_f32, GGML_TYPE_F32);
+        }
+        if (reset_state_local) {
+            state_f32 = ggml_scale(ctx0, state_f32, 0.0f);
+            cb(state_f32, "state_reset", il);
+        }
+    } else {
+        state_dst = ggml_get_rows(ctx0, state_all, pxa_row_idx); // [state_dim, n_seqs]
+        state_f32 = state_dst;
+        if (state_f32->type != GGML_TYPE_F32) {
+            state_f32 = ggml_cast(ctx0, state_f32, GGML_TYPE_F32);
+        }
+        // PXA_LLAMA_FIX_v4: per-seq reset via mask multiply ([1,n_seqs] broadcast over state_dim): 0 zeros a fresh seq's
+        // carried state, 1 keeps it. Handles mixed batches where some seqs start (pos 0) and others continue. Falls back to
+        // the scalar reset_state_local only if no mask is supplied (keeps non-qwen3next callers, if any, working).
+        if (state_mask != nullptr) {
+            GGML_ASSERT(state_mask->ne[1] == n_seqs);
+            state_f32 = ggml_mul(ctx0, state_f32, state_mask);
+            cb(state_f32, "state_reset_masked", il);
+        } else if (reset_state_local) {
+            state_f32 = ggml_scale(ctx0, state_f32, 0.0f);
+            cb(state_f32, "state_reset", il);
+        }
     }
 
     // [state_dim, n_seqs] -> conv part [conv_state_dim, n_seqs] and ssm part [ssm_state_dim, n_seqs]
@@ -431,10 +454,17 @@ ggml_tensor * delta_net::build_qkv(ggml_context * ctx0, ggml_tensor * state_stor
     cb(new_conv_states_cont, "new_conv_states_cont", il);
     ggml_tensor * new_conv_flat = ggml_reshape_2d(ctx0, new_conv_states_cont, conv_state_dim, n_seqs);
     ggml_tensor * new_ssm_flat  = ggml_reshape_2d(ctx0, new_state, ssm_state_dim, n_seqs);
-    // PXA_LLAMA_FIX_v4: pack the new rows [state_dim, n_seqs] and SCATTER them back to their absolute seq rows with ONE
-    // ggml_set_rows. Single producer + single scatter => no per-token in-place aliasing => allocator-safe at any np.
-    ggml_tensor * pxa_new_row = ggml_concat(ctx0, new_conv_flat, new_ssm_flat, 0); // [state_dim, n_seqs]
-    auto state_cpy = ggml_set_rows(ctx0, state_storage, pxa_new_row, pxa_row_idx);
+    ggml_tensor * state_cpy;
+    if (pxa_fast) {
+        // PXA_PERF_NP1_FASTPATH: write the new [state_dim,1] row straight back into the static-offset view,
+        // in place -- no scatter copy (mirrors the pre-PR path).
+        state_cpy = ggml_concat_inplace(ctx0, new_conv_flat, new_ssm_flat, state_dst, 0);
+    } else {
+        // PXA_LLAMA_FIX_v4: pack the new rows [state_dim, n_seqs] and SCATTER them back to their absolute seq rows with ONE
+        // ggml_set_rows. Single producer + single scatter => no per-token in-place aliasing => allocator-safe at any np.
+        ggml_tensor * pxa_new_row = ggml_concat(ctx0, new_conv_flat, new_ssm_flat, 0); // [state_dim, n_seqs]
+        state_cpy = ggml_set_rows(ctx0, state_storage, pxa_new_row, pxa_row_idx);
+    }
     cb(state_cpy, "state_cpy", il);
     ggml_build_forward_expand(gf, state_cpy);
 
@@ -482,7 +512,7 @@ static ggml_tensor * get_input_tensor_sm_graph(ggml_context * ctx, ggml_tensor *
 
 ggml_tensor * delta_net::build_layer_attn_linear_core(ggml_context * ctx0, ggml_cgraph * gf,
             ggml_tensor * delta_input, ggml_tensor * state_row_idx, ggml_tensor * conv_seq_map, ggml_tensor * state_mask, ggml_tensor * inp_out_ids,
-            int64_t n_seqs, bool reset_state_local, int il, const llm_build_cb & cb) const {
+            int64_t n_seqs, bool reset_state_local, int il, const llm_build_cb & cb, int64_t pxa_static_slot) const {
 
     const int64_t n_tok = delta_input->ne[1];
     GGML_ASSERT(n_seqs > 0 && n_tok % n_seqs == 0);
@@ -577,7 +607,7 @@ ggml_tensor * delta_net::build_layer_attn_linear_core(ggml_context * ctx0, ggml_
             auto output = build_qkv(ctx0, split_s_l->splits[id], split_ssm_conv1d->splits[id], qkv_mixed, state_row_idx, conv_seq_map, state_mask, beta, gate,
                                head_k_dim, num_k_heads_id, head_v_dim, num_v_heads_id, hparams.ssm_d_conv,
                                n_seqs, qnext_state_slots, reset_state_local, hparams.f_norm_rms_eps,
-                               l.ssm_beta_alpha ? 0 : 1, il, cb, gf, per_step_ckpt, per_step_conv);
+                               l.ssm_beta_alpha ? 0 : 1, il, cb, gf, per_step_ckpt, per_step_conv, pxa_static_slot);
             split_norm = (ggml_split_tensor_t *)l.ssm_norm->extra;
             GGML_ASSERT(split_norm && split_norm->splits[id]);
             auto split_ssm_out = (ggml_split_tensor_t *)l.ssm_out->extra;
@@ -640,7 +670,7 @@ ggml_tensor * delta_net::build_layer_attn_linear_core(ggml_context * ctx0, ggml_
         qkv_mixed, state_row_idx, conv_seq_map, state_mask, beta, gate,
         head_k_dim, num_k_heads, head_v_dim, num_v_heads, hparams.ssm_d_conv,
         n_seqs, qnext_state_slots, reset_state_local, hparams.f_norm_rms_eps,
-        model.layers[il].ssm_beta_alpha ? 0 : 1, il, cb, gf, per_step_ckpt, per_step_conv);
+        model.layers[il].ssm_beta_alpha ? 0 : 1, il, cb, gf, per_step_ckpt, per_step_conv, pxa_static_slot);
 
     auto gated_output = build_gated_output(lctx, ctx0, model.layers[il].ssm_norm, model.layers[il].ssm_out, output, z, head_v_dim, num_v_heads, n_tok, il, cb);
     if (inp_out_ids) {
@@ -688,7 +718,13 @@ ggml_tensor * delta_net::build_layer_attn_linear(ggml_context * ctx0, ggml_cgrap
                 lctx.inp_conv_seq_map->nb[1], 0);
         ggml_tensor * state_mask = make_state_mask(1);
         bool reset_state = batch.pos != nullptr && batch.pos[0] == 0;
-        return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, 1, reset_state, il, cb);
+        // PXA_PERF_NP1_FASTPATH: the single sequence's absolute state row is known at build time -- it is exactly
+        // what llama_set_inputs writes to inp_s_seq_qnext[0] (batch.seq_id[0][0], clamped >=0). Pass it so build_qkv
+        // accesses the row in place (static-offset view) instead of get_rows/set_rows. pxa_seq_sig() encodes this
+        // slot for the all_same case, so graph reuse is invalidated if the active slot changes.
+        int64_t pxa_static_slot = token_seq_ids.empty() ? 0 : (int64_t) token_seq_ids.front();
+        if (pxa_static_slot < 0) pxa_static_slot = 0;
+        return build_layer_attn_linear_core(ctx0, gf, cur, state_row_idx, conv_seq_map, state_mask, inp_out_ids, 1, reset_state, il, cb, pxa_static_slot);
     }
 
     // PXA_LLAMA_MTP_FIX: generalized mixed/MTP path. The batch is decomposed into n_seqs DISTINCT

--- a/src/llama-delta-net.h
+++ b/src/llama-delta-net.h
@@ -22,7 +22,7 @@ struct delta_net {
     // mixed (concurrent) path runs ONE batched delta-net (n_seqs=n_tok) instead of a per-token subgraph loop.
     ggml_tensor * build_layer_attn_linear_core(ggml_context * ctx0, ggml_cgraph * gf,
             ggml_tensor * cur, ggml_tensor * state_row_idx, ggml_tensor * conv_seq_map, ggml_tensor * state_mask, ggml_tensor * inp_out_ids,
-            int64_t n_seqs, bool reset_state_local, int il, const llm_build_cb & cb) const;
+            int64_t n_seqs, bool reset_state_local, int il, const llm_build_cb & cb, int64_t pxa_static_slot = -1) const;
 
     ggml_tensor * build_layer_attn_linear(ggml_context * ctx0, ggml_cgraph * gf,
             ggml_tensor * cur, ggml_tensor * inp_out_ids, int il, const llm_build_cb & cb) const;
@@ -62,7 +62,7 @@ private:
             int64_t head_k_dim, int64_t num_k_heads, int64_t head_v_dim, int64_t num_v_heads, int64_t ssm_d_conv,
             int64_t n_seqs_in, uint32_t qnext_state_slots, bool reset_state_local,
             float eps_norm, int repeat_type, int il, const llm_build_cb & cb, ggml_cgraph * gf,
-            ggml_tensor * per_step_ssm = nullptr, ggml_tensor * per_step_conv = nullptr);
+            ggml_tensor * per_step_ssm = nullptr, ggml_tensor * per_step_conv = nullptr, int64_t pxa_static_slot = -1);
 
     static ggml_tensor * build_gated_output(llama_context & lctx, ggml_context * ctx0, ggml_tensor * ssm_norm, ggml_tensor * ssm_out,
             ggml_tensor * output, ggml_tensor * z, int64_t head_v_dim, int64_t num_v_heads, int64_t n_tok, int il, const llm_build_cb & cb);

--- a/src/llama-delta-net.h
+++ b/src/llama-delta-net.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "llama-build-context.h"
+#include "pxa-seq-decomp.h" // PXA_LLAMA_MTP_FIX: shared distinct-seq decomposition
 
 #include <utility>
 
@@ -33,6 +34,10 @@ private:
     std::vector<llama_seq_id> token_seq_ids;
     bool all_same_seq;
     bool has_unique_seq_ids;
+    // PXA_LLAMA_MTP_FIX: distinct-sequence decomposition (n_seqs, seq_slot[], n_seq_tokens, ...)
+    // computed once in the constructor and shared with the builder. Generalizes the v4
+    // "n_seqs == n_tok" assumption so an MTP verify batch (n_seq_tokens>1 per seq) is handled.
+    pxa_seq_decomp seq_decomp;
 
     static std::pair<ggml_tensor *, ggml_tensor *> build_qkvz(llama_context & lctx, ggml_context * ctx0,
             ggml_tensor * wqkv, ggml_tensor * wqkv_gate, ggml_tensor * input, int il, const llm_build_cb & cb,

--- a/src/llama-delta-net.h
+++ b/src/llama-delta-net.h
@@ -17,9 +17,11 @@ struct delta_net {
                       int il, const llm_build_cb & cb, int repeat_type,
                       ggml_tensor * per_step_ckpt = nullptr);
 
+    // PXA_LLAMA_FIX_v4: takes n_seqs + per-request runtime tensors (state_row_idx, conv_seq_map, state_mask) so the
+    // mixed (concurrent) path runs ONE batched delta-net (n_seqs=n_tok) instead of a per-token subgraph loop.
     ggml_tensor * build_layer_attn_linear_core(ggml_context * ctx0, ggml_cgraph * gf,
-            ggml_tensor * cur, ggml_tensor * inp_s_seq_qnext, ggml_tensor * inp_out_ids,
-            uint32_t state_seq_id_local, bool reset_state_local, int il, const llm_build_cb & cb) const;
+            ggml_tensor * cur, ggml_tensor * state_row_idx, ggml_tensor * conv_seq_map, ggml_tensor * state_mask, ggml_tensor * inp_out_ids,
+            int64_t n_seqs, bool reset_state_local, int il, const llm_build_cb & cb) const;
 
     ggml_tensor * build_layer_attn_linear(ggml_context * ctx0, ggml_cgraph * gf,
             ggml_tensor * cur, ggml_tensor * inp_out_ids, int il, const llm_build_cb & cb) const;
@@ -51,9 +53,9 @@ private:
             ggml_tensor * cur, int il, const llm_build_cb & cb, ggml_cgraph * gf);
 
     static ggml_tensor * build_qkv(ggml_context * ctx0, ggml_tensor * state_storage, ggml_tensor * ssm_conv1d,
-            ggml_tensor * qkv_mixed, ggml_tensor * inp_s_seq_qnext, ggml_tensor * beta, ggml_tensor * gate,
+            ggml_tensor * qkv_mixed, ggml_tensor * state_row_idx, ggml_tensor * conv_seq_map, ggml_tensor * state_mask, ggml_tensor * beta, ggml_tensor * gate,
             int64_t head_k_dim, int64_t num_k_heads, int64_t head_v_dim, int64_t num_v_heads, int64_t ssm_d_conv,
-            int64_t state_seq_id_local, uint32_t qnext_state_slots, bool reset_state_local,
+            int64_t n_seqs_in, uint32_t qnext_state_slots, bool reset_state_local,
             float eps_norm, int repeat_type, int il, const llm_build_cb & cb, ggml_cgraph * gf,
             ggml_tensor * per_step_ssm = nullptr, ggml_tensor * per_step_conv = nullptr);
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -579,7 +579,14 @@ static inline uint64_t pxa_seq_sig(const llama_batch & b) {
         // undecomposable -> treat as a unique "mixed" structure keyed by n_tokens (forces a rebuild)
         return 0x9E3779B97F4A7C15ULL ^ (uint64_t) (uint32_t) b.n_tokens;
     }
-    if (d.all_same) return 1ULL;
+    // PXA_PERF_NP1_FASTPATH: the single-sequence builder accesses its recurrent row via a STATIC-offset view
+    // (build-time slot = d.seqs[0]) for speed, so the slot is baked into the graph. Encode it here so a reused
+    // graph is invalidated when the active slot changes (different conversation/slot) -> rebuilt with the new
+    // offset. Single-stream decode keeps a constant slot -> sig constant -> full reuse (no extra rebuilds).
+    if (d.all_same) {
+        const int32_t slot0 = d.seqs.empty() ? 0 : (int32_t) d.seqs[0];
+        return 1ULL | (((uint64_t) (uint32_t) (slot0 < 0 ? 0 : slot0)) << 8);
+    }
     const uint64_t ns  = (uint64_t) d.n_seqs;
     const uint64_t nst = (uint64_t) (d.uniform_tok ? d.n_seq_tokens : 0);
     return (2ULL) | (ns << 8) | (nst << 40);
@@ -4793,7 +4800,10 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
         const int64_t n_tokens = batch.n_tokens;
         const pxa_seq_decomp d = pxa_decompose_seqs(batch);
 
-        if (lctx.inp_s_seq_qnext) {
+        // PXA_PERF_NP1_FASTPATH: the all_same fast path accesses the recurrent row via a static-offset view and
+        // does NOT consume inp_s_seq_qnext, so the graph allocator leaves it bufferless; skip the fill then
+        // (matches the guard already used for inp_conv_seq_map / inp_qnext_state_mask below).
+        if (lctx.inp_s_seq_qnext && lctx.inp_s_seq_qnext->buffer) {
             GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_s_seq_qnext->buffer));
             int32_t * data = (int32_t *) lctx.inp_s_seq_qnext->data;
             if (d.ok && !d.all_same) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -557,6 +557,7 @@ struct llama_context::Prev {
     int per_step_max_allocated;
     llama_mtp_op_type mtp_op_type;
     ggml_cgraph * graph;
+    uint64_t seq_sig; // PXA_LLAMA_FIX_v1: signature of the per-token seq_id mapping baked into this graph
 };
 
 void llama_context::reset_scheduler() {
@@ -565,6 +566,23 @@ void llama_context::reset_scheduler() {
     prev_mtp.reset();
 }
 
+// PXA_LLAMA_FIX_v4: with the batched delta-net fix, per-token seq->state-row routing is fully RUNTIME (via the
+// inp_s_seq_qnext / inp_conv_seq_map / inp_qnext_state_mask input tensors), NOT baked into the graph. The ONLY thing
+// that still changes graph STRUCTURE is the all_same(single-seq, n_seqs=1) vs mixed(concurrent, n_seqs=n_tok) branch in
+// build_layer_attn_linear. So the reuse signature need only encode that one bit -> full graph reuse within each regime
+// (no rebuild churn when the concurrent slot set merely changes), correct rebuild on the all_same<->mixed transition.
+static inline uint64_t pxa_seq_sig(const llama_batch & b) {
+    const int n = b.n_tokens;
+    bool all_same = true;
+    if (b.seq_id && n > 0) {
+        const int s0 = b.seq_id[0] ? (int) b.seq_id[0][0] : (int) b.all_seq_id;
+        for (int i = 1; i < n; ++i) {
+            const int sid = b.seq_id[i] ? (int) b.seq_id[i][0] : (int) b.all_seq_id;
+            if (sid != s0) { all_same = false; break; }
+        }
+    }
+    return all_same ? 1ULL : 2ULL;
+}
 bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
     if (!cparams.graph_reuse) return false;
     //if (kv_self.save_per_step_ssm) return false;
@@ -575,6 +593,8 @@ bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
     if (u_batch.embd) return false;
     if (the_prev->save_per_step_ssm != kv_self.save_per_step_ssm ||
         the_prev->per_step_max_allocated != kv_self.ckpt.per_step_max_allocated) return false;
+    // PXA_LLAMA_FIX_v1: recurrent/hybrid graphs encode the per-token seq->state-row mapping; reuse only if unchanged.
+    if ((llm_arch_is_recurrent(model.arch) || llm_arch_is_hybrid(model.arch)) && pxa_seq_sig(u_batch) != the_prev->seq_sig) return false;
     return u_batch.all_seq_id == the_prev->all_seq_id &&
            kv_self.head > 0 &&
            kv_self.n == the_prev->n_kv &&
@@ -4770,9 +4790,43 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
         GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_s_seq_qnext->buffer));
         int32_t * data = (int32_t *) lctx.inp_s_seq_qnext->data;
 
+        const bool _pxa_has_seq = (batch.seq_id != nullptr);
         for (int64_t j = 0; j < n_tokens; ++j) {
-            // qwen3next linear-attention path uses a single local recurrent state slot.
-            data[j] = 0;
+            // PXA_LLAMA_FIX_v2: the qwen3next/qwen35 recurrent-state pool s_l[il] has one row PER ABSOLUTE seq_id
+            // (qnext_state_slots == n_seq_max). Route each token to its OWN absolute state row at runtime so concurrent
+            // sequences never read/write each other's recurrent state. (Pool is absolute-indexed -> do NOT subtract head.)
+            int32_t _pxa_row = (_pxa_has_seq && batch.seq_id[j]) ? (int32_t) batch.seq_id[j][0] : 0;
+            if (_pxa_row < 0) _pxa_row = 0;
+            data[j] = _pxa_row;
+        }
+    }
+
+    // PXA_LLAMA_FIX_v4: conv seq-map for the ONE-batched mixed-seq delta-net path. Shape [n_kv=n_tokens, n_tokens].
+    // States are gathered into token-order columns, so token t reads conv-state column t -> identity in row 0.
+    // The multi-seq-UNIQUE conv fast path requires row 0 in-range & unique per token, and row >=1 OUT-of-range (-1).
+    if (lctx.inp_conv_seq_map && lctx.inp_conv_seq_map->buffer) {
+        const int64_t n_tokens = batch.n_tokens;
+        GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_conv_seq_map->buffer));
+        const int64_t n_kv_map = lctx.inp_conv_seq_map->ne[0];
+        int32_t * data = (int32_t *) lctx.inp_conv_seq_map->data;
+        for (int64_t t = 0; t < n_tokens; ++t) {
+            data[t*n_kv_map + 0] = (int32_t) t;
+            for (int64_t i = 1; i < n_kv_map; ++i) {
+                data[t*n_kv_map + i] = -1;
+            }
+        }
+    }
+
+    // PXA_LLAMA_FIX_v4: per-seq recurrent-state reset mask. The batched delta-net gathers each seq's state and
+    // multiplies by this mask (0 => fresh sequence at pos 0 => zero the carried state; 1 => keep). One col per token;
+    // the mixed path is one-token-per-seq, the all_same path uses col 0 for its single seq (token order => seq start).
+    if (lctx.inp_qnext_state_mask && lctx.inp_qnext_state_mask->buffer) {
+        const int64_t n_tokens = batch.n_tokens;
+        GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_qnext_state_mask->buffer));
+        float * data = (float *) lctx.inp_qnext_state_mask->data;
+        for (int64_t j = 0; j < n_tokens; ++j) {
+            const bool reset = (batch.pos != nullptr && batch.pos[j] == 0);
+            data[j] = reset ? 0.0f : 1.0f;
         }
     }
 
@@ -5288,7 +5342,7 @@ static int llama_decode_internal(
                         (int)u_batch.all_seq_id, (int)lctx.n_outputs, (int)lctx.kv_self.n,
                         (int)u_batch.n_tokens,
                         lctx.kv_self.save_per_step_ssm, lctx.kv_self.ckpt.per_step_max_allocated,
-                        cparams.mtp_op_type, gf});
+                        cparams.mtp_op_type, gf, pxa_seq_sig(u_batch)});
             }
         } else {
             //printf("Reusing graph with n_kv = %d, n_tokens = %d\n", (int)prev->n_kv, (int)prev->n_tokens);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -19,6 +19,7 @@
 #include "llama-context.h"
 #include "llama-spec-features.h"
 #include "llama-quantize.h"
+#include "pxa-seq-decomp.h" // PXA_LLAMA_MTP_FIX: shared distinct-seq decomposition (must match delta_net)
 
 #include "unicode.h"
 
@@ -566,22 +567,22 @@ void llama_context::reset_scheduler() {
     prev_mtp.reset();
 }
 
-// PXA_LLAMA_FIX_v4: with the batched delta-net fix, per-token seq->state-row routing is fully RUNTIME (via the
-// inp_s_seq_qnext / inp_conv_seq_map / inp_qnext_state_mask input tensors), NOT baked into the graph. The ONLY thing
-// that still changes graph STRUCTURE is the all_same(single-seq, n_seqs=1) vs mixed(concurrent, n_seqs=n_tok) branch in
-// build_layer_attn_linear. So the reuse signature need only encode that one bit -> full graph reuse within each regime
-// (no rebuild churn when the concurrent slot set merely changes), correct rebuild on the all_same<->mixed transition.
+// PXA_LLAMA_FIX_v4 / PXA_LLAMA_MTP_FIX: per-token seq->state-row routing is fully RUNTIME (via the
+// inp_s_seq_qnext / inp_conv_seq_map / inp_qnext_state_mask input tensors), NOT baked into the graph. What
+// changes graph STRUCTURE is the (all_same vs mixed) branch AND, in the mixed/MTP path, n_seqs (n_kv view
+// widths) and n_seq_tokens (q/k/v view strides + the n_seq_tokens>1 permute branch). The reuse signature
+// encodes (regime, n_seqs, n_seq_tokens) so a plain decode (n_seq_tokens=1) and an MTP verify batch
+// (n_seq_tokens=n_max+1) over the same #seqs never share a graph; reuse still holds within each regime.
 static inline uint64_t pxa_seq_sig(const llama_batch & b) {
-    const int n = b.n_tokens;
-    bool all_same = true;
-    if (b.seq_id && n > 0) {
-        const int s0 = b.seq_id[0] ? (int) b.seq_id[0][0] : (int) b.all_seq_id;
-        for (int i = 1; i < n; ++i) {
-            const int sid = b.seq_id[i] ? (int) b.seq_id[i][0] : (int) b.all_seq_id;
-            if (sid != s0) { all_same = false; break; }
-        }
+    const pxa_seq_decomp d = pxa_decompose_seqs(b);
+    if (!d.ok) {
+        // undecomposable -> treat as a unique "mixed" structure keyed by n_tokens (forces a rebuild)
+        return 0x9E3779B97F4A7C15ULL ^ (uint64_t) (uint32_t) b.n_tokens;
     }
-    return all_same ? 1ULL : 2ULL;
+    if (d.all_same) return 1ULL;
+    const uint64_t ns  = (uint64_t) d.n_seqs;
+    const uint64_t nst = (uint64_t) (d.uniform_tok ? d.n_seq_tokens : 0);
+    return (2ULL) | (ns << 8) | (nst << 40);
 }
 bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
     if (!cparams.graph_reuse) return false;
@@ -4784,49 +4785,67 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
         }
     }
 
-    if (lctx.inp_s_seq_qnext) {
+    // PXA_LLAMA_MTP_FIX: fill the three qnext input tensors from ONE shared decomposition so the host fill
+    // and the delta_net graph builder agree on n_seqs / seq_slot / reset (generalizes v4's n_seqs==n_tok
+    // to MTP verify batches where each seq carries n_seq_tokens>1 tokens with the same seq_id).
+    if (lctx.inp_s_seq_qnext || (lctx.inp_conv_seq_map && lctx.inp_conv_seq_map->buffer)
+                             || (lctx.inp_qnext_state_mask && lctx.inp_qnext_state_mask->buffer)) {
         const int64_t n_tokens = batch.n_tokens;
+        const pxa_seq_decomp d = pxa_decompose_seqs(batch);
 
-        GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_s_seq_qnext->buffer));
-        int32_t * data = (int32_t *) lctx.inp_s_seq_qnext->data;
-
-        const bool _pxa_has_seq = (batch.seq_id != nullptr);
-        for (int64_t j = 0; j < n_tokens; ++j) {
-            // PXA_LLAMA_FIX_v2: the qwen3next/qwen35 recurrent-state pool s_l[il] has one row PER ABSOLUTE seq_id
-            // (qnext_state_slots == n_seq_max). Route each token to its OWN absolute state row at runtime so concurrent
-            // sequences never read/write each other's recurrent state. (Pool is absolute-indexed -> do NOT subtract head.)
-            int32_t _pxa_row = (_pxa_has_seq && batch.seq_id[j]) ? (int32_t) batch.seq_id[j][0] : 0;
-            if (_pxa_row < 0) _pxa_row = 0;
-            data[j] = _pxa_row;
-        }
-    }
-
-    // PXA_LLAMA_FIX_v4: conv seq-map for the ONE-batched mixed-seq delta-net path. Shape [n_kv=n_tokens, n_tokens].
-    // States are gathered into token-order columns, so token t reads conv-state column t -> identity in row 0.
-    // The multi-seq-UNIQUE conv fast path requires row 0 in-range & unique per token, and row >=1 OUT-of-range (-1).
-    if (lctx.inp_conv_seq_map && lctx.inp_conv_seq_map->buffer) {
-        const int64_t n_tokens = batch.n_tokens;
-        GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_conv_seq_map->buffer));
-        const int64_t n_kv_map = lctx.inp_conv_seq_map->ne[0];
-        int32_t * data = (int32_t *) lctx.inp_conv_seq_map->data;
-        for (int64_t t = 0; t < n_tokens; ++t) {
-            data[t*n_kv_map + 0] = (int32_t) t;
-            for (int64_t i = 1; i < n_kv_map; ++i) {
-                data[t*n_kv_map + i] = -1;
+        if (lctx.inp_s_seq_qnext) {
+            GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_s_seq_qnext->buffer));
+            int32_t * data = (int32_t *) lctx.inp_s_seq_qnext->data;
+            if (d.ok && !d.all_same) {
+                // state_row_idx reads the FIRST n_seqs entries: distinct absolute seq rows (first-seen order).
+                for (int64_t s = 0; s < d.n_seqs; ++s) {
+                    int32_t row = (int32_t) d.seqs[s];
+                    data[s] = row < 0 ? 0 : row;
+                }
+                // remaining entries unused by the builder; keep them benign.
+                for (int64_t s = d.n_seqs; s < n_tokens; ++s) data[s] = 0;
+            } else {
+                // all_same / undecomposable: the builder reads entry 0 (single seq). Fill per-token for safety.
+                const bool _pxa_has_seq = (batch.seq_id != nullptr);
+                for (int64_t j = 0; j < n_tokens; ++j) {
+                    int32_t row = (_pxa_has_seq && batch.seq_id[j]) ? (int32_t) batch.seq_id[j][0] : 0;
+                    data[j] = row < 0 ? 0 : row;
+                }
             }
         }
-    }
 
-    // PXA_LLAMA_FIX_v4: per-seq recurrent-state reset mask. The batched delta-net gathers each seq's state and
-    // multiplies by this mask (0 => fresh sequence at pos 0 => zero the carried state; 1 => keep). One col per token;
-    // the mixed path is one-token-per-seq, the all_same path uses col 0 for its single seq (token order => seq start).
-    if (lctx.inp_qnext_state_mask && lctx.inp_qnext_state_mask->buffer) {
-        const int64_t n_tokens = batch.n_tokens;
-        GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_qnext_state_mask->buffer));
-        float * data = (float *) lctx.inp_qnext_state_mask->data;
-        for (int64_t j = 0; j < n_tokens; ++j) {
-            const bool reset = (batch.pos != nullptr && batch.pos[j] == 0);
-            data[j] = reset ? 0.0f : 1.0f;
+        // conv seq-map [n_kv, n_tokens]: column t row0 = seq_slot(t) (which gathered state column this token
+        // uses), rows>=1 = -1. all_same -> seq_slot==0 for all (n_kv view is 1 in the builder). The general
+        // ssm_conv kernel scans tokens in order, accumulating each seq's conv window across its n_seq_tokens.
+        if (lctx.inp_conv_seq_map && lctx.inp_conv_seq_map->buffer) {
+            GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_conv_seq_map->buffer));
+            const int64_t n_kv_map = lctx.inp_conv_seq_map->ne[0];
+            int32_t * data = (int32_t *) lctx.inp_conv_seq_map->data;
+            for (int64_t t = 0; t < n_tokens; ++t) {
+                int32_t slot = (d.ok && t < (int64_t) d.seq_slot.size()) ? d.seq_slot[t] : (int32_t) t;
+                data[t*n_kv_map + 0] = slot;
+                for (int64_t i = 1; i < n_kv_map; ++i) {
+                    data[t*n_kv_map + i] = -1;
+                }
+            }
+        }
+
+        // per-seq recurrent-state reset mask [1, n_seqs]: col s = 0 iff seq s's FIRST token has pos 0 (fresh seq).
+        if (lctx.inp_qnext_state_mask && lctx.inp_qnext_state_mask->buffer) {
+            GGML_ASSERT(ggml_backend_buffer_is_host(lctx.inp_qnext_state_mask->buffer));
+            float * data = (float *) lctx.inp_qnext_state_mask->data;
+            if (d.ok && !d.all_same) {
+                for (int64_t s = 0; s < d.n_seqs; ++s) data[s] = d.seq_reset[s] ? 0.0f : 1.0f;
+                for (int64_t s = d.n_seqs; s < n_tokens; ++s) data[s] = 1.0f;
+            } else {
+                // all_same: the builder reads col 0 (single seq); reset iff this seq starts at pos 0.
+                const bool reset0 = (batch.pos != nullptr && batch.pos[0] == 0);
+                data[0] = reset0 ? 0.0f : 1.0f;
+                for (int64_t j = 1; j < n_tokens; ++j) {
+                    const bool reset = (batch.pos != nullptr && batch.pos[j] == 0);
+                    data[j] = reset ? 0.0f : 1.0f;
+                }
+            }
         }
     }
 
@@ -5202,10 +5221,42 @@ static int llama_decode_internal(
             }
 
             if (can_check && any_diff && has_dup) {
-                n_tokens = 1;
-                if (!warned_qnext_mixed_repeat) {
-                    LLAMA_LOG_WARN("%s: qwen3next mixed-sequence batch contains repeated seq_id values; falling back to single-token chunking\n", __func__);
-                    warned_qnext_mixed_repeat = true;
+                // PXA_LLAMA_MTP_FIX: a "repeated seq_id" mixed batch is the MTP *verify* shape
+                // (np>1 slots, each carrying n_max+1 tokens with the same seq_id on consecutive
+                // positions). The generalized batched delta-net handles this directly IFF the slice
+                // is cleanly decomposable (per-seq contiguous + position-monotonic + uniform token
+                // count). Only fall back to the slow single-token chunking for genuinely
+                // interleaved / ragged batches that the batched path cannot represent.
+                llama_batch _pxa_slice = {
+                    /* .n_tokens   = */ (int32_t) n_tokens,
+                    /* .token      = */ batch_all.token     ? batch_all.token    + cur_token        : nullptr,
+                    /* .embd       = */ batch_all.embd      ? batch_all.embd     + cur_token*n_embd : nullptr,
+                    /* .pos        = */ batch_all.pos       ? batch_all.pos      + cur_token        : nullptr,
+                    /* .n_seq_id   = */ batch_all.n_seq_id  ? batch_all.n_seq_id + cur_token        : nullptr,
+                    /* .seq_id     = */ batch_all.seq_id    ? batch_all.seq_id   + cur_token        : nullptr,
+                    /* .logits     = */ batch_all.logits    ? batch_all.logits   + cur_token        : nullptr,
+                    /* .all_pos_0  = */ batch_all.all_pos_0 + (llama_pos) cur_token*batch_all.all_pos_1,
+                    /* .all_pos_1  = */ batch_all.all_pos_1,
+                    /* .all_seq_id = */ batch_all.all_seq_id,
+                };
+                const pxa_seq_decomp _pxa_d = pxa_decompose_seqs(_pxa_slice);
+                const bool _pxa_batched_ok = _pxa_d.ok && _pxa_d.uniform_tok && _pxa_d.n_seqs >= 1;
+                if (!_pxa_batched_ok) {
+                    // PXA_LLAMA_MTP_FIX: non-uniform multi-seq (e.g. concurrent prompts of different
+                    // length, or ragged verify) can't go through the uniform batched delta-net. Instead
+                    // of per-TOKEN chunking (slow + breaks the verify logits layout), split off ONE FULL
+                    // sequence at a time so each sub-ubatch is single-seq (all_same path = correct
+                    // recurrent state, full speed). The first run in the slice is seqs[0]'s contiguous
+                    // tokens; processing it advances cur_token to the next sequence.
+                    if (_pxa_d.ok && _pxa_d.n_seqs >= 1 && !_pxa_d.seq_count.empty()) {
+                        n_tokens = (uint32_t) _pxa_d.seq_count[0];
+                    } else {
+                        n_tokens = 1; // truly undecomposable -> last-resort per-token
+                    }
+                    if (!warned_qnext_mixed_repeat) {
+                        LLAMA_LOG_WARN("%s: qwen3next non-uniform multi-seq batch; splitting per-sequence (n_seqs=%lld)\n", __func__, (long long)_pxa_d.n_seqs);
+                        warned_qnext_mixed_repeat = true;
+                    }
                 }
             }
         }

--- a/src/pxa-seq-decomp.h
+++ b/src/pxa-seq-decomp.h
@@ -1,0 +1,112 @@
+#pragma once
+// PXA_LLAMA_MTP_FIX: shared distinct-sequence decomposition for the batched delta-net.
+//
+// Both the delta_net graph builder (src/llama-delta-net.cpp) and the input filler
+// (llama_set_inputs in src/llama.cpp) must agree EXACTLY on:
+//   - the number of distinct sequences in the ubatch (n_seqs),
+//   - the first-seen order of those distinct seq_ids (seqs[]),
+//   - the per-token slot index seq_slot[t] in [0, n_seqs),
+//   - the per-seq token count n_seq_tokens[s] (and whether it is uniform),
+//   - per-seq "starts at pos 0" (reset) flag.
+//
+// v4 hardwired n_seqs == n_tok (one token per seq) which is correct ONLY for plain
+// np>1 single-token decode. An MTP *verify* batch carries n_seqs sequences x (n_max+1)
+// tokens, the SAME seq_id repeated on consecutive positions. This decomposition
+// generalizes to that: one recurrent state row per sequence (gathered once /
+// scattered once), with the in-kernel conv/delta-net scan iterating n_seq_tokens
+// within each sequence.
+
+#include "llama.h"
+
+#include <cstdint>
+#include <vector>
+
+struct pxa_seq_decomp {
+    bool                       ok            = false; // batch is acceptable for the batched path
+    bool                       all_same      = false; // single distinct sequence
+    bool                       uniform_tok   = false; // every seq has the same n_seq_tokens
+    int64_t                    n_seqs        = 0;
+    int64_t                    n_seq_tokens  = 0;      // valid iff uniform_tok
+    std::vector<llama_seq_id>  seqs;                   // distinct absolute seq_ids, first-seen order
+    std::vector<int32_t>       seq_slot;               // per-token: index into seqs[] (size n_tokens)
+    std::vector<int32_t>       seq_count;              // per-distinct-seq token count (size n_seqs)
+    std::vector<llama_pos>     seq_first_pos;          // per-distinct-seq first token pos (size n_seqs)
+    std::vector<char>          seq_reset;              // per-distinct-seq: first token pos == 0
+};
+
+// Build the decomposition. Acceptance rule: each sequence's tokens must be
+// CONTIGUOUS in batch order and POSITION-MONOTONIC (strictly increasing pos).
+// This is true for plain decode (1 tok/seq) AND for an MTP verify batch
+// (slot-major: seqs assembled one after another, positions increasing).
+// Genuinely interleaved batches (a seq_id reappearing after a different seq) are
+// rejected (ok=false) so the caller can fall back / assert.
+static inline pxa_seq_decomp pxa_decompose_seqs(const struct llama_batch & batch) {
+    pxa_seq_decomp d;
+    const int n = batch.n_tokens;
+    if (n <= 0) { return d; }
+
+    const bool has_seq = (batch.n_seq_id != nullptr && batch.seq_id != nullptr);
+    d.seq_slot.resize(n, 0);
+
+    auto tok_seq = [&](int i) -> llama_seq_id {
+        if (has_seq && batch.seq_id[i]) return batch.seq_id[i][0];
+        return 0;
+    };
+    auto tok_pos = [&](int i) -> llama_pos {
+        return batch.pos ? batch.pos[i] : 0;
+    };
+
+    // If multi-seq-per-token is present we cannot decompose (not supported here).
+    if (has_seq) {
+        for (int i = 0; i < n; ++i) {
+            if (batch.n_seq_id[i] != 1) { return d; }
+        }
+    }
+
+    // First-seen distinct sequence list + per-token slot, requiring contiguity.
+    // We track the slot of the immediately-preceding token; a seq may only extend
+    // the current run or open a brand-new (never-before-seen) run.
+    int prev_slot = -1;
+    for (int i = 0; i < n; ++i) {
+        const llama_seq_id s = tok_seq(i);
+        int slot = -1;
+        if (prev_slot >= 0 && d.seqs[prev_slot] == s) {
+            slot = prev_slot; // extend current run
+        } else {
+            // must be a NEW sequence (contiguity): reject if seen before
+            for (size_t k = 0; k < d.seqs.size(); ++k) {
+                if (d.seqs[k] == s) { return d; } // reappeared non-contiguously -> reject
+            }
+            slot = (int) d.seqs.size();
+            d.seqs.push_back(s);
+            d.seq_count.push_back(0);
+            d.seq_first_pos.push_back(tok_pos(i));
+        }
+        // position-monotonic within a run
+        if (slot == prev_slot) {
+            if (tok_pos(i) <= tok_pos(i-1)) { return d; }
+        }
+        d.seq_slot[i]      = slot;
+        d.seq_count[slot] += 1;
+        prev_slot          = slot;
+    }
+
+    d.n_seqs   = (int64_t) d.seqs.size();
+    d.all_same = (d.n_seqs == 1);
+
+    d.uniform_tok = true;
+    for (int64_t s = 0; s < d.n_seqs; ++s) {
+        if (d.seq_count[s] != d.seq_count[0]) { d.uniform_tok = false; break; }
+    }
+    if (d.uniform_tok) {
+        d.n_seq_tokens = d.seq_count[0];
+    }
+
+    d.seq_reset.resize(d.n_seqs, 0);
+    for (int64_t s = 0; s < d.n_seqs; ++s) {
+        d.seq_reset[s] = (d.seq_first_pos[s] == 0) ? 1 : 0;
+    }
+
+    d.ok = true;
+    return d;
+}


### PR DESCRIPTION
Fixes the concurrent-decoding corruption reported in #1932.

### Problem
Hybrid / recurrent-state models (qwen3next Gated-DeltaNet — Coder-Next-80B, Qwen3-Next-80B; qwen35moe — Qwen3.5-35B/122B) corrupt their output under concurrent decoding (`-np >= 3`): concurrent slots bleed each other's recurrent state. `np=1`/`np=2` clean, `np>=3` dirty, worse as `np` rises. Non-hybrid `qwen3moe` (30B-A3B) is unaffected.

### Root cause
`build_layer_attn_linear`'s mixed-seq path builds N independent per-token subgraphs, each `get_rows`/`set_rows` on the persistent recurrent pool `s_l[il]`. `ggml-alloc` reuses freed buffer offsets by topological refcount; with N>=3 interleaved subgraphs a still-live recurrent scratch is aliased -> cross-sequence bleed. The per-token-loop structure is the bug.

### Fix
Replace the per-token loop with a single batched multi-seq delta-net call: one `ggml_ssm_conv` + one delta-net over all tokens, a `[n_kv, n_tokens]` seq map routing each token to its state row in-kernel, and one contiguous write-back — mirroring the existing concurrency-clean Mamba path (`src/graphs/build_mamba.cpp`). The delta-net CUDA kernel and the `ssm_conv` multi-seq-unique path already support `n_seqs>1`; only the graph builder looped.

### Testing
- Distinct-codeword cross-bleed harness: **CLEAN at np=4 and np=6** (was corrupt at np>=3).
- np=1 single-stream decode unchanged; non-hybrid qwen3moe unchanged.
- Verified on Tesla P100 (sm_60), offloaded 80B and 122B hybrid models.

### Notes
- Branched from `1520eda` (the base this was developed against) so the diff is exact; happy to **rebase onto `main`** if you'd like it mergeable as-is.
- Full root-cause writeup + standalone diff: https://github.com/poisonxa16/PXA_llama (docs/HYBRID-CONCURRENCY-BUG.md).

Thank you for ik_llama.cpp — the hybrid graph builders + IQK kernels are what make these models viable on an old P100 at all.
