### PR TITLE
Bump GGML_MAX_SRC to 16

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -242,7 +242,7 @@
 #endif
 #ifndef GGML_MAX_SRC
 // For the machines with 11+ GPUs use -DGGML_MAX_SRC=N
-#define GGML_MAX_SRC            12
+#define GGML_MAX_SRC            16
 #endif
 #ifndef GGML_MAX_NAME
 #define GGML_MAX_NAME           64


### PR DESCRIPTION

When experimenting on @magikRUKKOLA's system with 13 GPUs I keep forgetting to build with `-DGGML_MAX_SRC=13`, to only be greeted with a run-time failure when using split mode `graph` (because we can have a maximum of 12 GPUs participating on the current main branch). Enough is enough, so this PR increases max. sources to 16 (and let's hope that @magikRUKKOLA does not build a 17+-GPU system).   