### PR TITLE
Adjust split context for layer

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -179,13 +179,11 @@ struct create_tensors_helper : public create_tensors_helper_interface {
     inline ggml_context * ctx_for_layer(int i) const {
         return ctx_map.at(model.buft_layer[i].buft);
     }
-    inline ggml_context * ctx_for_layer_split(int i, bool force_split = false) const {
+    inline ggml_context * ctx_for_layer_split(int i) const {
         const bool is_mtp_layer = model.hparams.nextn_predict_layers > 0 &&
                                   static_cast<uint32_t>(i) >= model.hparams.n_layer - model.hparams.nextn_predict_layers;
-        if (is_mtp_layer && !force_split && model.arch != LLM_ARCH_GLM4_MOE) {
-            return ctx_map.at(model.buft_layer[i].buft);
-        }
-        return ctx_map.at(model.buft_layer[i].buft_matrix);
+        const bool mtp_can_use_graph_split = model.arch == LLM_ARCH_GLM4_MOE || model.arch == LLM_ARCH_QWEN35;
+        return is_mtp_layer && !mtp_can_use_graph_split ? ctx_map.at(model.buft_layer[i].buft) : ctx_map.at(model.buft_layer[i].buft_matrix);
     }
 
     std::map<ggml_backend_buffer_type_t, int> buft_layer_count;
@@ -1736,7 +1734,7 @@ bool create_tensors_helper::create_qwen35_tensors(const LLM_TN & tn) {
         const bool is_mtp_layer = hparams.nextn_predict_layers > 0 &&
                                   static_cast<uint32_t>(i) >= n_layer - hparams.nextn_predict_layers;
 
-        ggml_context * ctx_split = ctx_for_layer_split(i, true);
+        ggml_context * ctx_split = ctx_for_layer_split(i);
 
         int flags = 0;
         // Skip loading MTP layers if the feature is disabled


### PR DESCRIPTION

In #2047 I wanted @Nexesenex to use the same mechanism as I had used for Qwen35 to decide if the MTP layer is loaded into the layer or into the split context. But this turned out to be not a good idea as `ctx_for_layer_split` is used at two other places, which did not pass the optional `force_split` argument. Hence, after all, it is better to use the model arch in `ctx_for_layer_split` to decide. This PR does the change. 