### PR TITLE
Split mode graph for Laguna

### DIFF
--- a/src/graphs/build_laguna.cpp
+++ b/src/graphs/build_laguna.cpp
@@ -7,7 +7,7 @@ ggml_cgraph * llm_build_context::build_laguna() {
 
     ggml_tensor * inpL        = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
     ggml_tensor * inp_pos     = build_inp_pos();
-    ggml_tensor * inp_out_ids = build_inp_out_ids();
+    ggml_tensor * inp_out_ids = n_tokens > 1 ? build_inp_out_ids() : nullptr;
     ggml_tensor * KQ_mask     = build_inp_KQ_mask();
     ggml_tensor * KQ_mask_swa = build_inp_KQ_mask_swa();
 
@@ -15,105 +15,22 @@ ggml_cgraph * llm_build_context::build_laguna() {
         const bool is_swa = hparams.swa_layers[il];
         const int n_swa_l = is_swa ? hparams.n_swa : 0;
 
-        ggml_tensor * inpSA = inpL;
+        auto KQ_mask_l = is_swa ? KQ_mask_swa : KQ_mask;
+        auto rope_factors = is_swa ? nullptr : build_rope_factors(il);
 
-        ggml_tensor * cur = llm_build_norm(ctx0, inpL, hparams, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, cb, il);
-        cb(cur, "attn_norm", il);
-        ggml_tensor * input_normed = cur;
-
-        ggml_tensor * Qcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wq, cur);
-        cb(Qcur, "Qcur", il);
-        ggml_tensor * Kcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wk, cur);
-        cb(Kcur, "Kcur", il);
-        ggml_tensor * Vcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wv, cur);
-        cb(Vcur, "Vcur", il);
-        ggml_build_forward_expand(gf, Qcur);
-        ggml_build_forward_expand(gf, Kcur);
-        ggml_build_forward_expand(gf, Vcur);
-
-        const int64_t n_head_l      = hparams.n_head(il);
-        const int64_t n_head_kv_l   = hparams.n_head_kv(il);
-        const int64_t n_embd_head_k = hparams.n_embd_head_k(il);
-        const int64_t n_embd_head_v = hparams.n_embd_head_v(il);
-
-        Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head_k, n_head_l, n_tokens);
-        Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head_k, n_head_kv_l, n_tokens);
-
-        if (model.layers[il].attn_q_norm) {
-            Qcur = llm_build_norm(ctx0, Qcur, hparams, model.layers[il].attn_q_norm, nullptr, LLM_NORM_RMS, cb, il);
-            cb(Qcur, "Qcur_normed", il);
-            ggml_build_forward_expand(gf, Qcur);
-        }
-        if (model.layers[il].attn_k_norm) {
-            Kcur = llm_build_norm(ctx0, Kcur, hparams, model.layers[il].attn_k_norm, nullptr, LLM_NORM_RMS, cb, il);
-            cb(Kcur, "Kcur_normed", il);
-            ggml_build_forward_expand(gf, Kcur);
-        }
-
-        const float freq_base_l  = is_swa ? hparams.rope_freq_base_train_swa  : cparams.rope_freq_base;
-        const float freq_scale_l = is_swa ? hparams.rope_freq_scale_train_swa : cparams.rope_freq_scale;
-        const float ext_factor_l  = is_swa ? 0.0f  : ext_factor;
-        const float attn_factor_l = is_swa ? 1.0f  : attn_factor;
-        const float beta_fast_l   = is_swa ? 32.0f : beta_fast;
-        const float beta_slow_l   = is_swa ? 1.0f  : beta_slow;
-        ggml_tensor * rope_factors = is_swa ? nullptr : build_rope_factors(il);
-        const int n_rot_l = hparams.rope_n_rot(il);
-
-        Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, rope_factors,
-                n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-        Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, rope_factors,
-                n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-        cb(Qcur, "Qcur_roped", il);
-        cb(Kcur, "Kcur_roped", il);
-
-        cur = llm_build_kv(ctx0, lctx, kv_self, gf,
-                nullptr, nullptr,
-                Kcur, Vcur, Qcur,
-                is_swa ? KQ_mask_swa : KQ_mask,
-                n_tokens, kv_head, n_kv,
-                1.0f / sqrtf(float(n_embd_head_k)), cb, il, nullptr, n_swa_l);
-        cb(cur, "attn_out", il);
-
-        if (model.layers[il].wqkv_gate) {
-            ggml_tensor * gate = llm_build_lora_mm(lctx, ctx0, model.layers[il].wqkv_gate, input_normed);
-            cb(gate, "attn_gate", il);
-            gate = ggml_softplus(ctx0, gate);
-            cb(gate, "attn_gate_softplus", il);
-
-            ggml_tensor * attn_3d = ggml_reshape_3d(ctx0, cur, n_embd_head_v, n_head_l, n_tokens);
-            ggml_tensor * gate_3d = ggml_reshape_3d(ctx0, gate, 1, n_head_l, n_tokens);
-            cb(gate_3d, "attn_gate_3d", il);
-
-            cur = ggml_mul(ctx0, attn_3d, gate_3d);
-            cb(cur, "attn_gated_3d", il);
-            cur = ggml_reshape_2d(ctx0, cur, n_embd_head_v * n_head_l, n_tokens);
-            cb(cur, "attn_gated", il);
-        }
-
-        cur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wo, cur);
-        cb(cur, "attn_proj", il);
-
-        if (il == n_layer - 1 && inp_out_ids) {
-            cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
-            inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
-        }
-
-        ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
-        cb(ffn_inp, "ffn_inp", il);
+        auto cur = build_std_attention(gf, model.layers[il].attn_norm, inpL,
+                        inp_pos, il == n_layer - 1 ? inp_out_ids : nullptr, rope_factors,
+                        KQ_mask_l, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head_k)), 0.0f, n_swa_l, il, true, false, true);
 
         if (model.layers[il].ffn_gate_inp == nullptr) {
-            cur = llm_build_ffn(ctx0, lctx, model.layers[il].ffn_norm, ffn_inp,
+            cur = llm_build_ffn(ctx0, lctx, model.layers[il].ffn_norm, cur, //ffn_inp,
                     model.layers[il].ffn_up,   nullptr, nullptr,
                     model.layers[il].ffn_gate, nullptr, nullptr,
                     model.layers[il].ffn_down, nullptr, nullptr,
                     nullptr,
-                    LLM_FFN_SILU, LLM_FFN_PAR, cb, il);
-            cb(cur, "ffn_out", il);
-            cur = ggml_add(ctx0, cur, ffn_inp);
+                    LLM_FFN_SILU, LLM_FFN_PAR, cb, il, gf, true);
         } else {
-            cur = llm_build_std_moe_ffn(ctx0, lctx, model.layers[il].ffn_norm, ffn_inp,
+            cur = llm_build_std_moe_ffn(ctx0, lctx, model.layers[il].ffn_norm, cur, //ffn_inp,
                     model.layers[il].ffn_gate_inp,  model.layers[il].ffn_gate_inp_b,
                     model.layers[il].ffn_up_exps,   model.layers[il].ffn_up_exps_b,
                     model.layers[il].ffn_gate_exps, model.layers[il].ffn_gate_exps_b,

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -2548,7 +2548,17 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
     if (hparams.has_rope_freq_base_per_layer) {
         freq_base_l = hparams.rope_freq_base_per_layer[il];
     }
-    int n_rot_l = lctx.model.hparams.rope_n_rot(il);
+    int n_rot_l         = lctx.model.hparams.rope_n_rot(il);
+    float ext_factor_l  = ext_factor;
+    float attn_factor_l = attn_factor;
+    float beta_fast_l   = beta_fast;
+    float beta_slow_l   = beta_slow;
+    if (model.arch == LLM_ARCH_LAGUNA && n_swa > 0) {
+        ext_factor_l  = 0.0f;
+        attn_factor_l = 1.0f;
+        beta_fast_l   = 32.0f;
+        beta_slow_l   = 1.0f;
+    }
 #ifdef GGML_USE_VULKAN
     constexpr bool use_f32_precision = true;
 #else
@@ -2649,15 +2659,15 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                         std::copy(hparams.rope_sections.begin(), hparams.rope_sections.begin() + GGML_MROPE_SECTIONS, sections);
                         Qcur = ggml_rope_multi(ctx0, Qcur, inp_pos, rope_factors,
                                 n_rot_l, sections, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                                ext_factor, attn_factor, beta_fast, beta_slow);
+                                ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
                         Kcur = ggml_rope_multi(ctx0, Kcur, inp_pos, rope_factors,
                                 n_rot_l, sections, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                                ext_factor, attn_factor, beta_fast, beta_slow);
+                                ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
                     } else {
                         Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, rope_factors, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                                ext_factor, attn_factor, beta_fast, beta_slow);
+                                ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
                         Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, rope_factors, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                                ext_factor, attn_factor, beta_fast, beta_slow);
+                                ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
                     }
                 }
                 cb(Qcur, "Qcur", il_cb);
@@ -2764,11 +2774,18 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                     auto wqkv_gate = (ggml_split_tensor_t *)model.layers[il].wqkv_gate->extra;
                     GGML_ASSERT(wqkv_gate && wqkv_gate->splits[id]);
                     auto gate = llm_build_lora_mm(lctx, ctx0, wqkv_gate->splits[id], input_normed);
+                    if (model.arch == LLM_ARCH_LAGUNA) {
+                        gate = ggml_softplus(ctx0, gate);
+                    }
                     cb(gate, "attn_gate", il_cb);
                     int nh = split_wo->ne[0]/n_embd_head_v;
                     auto attn_3d = ggml_reshape_3d(ctx0, cur, n_embd_head_v, nh, n_tokens);
                     auto gate_3d = ggml_reshape_3d(ctx0, gate,            1, nh, n_tokens);
-                    cur = ggml_fused_mul_unary(ctx0, gate_3d, attn_3d, GGML_UNARY_OP_SIGMOID);
+                    if (model.arch == LLM_ARCH_LAGUNA) {
+                        cur = ggml_mul(ctx0, attn_3d, gate_3d);
+                    } else {
+                        cur = ggml_fused_mul_unary(ctx0, gate_3d, attn_3d, GGML_UNARY_OP_SIGMOID);
+                    }
                     cb(attn_3d, "attn_gated_3d", il_cb);
                 }
 
@@ -2860,15 +2877,15 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
             std::copy(hparams.rope_sections.begin(), hparams.rope_sections.begin() + GGML_MROPE_SECTIONS, sections);
             Qcur = ggml_rope_multi(ctx0, Qcur, inp_pos, rope_factors_in,
                     n_rot_l, sections, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                    ext_factor, attn_factor, beta_fast, beta_slow);
+                    ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
             Kcur = ggml_rope_multi(ctx0, Kcur, inp_pos, rope_factors_in,
                     n_rot_l, sections, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                    ext_factor, attn_factor, beta_fast, beta_slow);
+                    ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
         } else {
             Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, rope_factors_in, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                    ext_factor, attn_factor, beta_fast, beta_slow);
+                    ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
             Kcur = ggml_rope_ext( ctx0, Kcur, inp_pos, rope_factors_in, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
-                    ext_factor, attn_factor, beta_fast, beta_slow);
+                    ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
         }
     }
     cb(Qcur, "Qcur_roped", il);
@@ -2885,11 +2902,18 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                 Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa);
         cb(cur, "wqkv", il);
         auto gate = llm_build_lora_mm(lctx, ctx0, wqkv_gate, input_normed); // [n_head_l, n_tokens]
+        if (model.arch == LLM_ARCH_LAGUNA) {
+            gate = ggml_softplus(ctx0, gate);
+        }
         cb(gate, "attn_gate", il);
         int n_head_l = hparams.n_head(il);
         auto attn_3d = ggml_reshape_3d(ctx0, cur, n_embd_head_v, n_head_l, n_tokens);
         auto gate_3d = ggml_reshape_3d(ctx0, gate,            1, n_head_l, n_tokens);
-        cur = ggml_fused_mul_unary(ctx0, gate_3d, attn_3d, GGML_UNARY_OP_SIGMOID);
+        if (model.arch == LLM_ARCH_LAGUNA) {
+            cur = ggml_mul(ctx0, attn_3d, gate_3d);
+        } else {
+            cur = ggml_fused_mul_unary(ctx0, gate_3d, attn_3d, GGML_UNARY_OP_SIGMOID);
+        }
         cb(cur, "attn_gated_3d", il);
         cur = ggml_reshape_2d(ctx0, cur, n_embd_head_v * n_head_l, n_tokens);
         cb(cur, "attn_gated", il);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -3079,6 +3079,7 @@ static bool is_model_split_supported(const llama_model & model) {
         LLM_ARCH_GLM_DSA,
         LLM_ARCH_MISTRAL4,
         LLM_ARCH_MELLUM,
+        LLM_ARCH_LAGUNA,
     };
     auto it =  k_supported.find(model.arch);
     return it != k_supported.end();
@@ -6873,10 +6874,11 @@ struct llama_context * llama_init_from_model(
             cparams.reduce_type = GGML_TYPE_F32;
         }
     }
-    if (model->arch == LLM_ARCH_MELLUM && model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
+    if ((model->arch == LLM_ARCH_MELLUM || model->arch == LLM_ARCH_LAGUNA) && model->split_mode == LLAMA_SPLIT_MODE_GRAPH) {
         if (cparams.reduce_type == GGML_TYPE_F16) {
+            const char * mname = model->arch == LLM_ARCH_MELLUM ? "Mellum" : "Laguna";
             LLAMA_LOG_WARN("=====================================================================\n");
-            LLAMA_LOG_WARN("Mellum with split mode graph requires bf16 or f32 precision\n");
+            LLAMA_LOG_WARN("%s with split mode graph requires bf16 or f32 precision\n", mname);
             LLAMA_LOG_WARN("    => changing cparams.reduce_type to bf16\n");
             LLAMA_LOG_WARN("=====================================================================\n");
             cparams.reduce_type = GGML_TYPE_BF16;


### PR DESCRIPTION

Also standardize the compute graph.

Here some `sweep-bench` results on a 2x3090 system for `Q8_0` Laguna-256x2.2B

### Split model layer

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.361 |  5667.40 |    0.838 |   152.68 |
|  2048 |    128 |   2048 |    0.369 |  5550.12 |    0.886 |   144.43 |
|  2048 |    128 |   4096 |    0.388 |  5282.38 |    0.905 |   141.46 |
|  2048 |    128 |   6144 |    0.401 |  5109.42 |    0.915 |   139.91 |
|  2048 |    128 |   8192 |    0.417 |  4906.13 |    0.932 |   137.33 |
|  2048 |    128 |  10240 |    0.435 |  4706.76 |    0.950 |   134.76 |
|  2048 |    128 |  12288 |    0.452 |  4528.67 |    0.965 |   132.69 |
|  2048 |    128 |  14336 |    0.468 |  4371.58 |    0.972 |   131.65 |
|  2048 |    128 |  16384 |    0.485 |  4219.96 |    0.989 |   129.43 |
|  2048 |    128 |  18432 |    0.502 |  4076.08 |    1.000 |   127.98 |
|  2048 |    128 |  20480 |    0.518 |  3953.71 |    1.025 |   124.90 |
|  2048 |    128 |  22528 |    0.538 |  3810.03 |    1.031 |   124.19 |
|  2048 |    128 |  24576 |    0.552 |  3707.58 |    1.052 |   121.62 |
|  2048 |    128 |  26624 |    0.569 |  3597.97 |    1.058 |   120.93 |
|  2048 |    128 |  28672 |    0.588 |  3484.99 |    1.077 |   118.82 |
|  2048 |    128 |  30720 |    0.596 |  3438.55 |    1.083 |   118.22 |

### Split mode graph

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.302 |  6778.65 |    0.744 |   172.15 |
|  2048 |    128 |   2048 |    0.270 |  7594.61 |    0.785 |   163.06 |
|  2048 |    128 |   4096 |    0.278 |  7363.75 |    0.799 |   160.17 |
|  2048 |    128 |   6144 |    0.289 |  7093.01 |    0.808 |   158.38 |
|  2048 |    128 |   8192 |    0.298 |  6883.34 |    0.823 |   155.56 |
|  2048 |    128 |  10240 |    0.306 |  6693.14 |    0.831 |   154.10 |
|  2048 |    128 |  12288 |    0.315 |  6499.85 |    0.837 |   152.91 |
|  2048 |    128 |  14336 |    0.323 |  6332.03 |    0.845 |   151.53 |
|  2048 |    128 |  16384 |    0.332 |  6161.60 |    0.857 |   149.31 |
|  2048 |    128 |  18432 |    0.340 |  6018.04 |    0.866 |   147.87 |
|  2048 |    128 |  20480 |    0.352 |  5820.99 |    0.872 |   146.77 |
|  2048 |    128 |  22528 |    0.363 |  5644.19 |    0.879 |   145.61 |
|  2048 |    128 |  24576 |    0.372 |  5498.34 |    0.893 |   143.37 |
|  2048 |    128 |  26624 |    0.379 |  5398.51 |    0.901 |   142.11 |
|  2048 |    128 |  28672 |    0.391 |  5242.41 |    0.908 |   140.89 |
|  2048 |    128 |  30720 |    0.399 |  5131.67 |    0.915 |   139.82 |


