### PR TITLE
fix: initialize rpc_device endpoint and device index before parsing

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -176,6 +176,8 @@ static std::vector<rpc_device>  extract_device_from_rpc_device(std::vector<std::
     std::vector<rpc_device> rpc_servers;
     for (auto & device : devices) {
         rpc_device rpc;
+        rpc.device = 0;
+        rpc.endpoint = device;
         auto value = string_split(device, "|");
         if (value.size() == 2) {
             rpc.device = std::stoi(value[1]);


### PR DESCRIPTION
## Bug Fix: RPC device not added to model->devices when no device index specified

**Problem:**
When passing `--rpc <host>:<port>` without an explicit device index (e.g. `10.0.0.2:50052` instead of `10.0.0.2:50052|0`), the `extract_device_from_rpc_device` function never initializes `rpc.endpoint` or `rpc.device` because the `|` split check fails. This causes the RPC device to not be added to `model->devices`, so graph split mode silently falls back to single GPU and fails with "less than 2 devices".

**Fix:**
Initialize `rpc.device = 0` and `rpc.endpoint = device` before the split check so the defaults are always valid.

**Tested:**
Verified with Qwen2.5-32B Q5_K_M split across RTX 5080 (local) and Tesla V100 SXM2 (remote RPC) using `-sm graph`. Model now loads across both devices and both GPUs compute simultaneously.

- Self-reported review complexity:
- [x] Low