### PR TITLE
fix(rpc): update ggml_backend_cuda_init to 3-arg signature

### DIFF
--- a/examples/rpc/rpc-server.cpp
+++ b/examples/rpc/rpc-server.cpp
@@ -263,7 +263,7 @@ static ggml_backend_t create_gpu_backend(const rpc_server_params& params, uint32
     ggml_backend_t backend = NULL;
 #ifdef GGML_USE_CUDA
     fprintf(stderr, "%s: using CUDA backend: CUDA%d\n", __func__, device);
-    backend = ggml_backend_cuda_init(device, nullptr); // init device
+    backend = ggml_backend_cuda_init(device, nullptr, nullptr); // init device
     if (!backend) {
         fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
     }


### PR DESCRIPTION
## Problem

Upstream commit 75a5f6d0 (Per model CUDA contexts) added a third parameter `model` to `ggml_backend_cuda_init`, but the RPC server's call site was missed.

This caused a **cmake build failure** when compiling with `-DGGML_CUDA=ON -DGGML_RPC=ON`.

## Fix

Pass `nullptr` as the third argument to `ggml_backend_cuda_init` in `rpc-server.cpp`.

### Why `nullptr` is correct

The RPC server creates backends at startup, before any model is loaded. It acts as a pure compute proxy and does not host models locally. Passing `nullptr` serves as the context grouping key in `all_ctx`, which is sufficient since all RPC backends in the same process share the same group for multi-GPU reduce operations.

## Verification

- **Before:** cmake build fails with `-DGGML_CUDA=ON -DGGML_RPC=ON`
- **After:** build succeeds, RPC functionality tested and working correctly
