### PR TITLE
convert : recognize gpt-oss (o200k_harmony) tokenizer

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -715,6 +715,9 @@ class Model:
         if chkhsh == "9dcf830ee9990cdbf78cc523a5f7bd9ad8f3f9890c2d3581d2785ad10f07049d":
             # ref: https://huggingface.co/JetBrains/Mellum2-12B-A2.5B-Base
             res = "mellum2"
+        if chkhsh == "ccc2ef013c104be7bae2965776d611e1d7a8a2a9c547dd93a682c9a9fc80352e":
+            # ref: https://huggingface.co/openai/gpt-oss-20b
+            res = "gpt-4o"
         if res is None:
             logger.warning("\n")
             logger.warning("**************************************************************************************")

--- a/convert_hf_to_gguf_update.py
+++ b/convert_hf_to_gguf_update.py
@@ -106,6 +106,7 @@ models = [
     {"name": "grok-2",         "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/alvarobartt/grok-2-tokenizer", "chkhsh": "66b8d4e19ab16c3bfd89bce5d785fb7e0155e8648708a1f42077cb9fe002c273"},
     {"name": "minimax-m2",     "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/MiniMaxAI/MiniMax-M2", },
     {"name": "mellum2",        "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/JetBrains/Mellum2-12B-A2.5B-Base", },
+    {"name": "gpt-4o",         "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/openai/gpt-oss-20b", "chkhsh": "ccc2ef013c104be7bae2965776d611e1d7a8a2a9c547dd93a682c9a9fc80352e", },  # o200k_harmony shares the GPT-4o pre-tokenizer
 ]
 
 


### PR DESCRIPTION
Converting a gpt-oss model, or the z-lab gpt-oss DFlash drafts that reuse the gpt-oss tokenizer, currently fails at pre-tokenizer recognition. The o200k_harmony BPE checksum is not registered, so `get_vocab_base_pre()` returns `None` and conversion hits the "BPE pre-tokenizer was not recognized" warning path.

The o200k_harmony tokenizer shares the GPT-4o pre-tokenizer regex, which the runtime already implements as `LLAMA_VOCAB_PRE_TYPE_GPT4O`. So this patch registers the gpt-oss-20b tokenizer checksum against the existing `gpt-4o` pre-type rather than adding a new one.

The match is exact: this checksum is the gpt-4o o200k pre-tokenizer's own hash, so gpt-oss is using that same pre-tokenizer and `gpt-4o` is the right pre-type.

Changes:

- `convert_hf_to_gguf_update.py`: a models-list entry mapping `openai/gpt-oss-20b` to the `gpt-4o` pre-type, with an explicit `chkhsh` so regeneration doesn't need to re-download the tokenizer.
- `convert_hf_to_gguf.py`: the matching generated line in `get_vocab_base_pre()`.

That mirrors the existing z-lab Qwen3.5 DFlash entries, which map distinct draft tokenizer checksums onto the `qwen35` pre-type the same way.

Scope: converter only, and offline. This patch doesn't touch any model architecture, the inference path, or the runtime, and it adds no new pre-type. The only behavioral change is that the gpt-oss tokenizer checksum now resolves to the `gpt-4o` pre-type instead of falling through to the warning.

Validation: converted z-lab/gpt-oss-20b-DFlash with this mapping and the resulting GGUF loaded and generated coherently against a gpt-oss-20b target (that end-to-end run is in a companion DFlash PR, #2061).

- [x] I have read the contributing guidelines
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
