### PR TITLE
common: strip stray reasoning end markers from auto-parser content

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -166,6 +166,13 @@ common_peg_parser analyze_content::build_parser(parser_build_context & ctx) cons
         }
         return content + p.end();
     }
+    if (ctx.extracting_reasoning && ctx.reasoning && !ctx.reasoning->end.empty()) {
+        auto content = p.tag_with_safe_content(
+            common_chat_peg_builder::CONTENT,
+            trim_whitespace(ctx.reasoning->end),
+            p.optspace(ctx.reasoning->end));
+        return ctx.reasoning_parser + content + p.end();
+    }
     return ctx.reasoning_parser + p.content(p.rest()) + p.end();
 }
 

--- a/tests/test-chat-auto-parser.cpp
+++ b/tests/test-chat-auto-parser.cpp
@@ -58,6 +58,12 @@ static void test_nemotron_analysis(testing & t);
 static void test_nemotron_reasoning_detection(testing & t);
 static void test_nemotron_tool_format(testing & t);
 
+// Qwen template parser regression tests
+static void test_qwen_analysis(testing & t);
+static void test_qwen_no_think_stray_end_marker(testing & t);
+static void test_qwen_reasoning_none_preserves_marker(testing & t);
+static void test_qwen_initial_reasoning_still_routes(testing & t);
+
 // CohereForAI template analysis tests
 static void test_cohere_reasoning_detection(testing & t);
 static void test_cohere_analysis(testing & t);
@@ -103,6 +109,7 @@ int main(int argc, char * argv[]) {
     t.test("cohere", test_cohere_analysis);
     t.test("cohere2moe_parser", test_cohere2moe_parser);
     t.test("nemotron", test_nemotron_analysis);
+    t.test("qwen", test_qwen_analysis);
     t.test("smollm3", test_smollm3_analysis);
     t.test("standard_json_tools", test_standard_json_tools_formats);
     t.test("normalize_quotes_to_json", test_normalize_quotes_to_json);
@@ -1377,6 +1384,121 @@ static void test_nemotron_tool_format(testing & t) {
 
     // Verify tool support
     t.assert_true("should support tools", analysis.jinja_caps.supports_tools);
+}
+
+// ============================================================================
+// Qwen Template Parser Regression Tests
+// ============================================================================
+static common_chat_template load_qwen_template(testing & t) {
+    return load_template(t, "models/templates/Qwen3.5-4B.jinja");
+}
+
+static void test_qwen_analysis(testing & t) {
+    t.test("Qwen no-think stray end marker", test_qwen_no_think_stray_end_marker);
+    t.test("Qwen reasoning_format=NONE preserves marker", test_qwen_reasoning_none_preserves_marker);
+    t.test("Qwen initial reasoning still routes", test_qwen_initial_reasoning_still_routes);
+}
+
+static void test_qwen_no_think_stray_end_marker(testing & t) {
+    common_chat_template tmpl = load_qwen_template(t);
+    common_chat_templates_ptr tmpls(common_chat_templates_init(/* model = */ nullptr, tmpl.source()));
+
+    common_chat_msg user;
+    user.role    = "user";
+    user.content = "Hello";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages         = { user };
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    inputs.enable_thinking  = false;
+
+    auto params = common_chat_templates_apply(tmpls.get(), inputs);
+
+    common_peg_arena arena;
+    arena.load(params.parser);
+    common_chat_parser_params parser_params(params);
+
+    const std::string generated = "First answer.</think>Final answer.";
+    const std::string expected  = "First answer.Final answer.";
+
+    auto final_msg = common_chat_peg_parse(arena, generated, /* is_partial = */ false, parser_params);
+    t.assert_equal("final content should strip stray reasoning end marker", expected, final_msg.content);
+    t.assert_equal("final reasoning should stay empty", "", final_msg.reasoning_content);
+
+    common_chat_msg previous;
+    common_chat_msg accumulated;
+    previous.role = accumulated.role = "assistant";
+
+    for (size_t i = 1; i <= generated.size(); ++i) {
+        auto current = common_chat_peg_parse(arena, generated.substr(0, i), /* is_partial = */ i < generated.size(), parser_params);
+        for (const auto & diff : common_chat_msg_diff::compute_diffs(previous, current)) {
+            t.assert_true("streaming content delta should not leak stray reasoning end marker",
+                diff.content_delta.find("</think>") == std::string::npos);
+            accumulated.content += diff.content_delta;
+            accumulated.reasoning_content += diff.reasoning_content_delta;
+        }
+        previous = current;
+    }
+
+    t.assert_equal("streaming accumulated content should strip stray reasoning end marker", expected, accumulated.content);
+    t.assert_equal("streaming accumulated reasoning should stay empty", "", accumulated.reasoning_content);
+}
+
+static void test_qwen_reasoning_none_preserves_marker(testing & t) {
+    common_chat_template tmpl = load_qwen_template(t);
+    common_chat_templates_ptr tmpls(common_chat_templates_init(/* model = */ nullptr, tmpl.source()));
+
+    common_chat_msg user;
+    user.role    = "user";
+    user.content = "Hello";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages         = { user };
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_NONE;
+    inputs.enable_thinking  = false;
+
+    auto params = common_chat_templates_apply(tmpls.get(), inputs);
+
+    common_peg_arena arena;
+    arena.load(params.parser);
+    common_chat_parser_params parser_params(params);
+
+    const std::string generated = "First answer.</think>Final answer.";
+
+    auto final_msg = common_chat_peg_parse(arena, generated, /* is_partial = */ false, parser_params);
+    t.assert_true("reasoning_format=NONE should keep generated marker in content",
+        final_msg.content.find(generated) != std::string::npos);
+    t.assert_true("reasoning_format=NONE should keep marker before generated final text",
+        final_msg.content.find("</think>Final answer.") != std::string::npos);
+    t.assert_equal("reasoning_format=NONE should not populate reasoning", "", final_msg.reasoning_content);
+}
+
+static void test_qwen_initial_reasoning_still_routes(testing & t) {
+    common_chat_template tmpl = load_qwen_template(t);
+    common_chat_templates_ptr tmpls(common_chat_templates_init(/* model = */ nullptr, tmpl.source()));
+
+    common_chat_msg user;
+    user.role    = "user";
+    user.content = "Hello";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages         = { user };
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    inputs.enable_thinking  = true;
+
+    auto params = common_chat_templates_apply(tmpls.get(), inputs);
+
+    common_peg_arena arena;
+    arena.load(params.parser);
+    common_chat_parser_params parser_params(params);
+
+    const std::string generated           = "Reasoning</think>Final answer.";
+    const std::string expected_reasoning  = "Reasoning";
+    const std::string expected_content    = "Final answer.";
+
+    auto final_msg = common_chat_peg_parse(arena, generated, /* is_partial = */ false, parser_params);
+    t.assert_equal("initial reasoning should route to reasoning_content", expected_reasoning, final_msg.reasoning_content);
+    t.assert_equal("content after initial reasoning should stay visible", expected_content, final_msg.content);
 }
 
 static common_chat_template load_cohere_template(testing & t) {


### PR DESCRIPTION
First, acknowledging that I've been churning the parser, but for the Qwen models, I think this is probably worth it.

While testing a Qwen3.6-35B-A3B model through `llama-server`, I hit a streaming-only no-thinking leak where the model emitted a stray `</think>` after visible answer text had already started. Earlier Qwen fixes handle the empty no-thinking prefill at the start of the generation, but the generated auto-parser plain-content path could still pass a later reasoning end marker through as normal content.

Leak:

```text
First answer.</think>Final answer.
```

Under `enable_thinking=false` with reasoning extraction still enabled, that should stream as visible content without surfacing the reasoning delimiter:

```text
First answer.Final answer.
```

The actual change is small: when the auto-parser has plain content plus a known tag-based reasoning end marker, it now parses content through `tag_with_safe_content` and consumes that reasoning end marker instead of tagging it as content. This is only in the generated auto-parser content path when reasoning extraction is active and the template analysis found a reasoning end marker.

I also added Qwen coverage in `test-chat-auto-parser` using `models/templates/Qwen3.5-4B.jinja`. The tests cover final parsing, byte-by-byte streaming diff accumulation, `reasoning_format=NONE` preserving the marker as content, and normal thinking-on output still routing initial reasoning to `reasoning_content`.

**One risk to note:** a model that legitimately emits the literal marker string as visible content (output about thinking tags, a code block containing `</think>`) would now have it silently stripped with this PR. For reasoning models, a bare post-reasoning `</think>` is almost always a leak, but this is a trade-off worth reviewer consideration.

- `./build-cuda/bin/test-chat-auto-parser`: 61 tests, 475 assertions, 0 failures.

I marked this Medium because the code diff is small, but it changes generic generated-parser behavior for auto-parsed templates with tag-based reasoning markers.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
