### PR TITLE
CUDA: guard the MoE row-scatter kernels against out-of-range routing indices

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2723,6 +2723,15 @@ static __global__ void k_copy_src_to_contiguous(const char * __restrict__ src_or
                                                   int64_t ne10, int64_t ne11, size_t nb11, size_t nb12) {
     int32_t i = blockIdx.x;
 
+    // Defense-in-depth: skip rows whose routing indices are the "no valid expert" sentinel (INT32_MAX) or are
+    // otherwise out of any sane range. Real token/expert indices are always far below this bound, so valid
+    // routings are never skipped; this only fires on a degenerate/uninitialized row mapping and prevents a wild
+    // global access (seen as Xid 13 "Out Of Range Address" when an upstream kernel corrupts the MoE router).
+    if (row_mapping[i].i1 < 0 || row_mapping[i].i2 < 0 ||
+        row_mapping[i].i1 >= (1 << 30) || row_mapping[i].i2 >= (1 << 30)) {
+        return;
+    }
+
     const int32_t i11 = row_mapping[i].i1 % ne11;
     const int32_t i12 = row_mapping[i].i2;
 
@@ -2742,6 +2751,14 @@ static __global__ void k_copy_dst_from_contiguous(char * __restrict__ dst_origin
 
     const int32_t i1 = row_mapping[i].i1;
     const int32_t i2 = row_mapping[i].i2;
+
+    // Defense-in-depth: skip rows whose routing indices are the "no valid expert" sentinel (INT32_MAX) or are
+    // otherwise out of any sane range. Real token/expert indices are always far below this bound, so valid
+    // routings are never skipped; this only fires on a degenerate/uninitialized row mapping and prevents a wild
+    // global write (seen as Xid 13 "Out Of Range Address" when an upstream kernel corrupts the MoE router).
+    if (i1 < 0 || i2 < 0 || i1 >= (1 << 30) || i2 >= (1 << 30)) {
+        return;
+    }
 
     const float * dst_row_contiguous = (const float *)(dst_contiguous + i*nb1);
     float * dst_row_original = (float *)(dst_original + i1*nb1 + i2*nb2);


### PR DESCRIPTION
`CUDA: guard the MoE row-scatter kernels against out-of-range routing indices`

`k_copy_src_to_contiguous` and `k_copy_dst_from_contiguous` in `ggml-cuda.cu` scatter MoE
expert rows to and from the original tensors, indexing by the per-row routing indices in
`mmid_row_mapping` (`i1*nb1 + i2*nb2`). This adds a bounds check: skip the row when either
index is negative or `>= 2^30`. The individual indices are always small (`i1` is an expert id,
below the expert count; `i2` is a token index, below the token count), so valid routings are
never skipped and output is unchanged for every working model. The only rows skipped are
degenerate or uninitialized ones.

This is defense-in-depth for a shared kernel, not a fix for a bug that reproduces on a stock
model. I do not have a stock model that produces the corrupt mapping.

If an upstream kernel corrupts the MoE router so a mapping entry holds the `INT32_MAX`
"no valid expert" sentinel (or any out-of-range value), these kernels compute a wild address
and issue an out-of-bounds global access. On an NVIDIA GPU that surfaces as an Xid 13
("Out Of Range Address") that tears down the CUDA context and kills the process, with no hint
of where it came from. `k_copy_dst_from_contiguous` currently guards neither index;
`k_copy_src_to_contiguous` already bounds `i1` with `% ne11` but leaves `i2` open. This bounds
`i2` too, and applies the same guard to the dst kernel.

I hit this twice on a Pascal box while developing experimental attention kernels: once from an
in-progress quantized-KV kernel, and once, on a different day, from a different unidentified
experimental code path. In both cases a numerically degenerate attention output pushed the
router to emit the sentinel index, and the scatter turned it into a context-killing Xid instead
of skipping the bad row. It costs up to four cheap integer comparisons per block in a
memcpy-bound kernel, and it does not change output for valid routings.

## Validation (single P100, sm_60, CUDA 12.4)

- `test-backend-ops -o MUL_MAT_ID`: 1321/1322 before and after. The one failure (`iq4_xs`
  NMSE) is pre-existing on clean main, unrelated to this change.
- Output unchanged for valid routings: greedy-decode generations are identical with and without
  the guard on DeepSeek-V2-Lite (q8_0 and f16 KV) and a non-MLA MoE path (same model, `-mla 0`).
  The guard is unreachable for in-range indices, so this is a code-level guarantee, not a logit
  or perplexity measurement.
- No perf regression. DeepSeek-V2-Lite decode, same build and flags, single-run TG t/s
  (n_kv 0 -> 1792): main 66.0 -> 36.0, this PR 67.3 -> 36.8 (within run-to-run variance).
- llama-server boots clean and serves; CPU-only (`-ngl 0`) decode is unaffected, since the
  change is CUDA-only.
- Failure-mode repro: a kernel that emits the sentinel index reliably produced Xid 13 on main;
  with this guard the same run completes, the process exits normally, and the dmesg Xid count is
  unchanged.

