### PR TITLE
GLM-DSA: improve TG performance

### DIFF
--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -458,55 +458,55 @@ ggml_tensor * llm_build_context::build_deepseek2_dsa_indexer(
         indexer_score = ggml_cast(ctx0, indexer_score, GGML_TYPE_F32);
         cb(indexer_score, "indexer_score_f32", il);
     }
-    for (int head = 0; head < n_ihead; ++head) {
-        int il_cb = 1000*(il + 1) + head;
-        // [1, n_tokens]
-        auto w  = ggml_cont(ctx0, ggml_view_2d(ctx0, indexer_weights, 1, indexer_weights->ne[1], indexer_weights->nb[1], indexer_weights->nb[0]*head));
-        cb(w, "iweights", il_cb);
-        // [head_size, n_tokens]
-        auto q = ggml_view_2d(ctx0, indexer_q, indexer_q->ne[0], indexer_q->ne[2], indexer_q->nb[2], indexer_q->nb[1]*head);
-        // [n_kv, n_tokens]
-        auto kq = ggml_mul_mat(ctx0, indexer_k_b, q);
-        cb(kq, "ikq", il_cb);
-        // [n_kv, n_tokens]
-        kq = ggml_relu(ctx0, kq);
-        cb(kq, "ikq_relu", il_cb);
-        // [n_kv, n_tokens]
-        auto score = ggml_mul(ctx0, kq, w);
-        cb(score, "score", il_cb);
-        indexer_score = ggml_add_inplace(ctx0, indexer_score, score);
-        cb(indexer_score, "indexer_score", il_cb);
-        ggml_build_forward_expand(gf, indexer_score);
+    if (indexer_q->ne[2] <= 8) {
+        // This covers TG and small batches (as needed for instance for speculative decoding). It is quite a bit faster than
+        // the loop over attention heads in the other branch. We limit it to a maximum of 8 tokens to limit compute buffer size.
+        // For insrtance, at a context of 512k tokens (n_kv = 524288), with 32 indexer attention heads (GLM-5), the K*Q result is
+        // 512 MiB for 8 tokens (64 MiB for 1 token). The ggml_relu op will be scheduled in-place, so no extra buffer needed there.
+        // The ggml_mul op will be hopefully also in-place.
+        // The ggml_cont(ctx0, ggml_transpose(ctx0, indexer_kq)) will require a second buffer. We use ggml_cont for now
+        // because the CUDA ggml_mul implementation does not support non-contiguous tensors.
+        // So, worse case for 512k context and 8 tokens is 1 GiB compute buffer.
+        // A dedicated op that performs the relu, the multiplication, and the summation over attention heads would reduce
+        // this by a factor of 32 (and most likely also bring non-negligible performance gains).
+        // But for now, let's go with this.
+        indexer_q = ggml_reshape_2d(ctx0, indexer_q, indexer_q->ne[0], indexer_q->ne[1]*indexer_q->ne[2]); // [head_size, n_ihead*n_tokens]
+        auto indexer_kq = ggml_mul_mat(ctx0, indexer_k_b, indexer_q); // [n_kv, n_ihead*n_tokens]
+        cb(indexer_kq, "dsa_indexer_kq", il);
+        indexer_kq = ggml_relu(ctx0, indexer_kq);
+        cb(indexer_kq, "dsa_indexer_kq_relu", il);
+        indexer_kq = ggml_reshape_3d(ctx0, indexer_kq, indexer_kq->ne[0], indexer_q->ne[1], indexer_kq->ne[1]/indexer_q->ne[1]); // [n_kv, n_ihead, n_tokens]
+        indexer_kq = ggml_cont(ctx0, ggml_transpose(ctx0, indexer_kq));                                                          // [n_ihead, n_kv, n_tokens]
+        indexer_weights = ggml_reshape_3d(ctx0, indexer_weights, indexer_weights->ne[0], 1, indexer_weights->ne[1]);  // [n_ihead,    1, n_tokens]
+        indexer_kq = ggml_mul(ctx0, indexer_kq, indexer_weights);
+        cb(indexer_kq, "dsa_indexer_kq_w", il);
+        auto score = ggml_sum_rows(ctx0, indexer_kq); // [1, n_kv, n_tokens]
+        cb(score, "dsa_indexer_score", il);
+        score = ggml_reshape_2d(ctx0, score, score->ne[1], score->ne[2]);
+        indexer_score = ggml_add(ctx0, indexer_score, score);
+        cb(indexer_score, "dsa_indexer_score", il);
+    } else {
+        for (int head = 0; head < n_ihead; ++head) {
+            int il_cb = 1000*(il + 1) + head;
+            // [1, n_tokens]
+            auto w  = ggml_cont(ctx0, ggml_view_2d(ctx0, indexer_weights, 1, indexer_weights->ne[1], indexer_weights->nb[1], indexer_weights->nb[0]*head));
+            cb(w, "iweights", il_cb);
+            // [head_size, n_tokens]
+            auto q = ggml_view_2d(ctx0, indexer_q, indexer_q->ne[0], indexer_q->ne[2], indexer_q->nb[2], indexer_q->nb[1]*head);
+            // [n_kv, n_tokens]
+            auto kq = ggml_mul_mat(ctx0, indexer_k_b, q);
+            cb(kq, "ikq", il_cb);
+            // [n_kv, n_tokens]
+            kq = ggml_relu(ctx0, kq);
+            cb(kq, "ikq_relu", il_cb);
+            // [n_kv, n_tokens]
+            auto score = ggml_mul(ctx0, kq, w);
+            cb(score, "score", il_cb);
+            indexer_score = ggml_add_inplace(ctx0, indexer_score, score);
+            cb(indexer_score, "indexer_score", il_cb);
+            ggml_build_forward_expand(gf, indexer_score);
+        }
     }
-
-    //// {n_kv(keys), n_tokens(q), n_ihead}  (k's head dim broadcasts over n_ihead)
-    //ggml_tensor * indexer_kq = ggml_mul_mat(ctx0, indexer_k_b, indexer_q);
-    //cb(indexer_kq, "dsa_indexer_kq", il);
-
-    //// -> {n_ihead, n_tokens(q), n_kv(keys)} for per-head weighting
-    //indexer_kq = ggml_cont(ctx0, ggml_permute(ctx0, indexer_kq, 2, 1, 0, 3));
-
-    //ggml_tensor * indexer_score = ggml_relu(ctx0, indexer_kq);
-
-    //// weights {n_ihead, n_tokens} -> {n_ihead, n_tokens, 1} broadcast over keys
-    //indexer_weights = ggml_reshape_3d(ctx0, indexer_weights, n_ihead, n_tokens, 1);
-    //indexer_score = ggml_mul(ctx0, indexer_score, indexer_weights);
-
-    //// sum over heads -> {1, n_tokens(q), n_kv(keys)}
-    //indexer_score = ggml_sum_rows(ctx0, indexer_score);
-
-    //// -> {n_kv(keys), n_tokens(q), 1}
-    //indexer_score = ggml_cont(ctx0, ggml_permute(ctx0, indexer_score, 2, 1, 0, 3));
-    //cb(indexer_score, "dsa_indexer_score", il);
-
-    //// add base causal mask over the n_kv keys: first n_tokens query columns of KQ_mask {n_kv, n_tokens_pad}.
-    //ggml_tensor * causal = ggml_view_2d(ctx0, KQ_mask, n_kv, n_tokens, KQ_mask->nb[1], 0);
-    //// Under -fa 1 the dense KQ_mask is F16; CPU ggml_add only supports F32+F16 when src0 is F16,
-    //// not F32(score)+F16(mask) (it aborts). Cast the causal mask view to F32 so the add is valid on
-    //// CPU. (CUDA add accepts mixed types, so this only bit the CPU build.)
-    //if (causal->type != GGML_TYPE_F32) causal = ggml_cast(ctx0, ggml_cont(ctx0, causal), GGML_TYPE_F32);
-    //indexer_score = ggml_add(ctx0, indexer_score, causal);
-    //cb(indexer_score, "dsa_indexer_score_masked", il);
 
     // Attention-sink force-inclusion: add a finite positive boost to each query's OWN SEQUENCE's
     // first n_sink present tokens so the sink token(s) always survive the top-k selection. Masking


### PR DESCRIPTION

As part of the effort to reduce the compute buffer sizes required for GLM-DSA, the indexer computation was done in a loop over indexer attention heads.

This PR changes the approach for small batches (<=8) to compute the indexer score via a single matrix multiplication. RELU, and sum over attention heads. The change is limited for batch sizes <=8 to preserve the compute buffer reduction of the loop over attention heads.

The change improves GLM-DSA TG performance by nearly 10%.

DSA is still slower than no-DSA, but hopefully we can improve that in follow up PRs.

Below are some `sweep-bench` results with this PR compared to no-DSA. GLM-5.2-Q4_K_M, 13x3090 (limited to 200W each), Ryzen-3995WX CPU. Command line is
```
GGML_CUDA_NO_PINNED=1 ./bin/llama-sweep-bench \
    -m /zfsdata/data/GLM-5.2-GGUF/UD-Q4_K_M/GLM-5.2-UD-Q4_K_M-00001-of-00011.gguf \
    -t 64 -ngl 100 -b 4096 -ub 4096 -c 20480 -n 64 -amb 256 \
    --fit --fit-margin 2048 --gpu-fit-margin 0,614
```
which results in routed experts in 37 layers being left in RAM.

### No DSA

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   23.851 |   171.73 |    5.764 |    11.10 |
|  4096 |     64 |   4096 |   28.275 |   144.86 |    5.958 |    10.74 |
|  4096 |     64 |   8192 |   32.856 |   124.66 |    6.118 |    10.46 |
|  4096 |     64 |  12288 |   37.068 |   110.50 |    6.245 |    10.25 |
|  4096 |     64 |  16384 |   41.191 |    99.44 |    6.388 |    10.02 |

### DSA, this PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   25.027 |   163.66 |    5.860 |    10.92 |
|  4096 |     64 |   4096 |   30.496 |   134.31 |    6.183 |    10.35 |
|  4096 |     64 |   8192 |   35.914 |   114.05 |    6.419 |     9.97 |
|  4096 |     64 |  12288 |   40.847 |   100.28 |    6.613 |     9.68 |
|  4096 |     64 |  16384 |   45.941 |    89.16 |    6.776 |     9.45 |
 