### PR TITLE
llama-dflash: fix BLAS/Metal build by including ggml-blas.h / ggml-metal.h under their guards

### DIFF
--- a/src/llama-dflash.cpp
+++ b/src/llama-dflash.cpp
@@ -8,6 +8,12 @@
 
 #include "ggml.h"
 #include "ggml-backend.h"
+#ifdef GGML_USE_BLAS
+#  include "ggml-blas.h"
+#endif
+#ifdef GGML_USE_METAL
+#  include "ggml-metal.h"
+#endif
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
## Summary

`src/llama-dflash.cpp` calls `ggml_backend_blas_set_n_threads()` under `#ifdef GGML_USE_BLAS` (and `ggml_backend_metal_set_n_cb()` under `#ifdef GGML_USE_METAL`), but only includes `ggml.h` and `ggml-backend.h`. The declarations live in `ggml-blas.h` / `ggml-metal.h`, so any BLAS- or Metal-enabled build fails to compile:

```
src/llama-dflash.cpp:248:9: error: 'ggml_backend_blas_set_n_threads' was not declared in this scope; did you mean 'ggml_backend_cpu_set_n_threads'?
```

This trivially affects the default Nix package on plain `x86_64-linux`, where `.devops/nix/package.nix` sets `useBlas = true` (i.e. `-DGGML_BLAS=ON`).

The DFlash thread-setting logic was factored out of `src/llama.cpp`, which already guards these includes (lines 54-59), but the conditional includes were not carried over. #1977 fixed the pure-CPU path but not the BLAS/Metal include omission.

## Fix

Add the same guarded includes to `src/llama-dflash.cpp`, mirroring `src/llama.cpp`:

```cpp
#ifdef GGML_USE_BLAS
#  include "ggml-blas.h"
#endif
#ifdef GGML_USE_METAL
#  include "ggml-metal.h"
#endif
```

Closes #1982
