### PR TITLE
CPU FA: disable mask optimization

### DIFF
--- a/ggml/src/iqk/fa/iqk_fa_templates.h
+++ b/ggml/src/iqk/fa/iqk_fa_templates.h
@@ -39,6 +39,7 @@ namespace {
 // lengths and therefore different mask patterns.
 // Returns the number of K elements to process (multiple of k_step).
 inline int mask_effective_nk1(const char * mask, int n_rows, int stride_m, int nk1, int k_step) {
+    return nk1;
     int ik_max = 0;
     for (int j = 0; j < n_rows; ++j) {
         auto Mc = (const uint16_t *)(mask + j * stride_m);


### PR DESCRIPTION

Closes #1910.

The failure mode is triggered when processing a batch for a thread that is working on activation rows that have very few not-masked KV cache entries due to SWA. In that case stepping over the mask in steps of `k_step` may miss the few non-masked entries, thus resulting in processing only fully masked KV cache entries, which triggers the `S > 0` assert.
  