### PR TITLE
Fix Gemma4 MTP compute graph

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2347,8 +2347,6 @@ void common_speculative_checkpoint_restore(
     common_speculative_checkpoint_discard(ckpt, ctx);
 }
 
-static bool mtp_model_uses_recurrent_conditioning(const common_speculative_state_mtp & state);
-
 void common_speculative_commit(
         common_speculative * spec,
         llama_context * ctx,
@@ -2559,6 +2557,7 @@ static bool mtp_model_uses_recurrent_conditioning(const common_speculative_state
     if (state.ctx_mtp == nullptr) {
         return false;
     }
+    return true;
 
     const llama_model * model = llama_get_model(state.ctx_mtp);
     if (!llama_model_has_recurrent(model)) {

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -630,7 +630,8 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
         Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
         Qcur = llm_build_norm(ctx0, Qcur, hparams, model.layers[il].attn_q_norm, nullptr, LLM_NORM_RMS, cb, il);
         cb(Qcur, "Qcur_normed", il);
-        Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, nullptr, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
+        auto freq_factors = is_sliding ? nullptr : model.layers[il].rope_freqs;
+        Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, freq_factors, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
                 ext_factor, attn_factor, beta_fast, beta_slow);
         cb(Qcur, "Qcur_rope", il);
 
@@ -664,20 +665,23 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
         cb(cur, "l_out", il);
     }
 
-    ggml_tensor * mtp_embd = llm_build_lora_mm(lctx, ctx0, model.mtp_post_proj, cur);
+    cur = llm_build_norm(ctx0, cur, hparams, model.output_norm, nullptr, LLM_NORM_RMS, cb, -1);
+    cb(cur, "l_out_normed", -1);
+
+    auto mtp_embd = llm_build_lora_mm(lctx, ctx0, model.mtp_post_proj, cur);
     cb(mtp_embd, "result_mtp_embd", -1);
     ggml_set_output(mtp_embd);
     ggml_build_forward_expand(gf, mtp_embd);
 
-    ggml_tensor * logits;
     // E2B/E4B: The centroid/token-ordering tensors are kept in the GGUF for future use but
     // not required for correct inference — the full-vocab matmul against the tied output
     // weight still yields valid per-token logits.
-    {
-        logits = build_output(lctx, ctx0, cur, model.output, model.output_norm, cb, false);
-        cb(logits, "result_output", -1);
-    }
+    auto logits = llm_build_context::llm_build_lora_mm(lctx, ctx0, model.output, cur);
+    cb(logits, "result_output", -1);
+
     ggml_build_forward_expand(gf, logits);
+
+    return gf;
 
     GGML_UNUSED(n_embd);
     GGML_UNUSED(n_vocab);

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -519,8 +519,8 @@ static ggml_cgraph * build_gemma4_graph_parallel(llm_build_context & llm, llama_
     }
 
     cur = llm_build_context::build_output(lctx, ctx0, cur, model.output, model.output_norm, cb);
-    cb(cur, "almost_result", -1);
     if (hparams.f_final_logit_softcapping > 0) {
+        cb(cur, "almost_result", -1);
         cur = ggml_softcap(ctx0, cur, 1.0f / hparams.f_final_logit_softcapping, hparams.f_final_logit_softcapping);
     }
     cb(cur, "result_output", -1);
@@ -666,6 +666,7 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
 
     ggml_tensor * mtp_embd = llm_build_lora_mm(lctx, ctx0, model.mtp_post_proj, cur);
     cb(mtp_embd, "result_mtp_embd", -1);
+    ggml_set_output(mtp_embd);
     ggml_build_forward_expand(gf, mtp_embd);
 
     ggml_tensor * logits;


### PR DESCRIPTION

As far as I can tell, the output `rms_norm` needs to be applied **before** multiplication with the post projection tensor to produce the MTP embeddings used for the next token. 

The difference is not dramatic, but the change does improve acceptance rate. For the sayap test I see this for Gemma4-31B

|   n_max | acceptance (main) | acceptance (PR) |
| ---: | ---: | ---: |
| 1 | 91.2% | 91.2% |
| 2 | 80.0% | 80.5% |
| 3 | 71.6% | 74.7% |
| 4 | 61.2% | 65.8% |
| 5 | 51.0% | 60.4% |