### PR TITLE
fix: Normalize Disabled Context-Shift Overflow Error

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3386,7 +3386,7 @@ void server_context::context_shift() {
                     // we should never get here, because generation should already stopped in process_token()
                     slot.print_timings();
                     slot.release();
-                    send_error(slot, "context shift is disabled", ERROR_TYPE_SERVER);
+                    send_error(slot, "context_length_exceeded: the request exceeds the available context size; context shift is disabled", ERROR_TYPE_SERVER);
                     continue;
                 }
                 // Shift context


### PR DESCRIPTION
When generation reaches the context limit and context shifting is disabled,
`llama-server` currently returns:

```text
context shift is disabled
```

Agent harnesses such as Pi treat context overflow as recoverable only when the
provider error message matches common overflow wording. The terse message above
is a valid server-side failure, but it is not recognizable as context overflow,
so Pi does not auto-compact and retry.

This patch changes the generation-time disabled-context-shift error to:

```text
context_length_exceeded: the request exceeds the available context size; context shift is disabled
```

The behavior remains an error, but the message now includes both a generic
OpenAI-compatible fallback (`context_length_exceeded`) and existing llama.cpp
wording (`exceeds the available context size`).
