### PR TITLE
Fix Minimax M3 crash when -muge merges up/gate experts

### DIFF
--- a/src/graphs/build_minimaxm3.cpp
+++ b/src/graphs/build_minimaxm3.cpp
@@ -52,7 +52,7 @@ ggml_cgraph* llm_build_context::build_minimaxm3() {
                     hparams.expert_weights_scale != 0.0f, hparams.expert_weights_scale,
                     (llm_expert_gating_func_type) hparams.expert_gating_func,
                     LLM_FFN_SWIGLU_OAI,
-                    cb, il, gf, true);
+                    cb, il, gf, true, model.layers[il].ffn_up_gate_exps);
         }
 
         cur = lctx.cvec.apply_to(ctx0, cur, il);


### PR DESCRIPTION
The graph builder for Minimax M3 (build_minimaxm3.cpp) was not passing model.layers[il].ffn_up_gate_exps to llm_build_std_moe_ffn, unlike Minimax M2 and all other MoE model graph builders.

When -muge (merge_up_gate_experts) is enabled, the merge creates a single ffn_up_gate_exps tensor with ffn_up_exps and ffn_gate_exps as views. Only the parent merged tensor gets the split 'extra' pointer set. Without passing it as up_gate_exps parameter, the function sees null split pointers for up/gate (the views) while split_down_exps is valid, causing the assertion at llama-build-context.cpp:1453 (on my .nxs fork, the line on main might be different) to fail.

```
Q:\GitHub\ik_llama.cpp.fks\src\llama-build-context.cpp:1453: GGML_ASSERT(((split_up_exps && split_gate_exps) || split_up_gate_exps) && split_down_exps) failed
```

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High