### PR TITLE
common: handle Laguna chat delimiters

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -226,8 +226,6 @@ common_peg_parser analyze_tools::build_tool_parser_json_native(parser_build_cont
         auto wrapped_content = ctx.content->build_optional_wrapped(ctx);
         return ctx.reasoning_parser + wrapped_content + tools_parser + p.end();
     }
-    auto content_end = ctx.content && ctx.content->is_end_delimited() ? p.optional(p.optspace(ctx.content->end)) : p.eps();
-
     std::string tool_start = "{";
     if (!format.section_start.empty()) {
         tool_start = format.section_start;
@@ -235,6 +233,11 @@ common_peg_parser analyze_tools::build_tool_parser_json_native(parser_build_cont
         tool_start = format.per_call_start;
     }
 
+    if (!ctx.content || !ctx.content->is_end_delimited()) {
+        return ctx.reasoning_parser + p.optional(p.content(p.until(tool_start))) + tools_parser + p.end();
+    }
+
+    auto content_end = p.optional(p.optspace(ctx.content->end));
     return ctx.reasoning_parser + p.space() + p.optional(p.content(p.until(tool_start))) + tools_parser + content_end + p.end();
 }
 
@@ -344,7 +347,12 @@ common_peg_parser analyze_tools::build_tool_parser_tag_json(parser_build_context
 
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
-    auto        content_end          = ctx.content && ctx.content->is_end_delimited() ? p.optional(p.optspace(ctx.content->end)) : p.eps();
+
+    if (!ctx.content || !ctx.content->is_end_delimited()) {
+        return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
+    }
+
+    auto content_end = p.optional(p.optspace(ctx.content->end));
     return ctx.reasoning_parser + p.space() + p.optional(p.content(content_before_tools)) + tool_calls + content_end + p.end();
 }
 
@@ -476,7 +484,12 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
 
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
-    auto        content_end          = ctx.content && ctx.content->is_end_delimited() ? p.optional(p.optspace(ctx.content->end)) : p.eps();
+
+    if (!ctx.content || !ctx.content->is_end_delimited()) {
+        return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
+    }
+
+    auto content_end = p.optional(p.optspace(ctx.content->end));
     return ctx.reasoning_parser + p.space() + p.optional(p.content(content_before_tools)) + tool_calls + content_end + p.end();
 }
 

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -93,7 +93,7 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs) cons
     }
     return build_chat_peg_parser([&](common_chat_peg_builder & p) {
         parser_build_context ctx(p, inputs);
-        bool                 extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+        bool                 extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && inputs.enable_thinking;
 
         ctx.extracting_reasoning = extract_reasoning && reasoning.mode != reasoning_mode::NONE;
         ctx.content              = &content;
@@ -154,6 +154,16 @@ common_peg_parser analyze_content::build_parser(parser_build_context & ctx) cons
             return ctx.reasoning_parser + start + p.content(p.until(end)) + end + p.end();
         }
         return p.content(p.until(start)) + start + p.content(p.until(end)) + end + p.end();
+    }
+    if (is_end_delimited()) {
+        auto content = p.choice({
+            p.content(p.until(end)) + p.optspace(end),
+            p.content(p.rest()),
+        });
+        if (ctx.extracting_reasoning) {
+            return ctx.reasoning_parser + p.space() + content + p.end();
+        }
+        return content + p.end();
     }
     return ctx.reasoning_parser + p.content(p.rest()) + p.end();
 }
@@ -216,6 +226,7 @@ common_peg_parser analyze_tools::build_tool_parser_json_native(parser_build_cont
         auto wrapped_content = ctx.content->build_optional_wrapped(ctx);
         return ctx.reasoning_parser + wrapped_content + tools_parser + p.end();
     }
+    auto content_end = ctx.content && ctx.content->is_end_delimited() ? p.optional(p.optspace(ctx.content->end)) : p.eps();
 
     std::string tool_start = "{";
     if (!format.section_start.empty()) {
@@ -224,7 +235,7 @@ common_peg_parser analyze_tools::build_tool_parser_json_native(parser_build_cont
         tool_start = format.per_call_start;
     }
 
-    return ctx.reasoning_parser + p.optional(p.content(p.until(tool_start))) + tools_parser + p.end();
+    return ctx.reasoning_parser + p.space() + p.optional(p.content(p.until(tool_start))) + tools_parser + content_end + p.end();
 }
 
 common_peg_parser analyze_tools::build_func_parser(common_chat_peg_builder & p, const std::string & name,
@@ -333,7 +344,8 @@ common_peg_parser analyze_tools::build_tool_parser_tag_json(parser_build_context
 
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
-    return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
+    auto        content_end          = ctx.content && ctx.content->is_end_delimited() ? p.optional(p.optspace(ctx.content->end)) : p.eps();
+    return ctx.reasoning_parser + p.space() + p.optional(p.content(content_before_tools)) + tool_calls + content_end + p.end();
 }
 
 common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_context & ctx) const {
@@ -464,7 +476,8 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
 
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
-    return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
+    auto        content_end          = ctx.content && ctx.content->is_end_delimited() ? p.optional(p.optspace(ctx.content->end)) : p.eps();
+    return ctx.reasoning_parser + p.space() + p.optional(p.content(content_before_tools)) + tool_calls + content_end + p.end();
 }
 
 }  // namespace autoparser

--- a/common/chat-auto-parser.h
+++ b/common/chat-auto-parser.h
@@ -101,6 +101,7 @@ enum class content_mode {
     PLAIN,                   // No content markers
     ALWAYS_WRAPPED,          // Content always wrapped with markers
     WRAPPED_WITH_REASONING,  // Content wrapped only when reasoning present
+    END_DELIMITED,           // Content is terminated by a marker but has no start marker
 };
 
 inline std::ostream & operator<<(std::ostream & os, const content_mode & mode) {
@@ -111,6 +112,8 @@ inline std::ostream & operator<<(std::ostream & os, const content_mode & mode) {
             return os << "ALWAYS_WRAPPED";
         case content_mode::WRAPPED_WITH_REASONING:
             return os << "WRAPPED_WITH_REASONING";
+        case content_mode::END_DELIMITED:
+            return os << "END_DELIMITED";
         default:
             return os << "UNKNOWN";
     }
@@ -286,6 +289,7 @@ struct analyze_content : analyze_base {
     common_peg_parser build_parser(parser_build_context & ctx) const override;
 
     bool is_always_wrapped() const;
+    bool is_end_delimited() const;
     common_peg_parser build_optional_wrapped(parser_build_context & ctx) const;
 };
 

--- a/common/chat-diff-analyzer.cpp
+++ b/common/chat-diff-analyzer.cpp
@@ -45,6 +45,28 @@ static std::vector<std::function<void(const common_chat_template & tmpl, autopar
               LOG_DBG(ANSI_ORANGE "[Patch: old Qwen/Deepseek thinking template]\n" ANSI_RESET);
           }
       },
+      // Poolside Laguna templates prefill <think> in the generation prompt, so generated
+      // reasoning starts immediately and is delimited only by </think>.
+      [](const common_chat_template & tmpl, autoparser & analysis) -> void {
+          if (tmpl.src.find("laguna_glm_thinking") != std::string::npos &&
+              tmpl.src.find("{{- \"<assistant>\\n\" -}}") != std::string::npos &&
+              tmpl.src.find("{{- '<think>' -}}") != std::string::npos) {
+              analysis.reasoning.mode  = reasoning_mode::TAG_BASED;
+              analysis.reasoning.start = "";
+              analysis.reasoning.end   = "</think>";
+              analysis.content.mode     = content_mode::END_DELIMITED;
+              analysis.content.end      = "</assistant>";
+              if (std::find(analysis.preserved_tokens.begin(), analysis.preserved_tokens.end(), "</think>") ==
+                  analysis.preserved_tokens.end()) {
+                  analysis.preserved_tokens.push_back("</think>");
+              }
+              if (std::find(analysis.preserved_tokens.begin(), analysis.preserved_tokens.end(), "</assistant>") ==
+                  analysis.preserved_tokens.end()) {
+                  analysis.preserved_tokens.push_back("</assistant>");
+              }
+              LOG_DBG(ANSI_ORANGE "[Patch: Poolside Laguna thinking template]\n" ANSI_RESET);
+          }
+      },
       // Granite 3.3, with separate reasoning and content markers
       [](const common_chat_template & tmpl, autoparser & analysis) -> void {
           if (tmpl.src.find("Write your thoughts between <think></think> and write your response between "
@@ -550,6 +572,10 @@ analyze_content::analyze_content(const common_chat_template & tmpl, const analyz
 
 bool analyze_content::is_always_wrapped() const {
     return mode == content_mode::ALWAYS_WRAPPED && !start.empty() && !end.empty();
+}
+
+bool analyze_content::is_end_delimited() const {
+    return mode == content_mode::END_DELIMITED && !end.empty();
 }
 
 analyze_tools::analyze_tools(const common_chat_template & tmpl,

--- a/docs/autoparser.md
+++ b/docs/autoparser.md
@@ -69,6 +69,7 @@ Three outcomes for reasoning-prefill handling (in `generate_parser()`):
 | `PLAIN`                  | No content markers                                             |
 | `ALWAYS_WRAPPED`         | Content always wrapped: `<response>...</response>`             |
 | `WRAPPED_WITH_REASONING` | Content wrapped only when reasoning is present                 |
+| `END_DELIMITED`          | Content has no start marker but ends at a marker               |
 
 **`tool_format`**: Classification of tool call structure.
 
@@ -357,6 +358,7 @@ A workaround array in `common/chat-diff-analyzer.cpp` applies post-hoc patches a
 3. **Cohere Command R+** — source contains `<|CHATBOT_TOKEN|>`: sets `ALWAYS_WRAPPED` content mode if no content start is already set
 4. **Functionary 3.1** — source contains `set has_code_interpreter`: forces `PLAIN` content, specific `per_call_start/end`, clears preserved tokens to only keep Functionary-specific markers
 5. **DeepSeek-R1-Distill-Qwen** — source contains `tool▁calls▁begin` markers: overrides tool section/per-call markers with the correct Unicode block characters
+6. **Poolside Laguna** — source contains `laguna_glm_thinking` and the Laguna generation prompt pattern: sets delimiter-style reasoning ending at `</think>` and `END_DELIMITED` content ending at `</assistant>`
 
 ### Parser Building
 
@@ -380,6 +382,7 @@ Note: The start marker may be empty either because the analyzer detected delimit
 | Tools present                          | Dispatches to `analyze_tools::build_parser()`                                   |
 | `ALWAYS_WRAPPED` with reasoning        | `reasoning + start + content(until(end)) + end + end()`                         |
 | `ALWAYS_WRAPPED` without reasoning     | `content(until(start)) + start + content(until(end)) + end + end()`             |
+| `END_DELIMITED`                        | `reasoning + content(until(end) or rest()) + optional end marker + end()`       |
 | Default (PLAIN)                        | `reasoning + content(rest()) + end()`                                           |
 
 #### Tool Parsers (`analyze_tools::build_parser`)
@@ -392,7 +395,7 @@ Dispatches by `format.mode`:
 - `build_json_tools_nested_keys()` — nested: `{"function": {"name": "X", "arguments": {...}}}`
 - `build_json_tools_flat_keys()` — flat: `{"name": "X", "arguments": {...}}`
 
-Handles content wrappers, array wrapping (`tools_array_wrapped`), parallel calls, and `parameter_order`.
+Handles content wrappers, array wrapping (`tools_array_wrapped`), parallel calls, and `parameter_order`. If content is `END_DELIMITED`, the content end marker is also accepted after parsed tool calls.
 
 **`build_tool_parser_tag_json()`**: For each tool function:
 
@@ -417,7 +420,7 @@ For closing: uses `function.close` if present; otherwise uses `peek(per_call_end
 All three tool parsers return:
 
 ```text
-reasoning + optional(content(until(trigger_marker))) + tool_calls + end()
+reasoning + optional(content(until(trigger_marker))) + tool_calls + optional(content_end) + end()
 ```
 
 Each returned parser is wrapped by `wrap_for_generation_prompt()`, which prepends a literal for any boilerplate prefix of the generation prompt (the portion before the reasoning start marker).


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

This fixes `llama-server` chat parsing for Poolside Laguna templates.

Laguna's template pre-fills `<think>` in the generation prompt when thinking is enabled, so the generated text starts directly with reasoning content and later emits `</think>`. The final answer is then terminated by `</assistant>`, which is an end delimiter rather than a normal start/end content wrapper. Before this change, the auto parser could leave `</think>` / `</assistant>` in the user-visible response, the web UI did not recognize the reasoning block correctly, and live tool-call responses could fall back to raw content with `<tool_call>` markers instead of parsed `tool_calls`.

Changes:

- add an `END_DELIMITED` content mode to the auto chat parser
- use that mode to parse content until an end marker, with a fallback for truncated generations that never emit the marker
- consume the end-delimited assistant marker after parsed tool calls, so Laguna's tool-call responses are not treated as raw content
- make auto-parser reasoning extraction respect `enable_thinking=false`, matching the behavior used by fixed parsers
- update `docs/autoparser.md` for the new content mode and Laguna workaround
- add a narrow workaround for the Poolside Laguna template fingerprint:
  - generated reasoning starts immediately and ends at `</think>`
  - generated content ends at `</assistant>`

The new `END_DELIMITED` mode implements the existing auto-parser TODO in `common/chat-diff-analyzer.cpp` for content that is "delimited at end but not at start." Laguna's `</assistant>` terminator is exactly that shape.

The same end-delimited assistant marker can appear after a generated tool-call block, so the tool parsers now accept that marker after parsed tool calls instead of requiring it to be part of raw content.

The `enable_thinking` guard aligns auto-parser reasoning extraction with the existing fixed-parser behavior, and prevents no-thinking Laguna responses from being classified as reasoning.

The Laguna-specific behavior is gated on the template source containing `laguna_glm_thinking` and the Laguna generation-prompt pattern. The new `END_DELIMITED` mode is generic, but currently only this Laguna workaround sets it. I marked the review complexity as Medium because the diff is small, but it adds a generic content mode and changes reasoning/tool-call parsing around `enable_thinking` and end delimiters, so the parser semantics deserve a careful look beyond the Laguna path.

Validation:

- Built successfully:

```bash
cmake --build build-cuda --target llama-server -j 8
```

- Tested locally with Q4 Laguna:

```bash
./build-cuda/bin/llama-server \
  -m /path/to/laguna-xs2-ikllama-Q4_K_M.gguf \
  -c 512 -ngl 0 -b 16 -ub 16 --no-warmup \
  --host 127.0.0.1 --port 19114 --jinja
```

Also ran a longer-context smoke with `-c 2048` for multi-turn and simulated tool-call history coverage.

Tested `/v1/chat/completions` cases:

- default thinking, non-streaming: `reasoning_content` is extracted, `content` has no `</think>` or `</assistant>`
- default thinking, streaming: reasoning deltas are emitted, content has no leaked delimiters
- `chat_template_kwargs.enable_thinking=false`: answer remains in `content`, no `reasoning_content`, no `</assistant>`
- short no-thinking generation: partial content is still returned cleanly
- thinking-mode cutoff after reasoning but before `</assistant>`: partial answer content is returned cleanly
- multi-turn thinking and no-thinking conversations: responses parse cleanly with no leaked delimiters
- simulated assistant `tool_calls` plus `tool` response history: final answer parses cleanly with no leaked tool/template tags
- live `tool_choice=required` request: parsed as `tool_calls` with clean `reasoning_content` and empty `content`, no leaked `</think>`, `<tool_call>`, or `</assistant>`
