### PR TITLE
GLM4_MoE: Split mode graph for the MTP tail layer

### DIFF
--- a/src/graphs/build_glm4.cpp
+++ b/src/graphs/build_glm4.cpp
@@ -319,7 +319,7 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
     ggml_tensor * ffn_inp;
     if (rope_cache == nullptr) {
         cur = build_std_attention(gf, mtp_layer.attn_norm, cur,
-                inp_pos, nullptr, nullptr,
+                inp_pos, inp_out_ids, nullptr,
                 KQ_mask, nullptr, nullptr,
                 kq_scale, 0.0f, 0, il, true, false, true, false, false, nullptr);
         ffn_inp = cur;
@@ -347,10 +347,9 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
                         kq_scale, cb, il);
         ffn_inp = ggml_add(ctx0, cur, inpSA);
         cb(ffn_inp, "mtp_ffn_inp", il);
-    }
-
-    if (inp_out_ids) {
-        ffn_inp = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
+        if (inp_out_ids) {
+            ffn_inp = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
+        }
     }
 
     // MoE FFN
@@ -371,15 +370,12 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
     cur = lctx.cvec.apply_to(ctx0, cur, il);
     cb(cur, "ffn_out", il);
 
-    cur = llm_build_norm(ctx0, cur, hparams, mtp_layer.nextn.shared_head_norm, NULL, LLM_NORM_RMS, cb, il);
-    cb(cur, "result_norm", -1);
-
     // If nextn.shared_head_head is missing (GLM-4.6), use model.output (Main LM Head)
     ggml_tensor * mtp_head_weights = mtp_layer.nextn.shared_head_head;
     if (mtp_head_weights == nullptr) {
         mtp_head_weights = model.output;
     }
-    cur = llm_build_lora_mm(lctx, ctx0, mtp_head_weights, cur);
+    cur = build_output(lctx, ctx0, cur, mtp_head_weights, mtp_layer.nextn.shared_head_norm, cb);
     cb(cur, "result_output", -1);
 
     return cur;

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -2140,7 +2140,8 @@ ggml_tensor * llm_build_context::build_output(llama_context & lctx, ggml_context
         int idx_out = ggml_backend_sched_get_backend_idx(lctx.sched, lctx.model.output->buffer);
         if (idx_out >= 0) idx = idx_out;
         const bool is_qwen_mtp = (lctx.model.arch == LLM_ARCH_QWEN35 ||
-                                  lctx.model.arch == LLM_ARCH_QWEN35MOE) && lctx.cparams.mtp;
+                                  lctx.model.arch == LLM_ARCH_QWEN35MOE ||
+                                  lctx.model.arch == LLM_ARCH_GLM4_MOE) && lctx.cparams.mtp;
         if (cur->op == GGML_OP_REDUCE && cur->src[idx] && !is_qwen_mtp) {
             // avoid copy to main GPU
             cur->view_src = cur->src[idx];

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -182,7 +182,10 @@ struct create_tensors_helper : public create_tensors_helper_interface {
     inline ggml_context * ctx_for_layer_split(int i, bool force_split = false) const {
         const bool is_mtp_layer = model.hparams.nextn_predict_layers > 0 &&
                                   static_cast<uint32_t>(i) >= model.hparams.n_layer - model.hparams.nextn_predict_layers;
-        return is_mtp_layer && !force_split ? ctx_map.at(model.buft_layer[i].buft) : ctx_map.at(model.buft_layer[i].buft_matrix);
+        if (is_mtp_layer && !force_split && model.arch != LLM_ARCH_GLM4_MOE) {
+            return ctx_map.at(model.buft_layer[i].buft);
+        }
+        return ctx_map.at(model.buft_layer[i].buft_matrix);
     }
 
     std::map<ggml_backend_buffer_type_t, int> buft_layer_count;
@@ -2870,10 +2873,6 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
         const bool is_mtp_layer = hparams.nextn_predict_layers > 0 &&
                                   static_cast<uint32_t>(i) >= n_layer - hparams.nextn_predict_layers;
 
-        if (is_mtp_layer) {
-            ctx_split = ctx_layer;
-        }
-
         int flags = 0;
         // Skip loading MTP layers if the feature is disabled
         if (!model.mtp) {
@@ -4610,6 +4609,7 @@ bool create_tensors_helper::create_tensors() {
             // For now only run MTP into the per-layer
             if (model.mtp && hparams.nextn_predict_layers > 0 &&
                 model.arch != LLM_ARCH_QWEN35 &&
+                model.arch != LLM_ARCH_GLM4_MOE &&
                 static_cast<uint32_t>(il) >= static_cast<uint32_t>(n_layer) - hparams.nextn_predict_layers) {
                 LLAMA_LOG_DEBUG("%s: not splitting MTP tail layer %d (forced non-split)\n", __func__, il);
                 continue;

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2955,7 +2955,7 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
             layer.nextn.embed_tokens     = create_tensor(nextn_host_ctx,
                     tn(LLM_TENSOR_NEXTN_EMBED_TOKENS, "weight", final_layer),
                     { n_embd, n_vocab },
-                    flags | llama_model_loader::TENSOR_NOT_REQUIRED);
+                    flags | llama_model_loader::TENSOR_NOT_REQUIRED | llama_model_loader::TENSOR_SKIP);
             layer.nextn.enorm            = create_tensor(nextn_ctx,
                     tn(LLM_TENSOR_NEXTN_ENORM, "weight", final_layer),
                     { n_embd },

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2967,7 +2967,7 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
             layer.nextn.shared_head_head = create_tensor(nextn_ctx,
                     tn(LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD, "weight", final_layer),
                     { n_embd, n_vocab },
-                    flags | llama_model_loader::TENSOR_NOT_REQUIRED);
+                    flags | llama_model_loader::TENSOR_NOT_REQUIRED | llama_model_loader::TENSOR_SKIP);
             layer.nextn.shared_head_norm = create_tensor(nextn_ctx,
                     tn(LLM_TENSOR_NEXTN_SHARED_HEAD_NORM, "weight", final_layer),
                     { n_embd },

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -182,10 +182,7 @@ struct create_tensors_helper : public create_tensors_helper_interface {
     inline ggml_context * ctx_for_layer_split(int i, bool force_split = false) const {
         const bool is_mtp_layer = model.hparams.nextn_predict_layers > 0 &&
                                   static_cast<uint32_t>(i) >= model.hparams.n_layer - model.hparams.nextn_predict_layers;
-        if (is_mtp_layer && !force_split && model.arch != LLM_ARCH_GLM4_MOE) {
-            return ctx_map.at(model.buft_layer[i].buft);
-        }
-        return ctx_map.at(model.buft_layer[i].buft_matrix);
+        return is_mtp_layer && !force_split ? ctx_map.at(model.buft_layer[i].buft) : ctx_map.at(model.buft_layer[i].buft_matrix);
     }
 
     std::map<ggml_backend_buffer_type_t, int> buft_layer_count;

--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -2868,7 +2868,7 @@ bool create_tensors_helper::create_glm4_moe_tensors(const LLM_TN & tn) {
 
     for (int i = 0; i < n_layer; ++i) {
         ggml_context * ctx_layer = ctx_for_layer(i);
-        ggml_context * ctx_split = ctx_for_layer_split(i);
+        ggml_context * ctx_split = ctx_for_layer_split(i, true);
 
         const bool is_mtp_layer = hparams.nextn_predict_layers > 0 &&
                                   static_cast<uint32_t>(i) >= n_layer - hparams.nextn_predict_layers;


### PR DESCRIPTION
Extends split_mode_graph (CUDA multi-GPU distribution) to the MTP (Multi-Token Prediction) tail layer of GLM4MoE, analogous to #2027 for Qwen35 dense MTP.

Notes:
- Skip loading shared_head_head (TENSOR_SKIP) — the runtime fallback to model.output works correctly and avoids hundreds of MiB stranded on CUDA0 when this optional tensor is present.
src/graphs/build_glm4.cpp
- nextn.eh_proj is kept monolithic because its matmul output feeds directly into build_std_attention's multi-device path, which expects a GGML_OP_REDUCE input — splitting it causes an illegal memory access in flash attention.

Verifications:
- Verified coherent output on GLM-4.6-355B and GLM-Steam-106B in Hybrid offload CUDA with some layers left on the CPU.
- On GLM 4.6, my MTP generation speed remains in the same tight bracket as what I had without.

Remark:
Your commit helped me to figure out what I missed to make it work on my own, @ikawrakow! (the adaptation of build_std_attention!)

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High