### PR TITLE
CUDA: fix flash attention for gpt-oss (SWA + attention sinks) on the tile kernels (no-tensor-core GPUs)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f16.cu
@@ -72,7 +72,8 @@ static __global__ void flash_attn_tile_ext_f16(
     // fattn.cu n_swa windowing re-points K/V/mask to the last nton tokens (ne11 = nton) while the mask keeps
     // its original row stride, so indexing the mask by ne11 reads garbage and yields NaN on the tile kernels.
     const int    stride_mask = nb31 / sizeof(half);
-    const half   * maskh = (const half   *)  mask + stride_mask*ic0;
+    const half   * maskh  = (const half   *)  mask + stride_mask*ic0;
+    const float  * sinksf = (const float  *)  sinks;
 
     const int stride_KV2 = nb11 / sizeof(half2);
 
@@ -260,6 +261,33 @@ static __global__ void flash_attn_tile_ext_f16(
         }
 
         __syncthreads();
+    }
+
+    // Apply attention sinks (e.g. gpt-oss): the sink is a per-head extra softmax logit whose value
+    // contribution is zero, so it only joins the running max and rescales the denominator/value
+    // accumulator. Only ip==0 adds the sink term so it is counted exactly once across the
+    // parallel_blocks KV split. Ported from fattn-vec-f16.cuh. kqmax is warp-uniform here (already
+    // warp_reduce_max'd in the KV loop), so no shared-mem reduction is needed.
+    if (sinksf && ip == 0) {
+        const half sink = __float2half(sinksf[blockIdx.y]);
+
+#pragma unroll
+        for (int j0 = 0; j0 < ncols; j0 += nwarps) {
+            const half kqmax_new_j = ggml_cuda_hmax(kqmax[j0/nwarps], sink);
+            const half2 KQ_max_scale = __half2half2(hexp(kqmax[j0/nwarps] - kqmax_new_j));
+            kqmax[j0/nwarps] = kqmax_new_j;
+
+            kqsum[j0/nwarps] = kqsum[j0/nwarps]*KQ_max_scale;
+            if (threadIdx.x == 0) {
+                // Add the sink term to only the low half; the epilogue sums low+high once per lane.
+                kqsum[j0/nwarps].x += hexp(sink - kqmax[j0/nwarps]);
+            }
+
+#pragma unroll
+            for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
+                VKQ[j0/nwarps][i0/WARP_SIZE] *= KQ_max_scale;
+            }
+        }
     }
 
 #pragma unroll

--- a/ggml/src/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f16.cu
@@ -68,7 +68,11 @@ static __global__ void flash_attn_tile_ext_f16(
     const float2 * Q_f2  = (const float2 *) (Q    + nb02* blockIdx.y              + nb01*ic0);
     const half2  * K_h2  = (const half2  *) (K    + nb12*(blockIdx.y / gqa_ratio));
     const half2  * V_h2  = (const half2  *) (V    + nb12*(blockIdx.y / gqa_ratio)); // K and V have same shape
-    const half   * maskh = (const half   *)  mask + ne11*ic0;
+    // Mask row stride must come from the mask tensor (nb31), not ne11 (= K->ne[1]). For SWA models the
+    // fattn.cu n_swa windowing re-points K/V/mask to the last nton tokens (ne11 = nton) while the mask keeps
+    // its original row stride, so indexing the mask by ne11 reads garbage and yields NaN on the tile kernels.
+    const int    stride_mask = nb31 / sizeof(half);
+    const half   * maskh = (const half   *)  mask + stride_mask*ic0;
 
     const int stride_KV2 = nb11 / sizeof(half2);
 
@@ -176,7 +180,7 @@ static __global__ void flash_attn_tile_ext_f16(
                 } else {
                     sum = __low2half(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]) + __high2half(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
                 }
-                sum += mask ? slopeh*maskh[j_KQ*ne11 + k_VKQ_0 + i_KQ] : __float2half(0.0f);
+                sum += mask ? slopeh*maskh[j_KQ*stride_mask + k_VKQ_0 + i_KQ] : __float2half(0.0f);
 
                 kqmax_new[j_KQ_0/nwarps] = ggml_cuda_hmax(kqmax_new[j_KQ_0/nwarps], sum);
 

--- a/ggml/src/ggml-cuda/fattn-tile-f32.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f32.cu
@@ -72,7 +72,8 @@ static __global__ void flash_attn_tile_ext_f32(
     // fattn.cu n_swa windowing re-points K/V/mask to the last nton tokens (ne11 = nton) while the mask keeps
     // its original row stride, so indexing the mask by ne11 reads garbage and yields NaN on the tile kernels.
     const int    stride_mask = nb31 / sizeof(half);
-    const half   * maskh = (const half   *)  mask + stride_mask*ic0;
+    const half   * maskh  = (const half   *)  mask + stride_mask*ic0;
+    const float  * sinksf = (const float  *)  sinks;
 
     const int stride_KV2 = nb11 / sizeof(half2);
 
@@ -258,6 +259,34 @@ static __global__ void flash_attn_tile_ext_f32(
         }
 
         __syncthreads();
+    }
+
+    // Apply attention sinks (e.g. gpt-oss): the sink is a per-head extra softmax logit whose value
+    // contribution is zero, so it only joins the running max and rescales the denominator/value
+    // accumulator. Only ip==0 adds the sink term so it is counted exactly once across the
+    // parallel_blocks KV split. Ported from fattn-vec-f16.cuh. kqmax is warp-uniform here (already
+    // warp_reduce_max'd in the KV loop); kqsum holds per-lane partials reduced in the epilogue, so
+    // the sink term is added on a single lane.
+    if (sinksf && ip == 0) {
+        const float sink = sinksf[blockIdx.y];
+
+#pragma unroll
+        for (int j0 = 0; j0 < ncols; j0 += nwarps) {
+            const float kqmax_new_j = fmaxf(kqmax[j0/nwarps], sink);
+            const float KQ_max_scale = expf(kqmax[j0/nwarps] - kqmax_new_j);
+            kqmax[j0/nwarps] = kqmax_new_j;
+
+            kqsum[j0/nwarps] = kqsum[j0/nwarps]*KQ_max_scale;
+            if (threadIdx.x == 0) {
+                kqsum[j0/nwarps] += expf(sink - kqmax[j0/nwarps]);
+            }
+
+#pragma unroll
+            for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
+                VKQ[j0/nwarps][i0/WARP_SIZE].x *= KQ_max_scale;
+                VKQ[j0/nwarps][i0/WARP_SIZE].y *= KQ_max_scale;
+            }
+        }
     }
 
 #pragma unroll

--- a/ggml/src/ggml-cuda/fattn-tile-f32.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f32.cu
@@ -68,7 +68,11 @@ static __global__ void flash_attn_tile_ext_f32(
     const float2 * Q_f2  = (const float2 *) (Q    + nb02* blockIdx.y              + nb01*ic0);
     const half2  * K_h2  = (const half2  *) (K    + nb12*(blockIdx.y / gqa_ratio));
     const half2  * V_h2  = (const half2  *) (V    + nb12*(blockIdx.y / gqa_ratio)); // K and V have same shape
-    const half   * maskh = (const half   *)  mask + ne11*ic0;
+    // Mask row stride must come from the mask tensor (nb31), not ne11 (= K->ne[1]). For SWA models the
+    // fattn.cu n_swa windowing re-points K/V/mask to the last nton tokens (ne11 = nton) while the mask keeps
+    // its original row stride, so indexing the mask by ne11 reads garbage and yields NaN on the tile kernels.
+    const int    stride_mask = nb31 / sizeof(half);
+    const half   * maskh = (const half   *)  mask + stride_mask*ic0;
 
     const int stride_KV2 = nb11 / sizeof(half2);
 
@@ -171,7 +175,7 @@ static __global__ void flash_attn_tile_ext_f32(
                     sum[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] = softcap * tanhf(sum[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
                 }
 
-                sum[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] += mask ? slope*__half2float(maskh[j_KQ*ne11 + k_VKQ_0 + i_KQ]) : 0.0f;
+                sum[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] += mask ? slope*__half2float(maskh[j_KQ*stride_mask + k_VKQ_0 + i_KQ]) : 0.0f;
 
                 kqmax_new[j_KQ_0/nwarps] = fmaxf(kqmax_new[j_KQ_0/nwarps], sum[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
 


### PR DESCRIPTION
On GPUs without tensor cores (Pascal / sm_60, e.g. Tesla P100), flash attention routes to the "tile" kernels (`fattn-tile-f16.cu` / `-f32.cu`). gpt-oss with `-fa 1` produced NaN at moderate context and, once that was worked around, numerically wrong output. Two independent defects in these kernels:

**1. Mask row stride.** The tile kernels index the KQ mask using `ne11` (= `K->ne[1]`) as the row stride. The SWA windowing in `ggml_cuda_flash_attn_ext` (the `n_swa` branch) re-points K/V/mask to the last `nton` tokens, setting `ne11 = nton` while the mask keeps its original row stride `nb31`. Indexing by `ne11` then reads across mask rows and yields NaN as soon as the window slice engages (context past `nton`). Fixed by using the mask tensor's own stride, `nb31 / sizeof(half)`. In the non-sliced case this equals `ne11`, so it is a no-op there.

**2. Attention sinks not applied.** The tile kernels take a `sinks` argument but never use it. gpt-oss has a per-head sink logit that must join the softmax normalization. The `-fa 0` path applies it (`ggml_soft_max_add_sinks`) and matches CPU, but the tile FA path dropped it, giving a wrong denominator. Fixed by applying the sink after the KV loop, mirroring `fattn-vec-f16.cuh`: the sink joins the running max and adds `exp(sink - max)` to `kqsum` once, rescaling `kqsum` and `VKQ`. It is guarded by a non-null `sinks` (no-op for non-sink models) and added only for `ip == 0`, so it is counted once across the `parallel_blocks` KV split (the epilogue writes the sink-inclusive max and denominator into `dst_meta` before the combine).

### Repro (before the fix)
`-fa 1` on gpt-oss NaNs once the SWA slice activates, and the onset tracks ubatch exactly, since the slice threshold `nton` scales with ubatch: at `-c 1024 -ub 512` it is NaN, at `-c 1024 -ub 1024` it is finite.

### Validation (Tesla P100, gpt-oss-20b MXFP4)
Perplexity on wikitext, `-ngl 99`; `-fa 1` (this fix) vs `-fa 0` vs CPU:

| config | -fa 1 (fix) | -fa 0 | CPU |
|---|---|---|---|
| -c 2048 -ub 512 | 1054.2 | 1073.2 | 1069.2 |
| -c 1024 -ub 512 (slice active) | 663.8 | 665.5 | - |

`-fa 1` now matches `-fa 0` / CPU within about 1.5 percent (it was NaN, and ~1285 with only the mask fix). A 43k needle retrieval with `-fa 1` returns the planted secret correctly. The `parallel_blocks > 1` path was exercised with a small ubatch (`-ub 16`, `parallel_blocks = 4`): 1047.6 vs `-fa 0` 1060.1.

No regression on non-sink / non-SWA models (the sink guard is a no-op and the mask-stride change is identity when not sliced): DeepSeek-V2-Lite (MLA) `-fa 1` = 5.27 unchanged; Qwen3.5-35B `-fa 1` = 5.6634 vs `-fa 0` 5.6641. The mask-stride change is additionally exercised by Gemma-4 (SWA window 1024, no sinks): `-fa 1` = 665, finite and correct.

### Notes
- gpt-oss (head dim 64) at default precision routes to the f16 tile kernel, which is what the numbers above exercise. The f32 tile change is structurally identical; it was force-exercised by temporarily routing the default-precision path to `tile_f32`, giving 1081.4 (matches `-fa 0` / CPU), so the f32 sink path is validated too.
- The mask-stride fix converges with mainline llama.cpp: its pre-#15178 `fattn-tile-f16.cu` had the same latent mismatch (`nb31 * ic0` pointer setup but `ne11` inner-loop stride), and its later unified tile kernel fixed it with the identical `const int stride_mask = nb31 / sizeof(half);`. The sink handling here is the tile-kernel equivalent of mainline PR #15178.
- The SWA windowing that exposes the mask-stride bug is specific to this fork, and both defects only surface on the tile kernels (the no-tensor-core path), which is why tensor-core users do not hit them.
- The wmma kernel (the Volta/Turing tensor-core fallback; Pascal never reaches it) is left untouched here for lack of Turing/Volta hardware to validate against. The same sink defect likely applies to it (mainline #15178 fixed wmma as well).
