### PR TITLE
DFlash: guard draft conversion against metadata-only output

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2506,6 +2506,15 @@ class DFlashDraftModel(Qwen3Model):
     def prepare_tensors(self):
         super().prepare_tensors()
 
+        if sum(len(tensors) for tensors in self.gguf_writer.tensors) == 0:
+            raise ValueError(
+                "DFlashDraftModel conversion did not find any tensors. "
+                "DFlash drafts may share target token_embd/output tensors, but the draft "
+                "model must still provide its own block weights. Make sure the draft "
+                "directory contains downloaded model weights that this converter can discover, "
+                "such as model*.safetensors or pytorch_model*.bin; a metadata-only GGUF is not usable."
+            )
+
         if self._saw_output and not self._saw_token_embd:
             raise ValueError(
                 "DFlashDraftModel conversion requires token_embd.weight when output.weight is present"


### PR DESCRIPTION
Issue #2043 shows DFlash conversion finishing successfully with `n_tensors = 0` for `Qwen3.5-397B-A17B-DFlash`. That output is metadata-only and not usable as a draft model. In the #2043 case, it turned out that the root cause was a wrong model name, but the bad outcome is still worth guarding against: current `DFlashDraftModel` conversion can finish successfully after adding zero tensor infos.

This patch leaves the existing DFlash tensor mapping alone. It only adds a `DFlashDraftModel` guard after tensor preparation: if conversion added zero tensor infos, it raises with a direct message saying that DFlash drafts can share target token embedding/output tensors, but still need their own draft block weights in a form the converter can discover, such as `model*.safetensors` or `pytorch_model*.bin`.

It does not change C++ runtime code, GGUF loading, speculative decoding, tokenizer handling, or tensor mapping.

Validation:

- `python3 -m py_compile convert_hf_to_gguf.py`
- Reproduced the missing-weight case with a minimal `DFlashDraftModel` `config.json`: conversion now fails with `DFlashDraftModel conversion did not find any tensors...`
- Confirmed that the missing-weight case does not write a metadata-only GGUF
- Earlier local conversion of the real `modal-labs/Qwen3.5-397B-A17B-DFlash` draft, using `Qwen/Qwen3.5-397B-A17B` config/tokenizer files as `--target-model-dir`, produced a GGUF with `n_tensors = 69` and `total_size = 2.6G`

Caveat: ~~I did not validate loading or runtime with the 397B target model. My local machine has 64 GB RAM and a 12 GB RTX 4070, so this validation is limited to converter behavior and draft GGUF output.~~

Update: I'd been meaning to try this, so I went ahead and also locally tested the converted BF16 DFlash draft with `llama-server` against OpenMOSE `Qwen3.5-REAP-212B-A17B-IQ2_M` and Bartowski `Qwen_Qwen3.5-397B-A17B-IQ1_S`; both targets loaded, initialized DFlash, generated text, and logged DFlash draft activity. I also ran a `cross_ctx=4100` / 4206-token prompt on both targets to cross the draft’s 4096-token SWA window without a DFlash/SWA crash. It worked, but this only proves load/generation and the SWA-crossing path did not crash, since performance or quality testing 397B would be painful here.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
