### PR TITLE
chat: Cohere2MoE/North Code: parse unopened thinking under --reasoning off (follow-up to #1968)

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1978,22 +1978,36 @@ static common_chat_params common_chat_params_init_cohere2moe(const common_chat_t
     };
 
     auto has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
-    auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+    auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && inputs.enable_thinking;
     auto include_grammar   = has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE;
 
     auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
         auto generation_prompt = p.prefix(inputs.generation_prompt, THINK_START);
         auto end               = p.optional(p.literal(TURN_END)) + p.end();
 
+        auto thinking_body = [&]() {
+            return p.until_one_of({ THINK_END, TEXT_START, ACTION_START });
+        };
+
         common_peg_parser reasoning = p.eps();
         if (extract_reasoning) {
-            reasoning = p.optional(p.literal(THINK_START) +
-                                   p.reasoning(p.until_one_of({ THINK_END, TEXT_START, ACTION_START })) +
-                                   p.optional(p.literal(THINK_END)));
+            auto opened = p.literal(THINK_START) +
+                          p.reasoning(thinking_body()) +
+                          p.optional(p.literal(THINK_END));
+            auto unopened = p.reasoning(thinking_body()) + p.literal(THINK_END);
+            reasoning = p.optional(p.choice({ opened, unopened }));
+        } else if (inputs.enable_thinking) {
+            auto opened = p.content(p.literal(THINK_START) +
+                                    thinking_body() +
+                                    p.optional(p.literal(THINK_END)));
+            auto unopened = p.content(thinking_body() + p.literal(THINK_END));
+            reasoning = p.optional(p.choice({ opened, unopened }));
         } else {
-            reasoning = p.optional(p.content(p.literal(THINK_START) +
-                                             p.until_one_of({ THINK_END, TEXT_START, ACTION_START }) +
-                                             p.optional(p.literal(THINK_END))));
+            auto opened = p.literal(THINK_START) +
+                          p.content(thinking_body()) +
+                          p.optional(p.literal(THINK_END));
+            auto unopened = p.content(thinking_body()) + p.literal(THINK_END);
+            reasoning = p.optional(p.choice({ opened, unopened }));
         }
 
         auto text_content = p.literal(TEXT_START) + p.content(p.until(TEXT_END)) + p.optional(p.literal(TEXT_END));
@@ -2629,4 +2643,3 @@ std::map<std::string, bool> common_chat_templates_get_caps(const common_chat_tem
     GGML_ASSERT(chat_templates->template_default != nullptr);
     return chat_templates->template_default->caps.to_map();
 }
-

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1988,7 +1988,8 @@ static common_chat_params common_chat_params_init_cohere2moe(const common_chat_t
 
     auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
         auto generation_prompt = p.prefix(inputs.generation_prompt, THINK_START);
-        auto end               = p.optional(p.literal(TURN_END)) + p.end();
+        // Cohere2MoE can emit a stray text terminator after an action envelope.
+        auto end               = p.optional(p.literal(TEXT_END)) + p.optional(p.literal(TURN_END)) + p.end();
 
         auto thinking_body = [&]() {
             return p.until_one_of({ THINK_END, TEXT_START, ACTION_START });

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1978,7 +1978,12 @@ static common_chat_params common_chat_params_init_cohere2moe(const common_chat_t
     };
 
     auto has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
-    auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && inputs.enable_thinking;
+    // Surface reasoning as reasoning_content whenever the output format requests it
+    // (Cohere2MoE has a non-empty THINK_START, so this matches the narrow condition
+    // from the reasoning-delimiter work). Under --reasoning off the model may still
+    // emit an (un)opened thinking block; keeping it in reasoning_content quarantines
+    // it from the user-facing content rather than leaking it into the answer.
+    auto extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
     auto include_grammar   = has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE;
 
     auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {

--- a/tests/test-chat-auto-parser.cpp
+++ b/tests/test-chat-auto-parser.cpp
@@ -1992,6 +1992,11 @@ static void test_cohere2moe_parser(testing & t) {
         /* .description = */ "I'm special",
         /* .parameters  = */ R"({"type":"object","properties":{"arg1":{"type":"integer"}},"required":["arg1"]})",
     };
+    common_chat_tool python{
+        /* .name        = */ "python",
+        /* .description = */ "Run Python code",
+        /* .parameters  = */ R"({"type":"object","properties":{"code":{"type":"string"}},"required":["code"]})",
+    };
 
     common_chat_msg user;
     user.role    = "user";
@@ -2001,6 +2006,11 @@ static void test_cohere2moe_parser(testing & t) {
         "<|START_ACTION|>[\n"
         "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
         "]<|END_ACTION|>";
+    const std::string act_numeric_id =
+        "<|START_ACTION|>[\n"
+        "    {\"tool_call_id\": 0, \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+        "]<|END_ACTION|>";
+    const std::string text_resp = "<|START_TEXT|>Hello, world!<|END_TEXT|>";
 
     struct cohere_case {
         const char *             name;
@@ -2021,11 +2031,22 @@ static void test_cohere2moe_parser(testing & t) {
           COMMON_REASONING_FORMAT_NONE, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "I'm\nthinking", "", 1 },
         { "unopened/DEEPSEEK/required -> reasoning_content", "I'm\nthinking<|END_THINKING|>" + act,
           COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_REQUIRED, "", "I'm\nthinking", 1 },
+        { "unopened text/DEEPSEEK -> reasoning_content + content", "I'm\nthinking<|END_THINKING|>" + text_resp,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "Hello, world!", "I'm\nthinking", 0 },
+        { "tool-choice-none text/DEEPSEEK -> reasoning_content + content", "I'm\nthinking<|END_THINKING|>" + text_resp,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_NONE, "Hello, world!", "I'm\nthinking", 0 },
         // Regression: reasoning enabled still routes thinking to reasoning_content.
         { "thinking-on/DEEPSEEK -> reasoning_content", "I'm\nthinking<|END_THINKING|>" + act,
           COMMON_REASONING_FORMAT_DEEPSEEK, true, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "I'm\nthinking", 1 },
+        { "thinking-on/NONE -> tagged content", "<|START_THINKING|>I'm\nthinking<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_NONE, true, COMMON_CHAT_TOOL_CHOICE_AUTO,
+          "<|START_THINKING|>I'm\nthinking<|END_THINKING|>", "", 1 },
         // Regression: existing #1968 shapes still parse to clean native tool calls.
         { "bare-end/DEEPSEEK -> clean call", "<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
+        { "bare-end/trailing-end-text/DEEPSEEK -> clean call", "<|END_THINKING|>" + act + "<|END_TEXT|>",
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
+        { "bare-end/numeric-id/DEEPSEEK -> clean call", "<|END_THINKING|>" + act_numeric_id,
           COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
         { "empty-block/DEEPSEEK -> clean call", "<|START_THINKING|><|END_THINKING|>" + act,
           COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
@@ -2059,7 +2080,48 @@ static void test_cohere2moe_parser(testing & t) {
         t.assert_equal(std::string(c.name) + " : tool calls", c.exp_tool_calls, msg.tool_calls.size());
         if (c.exp_tool_calls == 1 && msg.tool_calls.size() == 1) {
             t.assert_equal(std::string(c.name) + " : tool name", std::string("special_function"), msg.tool_calls[0].name);
+            t.assert_equal(std::string(c.name) + " : tool id",   std::string("0"),                msg.tool_calls[0].id);
         }
     }
-}
 
+    const std::string parallel_act =
+        "<|START_ACTION|>[\n"
+        "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}},\n"
+        "    {\"tool_call_id\": \"1\", \"tool_name\": \"python\", \"parameters\": {\"code\": \"print('hey')\"}}\n"
+        "]<|END_ACTION|>";
+
+    common_chat_templates_inputs parallel_inputs;
+    parallel_inputs.messages            = { user };
+    parallel_inputs.tools               = { special_function, python };
+    parallel_inputs.tool_choice         = COMMON_CHAT_TOOL_CHOICE_AUTO;
+    parallel_inputs.reasoning_format    = COMMON_REASONING_FORMAT_DEEPSEEK;
+    parallel_inputs.enable_thinking     = false;
+    parallel_inputs.parallel_tool_calls = true;
+
+    auto parallel_params = common_chat_templates_apply(tmpls.get(), parallel_inputs);
+    auto parallel_pos    = parallel_params.generation_prompt.rfind("<|START_THINKING|>");
+
+    common_peg_arena parallel_arena;
+    parallel_arena.load(parallel_params.parser);
+
+    common_chat_parser_params parallel_pp(parallel_params);
+    if (parallel_pos != std::string::npos) {
+        parallel_pp.generation_prompt = parallel_params.generation_prompt.substr(0, parallel_pos);
+    }
+
+    auto parallel_msg = common_chat_peg_parse(
+        parallel_arena,
+        "I'm\nthinking<|END_THINKING|>" + parallel_act,
+        /* is_partial = */ false,
+        parallel_pp);
+
+    t.assert_equal("parallel : content", std::string(""), parallel_msg.content);
+    t.assert_equal("parallel : reasoning", std::string("I'm\nthinking"), parallel_msg.reasoning_content);
+    t.assert_equal("parallel : tool calls", 2u, parallel_msg.tool_calls.size());
+    if (parallel_msg.tool_calls.size() == 2) {
+        t.assert_equal("parallel : tool 0 name", std::string("special_function"), parallel_msg.tool_calls[0].name);
+        t.assert_equal("parallel : tool 0 id",   std::string("0"),                parallel_msg.tool_calls[0].id);
+        t.assert_equal("parallel : tool 1 name", std::string("python"),           parallel_msg.tool_calls[1].name);
+        t.assert_equal("parallel : tool 1 id",   std::string("1"),                parallel_msg.tool_calls[1].id);
+    }
+}

--- a/tests/test-chat-auto-parser.cpp
+++ b/tests/test-chat-auto-parser.cpp
@@ -62,6 +62,9 @@ static void test_nemotron_tool_format(testing & t);
 static void test_cohere_reasoning_detection(testing & t);
 static void test_cohere_analysis(testing & t);
 
+// End-to-end Cohere2MoE (North Code) dedicated PEG parser coverage.
+static void test_cohere2moe_parser(testing & t);
+
 // SmolLM3 template analysis tests
 static void test_smollm3_analysis(testing & t);
 
@@ -98,6 +101,7 @@ int main(int argc, char * argv[]) {
     t.test("segments", test_marker_separation);
     t.test("seed_oss_diffs", test_seed_oss_tool_analysis);
     t.test("cohere", test_cohere_analysis);
+    t.test("cohere2moe_parser", test_cohere2moe_parser);
     t.test("nemotron", test_nemotron_analysis);
     t.test("smollm3", test_smollm3_analysis);
     t.test("standard_json_tools", test_standard_json_tools_formats);
@@ -1963,6 +1967,98 @@ static void test_tagged_args_with_embedded_quotes(testing & t) {
 
         } catch (const std::exception & e) {
             t.assert_true(std::string("arguments should be valid JSON: ") + e.what(), false);
+        }
+    }
+}
+
+// End-to-end coverage for the dedicated Cohere2MoE (North Code) parser:
+// template apply -> PEG parse -> assert message. Exercises the reasoning-mode
+// matrix, including the unopened-thinking-under---reasoning-off case (#1968
+// follow-up). Routing rule: reasoning surfaces to reasoning_content whenever the
+// output format != NONE (DEEPSEEK), and folds into content under NONE.
+static void test_cohere2moe_parser(testing & t) {
+    std::ifstream fin("models/templates/Cohere2MoE.jinja", std::ios::binary);
+    std::ostringstream buf; buf << fin.rdbuf();
+    std::string src = buf.str();
+    t.assert_true("Cohere2MoE template loaded", src.length() > 0);
+    if (src.empty()) {
+        return;
+    }
+
+    common_chat_templates_ptr tmpls(common_chat_templates_init(/* model = */ nullptr, src));
+
+    common_chat_tool special_function{
+        /* .name        = */ "special_function",
+        /* .description = */ "I'm special",
+        /* .parameters  = */ R"({"type":"object","properties":{"arg1":{"type":"integer"}},"required":["arg1"]})",
+    };
+
+    common_chat_msg user;
+    user.role    = "user";
+    user.content = "Hey";
+
+    const std::string act =
+        "<|START_ACTION|>[\n"
+        "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+        "]<|END_ACTION|>";
+
+    struct cohere_case {
+        const char *             name;
+        std::string              input;
+        common_reasoning_format  reasoning_format;
+        bool                     enable_thinking;
+        common_chat_tool_choice  tool_choice;
+        std::string              exp_content;
+        std::string              exp_reasoning;
+        size_t                   exp_tool_calls;
+    };
+
+    const std::vector<cohere_case> cases = {
+        // #1968 follow-up fix: orphaned thinking (no <|START_THINKING|>) under --reasoning off.
+        { "unopened/DEEPSEEK -> reasoning_content", "I'm\nthinking<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "I'm\nthinking", 1 },
+        { "unopened/NONE -> content", "I'm\nthinking<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_NONE, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "I'm\nthinking", "", 1 },
+        { "unopened/DEEPSEEK/required -> reasoning_content", "I'm\nthinking<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_REQUIRED, "", "I'm\nthinking", 1 },
+        // Regression: reasoning enabled still routes thinking to reasoning_content.
+        { "thinking-on/DEEPSEEK -> reasoning_content", "I'm\nthinking<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, true, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "I'm\nthinking", 1 },
+        // Regression: existing #1968 shapes still parse to clean native tool calls.
+        { "bare-end/DEEPSEEK -> clean call", "<|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
+        { "empty-block/DEEPSEEK -> clean call", "<|START_THINKING|><|END_THINKING|>" + act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
+        { "no-thinking/DEEPSEEK -> clean call", act,
+          COMMON_REASONING_FORMAT_DEEPSEEK, false, COMMON_CHAT_TOOL_CHOICE_AUTO, "", "", 1 },
+    };
+
+    for (const auto & c : cases) {
+        common_chat_templates_inputs inputs;
+        inputs.messages         = { user };
+        inputs.tools            = { special_function };
+        inputs.tool_choice      = c.tool_choice;
+        inputs.reasoning_format = c.reasoning_format;
+        inputs.enable_thinking  = c.enable_thinking;
+
+        auto params = common_chat_templates_apply(tmpls.get(), inputs);
+        auto pos    = params.generation_prompt.rfind("<|START_THINKING|>");
+
+        common_peg_arena arena;
+        arena.load(params.parser);
+
+        common_chat_parser_params pp(params);
+        if (pos != std::string::npos) {
+            pp.generation_prompt = params.generation_prompt.substr(0, pos);
+        }
+
+        auto msg = common_chat_peg_parse(arena, c.input, /* is_partial = */ false, pp);
+
+        t.assert_equal(std::string(c.name) + " : content",    c.exp_content,    msg.content);
+        t.assert_equal(std::string(c.name) + " : reasoning",  c.exp_reasoning,  msg.reasoning_content);
+        t.assert_equal(std::string(c.name) + " : tool calls", c.exp_tool_calls, msg.tool_calls.size());
+        if (c.exp_tool_calls == 1 && msg.tool_calls.size() == 1) {
+            t.assert_equal(std::string(c.name) + " : tool name", std::string("special_function"), msg.tool_calls[0].name);
         }
     }
 }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -7,7 +7,7 @@
 //
 #include "../src/llama-grammar.h"
 #include "../src/unicode.h"
-#include "../example/server/server-chat.h"
+#include "../examples/server/server-chat.h"
 #include "chat-auto-parser.h"
 #include "chat.h"
 #include "common.h"
@@ -95,7 +95,8 @@ template <class T> static void assert_equals(const T & expected, const T & actua
         oss_actual << actual;
         LOG_ERR("Expected: %s\n", oss_expected.str().c_str());
         LOG_ERR("Actual: %s\n", oss_actual.str().c_str());
-        common_log_flush(common_log_main());
+        fflush(stderr);
+        fflush(stdout);
         throw std::runtime_error("Test failed");
     }
 }
@@ -2330,6 +2331,38 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         // The generation prompt forces <|START_THINKING|>, so model output starts inside
         // the thinking block.
         auto tst = peg_tester("models/templates/Cohere2MoE.jinja", detailed_debug);
+        auto cohere2moe_tmpls = read_templates("models/templates/Cohere2MoE.jinja");
+        auto tst_without_forced_thinking = [&](common_reasoning_format reasoning_format) {
+            common_chat_templates_inputs inputs;
+            inputs.messages          = { message_user };
+            inputs.tools             = { special_function_tool };
+            inputs.reasoning_format  = reasoning_format;
+            inputs.enable_thinking   = false;
+
+            auto params = common_chat_templates_apply(cohere2moe_tmpls.get(), inputs);
+            auto pos    = params.generation_prompt.rfind("<|START_THINKING|>");
+            GGML_ASSERT(pos != std::string::npos);
+
+            common_peg_arena arena;
+            arena.load(params.parser);
+
+            common_chat_parser_params parser_params(params);
+            parser_params.generation_prompt = params.generation_prompt.substr(0, pos);
+
+            auto msg = common_chat_peg_parse(
+                arena,
+                "I'm\nthinking<|END_THINKING|>"
+                "<|START_ACTION|>[\n"
+                "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+                "]<|END_ACTION|>",
+                /* is_partial = */ false,
+                parser_params);
+
+            assert_msg_equals(
+                simple_assist_msg("I'm\nthinking", "", "special_function", "{\"arg1\": 1}", /* id = */ "0"),
+                msg,
+                true);
+        };
 
         tst.test("I'm\nthinking<|END_THINKING|><|START_TEXT|>Hello, world!\nWhat's up?<|END_TEXT|>")
             .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
@@ -2387,6 +2420,52 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .enable_thinking(false)
             .tools({ special_function_tool })
             .tool_choice(COMMON_CHAT_TOOL_CHOICE_REQUIRED)
+            .expect(message_assist_call_idx)
+            .run();
+
+        tst_without_forced_thinking(COMMON_REASONING_FORMAT_DEEPSEEK);
+        tst_without_forced_thinking(COMMON_REASONING_FORMAT_NONE);
+
+        tst.test(
+               "I'm\nthinking<|END_THINKING|>"
+               "<|START_ACTION|>[\n"
+               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+               "]<|END_ACTION|>")
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
+            .enable_thinking(false)
+            .tools({ special_function_tool })
+            .expect(simple_assist_msg("I'm\nthinking", "", "special_function", "{\"arg1\": 1}", /* id = */ "0"))
+            .run();
+
+        tst.test(
+               "I'm\nthinking<|END_THINKING|>"
+               "<|START_ACTION|>[\n"
+               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+               "]<|END_ACTION|>")
+            .reasoning_format(COMMON_REASONING_FORMAT_NONE)
+            .enable_thinking(false)
+            .tools({ special_function_tool })
+            .expect(simple_assist_msg("I'm\nthinking", "", "special_function", "{\"arg1\": 1}", /* id = */ "0"))
+            .run();
+
+        tst.test(
+               "<|START_ACTION|>[\n"
+               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+               "]<|END_ACTION|>")
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
+            .enable_thinking(false)
+            .tools({ special_function_tool })
+            .expect(message_assist_call_idx)
+            .run();
+
+        tst.test(
+               "<|START_THINKING|><|END_THINKING|>"
+               "<|START_ACTION|>[\n"
+               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
+               "]<|END_ACTION|>")
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
+            .enable_thinking(false)
+            .tools({ special_function_tool })
             .expect(message_assist_call_idx)
             .run();
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -7,7 +7,7 @@
 //
 #include "../src/llama-grammar.h"
 #include "../src/unicode.h"
-#include "../examples/server/server-chat.h"
+#include "../example/server/server-chat.h"
 #include "chat-auto-parser.h"
 #include "chat.h"
 #include "common.h"
@@ -95,8 +95,7 @@ template <class T> static void assert_equals(const T & expected, const T & actua
         oss_actual << actual;
         LOG_ERR("Expected: %s\n", oss_expected.str().c_str());
         LOG_ERR("Actual: %s\n", oss_actual.str().c_str());
-        fflush(stderr);
-        fflush(stdout);
+        common_log_flush(common_log_main());
         throw std::runtime_error("Test failed");
     }
 }
@@ -2331,38 +2330,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         // The generation prompt forces <|START_THINKING|>, so model output starts inside
         // the thinking block.
         auto tst = peg_tester("models/templates/Cohere2MoE.jinja", detailed_debug);
-        auto cohere2moe_tmpls = read_templates("models/templates/Cohere2MoE.jinja");
-        auto tst_without_forced_thinking = [&](common_reasoning_format reasoning_format) {
-            common_chat_templates_inputs inputs;
-            inputs.messages          = { message_user };
-            inputs.tools             = { special_function_tool };
-            inputs.reasoning_format  = reasoning_format;
-            inputs.enable_thinking   = false;
-
-            auto params = common_chat_templates_apply(cohere2moe_tmpls.get(), inputs);
-            auto pos    = params.generation_prompt.rfind("<|START_THINKING|>");
-            GGML_ASSERT(pos != std::string::npos);
-
-            common_peg_arena arena;
-            arena.load(params.parser);
-
-            common_chat_parser_params parser_params(params);
-            parser_params.generation_prompt = params.generation_prompt.substr(0, pos);
-
-            auto msg = common_chat_peg_parse(
-                arena,
-                "I'm\nthinking<|END_THINKING|>"
-                "<|START_ACTION|>[\n"
-                "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
-                "]<|END_ACTION|>",
-                /* is_partial = */ false,
-                parser_params);
-
-            assert_msg_equals(
-                simple_assist_msg("I'm\nthinking", "", "special_function", "{\"arg1\": 1}", /* id = */ "0"),
-                msg,
-                true);
-        };
 
         tst.test("I'm\nthinking<|END_THINKING|><|START_TEXT|>Hello, world!\nWhat's up?<|END_TEXT|>")
             .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
@@ -2420,52 +2387,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .enable_thinking(false)
             .tools({ special_function_tool })
             .tool_choice(COMMON_CHAT_TOOL_CHOICE_REQUIRED)
-            .expect(message_assist_call_idx)
-            .run();
-
-        tst_without_forced_thinking(COMMON_REASONING_FORMAT_DEEPSEEK);
-        tst_without_forced_thinking(COMMON_REASONING_FORMAT_NONE);
-
-        tst.test(
-               "I'm\nthinking<|END_THINKING|>"
-               "<|START_ACTION|>[\n"
-               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
-               "]<|END_ACTION|>")
-            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
-            .enable_thinking(false)
-            .tools({ special_function_tool })
-            .expect(simple_assist_msg("I'm\nthinking", "", "special_function", "{\"arg1\": 1}", /* id = */ "0"))
-            .run();
-
-        tst.test(
-               "I'm\nthinking<|END_THINKING|>"
-               "<|START_ACTION|>[\n"
-               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
-               "]<|END_ACTION|>")
-            .reasoning_format(COMMON_REASONING_FORMAT_NONE)
-            .enable_thinking(false)
-            .tools({ special_function_tool })
-            .expect(simple_assist_msg("I'm\nthinking", "", "special_function", "{\"arg1\": 1}", /* id = */ "0"))
-            .run();
-
-        tst.test(
-               "<|START_ACTION|>[\n"
-               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
-               "]<|END_ACTION|>")
-            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
-            .enable_thinking(false)
-            .tools({ special_function_tool })
-            .expect(message_assist_call_idx)
-            .run();
-
-        tst.test(
-               "<|START_THINKING|><|END_THINKING|>"
-               "<|START_ACTION|>[\n"
-               "    {\"tool_call_id\": \"0\", \"tool_name\": \"special_function\", \"parameters\": {\"arg1\": 1}}\n"
-               "]<|END_ACTION|>")
-            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
-            .enable_thinking(false)
-            .tools({ special_function_tool })
             .expect(message_assist_call_idx)
             .run();
 


### PR DESCRIPTION
## Summary

#1968 added a dedicated Cohere2MoE / North Code parser that returns native OpenAI tool calls. I found one remaining leak shape in live use: with `--reasoning off`, North can still emit reasoning prose followed by `<|END_THINKING|>` without a preceding `<|START_THINKING|>`. The parser didn't consume that unopened thinking block, so it never reached the `<|START_ACTION|>` rule. The whole tool-call turn then fell back to `message.content`.

This PR handles that shape in the Cohere2MoE parser and moves the regression coverage into the active `test-chat-auto-parser` target.

## Root cause

The reasoning rule expected a literal `<|START_THINKING|>`. With no opener present, it matched empty. The orphaned prose then couldn't match the tool-call rule, which needs `<|START_ACTION|>`, or the text rule, which needs `<|START_TEXT|>`. The parse failed, and the server returned the raw turn with `finish_reason=stop`.

#1968 covered reasoning-on prose and reasoning-off with a bare `<|END_THINKING|>`. It did not cover reasoning-off with prose before `<|END_THINKING|>`.

## Fix

- Cohere2MoE's reasoning rule now accepts an unopened thinking block, meaning reasoning/content that ends at `<|END_THINKING|>` without an opener.
- The unopened branch still requires the terminating `<|END_THINKING|>`, so ordinary content is not reclassified as reasoning.
- Routing follows the existing gate. With `reasoning_format != NONE`, the thinking goes to `reasoning_content` and `content` stays clean. Under `NONE`, it folds into `content`. For Cohere2MoE this matches the `extract_reasoning` condition from #1951, since the template has a non-empty reasoning start tag.
- The parser also tolerates an optional trailing `<|END_TEXT|>` after an action envelope, which showed up in follow-up parser testing.

## Scope and safety

The production parser changes are inside `common_chat_params_init_cohere2moe`, which is selected only when the template contains both `<|START_TEXT|>` and `<|START_ACTION|>`. In the current template set, that combination is unique to the Cohere2 North template, so behavior for non-North models is unchanged. The only production-code change outside the function is removing one trailing blank line.

It does not add a generic action-envelope fallback or `tool`/`arguments` argument aliases. Those are not part of the native Cohere2MoE template dialect, which uses `tool_name`/`parameters`, and the native path returns clean tool calls without them.

## Tests

`tests/test-chat-auto-parser.cpp` gains `test_cohere2moe_parser` with 64 assertions. It covers:

- unopened thinking under DEEPSEEK and NONE
- reasoning-on output
- bare `<|END_THINKING|>`
- empty thinking block
- no thinking block
- `tool_choice` auto/required/none
- trailing `<|END_TEXT|>` after action
- numeric `tool_call_id`
- parallel calls

#1968's Cohere2MoE cases were added to `tests/test-chat.cpp`, which is disabled in `tests/CMakeLists.txt`, so they did not run in CI. This PR places coverage in the active `test-chat-auto-parser` target.

## Validation

- Unit: `./build-cpu/bin/test-chat-auto-parser cohere2moe_parser` passes 64 assertions.
- A full local `test-chat-auto-parser` run exits nonzero only because pre-existing Seed-OSS cases require a template file not present in this checkout. The Cohere2MoE coverage is green.
- Live: North Mini Code 1.0 (Q6_K) served by this build through an OpenAI-compatible client. A prompt that previously leaked the `<|START_ACTION|>` envelope now returns a native tool call with clean content and no leaked delimiters.
- Live `--reasoning on --reasoning-budget -1` smoke: a required `read` tool call returned `finish_reason=tool_calls`, empty `content`, populated `reasoning_content`, and a native `read` call with `{"path":"README.md"}`. The raw response had no Cohere2MoE delimiter tags.

## Diff

2 files changed, 185 insertions(+), 8 deletions(-).

- `common/chat.cpp`: +27 / -8 (parser, North-scoped)
- `tests/test-chat-auto-parser.cpp`: +158 (tests)

## PR checklist

- [x] I have read the contributing guidelines.
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
