### PR TITLE
cmake: drop ggml-blas.h from GGML_PUBLIC_HEADERS

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -218,7 +218,6 @@ set(GGML_PUBLIC_HEADERS
     include/ggml.h
     include/ggml-alloc.h
     include/ggml-backend.h
-    include/ggml-blas.h
     include/ggml-cann.h
     include/ggml-cuda.h
     include/ggml.h


### PR DESCRIPTION
Current build fails if set up to install the headers:

```
-- Installing: /var/tmp/portage/sci-misc/ik_llama-cpp-9999/image/usr/include/ik_llama.cpp/ggml.h
-- Installing: /var/tmp/portage/sci-misc/ik_llama-cpp-9999/image/usr/include/ik_llama.cpp/ggml-alloc.h
-- Installing: /var/tmp/portage/sci-misc/ik_llama-cpp-9999/image/usr/include/ik_llama.cpp/ggml-backend.h
CMake Error at ggml/cmake_install.cmake:82 (file):
  file INSTALL cannot find
  "/var/tmp/portage/sci-misc/ik_llama-cpp-9999/work/ik_llama-cpp-9999/ggml/include/ggml-blas.h":
  No such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:47 (include)
```



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
