### PR TITLE
GLM-DSA: much better PP performance (CPU-only)

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -21919,7 +21919,8 @@ static void ggml_compute_forward_flash_attn_ext_f16(
                 Dk, Dv, neq1, nek1, q->nb[1], k->nb[1], v->nb[1], mask ? mask->nb[1] : 0,
                 q->data, k->data, v->data, mask ? mask->data : NULL, sinks ? sinks->data : NULL,
                 scale, softcap, (float *)dst->data,
-                params->wdata, (barrier_t)ggml_barrier, (void *)params->shared, ith, nth, dst->op_params[4])) return;
+                params->wdata, (barrier_t)ggml_barrier, (void *)params->shared, ith, nth, dst->op_params[4],
+                dst->src[5])) return;
 
 //    if (max_bias <= 0.0f && q->type == GGML_TYPE_F32 && mask && mask->type == GGML_TYPE_F16) {
 //        //if (ith == 0) printf("k: %ld x %ld x %ld, q: %ld x %ld x %ld, v: %ld x %ld x %ld mask: %ld x %ld x %ld\n",

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -177,9 +177,6 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
 
     if (indexer && indexer->type == GGML_TYPE_I32) {
         if (indexer->ne[0] < nek1 && neq1 >= nth && neq3 == 1 && nek3 == 1 && nev3 == 1 && nek2 == 1) {
-            //if (ith == 0) {
-            //    printf("%s: could use indexer as indexer->ne[0] = %ld, neq1 = %d, nek1 = %d, nek2 = %d nth = %d\n", __func__, indexer->ne[0], neq1, nek1, nek2, nth);
-            //}
             int npt = (neq1 + nth - 1)/nth;
             int ith_mid = nth;
             int neq1_this_thread = npt;
@@ -212,13 +209,6 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
                 }
                 auto this_q = (const char *)q + iq*stride_q;
                 auto this_qkv = qkv + iq*ne1*nb1/sizeof(float);
-                //iqk_flash_attn_noalibi(type_q, type_mask, max_bias,
-                //        neq3, neq2, nbq3, nbq2, nek3, nek2, nbk3, nbk2, nev3, nev2, nbv3, nbv2, ne2, ne1, nb1,
-                //        int_type_k_in, int_type_v, Dk, Dv, 1, nkv,
-                //        stride_q, row_size_k, row_size_v, 0,
-                //        this_q, work_k, work_v, work_m,
-                //        sinks, scale, softcap, this_qkv,
-                //        nullptr, barrier, barrier_data, 0, 1, 0, nullptr);
                 if (!iqk_flash_attn_impl(int_type_k_in, int_type_v,
                          Dk, Dv, neq2, nkv, nbq2, row_size_k, row_size_v, 0, Dv,
                          (const float *)this_q, work_k, work_v, work_m, nullptr, 0,

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -51,6 +51,14 @@ size_t iqk_fa_work_buffer_size(const struct ggml_tensor * dst, int nth) {
     auto Q = dst->src[0];
     auto K = dst->src[1];
     auto V = dst->src[2];
+    auto indexer = dst->src[5];
+    if (indexer && indexer->type == GGML_TYPE_I32 && indexer->ne[0] < K->ne[1] && Q->ne[1] >= nth &&
+        Q->ne[3] == 1 && K->ne[3] == 1 && V->ne[3] == 1 && K->ne[2] == 1) {
+        auto row_size_k = ggml_row_size(K->type, K->ne[0]);
+        auto row_size_v = ggml_row_size(V->type, V->ne[0]);
+        auto work_size  = (row_size_k + row_size_v + 64) * indexer->ne[0];
+        return work_size * nth;
+    }
     int rk2 = Q->ne[2]/K->ne[2];
     size_t size = 0;
     if (Q->ne[1] >= 8 && K->type == GGML_TYPE_Q8_0) {
@@ -163,9 +171,63 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
                             float         softcap,  // if > 0, a "soft-cap" operation is applied before softmax
                             float       * qkv,      // v*softmax(scale*(k*q))
                             [[maybe_unused]] void * work_buffer_in, [[maybe_unused]] barrier_t barrier, [[maybe_unused]] void * barrier_data,
-                            int ith, int nth, int n_swa) {
+                            int ith, int nth, int n_swa, [[maybe_unused]] ggml_tensor * indexer) {
 
     if (type_q != 0 || type_mask != 1 || max_bias > 0) return false;
+
+    if (indexer && indexer->type == GGML_TYPE_I32) {
+        if (indexer->ne[0] < nek1 && neq1 >= nth && neq3 == 1 && nek3 == 1 && nev3 == 1 && nek2 == 1) {
+            //if (ith == 0) {
+            //    printf("%s: could use indexer as indexer->ne[0] = %ld, neq1 = %d, nek1 = %d, nek2 = %d nth = %d\n", __func__, indexer->ne[0], neq1, nek1, nek2, nth);
+            //}
+            int npt = (neq1 + nth - 1)/nth;
+            int ith_mid = nth;
+            int neq1_this_thread = npt;
+            int first = ith*npt;
+            if (npt*nth > neq1) {
+                ith_mid = neq1 - nth*(npt - 1);
+                if (ith >= ith_mid) {
+                    --neq1_this_thread;
+                    first = ith_mid*npt + (ith - ith_mid)*neq1_this_thread;
+                }
+            }
+            // Workbuffer: we need
+            // * indexer->ne[0] * sizeof(ggml_half) to extract the mask for a row
+            // * indexer->ne[0] * ggml_row_size(int_type_k_in, Dk) to extract the selected K cache entries
+            // * indexer->ne[0] * ggml_row_size(int_type_v, Dv) to extract the selected V cache entries
+            auto row_size_k = ggml_row_size(ggml_type(int_type_k_in), Dk);
+            auto row_size_v = ggml_row_size(ggml_type(int_type_v   ), Dv);
+            auto work_size  = (row_size_k + row_size_v + 64) * indexer->ne[0];
+            auto work_k = (char *)work_buffer_in + ith*work_size;
+            auto work_v = work_k + row_size_k*indexer->ne[0];
+            auto work_m = (uint16_t *)(work_v + row_size_v*indexer->ne[0]);
+            int  nkv = indexer->ne[0];
+            for (int iq = first; iq < first + neq1_this_thread; ++iq) {
+                auto idx = (const int *)((const char *)indexer->data + iq*indexer->nb[1]);
+                auto M = (const uint16_t *)((const char *)mask + iq*stride_m);
+                for (int j = 0; j < nkv; ++j) {
+                    std::memcpy(work_k + row_size_k*j, ((const char *)k + idx[j]*stride_k), row_size_k);
+                    std::memcpy(work_v + row_size_v*j, ((const char *)v + idx[j]*stride_v), row_size_v);
+                    work_m[j] = M[idx[j]];
+                }
+                auto this_q = (const char *)q + iq*stride_q;
+                auto this_qkv = qkv + iq*ne1*nb1/sizeof(float);
+                //iqk_flash_attn_noalibi(type_q, type_mask, max_bias,
+                //        neq3, neq2, nbq3, nbq2, nek3, nek2, nbk3, nbk2, nev3, nev2, nbv3, nbv2, ne2, ne1, nb1,
+                //        int_type_k_in, int_type_v, Dk, Dv, 1, nkv,
+                //        stride_q, row_size_k, row_size_v, 0,
+                //        this_q, work_k, work_v, work_m,
+                //        sinks, scale, softcap, this_qkv,
+                //        nullptr, barrier, barrier_data, 0, 1, 0, nullptr);
+                if (!iqk_flash_attn_impl(int_type_k_in, int_type_v,
+                         Dk, Dv, neq2, nkv, nbq2, row_size_k, row_size_v, 0, Dv,
+                         (const float *)this_q, work_k, work_v, work_m, nullptr, 0,
+                         scale, softcap,
+                         this_qkv, nullptr, nullptr)) return false;
+            }
+            return true;
+        }
+    }
 
     if (auto type_k = ggml_type(int_type_k_in), type_v = ggml_type(int_type_v); !are_kv_types_supported(type_k, type_v)) {
         if (ith == 0) {
@@ -520,7 +582,7 @@ bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int ty
                             [[maybe_unused]] float         softcap,  // if > 0, a "soft-cap" operation is applied before softmax
                             [[maybe_unused]] float       * qkv,      // v*softmax(scale*(k*q))
                             [[maybe_unused]] void * work_buffer, [[maybe_unused]] barrier_t barrier, [[maybe_unused]] void * barrier_data,
-                            [[maybe_unused]] int ith, [[maybe_unused]] int nth, [[maybe_unused]] int n_swa) {
+                            [[maybe_unused]] int ith, [[maybe_unused]] int nth, [[maybe_unused]] int n_swa, [[maybe_unused]] ggml_tensor * indexer) {
     return false;
 }
 

--- a/ggml/src/iqk/iqk_mul_mat.h
+++ b/ggml/src/iqk/iqk_mul_mat.h
@@ -68,7 +68,7 @@ IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float max_bias,
                             float         softcap,  // if > 0, a "soft-cap" operation is applied before softmax
                             float       * qkv,      // v*softmax(scale*(k*q))
                             void * work_buffer, barrier_t barrier, void * barrier_data,
-                            int ith, int nth, int n_swa);
+                            int ith, int nth, int n_swa, struct ggml_tensor * indexer);
 
 IQK_API void iqk_topk_moe(int n_experts, int n_experts_used, int nrows, const float * logits,
         float * weights, int32_t * ids, int ith, int nth);

--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -1007,6 +1007,9 @@ ggml_tensor * llm_build_context::build_deepseek2_layer_attention(
                     if (use_f32_attn_precision || q->ne[1] <= 8) {
                         ggml_flash_attn_ext_set_prec(kqv, GGML_PREC_F32);
                     }
+                    if (use_dsa && dsa_last_full_sorted) {
+                        kqv->src[5] = dsa_last_full_sorted;
+                    }
                     cb(kqv, "kqv", il);
 
                     if (iter == 0) {
@@ -1063,6 +1066,9 @@ ggml_tensor * llm_build_context::build_deepseek2_layer_attention(
 
                     if (use_f32_attn_precision) {
                         ggml_flash_attn_ext_set_prec(kqv_compressed, GGML_PREC_F32);
+                    }
+                    if (use_dsa && dsa_last_full_sorted) {
+                        kqv_compressed->src[5] = dsa_last_full_sorted;
                     }
 
                     kqv_compressed = ggml_permute(ctx0, kqv_compressed, 0, 2, 1, 3);


### PR DESCRIPTION

This PR improves PP performance for GLM-5 DSA for CPU-only inference. At a context of 64k tokens PP performance is 4.2X better than the main branch, and 3.6X better than not using DSA.

>[!IMPORTANT]
> In order to get the performance improvement, `-mla 1` must be used on the command line.

Here some `sweep-bench` results for GLM-5.2-Q4_K_M running on a Ryzen-3995WX. 

### DSA (this PR with mla = 1)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     32 |      0 |  125.589 |    32.61 |    8.454 |     3.78 |
|  4096 |     32 |   4096 |  135.049 |    30.33 |    9.901 |     3.23 |
|  4096 |     32 |   8192 |  144.681 |    28.31 |   10.017 |     3.19 |
|  4096 |     32 |  12288 |  151.434 |    27.05 |   10.230 |     3.13 |
|  4096 |     32 |  16384 |  158.876 |    25.78 |   10.402 |     3.08 |
|  4096 |     32 |  20480 |  164.886 |    24.84 |   10.495 |     3.05 |
|  4096 |     32 |  24576 |  173.873 |    23.56 |   10.669 |     3.00 |
|  4096 |     32 |  28672 |  175.318 |    23.36 |   10.753 |     2.98 |
|  4096 |     32 |  32768 |  184.922 |    22.15 |   10.815 |     2.96 |
|  4096 |     32 |  36864 |  189.895 |    21.57 |   10.920 |     2.93 |
|  4096 |     32 |  40960 |  196.898 |    20.80 |   11.038 |     2.90 |
|  4096 |     32 |  45056 |  201.804 |    20.30 |   11.125 |     2.88 |
|  4096 |     32 |  49152 |  210.356 |    19.47 |   11.238 |     2.85 |
|  4096 |     32 |  53248 |  214.936 |    19.06 |   11.296 |     2.83 |
|  4096 |     32 |  57344 |  221.814 |    18.47 |   11.371 |     2.81 |
|  4096 |     32 |  61440 |  220.559 |    18.57 |   11.494 |     2.78 |


### DSA (PR #2068 with mla = 3)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     32 |      0 |  122.268 |    33.50 |    8.230 |     3.89 |
|  4096 |     32 |   4096 |  181.537 |    22.56 |    9.874 |     3.24 |
|  4096 |     32 |   8192 |  244.238 |    16.77 |   10.058 |     3.18 |
|  4096 |     32 |  12288 |  289.793 |    14.13 |   10.192 |     3.14 |
|  4096 |     32 |  16384 |  371.025 |    11.04 |   10.376 |     3.08 |
|  4096 |     32 |  20480 |  426.061 |     9.61 |   10.542 |     3.04 |
|  4096 |     32 |  24576 |  469.453 |     8.73 |   10.688 |     2.99 |
|  4096 |     32 |  28672 |  515.636 |     7.94 |   10.816 |     2.96 |
|  4096 |     32 |  32768 |  557.992 |     7.34 |   10.848 |     2.95 |
|  4096 |     32 |  36864 |  662.354 |     6.18 |   10.906 |     2.93 |
|  4096 |     32 |  40960 |  713.191 |     5.74 |   11.008 |     2.91 |
|  4096 |     32 |  45056 |  748.069 |     5.48 |   11.178 |     2.86 |
|  4096 |     32 |  49152 |  801.007 |     5.11 |   11.244 |     2.85 |
|  4096 |     32 |  53248 |  848.963 |     4.82 |   11.311 |     2.83 |
|  4096 |     32 |  57344 |  887.810 |     4.61 |   11.443 |     2.80 |
|  4096 |     32 |  61440 |  934.813 |     4.38 |   11.513 |     2.78 |

### MLA (using mla = 3)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     32 |      0 |  111.375 |    36.78 |    8.268 |     3.87 |
|  4096 |     32 |   4096 |  157.545 |    26.00 |    8.846 |     3.62 |
|  4096 |     32 |   8192 |  211.841 |    19.34 |   10.406 |     3.08 |
|  4096 |     32 |  12288 |  247.579 |    16.54 |   10.980 |     2.91 |
|  4096 |     32 |  16384 |  314.688 |    13.02 |   11.484 |     2.79 |
|  4096 |     32 |  20480 |  353.252 |    11.60 |   11.711 |     2.73 |
|  4096 |     32 |  24576 |  390.263 |    10.50 |   12.177 |     2.63 |
|  4096 |     32 |  28672 |  431.292 |     9.50 |   12.701 |     2.52 |
|  4096 |     32 |  32768 |  468.686 |     8.74 |   13.213 |     2.42 |
|  4096 |     32 |  36864 |  558.137 |     7.34 |   13.776 |     2.32 |
|  4096 |     32 |  40960 |  602.965 |     6.79 |   14.224 |     2.25 |
|  4096 |     32 |  45056 |  633.496 |     6.47 |   14.706 |     2.18 |
|  4096 |     32 |  49152 |  677.268 |     6.05 |   15.274 |     2.10 |
|  4096 |     32 |  53248 |  712.104 |     5.75 |   15.717 |     2.04 |
|  4096 |     32 |  57344 |  743.216 |     5.51 |   16.289 |     1.96 |
|  4096 |     32 |  61440 |  789.242 |     5.19 |   16.809 |     1.90 |

