### PR TITLE
common: gate empty-start reasoning extraction

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -93,7 +93,8 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs) cons
     }
     return build_chat_peg_parser([&](common_chat_peg_builder & p) {
         parser_build_context ctx(p, inputs);
-        bool                 extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+        bool                 extract_reasoning =
+            inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && (inputs.enable_thinking || !reasoning.start.empty());
 
         ctx.extracting_reasoning = extract_reasoning && reasoning.mode != reasoning_mode::NONE;
         ctx.content              = &content;


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Small follow-up to #1943, #1950, and #1951.

#1951 correctly restored reasoning extraction for Qwen-style templates where `enable_thinking=false` can still emit an explicit empty `<think></think>` block. However, that also re-enabled extraction for Laguna's delimiter-style reasoning, where `reasoning.start` is empty. In Laguna no-thinking mode, normal answer text can then be captured as `reasoning_content`.

This PR keeps the Qwen fix while preserving Laguna no-thinking behavior by changing the auto-parser reasoning gate to:

`inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && (inputs.enable_thinking || !reasoning.start.empty())`

So:

- Qwen-style explicit `<think>...</think>` formats are still parsed/stripped even when thinking is disabled.
- Empty-start delimiter-style reasoning is only extracted when thinking is enabled.

Validation:

- Built successfully: `cmake --build build-cuda --target llama-server -j 8`
- Qwen3.6-27B IQ4_XS with `enable_thinking=false`: clean `content`, `reasoning_content = null`, no `<think>` / `</think>` leak
- Laguna Q4 default thinking: clean `reasoning_content`, no leaked delimiters
- Laguna Q4 with `enable_thinking=false`: answer stays in `content`, `reasoning_content = null`, no leaked delimiters
- Laguna Q4 live `tool_choice=required`: parsed as `tool_calls`, no leaked `</think>`, `</assistant>`, or tool tags
