### PR TITLE
Add Laguna M.1 GGUF support

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5427,6 +5427,12 @@ class LagunaModel(Model):
         rope_params = hparams.get("rope_parameters", {})
         full_rope = rope_params.get("full_attention", rope_params)
         swa_rope = rope_params.get("sliding_attention", {})
+        # Laguna can specify different rotary widths for full-attention and SWA layers.
+        # M.1 uses the full-attention value from rope_parameters; XS.2 SWA omits the key
+        # because those layers rotate the whole head.
+        partial_rotary_factor = float(hparams.get("partial_rotary_factor", 1.0))
+        partial_rotary_factor_full = float(full_rope.get("partial_rotary_factor", partial_rotary_factor))
+        partial_rotary_factor_swa = float(swa_rope.get("partial_rotary_factor", 1.0))
 
         self.gguf_writer.add_context_length(int(hparams["max_position_embeddings"]))
         self.gguf_writer.add_embedding_length(int(hparams["hidden_size"]))
@@ -5443,8 +5449,11 @@ class LagunaModel(Model):
         self.gguf_writer.add_file_type(self.ftype)
 
         self.gguf_writer.add_sliding_window(int(hparams["sliding_window"]))
-        self.gguf_writer.add_rope_dimension_count(head_dim // 2)
-        self.gguf_writer.add_uint32(f"{arch}.rope.dimension_count_swa", head_dim)
+        # GGUF's rope.dimension_count is the number of scalar Q/K dimensions
+        # that ggml_rope_ext should rotate. It is not the number of RoPE pairs;
+        # the frequency table uses dimension_count / 2 entries later.
+        self.gguf_writer.add_rope_dimension_count(int(head_dim * partial_rotary_factor_full))
+        self.gguf_writer.add_uint32(f"{arch}.rope.dimension_count_swa", int(head_dim * partial_rotary_factor_swa))
         self.gguf_writer.add_rope_freq_base(float(full_rope.get("rope_theta", 500000.0)))
         self.gguf_writer.add_float32(f"{arch}.rope.freq_base_swa", float(swa_rope.get("rope_theta", 10000.0)))
         if full_rope.get("rope_type") == "yarn":
@@ -5454,7 +5463,9 @@ class LagunaModel(Model):
                 "original_max_position_embeddings",
                 rope_params.get("original_max_position_embeddings", hparams["max_position_embeddings"]),
             )))
-            self.gguf_writer.add_rope_scaling_yarn_ext_factor(float(full_rope.get("factor", 1.0)))
+            # GGUF's YaRN ext_factor is the config's extrapolation_factor. The main
+            # factor above is the context-extension scale and should not be mirrored here.
+            self.gguf_writer.add_rope_scaling_yarn_ext_factor(float(full_rope.get("extrapolation_factor", 1.0)))
             self.gguf_writer.add_rope_scaling_yarn_attn_factor(float(full_rope.get("attention_factor", 1.0)))
             self.gguf_writer.add_rope_scaling_yarn_beta_fast(float(full_rope.get("beta_fast", 32.0)))
             self.gguf_writer.add_rope_scaling_yarn_beta_slow(float(full_rope.get("beta_slow", 1.0)))

--- a/src/graphs/build_laguna.cpp
+++ b/src/graphs/build_laguna.cpp
@@ -9,13 +9,18 @@ ggml_cgraph * llm_build_context::build_laguna() {
     ggml_tensor * inp_pos     = build_inp_pos();
     ggml_tensor * inp_out_ids = n_tokens > 1 ? build_inp_out_ids() : nullptr;
     ggml_tensor * KQ_mask     = build_inp_KQ_mask();
-    ggml_tensor * KQ_mask_swa = build_inp_KQ_mask_swa();
+    // Laguna M.1 has only global-attention layers and leaves n_swa at zero; building
+    // the SWA mask in that case trips the generic SWA precondition.
+    ggml_tensor * KQ_mask_swa = hparams.n_swa > 0 ? build_inp_KQ_mask_swa() : nullptr;
 
     for (int il = 0; il < n_layer; ++il) {
         const bool is_swa = hparams.swa_layers[il];
         const int n_swa_l = is_swa ? hparams.n_swa : 0;
 
         auto KQ_mask_l = is_swa ? KQ_mask_swa : KQ_mask;
+        // If a future Laguna GGUF marks SWA layers, it must also carry a real
+        // sliding-window size so those layers get an SWA mask.
+        GGML_ASSERT(KQ_mask_l != nullptr);
         auto rope_factors = is_swa ? nullptr : build_rope_factors(il);
 
         auto cur = build_std_attention(gf, model.layers[il].attn_norm, inpL,

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -2910,10 +2910,19 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                     cb(gate, "attn_gate", il_cb);
                     int nh = split_wo->ne[0]/n_embd_head_v;
                     auto attn_3d = ggml_reshape_3d(ctx0, cur, n_embd_head_v, nh, n_tokens);
-                    auto gate_3d = ggml_reshape_3d(ctx0, gate,            1, nh, n_tokens);
                     if (model.arch == LLM_ARCH_LAGUNA) {
-                        cur = ggml_mul(ctx0, attn_3d, gate_3d);
+                        // Laguna uses a softplus gate. XS.2 stores one gate per head,
+                        // while M.1 stores one gate per attention output element.
+                        if (gate->ne[0] == nh) {
+                            auto gate_3d = ggml_reshape_3d(ctx0, gate, 1, nh, n_tokens);
+                            cur = ggml_mul(ctx0, attn_3d, gate_3d);
+                        } else {
+                            GGML_ASSERT(gate->ne[0] == split_wo->ne[0]);
+                            cur = ggml_reshape_2d(ctx0, cur, split_wo->ne[0], n_tokens);
+                            cur = ggml_mul(ctx0, cur, gate);
+                        }
                     } else {
+                        auto gate_3d = ggml_reshape_3d(ctx0, gate, 1, nh, n_tokens);
                         cur = ggml_fused_mul_unary(ctx0, gate_3d, attn_3d, GGML_UNARY_OP_SIGMOID);
                     }
                     cb(attn_3d, "attn_gated_3d", il_cb);
@@ -3031,17 +3040,25 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
                 nullptr, nullptr,
                 Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa);
         cb(cur, "wqkv", il);
-        auto gate = llm_build_lora_mm(lctx, ctx0, wqkv_gate, input_normed); // [n_head_l, n_tokens]
+        auto gate = llm_build_lora_mm(lctx, ctx0, wqkv_gate, input_normed);
         if (model.arch == LLM_ARCH_LAGUNA) {
             gate = ggml_softplus(ctx0, gate);
         }
         cb(gate, "attn_gate", il);
         int n_head_l = hparams.n_head(il);
         auto attn_3d = ggml_reshape_3d(ctx0, cur, n_embd_head_v, n_head_l, n_tokens);
-        auto gate_3d = ggml_reshape_3d(ctx0, gate,            1, n_head_l, n_tokens);
         if (model.arch == LLM_ARCH_LAGUNA) {
-            cur = ggml_mul(ctx0, attn_3d, gate_3d);
+            // Laguna uses a softplus gate. XS.2 stores one gate per head,
+            // while M.1 stores one gate per attention output element.
+            if (gate->ne[0] == n_head_l) {
+                auto gate_3d = ggml_reshape_3d(ctx0, gate, 1, n_head_l, n_tokens);
+                cur = ggml_mul(ctx0, attn_3d, gate_3d);
+            } else {
+                GGML_ASSERT(gate->ne[0] == n_embd_head_v * n_head_l);
+                cur = ggml_mul(ctx0, cur, gate);
+            }
         } else {
+            auto gate_3d = ggml_reshape_3d(ctx0, gate, 1, n_head_l, n_tokens);
             cur = ggml_fused_mul_unary(ctx0, gate_3d, attn_3d, GGML_UNARY_OP_SIGMOID);
         }
         cb(cur, "attn_gated_3d", il);

--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -1538,11 +1538,22 @@ void llm_load_hparams(
                     }
                 }
 
-                // GGUF stores the Poolside partial-rotary setting; the graph RoPE
-                // argument for full-attention Laguna layers follows the upstream
-                // Laguna loader and uses half of that count. SWA layers remain
-                // full-head rotary via n_rot_swa.
-                hparams.n_rot /= 2;
+                const bool found_rope_dim     = ml.get_key(LLM_KV_ROPE_DIMENSION_COUNT,     hparams.n_rot,     false);
+                const bool found_rope_dim_swa = ml.get_key(LLM_KV_ROPE_DIMENSION_COUNT_SWA, hparams.n_rot_swa, false);
+
+                // Laguna GGUFs store the number of scalar Q/K dimensions that ggml_rope_ext
+                // rotates. Correct files carry those values explicitly. Some early public
+                // XS.2 GGUFs omitted both keys, so fall back to the HF XS.2 layout only for
+                // missing metadata: full-attention layers rotate half the head, SWA layers
+                // rotate the full head. Explicit but wrong halved metadata still needs repair.
+                if (hparams.n_swa > 0) {
+                    if (!found_rope_dim) {
+                        hparams.n_rot = hparams.n_embd_head_k_full / 2;
+                    }
+                    if (!found_rope_dim_swa) {
+                        hparams.n_rot_swa = hparams.n_embd_head_k_swa;
+                    }
+                }
 
                 ml.get_key(LLM_KV_ROPE_SCALING_YARN_EXT_FACTOR, hparams.yarn_ext_factor, false);
                 ml.get_key(LLM_KV_ROPE_SCALING_YARN_ATTN_FACTOR, hparams.yarn_attn_factor, false);
@@ -1552,12 +1563,6 @@ void llm_load_hparams(
                 if (!ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_COUNT_PER_LAYER, hparams.rope_dim_per_layer, hparams.n_layer, false)) {
                     for (uint32_t i = 0; i < hparams.n_layer; ++i) {
                         hparams.rope_dim_per_layer[i] = hparams.swa_layers[i] ? hparams.n_rot_swa : hparams.n_rot;
-                    }
-                } else {
-                    for (uint32_t i = 0; i < hparams.n_layer; ++i) {
-                        if (!hparams.swa_layers[i]) {
-                            hparams.rope_dim_per_layer[i] /= 2;
-                        }
                     }
                 }
 

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -1198,8 +1198,18 @@ bool create_tensors_helper::create_step35_tensors(const LLM_TN & tn) {
         //layer.wk = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k_gqa}, 0);
         //layer.wv = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_v_gqa}, 0);
         layer.wo = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_v * n_head_l, n_embd}, 0);
-        // head-wise attention gate (Step35 self_attn.g_proj)
-        layer.wqkv_gate = create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_GATE, "weight", i), {n_embd, n_head_l}, llama_model_loader::TENSOR_NOT_REQUIRED);
+        const std::string attn_gate_name = tn(LLM_TENSOR_ATTN_GATE, "weight", i);
+        int64_t n_attn_gate = n_head_l;
+        if (model.arch == LLM_ARCH_LAGUNA) {
+            // Step35-style models normally use a head-wise attention gate. Laguna
+            // XS.2 keeps that layout, but M.1 gates every attention output element,
+            // so infer the width from GGUF metadata instead of baking in a model size.
+            const ggml_tensor * meta = ml.get_tensor_meta(attn_gate_name.c_str());
+            if (meta && meta->ne[1] == n_embd_head_v * n_head_l) {
+                n_attn_gate = n_embd_head_v * n_head_l;
+            }
+        }
+        layer.wqkv_gate = create_tensor(ctx_split, attn_gate_name, {n_embd, n_attn_gate}, llama_model_loader::TENSOR_NOT_REQUIRED);
         layer.ffn_norm = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
         // dense MLP (leading dense blocks)
         layer.ffn_gate = create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, llama_model_loader::TENSOR_NOT_REQUIRED);
@@ -4681,11 +4691,15 @@ bool create_tensors_helper::create_tensors() {
                 }
                 if (layer.wqkv_gate) {
                     auto wqkv_gate_split = split_kq;
-                    LLAMA_LOG_DEBUG("=================== wqkv_gate_split:");
-                    for (auto & s : wqkv_gate_split) {
-                        s /= hparams.n_embd_head_k(il);
-                        LLAMA_LOG_DEBUG(" %d", s);
+                    if (model.arch == LLM_ARCH_LAGUNA && layer.wqkv_gate->ne[1] == layer.wo->ne[0]) {
+                        // Full-width Laguna M.1 gates follow the value/output partition.
+                        // Head-wise gates still follow the K/Q partition collapsed by head size.
+                        wqkv_gate_split = split_vo;
+                    } else {
+                        for (auto & s : wqkv_gate_split) s /= hparams.n_embd_head_k(il);
                     }
+                    LLAMA_LOG_DEBUG("=================== wqkv_gate_split:");
+                    for ([[maybe_unused]] auto s : wqkv_gate_split) LLAMA_LOG_DEBUG(" %d", s);
                     LLAMA_LOG_DEBUG("\n");
                     prepare_split_tensors(1, ctx_split, layer.wqkv_gate, layer.split_wqkv_gate, wqkv_gate_split, mem_used);
                 }


### PR DESCRIPTION
## Summary

This PR adds the remaining Laguna GGUF support needed for Laguna M.1 while keeping Laguna XS.2 working with both current and early public GGUF conversions.

Laguna M.1 differs from XS.2 in a few places that were previously implicit in the XS.2-only path:

- M.1 uses global attention in every layer, so there may be no SWA mask/layers.
- M.1 uses full partial RoPE, while XS.2 uses partial RoPE for full-attention layers and full RoPE for SWA layers.
- M.1 attention output gating is full output-width, while XS.2 uses the existing per-head gate shape.

The [Laguna M.1/XS.2 Technical Report](https://poolside.ai/assets/laguna/laguna-m1-xs2-technical-report.pdf) describes M.1 and XS.2 as related but architecturally distinct Laguna models. Because future Laguna models may not all match the original XS.2 assumptions or M.1 architecture, my changes keep compatibility handling narrow and derive model-specific behavior from explicit config/metadata where possible.

**Review Complexity : Medium**

I reviewed and understand the [Contribution Guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/d47f484d299cafad2e606afc0d31677a91b242d0/CONTRIBUTING.md)

## Changes

- Update `convert_hf_to_gguf.py` to read Laguna RoPE settings from the nested `rope_parameters.full_attention` and `rope_parameters.sliding_attention` configs.
- Write Laguna RoPE dimension metadata as the scalar Q/K dimension consumed by `ggml_rope_ext`, not as a pair count.
- Add `laguna.rope.dimension_count_swa` for the SWA RoPE dimension and preserve the full-attention YaRN extrapolation factor.
- Remove the old unconditional Laguna runtime divide-by-two compensation for `n_rot`.
- Add a narrow fallback for early Laguna XS.2 GGUFs that omit both explicit RoPE dimension keys.
- Allow Laguna graph construction when `n_swa == 0` by skipping the SWA mask and asserting that the selected mask exists.
- Infer Laguna attention gate layout from tensor metadata during split loading:
  - XS.2 per-head gate: split by attention heads.
  - M.1 full-output gate: split with the VO/output path.
- Apply Laguna attention output gating with `softplus` and support both per-head and full-output gate shapes.

## Compatibility Notes

New Laguna GGUFs should store explicit RoPE dimension metadata:

- Laguna M.1: `laguna.rope.dimension_count = 128`
- Laguna XS.2: `laguna.rope.dimension_count = 64`
- Laguna XS.2: `laguna.rope.dimension_count_swa = 128`

The fallback in `llama-hparams.cpp` is intentionally narrow. It only applies to Laguna models with SWA layers when one of the RoPE dimension keys is absent, which covers early public XS.2 GGUFs that did not write these keys. GGUFs with explicit but incorrect RoPE metadata should be regenerated rather than silently compensated for at runtime.

## Validation

Validated on my branch at commit `be7d53ce`:

- `git diff --check upstream/main...HEAD`
- CUDA build on DGX Spark:
  - `cmake --build /home/janet/src/ik_llama.cpp/build-cuda --target llama-cli llama-quantize -j$(nproc)`
- Laguna M.1 smoke test:
  - `laguna.rope.dimension_count = 128`
  - `n_rot = 128`
  - `offloaded 71/71 layers to GPU`
  - `__RC=0`
- Laguna XS.2 fallback smoke test:
  - `laguna.rope.dimension_count = 64`
  - `laguna.rope.dimension_count_swa = 128`
  - `n_rot = 64`
  - `offloaded 41/41 layers to GPU`
  - `__RC=0`
- Converter sanity check against the real HF configs:
  - Laguna M.1: `head_dim=128`, full RoPE dim `128`, YaRN ext factor `1.0`
  - Laguna XS.2: `head_dim=128`, full RoPE dim `64`, SWA RoPE dim `128`, YaRN ext factor `1.0`

I also attempted the repository low-perf CUDA CI path with fatal warnings enabled. The debug build failed before tests due unrelated existing IQK/CUDA warning-as-error build issues, including missing fixed-width integer declarations in `ggml/src/iqk/iqk_common.h`, missing IQK declarations, and CUDA unused-function warnings. The focused CUDA build and Laguna runtime smoke tests above pass.

## AI Assistance Disclosure

I used AI assistance from GPT-5.5 xhigh while developing and writing up this PR. I reviewed, tested, and iterated on the changes myself as a human before submitting them. I really don't like the idea of throwing an AI-slop PR at maintainers so I've tried to be very deliberate with what I'm doing here.