### PR TITLE
Parallelize weight loading for weights targeted at anonymous host ram and also GPU

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -76,7 +76,7 @@ struct llama_file::impl {
         return ret;
     }
 
-    impl(const char * fname, const char * mode) : path(fname) {
+    impl(const char * fname, const char * mode) : path(fname), mode(mode) {
         fp = ggml_fopen(fname, mode);
         if (fp == NULL) {
             throw std::runtime_error(format("failed to open %s: %s", fname, strerror(errno)));
@@ -163,7 +163,7 @@ struct llama_file::impl {
         }
     }
 #else
-    impl(const char * fname, const char * mode) : path(fname) {
+    impl(const char * fname, const char * mode) : path(fname), mode(mode) {
         fp = ggml_fopen(fname, mode);
         if (fp == NULL) {
             throw std::runtime_error(format("failed to open %s: %s", fname, strerror(errno)));
@@ -244,10 +244,19 @@ struct llama_file::impl {
 
     FILE * fp;
     size_t size;
+    std::string mode;
 };
 
 llama_file::llama_file(const char * fname, const char * mode) : pimpl(std::make_unique<impl>(fname, mode)) {}
 llama_file::~llama_file() = default;
+
+std::unique_ptr<llama_file> llama_file::clone() const {
+    //can only clone readable file pointers without truncating.
+    GGML_ASSERT(!pimpl->mode.empty() && pimpl->mode[0] == 'r'
+                && pimpl->mode.find('+') == std::string::npos);
+    return std::make_unique<llama_file>(pimpl->path.c_str(), pimpl->mode.c_str());
+}
+
 
 size_t llama_file::tell() const { return pimpl->tell(); }
 size_t llama_file::size() const { return pimpl->size; }

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -31,6 +31,8 @@ struct llama_file {
     void write_u32(uint32_t val) const;
     const std::string & get_path() const;
 
+    std::unique_ptr<llama_file> clone() const;
+
 private:
     struct impl;
     std::unique_ptr<impl> pimpl;

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1067,16 +1067,16 @@ bool llama_model_loader::load_all_data(
     std::vector<no_init<uint8_t>> read_buf;
     std::vector<std::future<std::pair<ggml_tensor *, bool>>> validation_result;
 
+    // Number of worker threads for cuda and host tensor loading.
+    const int n_workers = 8;
+
 #if defined(GGML_USE_CUDA)
-    // 4 staging buffers for async uploads, each sized 1MB seems to be a good default for single NVMe drives.
-    // NVMe raid configurations might require more / larger buffers.
-    constexpr size_t n_buffers = 4;
-    constexpr size_t buffer_size = 1 * 1024 * 1024; // 1MB
+    // One pinned staging buffer per worker for async uploads
+    constexpr size_t buffer_size = 16 * 1024 * 1024; // 16MB
 
     std::vector<ggml_backend_buffer_t> host_buffers;
     std::vector<void*> host_ptrs;
     std::vector<ggml_backend_event_t> events;
-    size_t buffer_idx = 0; // buffer to use for async loads
 
     ggml_backend_t cuda_backend = nullptr;
     if (!use_mmap && !check_tensors) {
@@ -1096,11 +1096,14 @@ bool llama_model_loader::load_all_data(
 
         // If the cuda backend is active create pinned memory buffers and events for synchronisation.
         if (cuda_backend) {
-            for (size_t idx = 0; idx < n_buffers; ++idx) {
+            for (size_t idx = 0; idx < (size_t)n_workers; ++idx) {
                 host_buffers.emplace_back(ggml_backend_buft_alloc_buffer(llama_default_buffer_type_cpu(true), buffer_size));
                 host_ptrs.emplace_back(ggml_backend_buffer_get_base(host_buffers[idx]));
                 events.emplace_back(ggml_backend_event_new(cuda_backend));
             }
+            // Force creation of the upload stream now
+            ggml_backend_event_record(events[0]);
+            ggml_backend_event_synchronize(events[0]);
         }
     }
 #endif
@@ -1113,9 +1116,9 @@ bool llama_model_loader::load_all_data(
     // Load model weights into a backing buffer:
     // * mmap: host page cache        Serial
     // * host: system ram             Parallel
-    // * cuda: GPU                    Serial
+    // * cuda: GPU                    Parallel
     // * rest: All other backends,    Serial
-    auto load_tensor = [&](ggml_tensor * cur) -> size_t {
+    auto load_tensor = [&](ggml_tensor * cur, [[maybe_unused]] int thread_idx) -> size_t {
         const auto * weight = get_weight(ggml_get_name(cur));
         GGML_ASSERT(weight != nullptr);
         GGML_ASSERT(weight->idx < files.size());
@@ -1168,11 +1171,10 @@ bool llama_model_loader::load_all_data(
             return n_size;
         }
 
-        // cuda. Serialized
+        // cuda. Parallel
 #if defined(GGML_USE_CUDA)
         // If cuda_backend is valid load the tensor in chunks to pinned memory and upload the buffers asynchronously to the GPU.
         if (cuda_backend) {
-            std::lock_guard<std::mutex> lock(load_mutex);
             file->seek(weight->offs, SEEK_SET);
 
             size_t bytes_read = 0;
@@ -1180,14 +1182,12 @@ bool llama_model_loader::load_all_data(
             while (bytes_read < n_size) {
                 size_t read_iteration = std::min<size_t>(buffer_size, n_size - bytes_read);
 
-                ggml_backend_event_synchronize(events[buffer_idx]);
-                file->read_raw(host_ptrs[buffer_idx], read_iteration);
-                ggml_backend_tensor_set_async(cuda_backend, cur, host_ptrs[buffer_idx], bytes_read, read_iteration);
-                ggml_backend_event_record(events[buffer_idx]);
+                ggml_backend_event_synchronize(events[thread_idx]);
+                file->read_raw(host_ptrs[thread_idx], read_iteration);
+                ggml_backend_tensor_set_async(cuda_backend, cur, host_ptrs[thread_idx], bytes_read, read_iteration);
+                ggml_backend_event_record(events[thread_idx]);
 
                 bytes_read += read_iteration;
-                ++buffer_idx;
-                buffer_idx %= n_buffers;
             }
             return n_size;
         }
@@ -1236,7 +1236,7 @@ bool llama_model_loader::load_all_data(
     std::exception_ptr   first_exception;
 
     // threadpool worker.
-    auto worker = [&]() {
+    auto worker = [&](int thread_idx) {
         try {
             while (!cancelled.load() && !failed.load()) {
                 if (progress_callback) {
@@ -1251,7 +1251,7 @@ bool llama_model_loader::load_all_data(
                 if (!cur) {
                     break;
                 }
-                const size_t n_size = load_tensor(cur);
+                const size_t n_size = load_tensor(cur, thread_idx);
                 loaded.fetch_add(n_size, std::memory_order_relaxed);
             }
         } catch (...) {
@@ -1262,13 +1262,9 @@ bool llama_model_loader::load_all_data(
         }
     };
 
-    // Number of threads used to keep host-mapped reads disk-limited.
-    // For all other backend buffer types, loading is single threaded
-    // which is controlled by `load_mutex`
-    const int n_workers = 8;
     std::vector<std::thread> pool;
-    for (int i = 0; i < n_workers; ++i) {
-        pool.emplace_back(worker);
+    for (int thread_idx = 0; thread_idx < n_workers; ++thread_idx) {
+        pool.emplace_back(worker, thread_idx);
     }
     for (auto & t : pool) {
         t.join();
@@ -1285,7 +1281,7 @@ bool llama_model_loader::load_all_data(
 #if defined(GGML_USE_CUDA)
     // free temporary resources used for async cuda uploads
     if (cuda_backend) {
-        for (size_t idx = 0; idx < n_buffers;++idx) {
+        for (size_t idx = 0; idx < (size_t)n_workers;++idx) {
             ggml_backend_event_synchronize(events[idx]);
             ggml_backend_event_free(events[idx]);
             ggml_backend_buffer_free(host_buffers[idx]);

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -3,6 +3,7 @@
 #include "llama-mmap.h"
 #include "llama-model.h"
 #include "ggml.h"
+#include <memory>
 //#include "ggml-backend.h"
 
 #ifdef GGML_USE_CUDA
@@ -24,6 +25,9 @@
 #include <future>
 #include <regex>
 #include <algorithm>
+#include <thread>
+#include <atomic>
+#include <mutex>
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
@@ -1101,22 +1105,26 @@ bool llama_model_loader::load_all_data(
     }
 #endif
 
-    for (struct ggml_tensor * cur = ggml_get_first_tensor(ctx); cur != NULL; cur = ggml_get_next_tensor(ctx, cur)) {
+
+    // Tensors are loaded in a threadpool. A lot of the ops are serialized
+    // and this is the mutex we use.
+    std::mutex load_mutex;
+
+    // Load model weights into a backing buffer:
+    // * mmap: host page cache        Serial
+    // * host: system ram             Parallel
+    // * cuda: GPU                    Serial
+    // * rest: All other backends,    Serial
+    auto load_tensor = [&](ggml_tensor * cur) -> size_t {
         const auto * weight = get_weight(ggml_get_name(cur));
-        if (weight == nullptr) {
-            // this can happen with split experts models
-            continue;
-        }
+        GGML_ASSERT(weight != nullptr);
+        GGML_ASSERT(weight->idx < files.size());
+        const size_t n_size = ggml_nbytes(cur);
+        const auto file = files.at(weight->idx)->clone();
 
-        if (progress_callback) {
-            if (!progress_callback((float) size_done / size_data, progress_callback_user_data)) {
-                return false;
-            }
-        }
-
-        size_t n_size = ggml_nbytes(cur);
-
+        // mmap. Serialized.
         if (use_mmap) {
+            std::lock_guard<std::mutex> lock(load_mutex);
             const auto & mapping = mappings.at(weight->idx);
             ggml_backend_buffer_t buf_mmap = nullptr;
             if (bufs_mmap.count(weight->idx)) {
@@ -1144,53 +1152,134 @@ bool llama_model_loader::load_all_data(
             } else {
                 ggml_backend_tensor_set(cur, data, 0, n_size);
             }
-        } else {
-            GGML_ASSERT(weight->idx < files.size());
-            const auto & file = files.at(weight->idx);
-            if (ggml_backend_buffer_is_host(cur->buffer)) {
-                file->seek(weight->offs, SEEK_SET);
-                file->read_raw(cur->data, n_size);
-                if (check_tensors) {
-                    validation_result.emplace_back(std::async(std::launch::async, [cur, n_size] {
-                                return std::make_pair(cur, ggml_validate_row_data(cur->type, cur->data, n_size));
-                                }));
-                }
-            } else {
-#if defined(GGML_USE_CUDA)
-                // If cuda_backend is valid load the tensor in chunks to pinned memory and upload the buffers asynchronously to the GPU.
-                if (cuda_backend) {
-                    file->seek(weight->offs, SEEK_SET);
-
-                    size_t bytes_read = 0;
-
-                    while (bytes_read < n_size) {
-                        size_t read_iteration = std::min<size_t>(buffer_size, n_size - bytes_read);
-
-                        ggml_backend_event_synchronize(events[buffer_idx]);
-                        file->read_raw(host_ptrs[buffer_idx], read_iteration);
-                        ggml_backend_tensor_set_async(cuda_backend, cur, host_ptrs[buffer_idx], bytes_read, read_iteration);
-                        ggml_backend_event_record(events[buffer_idx]);
-
-                        bytes_read += read_iteration;
-                        ++buffer_idx;
-                        buffer_idx %= n_buffers;
-                    }
-                }
-                else
-#endif
-                {
-                    read_buf.resize(n_size);
-                    file->seek(weight->offs, SEEK_SET);
-                    file->read_raw(read_buf.data(), n_size);
-                    ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
-                    if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {
-                        throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
-                    }
-                }
-            }
+            return n_size;
         }
 
-        size_done += n_size;
+        // host. Parallel.
+        if (ggml_backend_buffer_is_host(cur->buffer)) {
+            file->seek(weight->offs, SEEK_SET);
+            file->read_raw(cur->data, n_size);
+            if (check_tensors) {
+                std::lock_guard<std::mutex> lock(load_mutex);
+                validation_result.emplace_back(std::async(std::launch::async, [cur, n_size] {
+                            return std::make_pair(cur, ggml_validate_row_data(cur->type, cur->data, n_size));
+                            }));
+            }
+            return n_size;
+        }
+
+        // cuda. Serialized
+#if defined(GGML_USE_CUDA)
+        // If cuda_backend is valid load the tensor in chunks to pinned memory and upload the buffers asynchronously to the GPU.
+        if (cuda_backend) {
+            std::lock_guard<std::mutex> lock(load_mutex);
+            file->seek(weight->offs, SEEK_SET);
+
+            size_t bytes_read = 0;
+
+            while (bytes_read < n_size) {
+                size_t read_iteration = std::min<size_t>(buffer_size, n_size - bytes_read);
+
+                ggml_backend_event_synchronize(events[buffer_idx]);
+                file->read_raw(host_ptrs[buffer_idx], read_iteration);
+                ggml_backend_tensor_set_async(cuda_backend, cur, host_ptrs[buffer_idx], bytes_read, read_iteration);
+                ggml_backend_event_record(events[buffer_idx]);
+
+                bytes_read += read_iteration;
+                ++buffer_idx;
+                buffer_idx %= n_buffers;
+            }
+            return n_size;
+        }
+#endif
+        // rest. Serialized.
+        {
+            std::lock_guard<std::mutex> lock(load_mutex);
+            read_buf.resize(n_size);
+            file->seek(weight->offs, SEEK_SET);
+            file->read_raw(read_buf.data(), n_size);
+            ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
+            if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {
+                throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
+            }
+            return n_size;
+        }
+    };
+
+    // An iterator that the threadpool shares to get the next tensor for loading.
+    // Each thread loops over this function until there are no more tensors left to load.
+    auto make_next_tensor = [&]() {
+        auto cursor = std::make_shared<std::atomic<ggml_tensor *>>(ggml_get_first_tensor(ctx));
+        auto next_tensor = [this, ctx, cursor]() -> ggml_tensor * {
+            while (true) {
+                ggml_tensor * cur = cursor->load();
+                if (!cur) {
+                    return nullptr;
+                }
+                if (!cursor->compare_exchange_weak(cur, ggml_get_next_tensor(ctx, cur))) {
+                    continue;
+                }
+
+                // With split experts models get_weight can return nullptr.
+                if (get_weight(ggml_get_name(cur))) {
+                    return cur;
+                }
+            }
+        };
+        return next_tensor;
+    };
+    auto next_tensor = make_next_tensor();
+
+    std::atomic<size_t>  loaded{size_done}; // bytes loaded so far, for the progress bar
+    std::atomic<bool>    cancelled{false};
+    std::atomic<bool>    failed{false};
+    std::exception_ptr   first_exception;
+
+    // threadpool worker.
+    auto worker = [&]() {
+        try {
+            while (!cancelled.load() && !failed.load()) {
+                if (progress_callback) {
+                    const size_t done   = loaded.load(std::memory_order_relaxed);
+                    std::lock_guard<std::mutex> lock(load_mutex);
+                    if (!progress_callback((float) done / size_data, progress_callback_user_data)) {
+                        cancelled.store(true);
+                        break;
+                    }
+                }
+                ggml_tensor * cur = next_tensor();
+                if (!cur) {
+                    break;
+                }
+                const size_t n_size = load_tensor(cur);
+                loaded.fetch_add(n_size, std::memory_order_relaxed);
+            }
+        } catch (...) {
+            std::lock_guard<std::mutex> lock(load_mutex);
+            if (!failed.exchange(true)) {
+                first_exception = std::current_exception();
+            }
+        }
+    };
+
+    // Number of threads used to keep host-mapped reads disk-limited.
+    // For all other backend buffer types, loading is single threaded
+    // which is controlled by `load_mutex`
+    const int n_workers = 8;
+    std::vector<std::thread> pool;
+    for (int i = 0; i < n_workers; ++i) {
+        pool.emplace_back(worker);
+    }
+    for (auto & t : pool) {
+        t.join();
+    }
+
+    size_done = loaded.load();
+    if (first_exception) {
+        std::rethrow_exception(first_exception);
+    }
+    if (cancelled.load()) {
+        return false;
     }
 
 #if defined(GGML_USE_CUDA)

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -28,6 +28,7 @@
 #include <thread>
 #include <atomic>
 #include <mutex>
+#include <cstring>
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
@@ -1064,11 +1065,12 @@ bool llama_model_loader::load_all_data(
             void * progress_callback_user_data) {
     GGML_ASSERT(size_data != 0 && "call init_mappings() first");
 
-    std::vector<no_init<uint8_t>> read_buf;
     std::vector<std::future<std::pair<ggml_tensor *, bool>>> validation_result;
 
     // Number of worker threads for cuda and host tensor loading.
     const int n_workers = 8;
+
+    std::vector<std::vector<no_init<uint8_t>>> read_bufs(n_workers);
 
 #if defined(GGML_USE_CUDA)
     // One pinned staging buffer per worker for async uploads
@@ -1114,11 +1116,12 @@ bool llama_model_loader::load_all_data(
     std::mutex load_mutex;
 
     // Load model weights into a backing buffer:
-    // * mmap: host page cache        Serial
-    // * host: system ram             Parallel
-    // * cuda: GPU                    Parallel
-    // * rest: All other backends,    Serial
-    auto load_tensor = [&](ggml_tensor * cur, [[maybe_unused]] int thread_idx) -> size_t {
+    // * mmap:               host page cache        Serial
+    // * host:               system ram             Parallel
+    // * cuda:               GPU                    Parallel
+    // * --split-mode graph: GPU                    Parallel
+    // * rest:               All other backends,    Serial
+    auto load_tensor = [&](ggml_tensor * cur, int thread_idx) -> size_t {
         const auto * weight = get_weight(ggml_get_name(cur));
         GGML_ASSERT(weight != nullptr);
         GGML_ASSERT(weight->idx < files.size());
@@ -1191,10 +1194,29 @@ bool llama_model_loader::load_all_data(
             }
             return n_size;
         }
+
+        // --split-mode graph. Parallel
+        const char * buffer_name = ggml_backend_buffer_name(cur->buffer);
+        const bool   is_probably_split_mode_graph = std::strncmp(buffer_name, GGML_CUDA_NAME, strlen(GGML_CUDA_NAME)) == 0;
+        if (is_probably_split_mode_graph) {
+            auto & read_buf = read_bufs[thread_idx];
+            if (read_buf.capacity() > n_size) {
+                read_buf = std::vector<no_init<uint8_t>>();
+            }
+            read_buf.resize(n_size);
+            file->seek(weight->offs, SEEK_SET);
+            file->read_raw(read_buf.data(), n_size);
+            ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
+            if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {
+                throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
+            }
+            return n_size;
+        }
 #endif
         // rest. Serialized.
         {
             std::lock_guard<std::mutex> lock(load_mutex);
+            auto & read_buf = read_bufs[thread_idx];
             read_buf.resize(n_size);
             file->seek(weight->offs, SEEK_SET);
             file->read_raw(read_buf.data(), n_size);


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Medium

Another PR to speed up model loading. Another PR in a  "spend my pocket money on runpod to spend less pocket money on runpod" series.

### Observation
I'm playing with kimi k2.5/6/7 on cheap runpod nodes. Startup time is dominated by the "loading weights into buffer" phase. When I look at htop, cpu usage is low (25% of a single core), and disk read rate is moderate (0.7G/s -- big metal on runpod is often good for nearly 10G/s )

So, I observe:
* Reading model weights into host ram is currently single threaded, and pingponging between IO and CPU.
* The task should be trivially parallelizable. My expectation is that sequential disk read should be the limiting factor for performance.
* Obvious answer is to add threads.

### Implementation
Existing loader function can load weights into 4 backend buffer kinds, all serialized loading. I am targeting the "load to host ram" path and my intention is to leave the rest alone.


Backend | Description | Execution
-- | -- | --
mmap | host page cache | Serial
host | system RAM | **Parallel** 🎯
cuda | GPU | Serial
rest | All other backends | Serial

Implementation is to extract main body of the loading function into a lambda, spawn a fixed number of threads for loading. To prevent changes in of behavior for the other three buffer "kinds" which I do not intent to parellelize, I added a mutex so that only one thread can progress at a time.

### Design considerations
* **Why do you spawn a fixed number of threads even for serialized loading and then make them fight over a mutex?**
  * This is extreme coarse grained work, so the contention will never dominate.
  * This implementation is actually the most reduced code churn compared to my first attempt. My first draft had a separated "serial path" and "parallel path", which was hard to handle. 
* **Why did you pick 8 threads?** This number nearly saturated the disk read speed on the runpod I am testing (actually 16 threads is 25% faster, but 8 threads is good). I claim _all_ SSDs (including enterprise and consumer) do not suffer significant throughput penalty for saturating with large sequential reads, so a fixed number of threads is not harmful.
* In the existing code, there's a note that says that a tensor may have no weights with a continue statement. This check is still present but it is moved to `make_next_tensor`.

## Benchmarks
* CPU: `AMD EPYC 7742 64-Core Processor`
* Storage `8x Samsung Electronics Co Ltd NVMe SSD Controller PM173X`
* Model: [https://huggingface.co/AesSedai/Kimi-K2.7-Code-GGUF](AesSedai/Kimi-K2.7-Code-GGUF)
* Amount of model weights loaded to host:  `479.57 GiB` 

Sequential loading | Parallel loading
-- | --
955s | 409s

## todo
* I tested on the big metal, but I will test on my home rig too. There should be a similar speedup
* Cuda path seems unchanged.
* I did not test the `mmap` path is not broken or regressed yet. I will do this. 
* I should test on windows. This will take some willpower to set up a build but I will do this. I don't have mac hardware so I can't test that.
* I did not check the `rest` path. (is this for vulkan? sycl?) Anyway I declare that I did not break it because I don't know how to activate it.

## Thoughts
* On the test rig, This patch accelerated host load speed from `0.7G/s` to `5G/s` average. The Cuda load path is doing disk reads at `0.7G/s` average, so maybe a similar speedup is available.
* `16`  threads is faster than `8` on the big metal rig.  I am scared to propose `16` because it sounds like a very high number, so this patch has `8`
