### PR TITLE
convert : map self-contained DFlash draft embed_tokens

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2592,6 +2592,8 @@ class DFlashDraftModel(Qwen3Model):
             return [(f"{gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.ATTN_SINKS].format(bid=bid)}.weight", data_torch)]
         if name == "norm.weight":
             name = "model.norm.weight"
+        elif name == "embed_tokens.weight":
+            name = "model.embed_tokens.weight"
         elif name.startswith("layers."):
             name = f"model.{name}"
 


### PR DESCRIPTION
DFlash drafts come in at least two shapes: some share the target model's token embeddings, and some carry their own. `DFlashDraftModel.modify_tensors` already rewrites a draft's flat-named `norm.weight` and `layers.N.*` tensors to their `model.*` form before handing them to the Qwen3 tensor mapper, but it does not do the same for `embed_tokens.weight`. A draft that ships its own (self-contained) token embeddings under the flat naming therefore cannot be converted:

```
ValueError: Can not map tensor 'embed_tokens.weight'
```

This patch adds the missing case, mirroring the existing `norm.weight` handling, with two insertions to `convert_hf_to_gguf.py`:

```python
if name == "norm.weight":
    name = "model.norm.weight"
elif name == "embed_tokens.weight":       <---
    name = "model.embed_tokens.weight"    <---
elif name.startswith("layers."):
    name = f"model.{name}"
```

The change is scoped to the flat `embed_tokens.weight` name. A draft that already uses `model.embed_tokens.weight`, or that shares the target's embeddings, is unaffected.

Verified by converting a self-contained Qwen3-backbone draft (`z-lab/MiniMax-M2.5-DFlash`) with its `MiniMaxAI/MiniMax-M2.5` target as `--target-model-dir`. The resulting GGUF loads with all tensors claimed and the DFlash metadata intact, and it runs speculation against a live MiniMax-M2 target with coherent output and draft acceptance around 50–60% (up to 84% on more predictable spans).

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
