### PR TITLE
allow user to use THP for host allocations with GGML_CUDA_HOST_MALLOC_THP

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -1409,18 +1409,16 @@ static void * ggml_cuda_host_malloc(size_t size) {
         return nullptr;
     }
 
-// Whether to request the kernel to attempt to defragment memory to back the region with 2M hugepages.
-// Otherwise dependent on kernel settings:
-//   * enabled="always":  Hand over whatever 2M pages it has on hand and the rest will be 4k 
-//   * enabled="madvise": 4k pages
-//   * enabled="never":   4k pages
-// Potluck on performance. If there's not much defragmentation to do, then you win. Otherwise come back in an hour.
-// Defaults to disabled unless GGML_CUDA_HOST_MALLOC_THP is set.
-#ifdef MADV_HUGEPAGE
+    // Whether to request the kernel to attempt to defragment memory to back the region with 2M hugepages.
+    // Otherwise dependent on kernel settings:
+    //   * enabled="always":  Hand over whatever 2M pages it has on hand and the rest will be 4k 
+    //   * enabled="madvise": 4k pages
+    //   * enabled="never":   4k pages
+    // Potluck on performance. If there's not much defragmentation to do, then you win. Otherwise come back in an hour.
+    // Defaults to disabled unless GGML_CUDA_HOST_MALLOC_THP is set.
     if (getenv("GGML_CUDA_HOST_MALLOC_THP") != nullptr) {
         madvise(ptr, size, MADV_HUGEPAGE);
     }
-#endif
 
     // prefault the whole region. If the kernel knows how to do this then let it do so.
     // Might be worth spawning threads to speed up this process on huge allocations.

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -1415,10 +1415,11 @@ static void * ggml_cuda_host_malloc(size_t size) {
 //   * enabled="madvise": 4k pages
 //   * enabled="never":   4k pages
 // Potluck on performance. If there's not much defragmentation to do, then you win. Otherwise come back in an hour.
-#if 0
+// Defaults to disabled unless GGML_CUDA_HOST_MALLOC_THP is set.
 #ifdef MADV_HUGEPAGE
-    madvise(ptr, size, MADV_HUGEPAGE);
-#endif
+    if (getenv("GGML_CUDA_HOST_MALLOC_THP") != nullptr) {
+        madvise(ptr, size, MADV_HUGEPAGE);
+    }
 #endif
 
     // prefault the whole region. If the kernel knows how to do this then let it do so.
@@ -1427,8 +1428,7 @@ static void * ggml_cuda_host_malloc(size_t size) {
 #ifdef MADV_POPULATE_WRITE
     needs_manual_prefault = madvise(ptr, size, MADV_POPULATE_WRITE);
 #endif
-    if (needs_manual_prefault)
-    {
+    if (needs_manual_prefault) {
         char * p = (char *) ptr;
         for (size_t off = 0; off < size; off += 4096) {
             p[off] = 0;


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low

Followup to #1988 where I considered:
* Using threads for fault the memory into existence faster, while keeping it on the same NUMA node as the original implementation
* Allowing allocation of transparent huge pages to speed up large pinned host memory allocations

I initially produced an implementation of both and features and ran some benchmarks on my personal PC and some rented boxes. Results show:
* Mulithreaded page faulting is slower than single threaded. Apparantly it _can_ be faster but you basically have to have a freshly booted PC. I couldn't make this happen, so I declare it's not worth it.
* Transparent huge pages: Doubled the speed on my home PC and one rented box. On the other rented box, allocation was **5x slower**

Since this allows either a `2x speedup` or a `5x slowdown`, I decided to put this feature in an envvar.  So this pull request allows the user to set `GGML_CUDA_HOST_MALLOC_THP` to use transparent huge pages for allocation of pinned memory. 

# Naming
There is a misleadingly named commandline flag called [`-thp`](https://github.com/ikawrakow/ik_llama.cpp/blob/6c00e87ac84404af588ad2e65935bd6f079c696f/src/llama-mmap.cpp#L289) that actually uses [`explicit hugepages`](https://github.com/ikawrakow/ik_llama.cpp/blob/6c00e87ac84404af588ad2e65935bd6f079c696f/src/llama-mmap.cpp#L292) (the same memory but preallocated). One way of fixing this naming issue may be to route that flag to also activate this feature, as then the flag will do what its name suggests (`-thp` would acutually give you transparent hugepages, but with bonus explicit hugepages if you configure it).


I didn't benchmark PP or TG, but that has already been done in #278 (summary: "thp speeds up your model, slower it down, or makes no difference.")

# Allocation timings

##  (Ryzen 9950X, Zen 5, 16c) 32 GiB

| thp | 1 thread (s) | 8 thread (s) |
|-----|--------------|--------------|
| 0   | 3.0          | 3.0          |
| 1   | 1.5          | 1.5          |

##   (EPYC 9575Fx2, Zen 5, 128c) 497 GiB

| thp | 1 thread (s) | 8 thread (s) |
|-----|--------------|--------------|
| 0   | 54.5         | 58.6         |
| 1   | 28.0         | 29.0         |

##  (EPYC 7742, Zen 2, 64c) 435 GiB

| thp | 1 thread (s) |
|-----|--------------|
| 0   | 163.9        |
| 1   | 939.2   ⚠️     |
