### PR TITLE
Correct image resize algorithm for all qwens after qwen2vl and gemma4

### DIFF
--- a/examples/mtmd/clip.cpp
+++ b/examples/mtmd/clip.cpp
@@ -4708,7 +4708,7 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
                     params.patch_size * cur_merge,
                     params.image_min_pixels,
                     params.image_max_pixels);
-                img_tool::resize(*img, resized, new_size, img_tool::RESIZE_ALGO_BILINEAR, false);
+                img_tool::resize(*img, resized, new_size, img_tool::RESIZE_ALGO_BICUBIC, false);
                 // clip_image_save_to_bmp(resized, "preproc.bmp");
                 clip_image_f32_ptr img_f32(clip_image_f32_init());
                 // clip_image_f32_ptr res(clip_image_f32_init());


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  
Reference implementations for these models all use bicubic resize.

# Repro

```python
# /// script
# requires-python = ">=3.12,<3.13"
# dependencies = [
#     "transformers",
#     "torch",
#     "torchvision",
#     "pillow",
#     "numpy",
# ]
#
# [[tool.uv.index]]
# name = "pytorch-cpu"
# url = "https://download.pytorch.org/whl/cpu"
# explicit = true
#
# [tool.uv.sources]
# torch = { index = "pytorch-cpu" }
# torchvision = { index = "pytorch-cpu" }
# ///

import PIL
import torchvision.transforms.v2.functional as tvf
from transformers import AutoImageProcessor
import numpy as np

global interps; interps = {}
global model; model = ""

# torchvision backend
def torchvision_resize(img, size, interpolation=None, *args, **kwargs):
    global interps, model
    interps.setdefault(model, {})["torchvision"] = repr(interpolation)
    raise NotImplementedError()
tvf.resize = torchvision_resize


# PIL backend
def pil_resize(self, size, resample=None, *args, **kwargs):
    global interps, model
    interps.setdefault(model, {})["pil"] = repr(resample)
    raise NotImplementedError()
PIL.Image.Image.resize = pil_resize


models = [
    "Qwen/Qwen2-VL-2B-Instruct",      # PROJECTOR_TYPE_QWEN2VL
    "Qwen/Qwen2.5-VL-3B-Instruct",    # PROJECTOR_TYPE_QWEN25VL
    "Qwen/Qwen3-VL-2B-Instruct",      # PROJECTOR_TYPE_QWEN3VL
    "Qwen/Qwen3.5-0.8B",              # PROJECTOR_TYPE_QWEN3VL (qwen3.5)
    "google/gemma-4-12B-it",          # PROJECTOR_TYPE_GEMMA4V
]
global backend; backend = ""

for curr_model in models:
    for backend in ["torchvision", "pil"]:
        model = curr_model
        try:
            image = PIL.Image.fromarray(np.zeros((100, 200, 3), dtype=np.uint8))
            processor = AutoImageProcessor.from_pretrained(model, backend=backend)
            processor(image, return_tensors="np")
        except NotImplementedError:
            pass

import json
print(json.dumps(interps, indent=4))
```

# output
```json
{
    "Qwen/Qwen2-VL-2B-Instruct": {
        "torchvision": "<InterpolationMode.BICUBIC: 'bicubic'>",
        "pil": "<Resampling.BICUBIC: 3>"
    },
    "Qwen/Qwen2.5-VL-3B-Instruct": {
        "torchvision": "<InterpolationMode.BICUBIC: 'bicubic'>",
        "pil": "<Resampling.BICUBIC: 3>"
    },
    "Qwen/Qwen3-VL-2B-Instruct": {
        "torchvision": "<InterpolationMode.BICUBIC: 'bicubic'>",
        "pil": "<Resampling.BICUBIC: 3>"
    },
    "Qwen/Qwen3.5-0.8B": {
        "torchvision": "<InterpolationMode.BICUBIC: 'bicubic'>",
        "pil": "<Resampling.BICUBIC: 3>"
    },
    "google/gemma-4-12B-it": {
        "torchvision": "3"
    }
}
```