### PR TITLE
server: variance-based checkpoint eviction

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3608,13 +3608,59 @@ bool server_context::create_checkpoint(server_slot & slot) {
     if (do_checkpoint) {
         const int64_t t_start = ggml_time_us();
         while (slot.server_cached_prompt.checkpoints.size() >= (size_t)params_base.ctx_checkpoints_n) {
-            // make room for the new checkpoint, if needed
-            const auto & cur = slot.server_cached_prompt.checkpoints.front();
+            // Collect n_tokens into a vector for random access (checkpoints is a std::list).
+            std::vector<int64_t> tokens;
+            tokens.reserve(slot.server_cached_prompt.checkpoints.size());
+            for (const auto & ckpt : slot.server_cached_prompt.checkpoints) {
+                tokens.push_back(ckpt.n_tokens);
+            }
 
-            SLT_WRN(slot, "erasing old context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
-                cur.pos_min, cur.pos_max, cur.n_tokens, (float)cur.data.size() / 1024 / 1024);
+            // Remove the checkpoint that makes the distribution most even after removal.
+            // For each interior checkpoint, compute the variance of gaps that would result
+            // if it were removed. Pick the one with the lowest variance (most uniform spacing).
+            size_t best_idx = 1;
+            double best_variance = 1e30;
 
-            slot.server_cached_prompt.checkpoints.erase(slot.server_cached_prompt.checkpoints.begin());
+            const size_t n = tokens.size();
+            const size_t start = 1; // never remove the first
+            const size_t end   = n - 1; // never remove the last
+
+            for (size_t i = start; i < end; i++) {
+                // Compute the gaps that would exist if checkpoint i were removed.
+                // The merged gap at position i-1 would be: tokens[i+1] - tokens[i-1]
+                // All other gaps remain the same.
+                double sum_sq = 0;
+                size_t gap_count = 0;
+                for (size_t j = 0; j < n - 1; j++) {
+                    int64_t gap;
+                    if (j == i - 1) {
+                        // This gap merges tokens[i-1..i] and tokens[i..i+1]
+                        gap = tokens[i + 1] - tokens[i - 1];
+                    } else if (j == i) {
+                        // Skip: this gap is consumed by the merge above
+                        continue;
+                    } else {
+                        gap = tokens[j + 1] - tokens[j];
+                    }
+                    sum_sq += (double)gap * (double)gap;
+                    gap_count++;
+                }
+                double mean = (double)(tokens.back() - tokens.front()) / gap_count;
+                double variance = (sum_sq / gap_count) - mean * mean;
+                if (variance < best_variance) {
+                    best_variance = variance;
+                    best_idx = i;
+                }
+            }
+
+            auto it = slot.server_cached_prompt.checkpoints.begin();
+            std::advance(it, best_idx);
+            const auto & cur = *it;
+
+            SLT_WRN(slot, "erasing checkpoint at index %zu (n_tokens = %" PRId64 "), variance after removal = %.1f\n",
+                best_idx, cur.n_tokens, best_variance);
+
+            slot.server_cached_prompt.checkpoints.erase(it);
         }
 
         auto & cur = slot.server_cached_prompt.checkpoints.emplace_back();


### PR DESCRIPTION

- [x] I have absolutely not read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Instead of simply erasing the oldest checkpoint (beats the purpose, doesn't it?), let's have a nice algo which evens/thins out one from a group of checkpoints whose members are real close to each other. Check it out in action and it'll make sense:

```
slot create_check: id  0 | task 38537 | checkpoints: 8192 16384 24576 32768 40960 49152 57344 65536 73728 81920 90112 98304 106496 112606 113776 114308 115317 116412 117180 118032 118990 120001 122319 122741 123697 124926 125438 126610 127122 128066 129715 129889
[0mslot create_check: id  0 | task 38537 | erasing checkpoint at index 30 (n_tokens = 129715), variance after removal = 12339301.3
[0mslot create_check: id  0 | task 38537 | created context checkpoint 32 of 32 (n_tokens = 131115, size = 149.626 MiB)
[0mslot update_slots: id  0 | task 38537 | n_tokens = 131627, memory_seq_rm [131627, end)
slot init_sampler: id  0 | task 38537 | init sampler, took 19.47 ms, tokens: text = 131631, total = 131631
slot update_slots: id  0 | task 38537 | prompt processing done, n_tokens = 131631, batch.n_tokens = 4
slot create_check: id  0 | task 38537 | checkpoints: 8192 16384 24576 32768 40960 49152 57344 65536 73728 81920 90112 98304 106496 112606 113776 114308 115317 116412 117180 118032 118990 120001 122319 122741 123697 124926 125438 126610 127122 128066 129889 131115
...
slot create_check: id  0 | task 38654 | checkpoints: 8192 16384 24576 32768 40960 49152 57344 65536 73728 81920 90112 98304 106496 112606 113776 114308 115317 116412 117180 118032 118990 120001 122319 123697 124926 125438 126610 127122 128066 129889 131115 131627
[0mslot create_check: id  0 | task 38654 | erasing checkpoint at index 27 (n_tokens = 127122), variance after removal = 11983882.2
[0mslot create_check: id  0 | task 38654 | created context checkpoint 32 of 32 (n_tokens = 131742, size = 149.626 MiB)
...
slot create_check: id  0 | task 39778 | checkpoints: 8192 16384 24576 32768 40960 49152 57344 65536 73728 81920 90112 98304 106496 112606 113776 114308 115317 116412 117180 118032 118990 120001 122319 123697 124926 125438 126610 128066 129889 131115 131742 131913
[0mslot create_check: id  0 | task 39778 | erasing checkpoint at index 30 (n_tokens = 131742), variance after removal = 11917830.2
[0mslot create_check: id  0 | task 39778 | created context checkpoint 32 of 32 (n_tokens = 133157, size = 149.626 MiB)
...
slot create_check: id  0 | task 39833 | checkpoints: 8192 16384 24576 32768 40960 49152 57344 65536 73728 81920 90112 98304 106496 112606 113776 115317 116412 117180 118032 118990 120001 122319 123697 124926 125438 126610 128066 129889 131115 131913 133556 134274
[0mslot create_check: id  0 | task 39833 | erasing checkpoint at index 24 (n_tokens = 125438), variance after removal = 11445469.5
[0mslot create_check: id  0 | task 39833 | created context checkpoint 32 of 32 (n_tokens = 134786, size = 149.626 MiB)
...
slot create_check: id  0 | task 39996 | checkpoints: 8192 16384 24576 32768 40960 49152 57344 65536 73728 81920 90112 98304 106496 112606 113776 115317 116412 117180 118032 118990 120001 122319 123697 124926 126610 128066 129889 131115 131913 133556 134274 134786
[0mslot create_check: id  0 | task 39996 | erasing checkpoint at index 30 (n_tokens = 134274), variance after removal = 11334970.8
[0mslot create_check: id  0 | task 39996 | created context checkpoint 32 of 32 (n_tokens = 134946, size = 149.626 MiB)
```

This way you always have early checkpoints as well as newer ones (provided that the maximum amount of checkpoints "sensibly" covers the context's length).