### PR TITLE
DFlash: enable sliding-window attention for draft models

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2477,6 +2477,17 @@ class DFlashDraftModel(Qwen3Model):
 
         self.gguf_writer.add_uint32(f"{arch}.dflash.n_target_features", n_target_features)
 
+        # DFlash drafts may be trained with sliding-window attention (for long-context). When the
+        # source config enables it, emit the window size + an all-layers SWA pattern so the runtime
+        # activates the kq_mask_swa path. Absent/false => dense draft (behavior unchanged).
+        use_sliding_window = self.hparams.get("use_sliding_window")
+        sliding_window = self.hparams.get("sliding_window")
+        if use_sliding_window and sliding_window:
+            n_swa_layers = int(self.hparams.get("num_hidden_layers", self.block_count))
+            self.gguf_writer.add_sliding_window(int(sliding_window))
+            self.gguf_writer.add_sliding_window_pattern([True] * n_swa_layers)
+            logger.info("DFlashDraftModel: sliding_window=%d, all %d layers SWA", int(sliding_window), n_swa_layers)
+
         logger.info(
             "DFlashDraftModel metadata: block_size=%s mask_token_id=%s target_layer_ids=%s n_target_features=%s",
             block_size,

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2478,15 +2478,22 @@ class DFlashDraftModel(Qwen3Model):
         self.gguf_writer.add_uint32(f"{arch}.dflash.n_target_features", n_target_features)
 
         # DFlash drafts may be trained with sliding-window attention (for long-context). When the
-        # source config enables it, emit the window size + an all-layers SWA pattern so the runtime
-        # activates the kq_mask_swa path. Absent/false => dense draft (behavior unchanged).
+        # source config enables it, emit the window size + the per-layer SWA pattern so the runtime
+        # activates the kq_mask_swa path. These drafts are typically all sliding-window except a
+        # final full-attention (global) layer, so honor layer_types when present; fall back to
+        # all-SWA only when it is absent. Absent/false use_sliding_window => dense draft (unchanged).
         use_sliding_window = self.hparams.get("use_sliding_window")
         sliding_window = self.hparams.get("sliding_window")
         if use_sliding_window and sliding_window:
             n_swa_layers = int(self.hparams.get("num_hidden_layers", self.block_count))
+            layer_types = self.hparams.get("layer_types")
+            if layer_types:
+                swa_pattern = [str(t) == "sliding_attention" for t in layer_types]
+            else:
+                swa_pattern = [True] * n_swa_layers
             self.gguf_writer.add_sliding_window(int(sliding_window))
-            self.gguf_writer.add_sliding_window_pattern([True] * n_swa_layers)
-            logger.info("DFlashDraftModel: sliding_window=%d, all %d layers SWA", int(sliding_window), n_swa_layers)
+            self.gguf_writer.add_sliding_window_pattern(swa_pattern)
+            logger.info("DFlashDraftModel: sliding_window=%d, SWA pattern=%s", int(sliding_window), swa_pattern)
 
         logger.info(
             "DFlashDraftModel metadata: block_size=%s mask_token_id=%s target_layer_ids=%s n_target_features=%s",

--- a/src/graphs/build_dflash.cpp
+++ b/src/graphs/build_dflash.cpp
@@ -171,16 +171,34 @@ ggml_cgraph * llm_build_context::build_dflash() {
     }();
     const ggml_type mask_type = flash_attn ? GGML_TYPE_F16 : GGML_TYPE_F32;
 
-    lctx.dflash.inputs.kq_mask = ggml_new_tensor_2d(ctx0, mask_type, n_kv_total, GGML_PAD(n_tokens, GGML_KQ_MASK_PAD));
-    lctx.dflash.kv.kq_mask_tensor = lctx.dflash.inputs.kq_mask;
-    ggml_set_input(lctx.dflash.inputs.kq_mask);
-    cb(lctx.dflash.inputs.kq_mask, "dflash_kq_mask", -1);
+    // The full (non-SWA) mask is only consumed by non-SWA layers. For an all-SWA draft every layer
+    // uses kq_mask_swa, leaving the full mask a dead graph node that the scheduler never backs with a
+    // buffer (and the unconditional input-set then asserts buf!=NULL). So create each mask only when
+    // some layer uses it: full mask iff any non-SWA layer; swa mask iff needs_swa_mask.
+    const bool needs_full_mask = !needs_swa_mask || [&]() {
+        for (int il = 0; il < n_layer; ++il) {
+            if (!hparams.swa_layers[il]) {
+                return true;
+            }
+        }
+        return false;
+    }();
+
+    lctx.dflash.inputs.kq_mask = nullptr;
+    lctx.dflash.kv.kq_mask_tensor = nullptr;
+    ggml_tensor * dflash_kq_mask_full = nullptr;
+    if (needs_full_mask) {
+        lctx.dflash.inputs.kq_mask = ggml_new_tensor_2d(ctx0, mask_type, n_kv_total, GGML_PAD(n_tokens, GGML_KQ_MASK_PAD));
+        lctx.dflash.kv.kq_mask_tensor = lctx.dflash.inputs.kq_mask;
+        ggml_set_input(lctx.dflash.inputs.kq_mask);
+        cb(lctx.dflash.inputs.kq_mask, "dflash_kq_mask", -1);
+        dflash_kq_mask_full = lctx.dflash.inputs.kq_mask;
+    }
 
     lctx.dflash.kv.draft_tail_rows_tensor = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_tokens);
     ggml_set_input(lctx.dflash.kv.draft_tail_rows_tensor);
     cb(lctx.dflash.kv.draft_tail_rows_tensor, "dflash_draft_tail_rows", -1);
 
-    ggml_tensor * dflash_kq_mask_full = lctx.dflash.inputs.kq_mask;
     ggml_tensor * dflash_kq_mask_swa = nullptr;
     lctx.dflash.inputs.kq_mask_swa = nullptr;
     lctx.dflash.kv.kq_mask_swa_tensor = nullptr;

--- a/src/llama-dflash.cpp
+++ b/src/llama-dflash.cpp
@@ -613,7 +613,10 @@ bool llama_prepare_dflash_graph_inputs(
 
                 for (int32_t k = cross_ctx; k < cross_ctx + (int32_t) n_tokens; ++k) {
                     const int32_t block_k = k - cross_ctx;
-                    if (block_k <= (int32_t) j) {
+                    // intra-block draft tokens are contiguous from draft_pos_base, so the
+                    // SWA distance is (j - block_k); apply the same window bound as the
+                    // cross-context section above (causal AND within n_swa).
+                    if (block_k <= (int32_t) j && ((int32_t) j - block_k) < swa_window) {
                         row[k] = h_zero;
                     }
                 }
@@ -637,7 +640,10 @@ bool llama_prepare_dflash_graph_inputs(
 
                 for (int32_t k = cross_ctx; k < cross_ctx + (int32_t) n_tokens; ++k) {
                     const int32_t block_k = k - cross_ctx;
-                    if (block_k <= (int32_t) j) {
+                    // intra-block draft tokens are contiguous from draft_pos_base, so the
+                    // SWA distance is (j - block_k); apply the same window bound as the
+                    // cross-context section above (causal AND within n_swa).
+                    if (block_k <= (int32_t) j && ((int32_t) j - block_k) < swa_window) {
                         row[k] = 0.0f;
                     }
                 }

--- a/src/llama-dflash.cpp
+++ b/src/llama-dflash.cpp
@@ -327,7 +327,10 @@ bool llama_prepare_dflash_graph_inputs(
     ggml_tensor * kq_mask = lctx.dflash.kv.kq_mask_tensor;
     ggml_tensor * kq_mask_swa = lctx.dflash.kv.kq_mask_swa_tensor;
 
-    if (kq_mask == nullptr) {
+    // An all-SWA draft has no full mask; an all-full draft has no SWA mask. Both masks share the
+    // same dimensions, so use whichever one is live to derive shape.
+    ggml_tensor * mask_dims = kq_mask != nullptr ? kq_mask : kq_mask_swa;
+    if (mask_dims == nullptr) {
         LLAMA_LOG_ERROR("%s: DFlash graph inputs are not initialized\n", __func__);
         return false;
     }
@@ -351,8 +354,8 @@ bool llama_prepare_dflash_graph_inputs(
     const int32_t append_rows_available = lctx.dflash.target.append_features_n_rows;
     const int32_t width = (int32_t) lctx.model.hparams.dflash_n_target_features;
     const int32_t graph_cross_ctx = (int32_t) lctx.dflash.kv.cache_pos.size();
-    const int32_t n_mask_tokens = (int32_t) kq_mask->ne[1];
-    const int32_t n_kv_total = (int32_t) kq_mask->ne[0];
+    const int32_t n_mask_tokens = (int32_t) mask_dims->ne[1];
+    const int32_t n_kv_total = (int32_t) mask_dims->ne[0];
     ggml_tensor * draft_tail_rows = lctx.dflash.kv.draft_tail_rows_tensor;
 
     if (graph_cross_ctx != cross_ctx) {
@@ -559,7 +562,10 @@ bool llama_prepare_dflash_graph_inputs(
     ggml_backend_tensor_set(draft_tail_rows, draft_tail_rows_data.data(), 0, ggml_nbytes(draft_tail_rows));
 
     const size_t mask_elems = (size_t) n_kv_total * (size_t) n_mask_tokens;
-    if (kq_mask->type == GGML_TYPE_F16) {
+    if (kq_mask == nullptr) {
+        // all-SWA draft: the full mask was not created (no non-SWA layer consumes it); only the
+        // SWA mask below is populated.
+    } else if (kq_mask->type == GGML_TYPE_F16) {
         const ggml_fp16_t h_inf = ggml_fp32_to_fp16(-INFINITY);
         const ggml_fp16_t h_zero = ggml_fp32_to_fp16(0.0f);
         std::vector<ggml_fp16_t> mask_f16(mask_elems, h_inf);

--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -903,6 +903,11 @@ void llm_load_hparams(
                 ml.get_key(LLM_KV_DFLASH_MASK_TOKEN_ID,     hparams.dflash_mask_token_id, false);
                 ml.get_key(LLM_KV_DFLASH_N_TARGET_FEATURES, hparams.dflash_n_target_features, false);
                 load_dflash_target_layer_ids(ml, LLM_KV(model.arch)(LLM_KV_DFLASH_TARGET_LAYER_IDS), hparams, false);
+                // DFlash drafts may be trained with sliding-window attention (for long-context).
+                // Read the window + per-layer pattern so the SWA mask path activates; absent keys
+                // leave n_swa=0 / swa_layers all-zero (dense behavior, unchanged).
+                ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
+                ml.get_key_or_arr(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, hparams.swa_layers, hparams.n_layer, false);
                 validate_dflash_hparams(hparams, model.arch);
 
                 hparams.n_layer_kv_from_start = hparams.n_layer;


### PR DESCRIPTION
Following the lead of @SamuelOliveirads, this PR enables sliding-window attention (SWA) for DFlash draft models, and the conversion that goes with it.

Current main runs DFlash drafts trained with SWA at full attention: the draft loader doesn't read the window keys and the converter doesn't write them, so an SWA-trained draft silently runs outside the regime it was trained for. This PR wires it end to end, so the draft attends the way it was trained. 4 files, +64/-11, and dense drafts are byte-identical.

The payoff shows up at long context and grows with it. On Qwen3.6-35B-A3B the SWA draft gains up to +17.4 pp of draft acceptance and +44% tok/s once the prompt runs well past the 4096 draft window, and it never regresses at any depth. Full curves on two models are below.

## Changes

- `convert_hf_to_gguf.py` (`DFlashDraftModel`): emit `attention.sliding_window` and the per-layer `sliding_window_pattern`, derived from the draft's `layer_types`. These drafts are sliding-window on every layer except a final full-attention (global) layer. The base `Qwen3Model` chain this class derives from does not emit these keys.
- `llama-hparams.cpp` (`LLM_ARCH_DFLASH_DRAFT`): read `sliding_window` and the pattern into `n_swa` and `swa_layers`. With the keys absent the draft stays dense, exactly as before.
- `build_dflash.cpp` and `llama-dflash.cpp`: allocate and write each attention mask only when a layer actually uses it, and take the mask dimensions from whichever mask is live. For these drafts both masks are live (the sliding layers and the final global layer); this also keeps an all-sliding-window draft safe, where the otherwise-unused full mask would be a dead graph node that asserts on write.
- `llama-dflash.cpp`: bound intra-block draft tokens to the window in the F16 and F32 mask loops, matching the cross-context section. A no-op at realistic window sizes (the window dwarfs the 16-token block); included for correctness.

## Long-context win

Measured on an RTX 4070, deterministic, 4 runs per config, `--cpu-moe`. For each model I converted the same draft two ways, full attention (no window keys) and SWA (the corrected per-layer pattern), and compared draft acceptance as the prompt grows past the draft window. Clip is the share of attended context beyond the window, `(prompt - W) / prompt`. At and below the window the two are neutral; the gap opens and widens as the prompt overflows.

### Table 1: Qwen3.6-35B-A3B, draft window 4096

| prompt tok | clip% | accept, full-attn | accept, SWA | acceptance gain | tok/s change |
|---|---|---|---|---|---|
| 37 | 0% | 36.1% | 39.2% | +3.0 pp | +6.8% |
| 5613 | 27% | 28.4% | 28.6% | +0.2 pp (tie, within noise) | -1.1% |
| 8044 | 49% | 22.3% | 27.7% | +5.4 pp | +9.9% |
| 11005 | 63% | 15.9% | 26.4% | +10.5 pp | +23% |
| 19946 | 80% | 5.5% | 23.0% | +17.4 pp | +44% |

The gain grows monotonically and does not saturate. As the prompt overflows the window, the full-attention draft is forced to attend an ever-larger, mostly-irrelevant context and its acceptance collapses, from 36.1% with no clipping to 5.5% at 80% clip, while the SWA draft stays focused inside its 4096 window and holds at roughly 23 to 28%. The win is that widening gap: a tie at mild clip, +10.5 pp at 63%, and +17.4 pp with +44% tok/s by 80%.

### Table 2: Gemma-4-26B-A4B, draft window 2048

| prompt tok | clip% | accept, full-attn | accept, SWA | acceptance gain | tok/s change |
|---|---|---|---|---|---|
| 1413 | 0% | 14.4% | 15.2% | +0.7 pp | +1.9% |
| 2751 | 26% | 17.1% | 17.1% | +0.0 pp | -1.1% |
| 3923 | 48% | 12.0% | 15.9% | +3.9 pp (within noise) | +7.9% |
| 5426 | 62% | 13.8% | 14.7% | +0.9 pp (within noise) | +0.5% |
| 10673 | 81% | 10.6% | 18.1% | +7.5 pp | +16% |

Gemma4 with a smaller window shows the same shape: neutral at and below the window, then a win that grows with clip depth, reaching +7.5 pp and +16% tok/s at 81% clip with the run-to-run bands cleanly separated. This draft is intrinsically weaker and noisier than the 35B-A3B one (lower absolute acceptance and a wider per-run spread), so the mid-clip rows are positive but within run-to-run noise and only the deepest clip clears it; and the gemma4 target is itself sliding-window, so the full-attention draft's effective context is less monotonic.

Generally, for draft window W: neutral up to about 1.4x W of prompt; the gain then grows with depth, and on the 35B it is still climbing at about 5x W (+17.4 pp accept, +44% tok/s).

## Scope and validation

Dense drafts are byte-identical, since SWA turns on only from the draft's own metadata and there are no new flags. I built the CUDA `llama-server` and ran both corrected drafts (sliding on every layer but the final global one) across five prompt depths each on the two models above. Because the drafts have a non-SWA layer, this runs the path where the full and sliding masks are both live, including the deepest roughly 80% overflow. No `buf != NULL`, no assert, no OOM at any depth on either model; coherent output; and no meaningful regression against full attention at any depth. `bulgaria`, `quicksort`, `sayap` generate expected outputs for these models.

## Reproduction

SWA only engages once the DFlash cross-context exceeds the draft window. Set it with `--spec-type dflash:n_max=4,cross_ctx=N` for an N larger than the window, and use a prompt longer than the window; the default `cross_ctx` of 512 does not grow with `-c`. DFlash draft sources ship without a tokenizer, so converting one needs `--target-model-dir` pointing at a directory that has the tokenizer merges, or the GGUF will not load. To reproduce a row, convert a z-lab `*-DFlash` draft (whose source sets `use_sliding_window`) on this branch, and compare it against the same draft converted with the window keys absent, at a prompt well past the window.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
