### PR TITLE
cuda : fix MLA flash-attn vec decode for asymmetric K/V head sizes

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f16.cuh
@@ -195,11 +195,11 @@ static __global__ void flash_attn_vec_ext_f16(
     //    printf("gridDims = %u, %u, %u, ncols = %d, head = %d, blockIdx.x = %d, blockIdx.y = %d, bounds = %d, %d, ne11 = %d, nb11 = %d, blockIdx.y*Dk = %d\n", gridDim.x, gridDim.y, gridDim.z, ncols, head, blockIdx.x, blockIdx.y, KV_min_max[sequence*gridDim.x + blockIdx.x].x, KV_min_max[sequence*gridDim.x + blockIdx.x].y, ne11, nb11, blockIdx.y*Dk);
     //}
     K     += (first_y + blockIdx.y*Dk) * nb11;
-    V     += (first_y + blockIdx.y*Dv) * nb21;
+    V     += (first_y + blockIdx.y*Dk) * nb21;
     maskh += (first_y + blockIdx.y*Dk);
     for (int k_VKQ_0 = first_y + blockIdx.y*Dk; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*Dk,
              // Increment pointers after each loop:
-             K += gridDim.y*Dk*nb11, V += gridDim.y*Dv*nb21, maskh += gridDim.y*Dk) {
+             K += gridDim.y*Dk*nb11, V += gridDim.y*Dk*nb21, maskh += gridDim.y*Dk) {
 
         // For unknown reasons using a half array of size 1 for kqmax_new causes a performance regression,
         // see https://github.com/ggerganov/llama.cpp/pull/7061 .
@@ -278,15 +278,23 @@ static __global__ void flash_attn_vec_ext_f16(
 
         __syncthreads();
 
+        // Accumulate V over all Dk scored KV positions of this block (not Dv). For asymmetric MLA
+        // head sizes (Dk=576 K, Dv=512 V) the K/score loop above covers Dk KV rows, so the V loop and
+        // the V pointer stride must also step Dk KV rows or K and V desync (= garbage decode on sm_60,
+        // which uses this vec kernel for MLA -fa 1 batch=1). Dk==Dv leaves every other case unchanged.
 #pragma unroll
-        for (int k0 = 0; k0 < Dv; k0 += 2) {
-            if (FATTN_KQ_STRIDE % Dv != 0 && k_VKQ_0 + k0 >= ne11) {
+        for (int k0 = 0; k0 < Dk; k0 += 2) {
+            if (FATTN_KQ_STRIDE % Dk != 0 && k_VKQ_0 + k0 >= ne11) {
                 break;
             }
 
-            half2 V_k;
-            reinterpret_cast<half&>(V_k.x) = dequantize_1_v(V + (k0 + 0)*nb21, tid);
-            reinterpret_cast<half&>(V_k.y) = dequantize_1_v(V + (k0 + 1)*nb21, tid);
+            // For asymmetric Dk>Dv the V row is only Dv wide, so threads tid>=Dv have no V element
+            // (their VKQ lane is discarded at output anyway). Read 0 to avoid stepping past the row.
+            half2 V_k = make_half2(0.0f, 0.0f);
+            if (tid < Dv) {
+                reinterpret_cast<half&>(V_k.x) = dequantize_1_v(V + (k0 + 0)*nb21, tid);
+                reinterpret_cast<half&>(V_k.y) = dequantize_1_v(V + (k0 + 1)*nb21, tid);
+            }
 #pragma unroll
             for (int j = 0; j < ncols; ++j) {
                 VKQ[j] += V_k*KQ2[j*(Dk/2) + k0/2];

--- a/ggml/src/ggml-cuda/fattn-vec-f32.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec-f32.cuh
@@ -189,11 +189,11 @@ static __global__ void flash_attn_vec_ext_f32(
     const int first_y = KV_min_max ? KV_min_max[sequence*gridDim.x + blockIdx.x].x : 0;
 
     K     += (first_y + blockIdx.y*Dk) * nb11;
-    V     += (first_y + blockIdx.y*Dv) * nb21;
+    V     += (first_y + blockIdx.y*Dk) * nb21;
     maskh += (first_y + blockIdx.y*Dk);
     for (int k_VKQ_0 = first_y + blockIdx.y*Dk; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*Dk,
              // Increment pointers after each loop:
-             K += gridDim.y*Dk*nb11, V += gridDim.y*Dv*nb21, maskh += gridDim.y*Dk) {
+             K += gridDim.y*Dk*nb11, V += gridDim.y*Dk*nb21, maskh += gridDim.y*Dk) {
 
         // Calculate KQ tile and keep track of new maximum KQ values:
 
@@ -266,13 +266,19 @@ static __global__ void flash_attn_vec_ext_f32(
 
         __syncthreads();
 
+        // Accumulate V over all Dk scored KV positions of this block (not Dv). For asymmetric MLA
+        // head sizes (Dk=576 K, Dv=512 V) the K/score loop above covers Dk KV rows, so the V loop and
+        // the V pointer stride must also step Dk KV rows or K and V desync (= garbage decode on sm_60,
+        // which uses this vec kernel for MLA -fa 1 batch=1). Dk==Dv leaves every other case unchanged.
 #pragma unroll
-        for (int k = 0; k < Dv; ++k) {
-            if (FATTN_KQ_STRIDE % Dv != 0 && k_VKQ_0 + k >= ne11) {
+        for (int k = 0; k < Dk; ++k) {
+            if (FATTN_KQ_STRIDE % Dk != 0 && k_VKQ_0 + k >= ne11) {
                 break;
             }
 
-            const float V_ki = dequantize_1_v(V + k*nb21, tid);
+            // For asymmetric Dk>Dv the V row is only Dv wide, so threads tid>=Dv have no V element
+            // (their VKQ lane is discarded at output anyway). Read 0 to avoid stepping past the row.
+            const float V_ki = tid < Dv ? dequantize_1_v(V + k*nb21, tid) : 0.0f;
 #pragma unroll
             for (int j = 0; j < ncols; ++j) {
                 VKQ[j] += V_ki*KQ[j*Dk + k];


### PR DESCRIPTION
The flash-attn vec kernels (`flash_attn_vec_ext_f16`/`_f32`) walk the KV cache in
blocks of `Dk` rows for the score loop but accumulate V in blocks of `Dv`. When
`Dk == Dv` that is the same thing, so every normal attention shape is fine. For the
absorbed MLA shapes where the K and V head sizes differ (Dk=576/Dv=512, and
Dk=192/Dv=128) the two loops step different numbers of KV rows, so K and V drift out
of sync after the first block and the V pointer lands on the wrong cache rows.

This only shows up at decode (batch=1) on cards that fall back to the vec kernel for
MLA, which on NVIDIA is pre-Volta (no mma). On those cards `deepseek2`/GLM MLA models
with `-mla 1 -fa 1` or `-mla 3 -fa 1` produce coherent text for short prompts but
collapse into garbage once `n_kv` grows past the first KV block (Dk=576), e.g.
`The , the and the \22222 ... ## 1.`. Prefill/PPL is unaffected because prefill takes
the tile kernel, not the vec kernel, so a PPL run at short context misses it entirely.

The bug is in the kernel, not the dispatch. The score loop already covers `Dk` KV rows,
so the V loop and the V pointer have to step `Dk` rows too. For asymmetric Dk>Dv the V
row is only `Dv` wide, so threads with `tid >= Dv` have no V element to read; their VKQ
lane is discarded at the output store anyway, so they read 0 instead of stepping past
the row.

Because the change keys off `Dk != Dv` (a compile-time constant), every symmetric
instantiation compiles to byte-identical code. The asymmetric vec path is only reached
on the non-mma fallback, so this cannot change behavior on any modern GPU.

Tested on a Tesla P100 (sm_60, single GPU), CUDA 12, DeepSeek-V2-Lite Q4_K_M
(kv_lora=512, k=192, v=128, so `-mla 1` exercises 192/128 and `-mla 3` exercises
576/512). KLD is computed against the `-fa 0` soft_max path (the known-good decode
reference) with `-b 1 -ub 1` so every token goes through the single-token vec kernel.

Decode coherence at long context (prompt then 100+ tokens at temp 0, n_kv past 576):

| config            | before      | after     |
| ----------------- | ----------- | --------- |
| -mla 1 -fa 1      | garbage     | coherent  |
| -mla 3 -fa 1      | garbage     | coherent  |
| -mla 2 -fa 1      | coherent    | coherent  |
| -mla 1/2/3 -fa 0  | coherent    | coherent  |

KLD of `-mla 1 -fa 1` vs `-mla 1 -fa 0`, c1024 (n_kv up to 1024 > 576), batch 1:

| metric      | before  | after    |
| ----------- | ------- | -------- |
| Mean KLD    | 4.7904  | 0.000139 |
| Same top-p  | 26.9%   | 100.0%   |
| Mean Δp     | -89.2%  | +0.03%   |
| RMS Δp      | 91.5%   | 0.55%    |

The residual after the fix (mean KLD 1.4e-4, 100% same top token) is just the expected
f16-vs-f32 accumulation gap between the FA kernel and the soft_max reference.

No perf change. llama-bench, DeepSeek-V2-Lite Q4_K_M, P100, -ngl 99 -mla 1 -fa 1:

| test  | before        | after         |
| ----- | ------------- | ------------- |
| pp512 | 627.3 t/s     | 631.1 t/s     |
| tg128 | 82.83 t/s     | 82.69 t/s     |

No regression on a non-MLA model: Qwen3.5-4B Q4_K_M (dense, head_dim 128 symmetric)
`-fa 1` decode is coherent and unchanged, as expected since the symmetric path is
untouched.

I couldn't run `tests/test-backend-ops` here, it isn't wired as a build target in the
tree, so I validated with the KLD-vs-soft_max numbers above instead.

## Regression across the model zoo

To back the byte-identical claim and to show the MLA fix is not specific to the one
repro model, I ran a long-context `-fa 1` decode check on a spread of architectures on
the same P100 rig. Each model gets a prompt plus a forced run of tokens at temp 0 so
that decode keeps going past `n_kv` 576 (the depth where the bug bites), then I read the
output for coherence and pull PP/TG off `llama-sweep-bench` at `N_KV` 768. The non-MLA
models are the no-regression evidence: their kernel is byte-identical, so they have to
stay coherent and keep the same numbers. The MLA models are the generalization evidence:
they take the patched asymmetric path and now decode clean.

| model                    | arch       | MLA | -fa 1 decode | PP t/s | TG t/s | note                          |
| ------------------------ | ---------- | --- | ------------ | ------ | ------ | ----------------------------- |
| Qwen3.5-4B Q4_K_M        | qwen35     | no  | coherent     | 708    | 57.2   | dense, head 256 sym; matches ~58 |
| Nemotron-3-Nano-4B Q4    | nemotron_h | no  | coherent     | 861    | 52.9   | hybrid; matches ~53           |
| Qwen3-Coder-30B IQ4_KSS  | qwen3moe   | no  | coherent     | 308    | 42.9   | hybrid, n-cpu-moe 8; near ~47 |
| Qwen3.5-35B-A3B Q4_K_M   | qwen35moe  | no  | coherent     | 283    | 58.6   | 3 GPU; matches ~59            |
| Mellum2-12B-A2.5B Q4_K_M | mellum     | no  | coherent     | 581    | 90.8   | MoE, head 128 sym             |
| DeepSeek-V2-Lite-REAP48  | deepseek2  | mla 1 | coherent   | 468    | 64.7   | 192/128 asymmetric path       |
| DeepSeek-V2-Lite-REAP48  | deepseek2  | mla 3 | coherent   | 509    | 64.8   | 576/512 asymmetric path       |
| GLM-5.2 IQ2_M            | glm-dsa    | mla 3 | coherent   | 21.6   | 4.7    | 3 GPU + cpu-moe; PP/TG cpu-bound |

The non-MLA numbers line up with the figures we already had for these models, which is
expected since the symmetric vec kernel did not change. The two DeepSeek configs cover
both asymmetric shapes the patch handles (192/128 at `-mla 1` and 576/512 at `-mla 3`)
on a REAP-pruned build that is a different file from the one in the KLD section, so the
fix is not tied to a single checkpoint. For DeepSeek-V2-Lite I also confirmed `-mla 1
-fa 1` and `-mla 1 -fa 0` produce byte-identical greedy output past `n_kv` 576, so the
patched FA path now tracks the soft_max reference exactly.

GLM-5.2 IQ2_M is the largest MLA case (glm-dsa, absorbed MLA 576/512 at `-mla 3`, 3 GPU
with all MoE experts on CPU, so the low PP/TG is a memory-fit choice, not a kernel
effect). With a normal prompt it decodes 500 greedy tokens past `n_kv` 576 cleanly: a
correct multi-paragraph explanation of the stride bug, no token salad, none of the
pre-fix garbage. I did hit one edge case worth stating plainly. On a deliberately
degenerate prompt (the same instruction pasted twice), `-fa 1` opened with a coherent
sentence and then fell into a `1 formula / 1 link / 1 list ...` repetition loop, while
`-fa 0` on the identical input recovered and answered. That is not the pre-fix failure
(no garbage tokens, and it only shows up on the doubled prompt, not a normal one): on a
2-bit quant the small f16-vs-f32 residual between the FA path and the soft_max reference,
the same residual the KLD section measures, is enough to tip greedy decoding onto a worse
branch near a confusing prompt. The single-prompt runs match the `-fa 0` reference in
quality, so I am reading this as a sampling knife-edge on IQ2_M, not a kernel defect, but
I am flagging it rather than hiding it.

Two hot models were left out of the table, and the reason matters. Kimi-Dev-72B (qwen2,
symmetric) decodes to garbage on this box, but it does so with `-fa 0` too, so it is the
known multi-GPU P2P DMA corruption on this platform, not the FA kernel. gemma-4-12B-qat
(gemma4) also decodes to garbage with `-fa 0`, a pre-existing gemma4 GPU issue unrelated
to attention strides. Both were excluded because their failures are independent of this
change and would have been misleading in a regression table. No model that is healthy on
this rig changed its output or its numbers.

Note on authorship: I worked this out with an AI coding assistant. I directed the
investigation and validated everything on my own P100 hardware, which is the part
this fix needed.

Complexity: Med.
