### PR TITLE
GLM-DSA: improve TG performance even more

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -2039,7 +2039,10 @@ static void ggml_backend_sched_copy_inputs(ggml_backend_sched_t sched, ggml_back
                     ggml_backend_tensor_get_async(ids_backend, ids_tensor, ids.data(), 0, ggml_nbytes(ids_tensor));
 
                     ggml_backend_synchronize(ids_backend);
-                    needs_sync[tensor_backend_id(ids_tensor)] = k_set_sync;
+                    if (auto id = tensor_backend_id(ids_tensor); id >= 0 && id < GGML_SCHED_MAX_BACKENDS) {
+                        needs_sync[id] = k_set_sync;
+                    }
+                    //needs_sync[tensor_backend_id(ids_tensor)] = k_set_sync;
 
                     unique_ids.resize((n_expert + 31)/32);
                     std::memset(unique_ids.data(), 0, unique_ids.size()*sizeof(uint32_t));

--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -323,6 +323,29 @@ ggml_tensor * llm_build_context::build_deepseek2_tp_attention(
     return combined;
 }
 
+static inline int dsa_n_top_k(const llama_context & lctx) {
+    int n_top_k = lctx.model.hparams.indexer_top_k;
+    if (lctx.cparams.dsa_top_k >= 0) n_top_k = lctx.cparams.dsa_top_k;
+    return n_top_k;
+}
+static inline bool dsa_should_use(const llama_context & lctx) {
+    return lctx.cparams.dsa && lctx.model.arch == LLM_ARCH_GLM_DSA && !lctx.kv_self.kr_l.empty();
+}
+static inline bool dsa_should_use(const llama_context & lctx, int il) {
+    return dsa_should_use(lctx) && lctx.model.layers[il].indexer_attn_q_b && lctx.kv_self.kr_l.size() > (size_t) il && lctx.kv_self.kr_l[il];
+}
+static inline bool dsa_can_use_fast_path(const llama_context & lctx, int n_tokens, int n_kv) {
+    auto n_top_k = dsa_n_top_k(lctx);
+    if (n_tokens == 1 && n_top_k < n_kv && n_top_k%256 == 0 && lctx.cparams.flash_attn && (lctx.cparams.mla_attn == 1 || lctx.cparams.mla_attn == 3)) {
+        // We need this check because we need to pretend that the KV cache is F32 so we can use ggml_get_rows to extract
+        // the rows selected by the indexer. In order this to work, the KV cache row size must be a multiple of sizeof(float).
+        auto k = lctx.kv_self.k_l[0];
+        auto row_size = ggml_row_size(k->type, k->ne[0]);
+        return row_size % sizeof(float) == 0;
+    }
+    return false;
+}
+
 // DSA lightning indexer (GLM-5.2 / DeepSeek-V3.2). CACHE-BACKED: the batch's indexer keys are
 // (Hadamard-rotated and) written to a persistent per-layer indexer-key cache (kv_self.kr_l[il]) at
 // kv_head, then the FULL [head_size, n_kv] cached key set is read back and scored against the current
@@ -722,6 +745,9 @@ ggml_tensor * llm_build_context::build_deepseek2_layer_attention(
     ggml_tensor * sparse_mask    = KQ_mask;
     ggml_tensor * sparse_mask_fa = KQ_mask;
 
+    bool use_dsa       = dsa_should_use(lctx, il);
+    bool dsa_fast_path = use_dsa && dsa_can_use_fast_path(lctx, n_tokens, n_kv);
+
     // self_attention
     {
         ggml_tensor * q = nullptr;
@@ -775,27 +801,30 @@ ggml_tensor * llm_build_context::build_deepseek2_layer_attention(
                 // for prefill AND decode (single sequence). Gate: --dsa opt-in (off by default) +
                 // GLM_DSA arch + indexer tensors + cache. When off, the model runs the dense MLA path,
                 // byte-identical to a build without this feature.
-                if (lctx.cparams.dsa && model.arch == LLM_ARCH_GLM_DSA && model.layers[il].indexer_attn_q_b
-                        && kv_self.kr_l.size() > (size_t) il && kv_self.kr_l[il]) {
+                if (use_dsa) {
                     // GLM-5.2 IndexShare: "full" layers compute their own lightning-indexer top-k;
                     // "shared" layers reuse the previous full layer's top-k (transformers reference:
                     // shared layer indexer=None, topk_indices=prev_topk_indices). The full/shared map is
                     // hparams.indexer_is_full (GGUF metadata or derived config rule). At a given step all
                     // layers share the same n_kv/n_tokens, so a full layer's argsort is valid to reuse.
                     if (hparams.indexer_is_full[il]) {
-                        auto sorted = build_deepseek2_dsa_indexer(gf, il, q, cur, KQ_mask, inp_pos);
-                        if (lctx.cparams.flash_attn) {
-                            last_sparse_mask_fa = ::build_deepseek2_dsa_fa_mask(lctx, ctx0, KQ_mask, sorted);
-                        } else {
-                            last_sparse_mask = build_deepseek2_dsa_sparse_mask(sorted, KQ_mask);
+                        dsa_last_full_sorted = build_deepseek2_dsa_indexer(gf, il, q, cur, KQ_mask, inp_pos);
+                        if (!dsa_fast_path) {
+                            if (lctx.cparams.flash_attn) {
+                                last_sparse_mask_fa = ::build_deepseek2_dsa_fa_mask(lctx, ctx0, KQ_mask, dsa_last_full_sorted);
+                            } else {
+                                last_sparse_mask = build_deepseek2_dsa_sparse_mask(dsa_last_full_sorted, KQ_mask);
+                            }
                         }
                     }
-                    if (lctx.cparams.flash_attn) {
-                        GGML_ASSERT(last_sparse_mask_fa);
-                        sparse_mask_fa = last_sparse_mask_fa;
-                    } else {
-                        GGML_ASSERT(last_sparse_mask);
-                        sparse_mask = last_sparse_mask;
+                    if (!dsa_fast_path) {
+                        if (lctx.cparams.flash_attn) {
+                            GGML_ASSERT(last_sparse_mask_fa);
+                            sparse_mask_fa = last_sparse_mask_fa;
+                        } else {
+                            GGML_ASSERT(last_sparse_mask);
+                            sparse_mask = last_sparse_mask;
+                        }
                     }
                 }
 
@@ -1009,13 +1038,27 @@ ggml_tensor * llm_build_context::build_deepseek2_layer_attention(
                 cb(q, "q", il);
 
                 if (lctx.cparams.flash_attn && (lctx.cparams.mla_attn == 1 || lctx.cparams.mla_attn == 3)) {
-                    ggml_tensor * kv_cache_lora = ggml_view_2d(ctx0, kv_self.k_l[il],
-                            kv_lora_rank, n_kv,
-                            ggml_row_size(kv_self.k_l[il]->type, kv_lora_rank + n_embd_head_qk_rope),
-                            ggml_row_size(kv_self.k_l[il]->type, n_embd_head_qk_rope));
-                    cb(kv_cache_lora, "kv_cache_lora", il);
 
-                    kqv_compressed = ggml_flash_attn_ext(ctx0, q, kv_cache, kv_cache_lora, sparse_mask_fa, kq_scale, hparams.f_max_alibi_bias, 0.f);
+                    if (dsa_fast_path) {
+                        auto row_size = ggml_row_size(kv_self.k_l[il]->type, kv_self.k_l[il]->ne[0]);
+                        GGML_ASSERT(row_size % sizeof(float) == 0);
+                        GGML_ASSERT(dsa_last_full_sorted);
+                        GGML_ASSERT(ggml_nrows(dsa_last_full_sorted) == 1);
+                        auto k32 = ggml_reshape_4d_ext(ctx0, kv_self.k_l[il], GGML_TYPE_F32, row_size/sizeof(float),
+                                kv_self.k_l[il]->ne[1], kv_self.k_l[il]->ne[2], kv_self.k_l[il]->ne[3]);
+                        k32 = ggml_get_rows(ctx0, k32, dsa_last_full_sorted);
+                        auto k = ggml_reshape_4d_ext(ctx0, k32, kv_self.k_l[il]->type, kv_self.k_l[il]->ne[0], k32->ne[1], k32->ne[2], k32->ne[3]);
+                        auto v = ggml_view_2d(ctx0, k, kv_lora_rank, k->ne[1], k->nb[1], ggml_row_size(k->type, n_embd_head_qk_rope));
+                        kqv_compressed = ggml_flash_attn_ext(ctx0, q, k, v, dsa_tg_fast_mask, kq_scale, hparams.f_max_alibi_bias, 0.f);
+                    } else {
+                        ggml_tensor * kv_cache_lora = ggml_view_2d(ctx0, kv_self.k_l[il],
+                                kv_lora_rank, n_kv,
+                                ggml_row_size(kv_self.k_l[il]->type, kv_lora_rank + n_embd_head_qk_rope),
+                                ggml_row_size(kv_self.k_l[il]->type, n_embd_head_qk_rope));
+                        cb(kv_cache_lora, "kv_cache_lora", il);
+
+                        kqv_compressed = ggml_flash_attn_ext(ctx0, q, kv_cache, kv_cache_lora, sparse_mask_fa, kq_scale, hparams.f_max_alibi_bias, 0.f);
+                    }
                     cb(kqv_compressed, "kqv_compressed", il);
 
                     if (use_f32_attn_precision) {
@@ -1202,7 +1245,7 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
     // KQ_mask (mask for 1 head, it will be broadcasted to all heads)
     struct ggml_tensor * KQ_mask = build_inp_KQ_mask();
 
-    if (lctx.cparams.dsa && model.arch == LLM_ARCH_GLM_DSA) {
+    if (dsa_should_use(lctx)) {
         static const int n_sink = []{ const char * e = getenv("DSA_SINK"); return e ? atoi(e) : 1; }();
         if (n_sink > 0 && n_sink < (int) n_kv) {
             lctx.inp_dsa_sink = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_kv, n_tokens);
@@ -1210,10 +1253,28 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
             ggml_set_input(lctx.inp_dsa_sink);
             ggml_build_forward_expand(gf, lctx.inp_dsa_sink);
         }
-        auto minus_inf = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, KQ_mask->ne[0], n_tokens);
-        minus_inf = ggml_fill_inplace(ctx0, minus_inf, -INFINITY);
-        ggml_build_forward_expand(gf, minus_inf);
-        lctx.inp_mask_inf = minus_inf;
+        if (dsa_can_use_fast_path(lctx, n_tokens, n_kv)) {
+            // For DSA token generation (i.e., n_tokens = 1), when we have more than n_top_k entries in the KV cache,
+            // we can simply pick the selected n_top_k entries from the cache via ggml_get_rows, so the mask we
+            // require is all ON (ideally we shouldn't require a mask, but I think we have places in the FA
+            // implementation which assume that there is a mask).
+            int n_top_k = dsa_n_top_k(lctx);
+            int n_padded = GGML_PAD(n_top_k, 256);
+            auto minus_inf = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, n_padded*KQ_mask->ne[1] - n_top_k);
+            minus_inf = ggml_fill_inplace(ctx0, minus_inf, -INFINITY);
+            auto zero = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, n_top_k);
+            zero = ggml_fill_inplace(ctx0, zero, 0.0f);
+            auto mask = ggml_concat(ctx0, zero, minus_inf, 0);
+            mask = ggml_cast(ctx0, mask, GGML_TYPE_F16);
+            mask = ggml_reshape_2d(ctx0, mask, n_padded, KQ_mask->ne[1]);
+            ggml_build_forward_expand(gf, mask);
+            dsa_tg_fast_mask = mask;
+        } else {
+            auto minus_inf = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, KQ_mask->ne[0], n_tokens);
+            minus_inf = ggml_fill_inplace(ctx0, minus_inf, -INFINITY);
+            ggml_build_forward_expand(gf, minus_inf);
+            lctx.inp_mask_inf = minus_inf;
+        }
     }
 
     last_sparse_mask = last_sparse_mask_fa = nullptr;

--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -329,7 +329,7 @@ static inline int dsa_n_top_k(const llama_context & lctx) {
     return n_top_k;
 }
 static inline bool dsa_should_use(const llama_context & lctx) {
-    return lctx.cparams.dsa && lctx.model.arch == LLM_ARCH_GLM_DSA && !lctx.kv_self.kr_l.empty();
+    return lctx.cparams.mtp_op_type == MTP_OP_NONE && lctx.cparams.dsa && lctx.model.arch == LLM_ARCH_GLM_DSA && !lctx.kv_self.kr_l.empty();
 }
 static inline bool dsa_should_use(const llama_context & lctx, int il) {
     return dsa_should_use(lctx) && lctx.model.layers[il].indexer_attn_q_b && lctx.kv_self.kr_l.size() > (size_t) il && lctx.kv_self.kr_l[il];
@@ -1277,7 +1277,7 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
         }
     }
 
-    last_sparse_mask = last_sparse_mask_fa = nullptr;
+    last_sparse_mask = last_sparse_mask_fa = dsa_last_full_sorted = dsa_tg_fast_mask = nullptr;
 
     // whether to use n_tokens as the matrix dimension during multiplication or n_head
     // n_tokens is higher during prompt processing, this allows to optimize for this case

--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -1277,7 +1277,7 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
         }
     }
 
-    last_sparse_mask = last_sparse_mask_fa = dsa_last_full_sorted = dsa_tg_fast_mask = nullptr;
+    last_sparse_mask = last_sparse_mask_fa = dsa_last_full_sorted = nullptr;
 
     // whether to use n_tokens as the matrix dimension during multiplication or n_head
     // n_tokens is higher during prompt processing, this allows to optimize for this case

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -102,6 +102,7 @@ struct llm_build_context {
     struct ggml_tensor * dsa_last_full_sorted = nullptr;
     struct ggml_tensor * last_sparse_mask_fa  = nullptr;
     struct ggml_tensor * last_sparse_mask     = nullptr;
+    struct ggml_tensor * dsa_tg_fast_mask     = nullptr;
 
     // TODO: consider making the entire interface noexcept
     llm_build_context(


### PR DESCRIPTION

This PR follows in the footsteps of #2066 and #2067 and further improves GLM TG performance when using DSA. TG performance is now better than no DSA for context length greater than 8k tokens or so.

For TG the trick to take advantage of sparse attention is relatively simple: we just need to take out from the MLA cache the `n_top_k` keys selected by the indexer, and then do FA with just those. Hence, past 2k tokens (`n_top_k = 2048` for GLM-5), FA is constant time per generated token. TG performance still slightly degrades with context length as the cost of the indexer increases linearly with context, but overall the performance decrease is very slow (see table below).    

Below are some sweep-bench results with this PR compared to no-DSA. GLM-5.2-Q4_K_M, 13x3090 (limited to 200W each), Ryzen-3995WX CPU. Command line is
```
GGML_CUDA_NO_PINNED=1 ./bin/llama-sweep-bench \
    -m /zfsdata/data/GLM-5.2-GGUF/UD-Q4_K_M/GLM-5.2-UD-Q4_K_M-00001-of-00011.gguf \
    -t 64 -ngl 100 -ub 2048 -c 65536 -n 64 -amb 256 -wgt 1 \
    --fit --fit-margin 2048 --gpu-fit-margin 0,6144 [-dsa]
```
which results in routed experts in 37 layers being left in RAM.

### No DSA

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |   17.296 |   118.41 |    5.755 |    11.12 |
|  2048 |     64 |   2048 |   17.964 |   114.01 |    5.919 |    10.81 |
|  2048 |     64 |   4096 |   18.838 |   108.72 |    5.955 |    10.75 |
|  2048 |     64 |   6144 |   19.827 |   103.29 |    5.983 |    10.70 |
|  2048 |     64 |   8192 |   20.845 |    98.25 |    6.087 |    10.51 |
|  2048 |     64 |  10240 |   21.607 |    94.78 |    6.153 |    10.40 |
|  2048 |     64 |  12288 |   22.630 |    90.50 |    6.223 |    10.28 |
|  2048 |     64 |  14336 |   23.640 |    86.63 |    6.274 |    10.20 |
|  2048 |     64 |  16384 |   24.656 |    83.06 |    6.386 |    10.02 |
|  2048 |     64 |  18432 |   24.930 |    82.15 |    6.441 |     9.94 |
|  2048 |     64 |  20480 |   25.760 |    79.50 |    6.510 |     9.83 |
|  2048 |     64 |  22528 |   26.875 |    76.21 |    6.558 |     9.76 |
|  2048 |     64 |  24576 |   27.895 |    73.42 |    6.677 |     9.59 |
|  2048 |     64 |  26624 |   28.774 |    71.18 |    6.785 |     9.43 |
|  2048 |     64 |  28672 |   29.821 |    68.68 |    6.798 |     9.42 |
|  2048 |     64 |  30720 |   30.708 |    66.69 |    6.882 |     9.30 |
|  2048 |     64 |  32768 |   31.620 |    64.77 |    6.992 |     9.15 |
|  2048 |     64 |  34816 |   32.508 |    63.00 |    7.111 |     9.00 |
|  2048 |     64 |  36864 |   39.366 |    52.02 |    7.076 |     9.05 |
|  2048 |     64 |  38912 |   40.443 |    50.64 |    7.176 |     8.92 |
|  2048 |     64 |  40960 |   41.706 |    49.11 |    7.273 |     8.80 |
|  2048 |     64 |  43008 |   42.938 |    47.70 |    7.274 |     8.80 |
|  2048 |     64 |  45056 |   44.136 |    46.40 |    7.416 |     8.63 |
|  2048 |     64 |  47104 |   45.519 |    44.99 |    7.444 |     8.60 |
|  2048 |     64 |  49152 |   46.851 |    43.71 |    7.474 |     8.56 |
|  2048 |     64 |  51200 |   48.149 |    42.53 |    7.531 |     8.50 |
|  2048 |     64 |  53248 |   49.261 |    41.57 |    7.615 |     8.40 |
|  2048 |     64 |  55296 |   50.569 |    40.50 |    7.651 |     8.37 |
|  2048 |     64 |  57344 |   51.710 |    39.61 |    7.765 |     8.24 |
|  2048 |     64 |  59392 |   52.900 |    38.71 |    7.802 |     8.20 |
|  2048 |     64 |  61440 |   54.233 |    37.76 |    7.875 |     8.13 |
|  2048 |     64 |  63488 |   55.434 |    36.94 |    7.918 |     8.08 |

### DSA (this PR)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |   17.767 |   115.27 |    5.865 |    10.91 |
|  2048 |     64 |   2048 |   18.530 |   110.53 |    6.027 |    10.62 |
|  2048 |     64 |   4096 |   19.720 |   103.85 |    6.062 |    10.56 |
|  2048 |     64 |   6144 |   21.038 |    97.35 |    6.078 |    10.53 |
|  2048 |     64 |   8192 |   22.202 |    92.24 |    6.093 |    10.50 |
|  2048 |     64 |  10240 |   23.409 |    87.49 |    6.115 |    10.47 |
|  2048 |     64 |  12288 |   24.580 |    83.32 |    6.139 |    10.42 |
|  2048 |     64 |  14336 |   25.767 |    79.48 |    6.132 |    10.44 |
|  2048 |     64 |  16384 |   27.159 |    75.41 |    6.143 |    10.42 |
|  2048 |     64 |  18432 |   27.805 |    73.66 |    6.153 |    10.40 |
|  2048 |     64 |  20480 |   29.058 |    70.48 |    6.161 |    10.39 |
|  2048 |     64 |  22528 |   30.311 |    67.57 |    6.214 |    10.30 |
|  2048 |     64 |  24576 |   31.310 |    65.41 |    6.196 |    10.33 |
|  2048 |     64 |  26624 |   32.364 |    63.28 |    6.230 |    10.27 |
|  2048 |     64 |  28672 |   33.615 |    60.93 |    6.221 |    10.29 |
|  2048 |     64 |  30720 |   34.585 |    59.22 |    6.271 |    10.21 |
|  2048 |     64 |  32768 |   35.748 |    57.29 |    6.236 |    10.26 |
|  2048 |     64 |  34816 |   36.888 |    55.52 |    6.250 |    10.24 |
|  2048 |     64 |  36864 |   43.920 |    46.63 |    6.258 |    10.23 |
|  2048 |     64 |  38912 |   45.225 |    45.28 |    6.293 |    10.17 |
|  2048 |     64 |  40960 |   46.860 |    43.70 |    6.305 |    10.15 |

The DSA run aborts with OOM on device 12 at a context of 43008 tokens, so I guess I need a larger margin there as well (so one less MoE layer offloaded). But we see that at a context of 40k tokens DSA TG is ~15% better than no DSA, with the gap likely increasing even further at longer context. PP is of course still worse by 10-15%, but improving this will be a separate effort.

     