### PR TITLE
Split mode graph for MiniMax-M3

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -3488,9 +3488,16 @@ static void ggml_cuda_up_gate_unary(ggml_backend_cuda_context & ctx, ggml_tensor
         }
     }
 
-    //printf("%s: using limit = %g\n", __func__, limit);
-    ggml_fused_mul_unary(ctx, (ggml_unary_op)dst->op_params[0], ggml_nelements(dst),
-                    (const float *)dst->data, dst_up.get(), (float *)dst->data, limit);
+    auto unary_op = (ggml_unary_op)dst->op_params[0];
+    if (unary_op == GGML_UNARY_OP_SWIGLU_OAI) {
+        ggml_swiglu_oai_cuda_f32((const float *)dst->data, (const float *)dst_up.get(),
+                (float *)dst->data, ggml_nelements(dst), dst->ne[0],  dst->ne[0],  dst->ne[0],
+                1.702f, 7.0f, stream);
+    } else {
+        //printf("%s: using limit = %g\n", __func__, limit);
+        ggml_fused_mul_unary(ctx, unary_op, ggml_nelements(dst),
+                (const float *)dst->data, dst_up.get(), (float *)dst->data, limit);
+    }
     CUDA_CHECK(cudaGetLastError());
 
 }

--- a/ggml/src/ggml-cuda/iqk_mmvq_templates.cuh
+++ b/ggml/src/ggml-cuda/iqk_mmvq_templates.cuh
@@ -190,6 +190,13 @@ static __device__ void iqk_fused_mul_mat_vec_q_kernel(
             float u = tmp_u[j][threadIdx.x];
             float g = tmp_g[j][threadIdx.x];
             float r;
+            if (unary_op == GGML_UNARY_OP_SWIGLU_OAI && !bias_u) {
+                constexpr float alpha = 1.702f;
+                constexpr float limit = 7.0f;
+                g = fminf(g, limit);
+                u = fmaxf(fminf(u, limit), -limit);
+                r = g / (1.0f + expf(-g * alpha)) * (1.0f + u);
+            } else {
             switch (unary_op) {
                 case GGML_UNARY_OP_SILU:
                     {
@@ -213,6 +220,7 @@ static __device__ void iqk_fused_mul_mat_vec_q_kernel(
                     u = fmaxf(fminf(u, limit), -limit);
                     r = g / (1.0f + expf(-g * alpha)) * (1.0f + u);
                 } break;
+            }
             }
             dst[j*nrows_dst + row0 + threadIdx.x] = r;
         }

--- a/ggml/src/ggml-cuda/mmvq-templates.cuh
+++ b/ggml/src/ggml-cuda/mmvq-templates.cuh
@@ -242,6 +242,13 @@ static __device__ void k_fused_mul_mat_vec_q(
             float u = tmp_u[j][threadIdx.x];
             float g = tmp_g[j][threadIdx.x];
             float r;
+            if (unary_op == GGML_UNARY_OP_SWIGLU_OAI && !bias_u) {
+                constexpr float alpha = 1.702f;
+                constexpr float limit = 7.0f;
+                g = fminf(g, limit);
+                u = fmaxf(fminf(u, limit), -limit);
+                r = g / (1.0f + expf(-g * alpha)) * (1.0f + u);
+            } else {
             switch (unary_op) {
                 case GGML_UNARY_OP_SILU:
                     {
@@ -265,6 +272,7 @@ static __device__ void k_fused_mul_mat_vec_q(
                   u = fmaxf(fminf(u, limit), -limit);
                   r = g / (1.0f + expf(-g * alpha)) * (1.0f + u);
                 } break;
+            }
             }
             dst[j*nrows_dst + row0 + threadIdx.x] = r;
         }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -262,7 +262,8 @@ void ggml_cuda_op_fused_mul_mat_vec_q_id(ggml_backend_cuda_context & ctx,
     if (!bias_u && !bias_g) {
         GGML_ASSERT(unary_op == GGML_UNARY_OP_SILU ||
                     unary_op == GGML_UNARY_OP_RELU ||
-                    unary_op == GGML_UNARY_OP_GELU);
+                    unary_op == GGML_UNARY_OP_GELU ||
+                    unary_op == GGML_UNARY_OP_SWIGLU_OAI);
     } else {
         GGML_ASSERT(unary_op == GGML_UNARY_OP_SWIGLU_OAI);
         GGML_ASSERT(bias_u && bias_g);

--- a/src/graphs/build_minimaxm3.cpp
+++ b/src/graphs/build_minimaxm3.cpp
@@ -47,7 +47,7 @@ ggml_cgraph* llm_build_context::build_minimaxm3() {
                     model.layers[il].ffn_down_shexp,
                     nullptr,
                     n_expert, n_expert_used,
-                    LLM_FFN_SWIGLU_OAI_MOE,
+                    LLM_FFN_SWIGLU_OAI,
                     hparams.expert_weights_norm,
                     hparams.expert_weights_scale != 0.0f, hparams.expert_weights_scale,
                     (llm_expert_gating_func_type) hparams.expert_gating_func,

--- a/src/graphs/build_openai.cpp
+++ b/src/graphs/build_openai.cpp
@@ -43,9 +43,9 @@ ggml_cgraph * llm_build_context::build_openai_moe() {
                 nullptr,
                 nullptr,  nullptr, nullptr,  nullptr, nullptr,  nullptr, // no shared experts
                 n_expert, n_expert_used,
-                LLM_FFN_SWIGLU_OAI_MOE, false, false, 0.0f,
+                LLM_FFN_SWIGLU_OAI, false, false, 0.0f,
                 LLM_EXPERT_GATING_FUNC_TYPE_SOFTMAX_WEIGHT,
-                LLM_FFN_SWIGLU_OAI_MOE, cb, il, gf, true,
+                LLM_FFN_SWIGLU_OAI, cb, il, gf, true,
                 model.layers[il].ffn_up_gate_exps, model.layers[il].ffn_up_gate_exps_b);
 
         cur = lctx.cvec.apply_to(ctx0, cur, il);

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -755,9 +755,10 @@ ggml_tensor * llm_build_context::llm_build_ffn(
 
     if (!up_b && !up_s && !gate_b && !gate_s && !down_b && !down_s &&
         up->extra && gate->extra && down->extra && type_gate == LLM_FFN_PAR &&
-        (type_op == LLM_FFN_SILU || type_op == LLM_FFN_RELU || (type_op == LLM_FFN_GELU && !act_scales))) {
+        (type_op == LLM_FFN_SILU || type_op == LLM_FFN_RELU || type_op == LLM_FFN_SWIGLU_OAI || (type_op == LLM_FFN_GELU && !act_scales))) {
         auto unary_op = type_op == LLM_FFN_SILU ? GGML_UNARY_OP_SILU :
-                        type_op == LLM_FFN_RELU ? GGML_UNARY_OP_RELU : GGML_UNARY_OP_GELU;
+                        type_op == LLM_FFN_RELU ? GGML_UNARY_OP_RELU :
+                        type_op == LLM_FFN_GELU ? GGML_UNARY_OP_GELU : GGML_UNARY_OP_SWIGLU_OAI;
         auto u = (ggml_split_tensor_t *)up->extra;
         auto g = (ggml_split_tensor_t *)gate->extra;
         auto d = (ggml_split_tensor_t *)down->extra;
@@ -833,9 +834,10 @@ ggml_tensor * llm_build_context::llm_build_ffn(
 
     if (lctx.cparams.fused_up_gate &&
         up && gate && !up_b && !up_s && !gate_b && !gate_s && type_gate == LLM_FFN_PAR &&
-        (type_op == LLM_FFN_SILU || type_op == LLM_FFN_RELU || (type_op == LLM_FFN_GELU && !act_scales))) {
+        (type_op == LLM_FFN_SILU || type_op == LLM_FFN_RELU || type_op == LLM_FFN_SWIGLU_OAI || (type_op == LLM_FFN_GELU && !act_scales))) {
         auto unary_op = type_op == LLM_FFN_SILU ? GGML_UNARY_OP_SILU :
-                        type_op == LLM_FFN_RELU ? GGML_UNARY_OP_RELU : GGML_UNARY_OP_GELU;
+                        type_op == LLM_FFN_RELU ? GGML_UNARY_OP_RELU :
+                        type_op == LLM_FFN_GELU ? GGML_UNARY_OP_GELU : GGML_UNARY_OP_SWIGLU_OAI;
         cur = ggml_fused_up_gate(ctx, up, gate, cur, unary_op);
         cb(cur, "ffn_up_gate", il);
         if (lctx.model.arch == LLM_ARCH_STEP35) {
@@ -1153,16 +1155,16 @@ llm_expert_gating_func_type   gating_op,
     // Hence, if we have biases, we cannot use fmoe.
     //
     //bool can_use_fmoe = !up_exps_b && !gate_exps_b && (type_op == LLM_FFN_SILU || type_op == LLM_FFN_GELU);
-    bool can_use_fmoe = (type_op == LLM_FFN_SILU || type_op == LLM_FFN_GELU || type_op == LLM_FFN_SWIGLU_OAI_MOE);
+    bool can_use_fmoe = (type_op == LLM_FFN_SILU || type_op == LLM_FFN_GELU || type_op == LLM_FFN_SWIGLU_OAI);
 
     ggml_tensor * par;
     if (can_use_fmoe && up_gate_exps) {
-        if (up_gate_exps_b || type_op == LLM_FFN_SWIGLU_OAI_MOE) {
+        if (up_gate_exps_b || type_op == LLM_FFN_SWIGLU_OAI) {
             par = ggml_moe_up_gate_ext(ctx, up_gate_exps, nullptr, cur, selected_experts, up_gate_exps_b, nullptr,
                     type_op == LLM_FFN_SILU ? GGML_UNARY_OP_SILU :
                     type_op == LLM_FFN_GELU ? GGML_UNARY_OP_GELU : GGML_UNARY_OP_SWIGLU_OAI);
         } else {
-            GGML_ASSERT(type_op != LLM_FFN_SWIGLU_OAI_MOE);
+            GGML_ASSERT(type_op != LLM_FFN_SWIGLU_OAI);
             par = ggml_moe_up_gate(ctx, up_gate_exps, nullptr, cur, selected_experts,
                     type_op == LLM_FFN_SILU ? GGML_UNARY_OP_SILU : GGML_UNARY_OP_GELU);
         }
@@ -1173,12 +1175,12 @@ llm_expert_gating_func_type   gating_op,
     GGML_ASSERT(!up_gate_exps && !up_gate_exps_b);
 
     if (can_use_fmoe && lctx.cparams.fused_moe_up_gate && up_exps->type == gate_exps->type) {
-        if (up_exps_b || gate_exps_b || type_op == LLM_FFN_SWIGLU_OAI_MOE) {
+        if (up_exps_b || gate_exps_b || type_op == LLM_FFN_SWIGLU_OAI) {
             par = ggml_moe_up_gate_ext(ctx, up_exps, gate_exps, cur, selected_experts, up_exps_b, gate_exps_b,
                     type_op == LLM_FFN_SILU ? GGML_UNARY_OP_SILU :
                     type_op == LLM_FFN_GELU ? GGML_UNARY_OP_GELU : GGML_UNARY_OP_SWIGLU_OAI);
         } else {
-            GGML_ASSERT(type_op != LLM_FFN_SWIGLU_OAI_MOE);
+            GGML_ASSERT(type_op != LLM_FFN_SWIGLU_OAI);
             par = ggml_moe_up_gate(ctx, up_exps, gate_exps, cur, selected_experts,
                     type_op == LLM_FFN_SILU ? GGML_UNARY_OP_SILU : GGML_UNARY_OP_GELU);
         }
@@ -1213,7 +1215,7 @@ llm_expert_gating_func_type   gating_op,
             if (lctx.model.arch == LLM_ARCH_STEP35) {
                 *((float *)(par->op_params + 1)) = lctx.model.hparams.swiglu_limits[il];
             }
-        } else if (type_op == LLM_FFN_SWIGLU_OAI_MOE) {
+        } else if (type_op == LLM_FFN_SWIGLU_OAI) {
             constexpr float alpha = 1.702f;
             constexpr float limit = 7.0f;
             par = ggml_swiglu_oai(ctx, gate, up, alpha, limit);

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -25,7 +25,6 @@ enum llm_ffn_op_type {
     LLM_FFN_RELU_SQR,
     LLM_FFN_SWIGLU,
     LLM_FFN_SWIGLU_OAI,
-    LLM_FFN_SWIGLU_OAI_MOE,
 };
 
 enum llm_ffn_gate_type {


### PR DESCRIPTION

There were some minor changes required to make it work.

Tested on a 2x3090+Ryzen-3995WX system with all routed experts left in RAM with the `UD-IQ4_XS` model from Unsloth. 

**Note**: MiniMax Sparse Attention (MSA) is not yet supported. 

### Split mode layer

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |    9.960 |   411.24 |    4.045 |    15.82 |
|  4096 |     64 |   4096 |   10.234 |   400.24 |    4.127 |    15.51 |
|  4096 |     64 |   8192 |   10.712 |   382.38 |    4.336 |    14.76 |
|  4096 |     64 |  12288 |   11.142 |   367.61 |    4.278 |    14.96 |
|  4096 |     64 |  16384 |   11.575 |   353.88 |    4.369 |    14.65 |
|  4096 |     64 |  20480 |   12.056 |   339.74 |    4.436 |    14.43 |
|  4096 |     64 |  24576 |   12.501 |   327.66 |    4.539 |    14.10 |
|  4096 |     64 |  28672 |   12.995 |   315.19 |    4.597 |    13.92 |
|  4096 |     64 |  32768 |   13.495 |   303.53 |    4.702 |    13.61 |
|  4096 |     64 |  36864 |   13.953 |   293.56 |    4.793 |    13.35 |
|  4096 |     64 |  40960 |   14.392 |   284.61 |    4.792 |    13.35 |
|  4096 |     64 |  45056 |   14.880 |   275.28 |    4.914 |    13.02 |
|  4096 |     64 |  49152 |   15.386 |   266.22 |    4.929 |    12.98 |
|  4096 |     64 |  53248 |   15.832 |   258.72 |    5.246 |    12.20 |
|  4096 |     64 |  57344 |   16.261 |   251.89 |    5.107 |    12.53 |
|  4096 |     64 |  61440 |   16.823 |   243.48 |    5.135 |    12.46 |

### Split mode graph (this PR)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |    9.580 |   427.55 |    3.985 |    16.06 |
|  4096 |     64 |   4096 |    9.649 |   424.50 |    3.996 |    16.02 |
|  4096 |     64 |   8192 |    9.881 |   414.51 |    4.160 |    15.38 |
|  4096 |     64 |  12288 |   10.068 |   406.84 |    4.123 |    15.52 |
|  4096 |     64 |  16384 |   10.266 |   398.99 |    4.152 |    15.41 |
|  4096 |     64 |  20480 |   10.484 |   390.69 |    4.175 |    15.33 |
|  4096 |     64 |  24576 |   10.658 |   384.31 |    4.221 |    15.16 |
|  4096 |     64 |  28672 |   10.895 |   375.97 |    4.368 |    14.65 |
|  4096 |     64 |  32768 |   11.146 |   367.48 |    4.303 |    14.87 |
|  4096 |     64 |  36864 |   11.379 |   359.97 |    4.336 |    14.76 |
|  4096 |     64 |  40960 |   11.584 |   353.59 |    4.426 |    14.46 |
|  4096 |     64 |  45056 |   11.853 |   345.55 |    4.539 |    14.10 |
|  4096 |     64 |  49152 |   12.108 |   338.28 |    4.531 |    14.13 |
|  4096 |     64 |  53248 |   12.320 |   332.46 |    4.530 |    14.13 |
|  4096 |     64 |  57344 |   12.520 |   327.16 |    4.529 |    14.13 |
|  4096 |     64 |  61440 |   12.808 |   319.80 |    4.647 |    13.77 |
 