### PR TITLE
Fix MTP warmup for GLM models

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2347,8 +2347,6 @@ void common_speculative_checkpoint_restore(
     common_speculative_checkpoint_discard(ckpt, ctx);
 }
 
-static bool mtp_model_uses_recurrent_conditioning(const common_speculative_state_mtp & state);
-
 void common_speculative_commit(
         common_speculative * spec,
         llama_context * ctx,
@@ -2559,6 +2557,7 @@ static bool mtp_model_uses_recurrent_conditioning(const common_speculative_state
     if (state.ctx_mtp == nullptr) {
         return false;
     }
+    return true;
 
     const llama_model * model = llama_get_model(state.ctx_mtp);
     if (!llama_model_has_recurrent(model)) {

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -519,8 +519,8 @@ static ggml_cgraph * build_gemma4_graph_parallel(llm_build_context & llm, llama_
     }
 
     cur = llm_build_context::build_output(lctx, ctx0, cur, model.output, model.output_norm, cb);
-    cb(cur, "almost_result", -1);
     if (hparams.f_final_logit_softcapping > 0) {
+        cb(cur, "almost_result", -1);
         cur = ggml_softcap(ctx0, cur, 1.0f / hparams.f_final_logit_softcapping, hparams.f_final_logit_softcapping);
     }
     cb(cur, "result_output", -1);
@@ -666,6 +666,7 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
 
     ggml_tensor * mtp_embd = llm_build_lora_mm(lctx, ctx0, model.mtp_post_proj, cur);
     cb(mtp_embd, "result_mtp_embd", -1);
+    ggml_set_output(mtp_embd);
     ggml_build_forward_expand(gf, mtp_embd);
 
     ggml_tensor * logits;


### PR DESCRIPTION

It seems the MTP warmup change in #1987 is not limited to Qwen35 (or recurrent/hybrid) models. If I apply the same change to GLM models, I also get a massive improvement in the acceptance rate for the sayap query.

Tested with ubergarm's GLM-4.5-AIR-IQ1_KT. Here is the acceptance rate I observe on the main branch and in this PR

| n_max | acceptance (main) | acceptance (PR) |
| ---: | ---: | ---: |
| 1 | 83.8% | 100% |
| 2 | 65.6% | 89.1% |
| 3 | 50.0% | 73.0% | 

Interestingly enough, after the change the acceptance rate for a single drafted token is 100%. But unlike Qwen3.6-27B, where for this test case the acceptance rate stays close to 100% even for 4 drafted tokens, here we see the acceptance rate dropping quite rapidly after the first draft token. The difference between the first and subsequent drafts is that for the first draft the MTP hidden state is 100% based on the main model embeddings, while for subsequent drafts the hidden state is given by the embeddings computed by the previous draft. Hence, I wouldn't be surprised if something is still not quite right for the GLM MTP compute graph. Or, perhaps, there is some additional special-casing for Qwen35 hidden somewhere? @SamuelOliveirads   