### PR TITLE
Fix minor GGML discrepencies

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -11719,13 +11719,13 @@ static void ggml_compute_forward_dup_bf16(
 
                         memcpy(dst_ptr, src0_ptr, sizeof(ggml_bf16_t));
 
-                        if (++i10 == ne00) {
+                        if (++i10 == ne0) {
                             i10 = 0;
-                            if (++i11 == ne01) {
+                            if (++i11 == ne1) {
                                 i11 = 0;
-                                if (++i12 == ne02) {
+                                if (++i12 == ne2) {
                                     i12 = 0;
-                                    if (++i13 == ne03) {
+                                    if (++i13 == ne3) {
                                         i13 = 0;
                                     }
                                 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -11415,13 +11415,13 @@ static void ggml_compute_forward_dup_f16(
 
                         memcpy(dst_ptr, src0_ptr, sizeof(ggml_fp16_t));
 
-                        if (++i10 == ne00) {
+                        if (++i10 == ne0) {
                             i10 = 0;
-                            if (++i11 == ne01) {
+                            if (++i11 == ne1) {
                                 i11 = 0;
-                                if (++i12 == ne02) {
+                                if (++i12 == ne2) {
                                     i12 = 0;
-                                    if (++i13 == ne03) {
+                                    if (++i13 == ne3) {
                                         i13 = 0;
                                     }
                                 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -26632,7 +26632,7 @@ struct ggml_cplan ggml_graph_plan(const struct ggml_cgraph * cgraph, int n_threa
             case GGML_OP_ACC:
                 {
                     if (ggml_is_quantized(node->src[0]->type)) {
-                        cur = ggml_type_size(GGML_TYPE_F32) * node->src[1]->ne[0] * n_tasks;
+                        cur = ggml_type_size(GGML_TYPE_F32) * node->src[0]->ne[0] * n_tasks;
                     }
                 } break;
             case GGML_OP_MUL_MAT:

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -26692,7 +26692,9 @@ struct ggml_cplan ggml_graph_plan(const struct ggml_cgraph * cgraph, int n_threa
                     }
                 } break;
             case GGML_OP_SOFT_MAX:
+            case GGML_OP_SOFT_CAP_MAX:
             case GGML_OP_ROPE:
+            case GGML_OP_ROPE_BACK:
                 {
                     cur = ggml_type_size(GGML_TYPE_F32) * node->ne[0] * n_tasks;
                 } break;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -13341,7 +13341,7 @@ static void ggml_compute_forward_add1_q_f32(
         const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
 
         void  * src0_row = (void *) ((char *) src0->data + (i1*nb01 + i2*nb02 + i3*nb03));
-        void  * dst_row  = (void *) ((char *)  dst->data + (i1*nb1  + i2*nb2  + i3*nb0 ));
+        void  * dst_row  = (void *) ((char *)  dst->data + (i1*nb1  + i2*nb2  + i3*nb3 ));
 
         assert(ne0 % 32 == 0);
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -14401,7 +14401,7 @@ static void ggml_compute_forward_sum_rows_f32(
     for (int ir = first_row; ir < last_row; ++ir) {
         int i3 = ir / (ne01*ne02);
         int i2 = (ir - i3*ne01*ne02)/ne01;
-        int i1 = ir - i3*ne01*ne0 - i2*ne01;
+        int i1 = ir - i3*ne01*ne02 - i2*ne01;
         const float * src_row = (const float *)((const char *)src0->data + i1*nb01 + i2*nb02 + i3*nb03);
               float * dst_row = (      float *)((      char *)dst->data  + i1*nb1  + i2*nb2  + i3*nb3);
         float row_sum = 0;


### PR DESCRIPTION
Here's a simple harvest :

1. b7770b04b4 — fix: wrong stride in batched quantized add1 (nb0 -> nb3) In the batched path of add1_q_f32, the batch-stride used nb0 (row stride) instead of nb3 (batch stride), causing wrong memory access when batch > 1.
Fix: src0->nb[0] → src0->nb[3] in the batched-add1 inner loop.

2. 1b152c8249 — fix: wrong dimension limits in dup_f16 non-contiguous path The non-contiguous copy branch in dup_f16 used ne00/ne01/ne02 (source dims) as loop bounds instead of ne0/ne1/ne2 (dst dims), causing under-copy when shapes differ.
Fix: ne00→ne0, ne01→ne1, ne02→ne2 in the inner-loop bounds.

3. 69a802d355 — fix: wrong dimension limits in dup_bf16 non-contiguous path Same dimension-variable bug as dup_f16 but in the BF16 variant.
Fix: ne00→ne0, ne01→ne1, ne02→ne2 in the non-contiguous copy loops.

4. 5bf9f30201 — fix: ACC work size uses src[1] instead of src[0] The dequantization work buffer for quantized ACC was sized against src[1]->ne[0] instead of src[0]->ne[0] (the tensor being dequantized).
Fix: node->src[1]->ne[0] → node->src[0]->ne[0] in the work-size formula.

5. 086ae0e247 — fix: missing work size for SOFT_CAP_MAX and ROPE_BACK Both ops dereference params->wdata in their forward functions but had cur = 0 (no allocation) — guaranteed NULL-pointer dereference at runtime.
Fix: added GGML_OP_SOFT_CAP_MAX and GGML_OP_ROPE_BACK to the existing SOFT_MAX/ROPE work-size case.

6. 47e258903e — fix: wrong dim in sum_rows_f32 dimension decomposition The flat-row decomposition i1 = ir - i3·ne01·ne0 - i2·ne01 used ne0 (=1, asserted) instead of ne02, breaking the formula for batched 2D inputs.
Fix: ne0 → ne02 in the i1 term, consistent with the i3/i2 terms above.

Cleanliness is godliness! :D

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
