### PR TITLE
Be able to force synchronization when copying graph inputs

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 # ggml core
 set(GGML_SCHED_MAX_COPIES  "1" CACHE STRING "ggml: max input copies for pipeline parallelism")
 set(GGML_MAX_CONTEXTS       "" CACHE STRING "ggml: max model contexts (override only; defaults to 64 in the code)")
+set(GGML_FORCE_SYNC         "" CACHE STRING "ggml-backend: control device copy synchronization")
 
 # 3rd party libs / backends
 option(GGML_ACCELERATE                      "ggml: enable Accelerate framework"               ON)

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1462,6 +1462,9 @@ add_library(ggml
 if (EMSCRIPTEN)
     set_target_properties(ggml PROPERTIES COMPILE_FLAGS "-msimd128")
 endif()
+if (GGML_FORCE_SYNC)
+    set_source_files_properties(ggml-backend.cpp PROPERTIES COMPILE_FLAGS -DGGML_FORCE_SYNC)
+endif()
 
 target_compile_definitions(ggml PUBLIC  ${GGML_CDEF_PUBLIC})
 target_compile_definitions(ggml PRIVATE $<$<CONFIG:Release>:NDEBUG>)

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1974,7 +1974,11 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
 static void ggml_backend_sched_copy_inputs(ggml_backend_sched_t sched, ggml_backend_sched_split * split, std::array<bool, GGML_SCHED_MAX_BACKENDS> & needs_sync,
         std::vector<int32_t> & ids, std::vector<uint32_t> & unique_ids, ggml_tensor * last_ids_tensor) {
     if (split->n_inputs < 1) return;
+#ifdef GGML_FORCE_SYNC
+    constexpr bool k_set_sync = true;
+#else
     constexpr bool k_set_sync = false;
+#endif
     int split_backend_id = split->backend_id;
     ggml_backend_t split_backend = sched->backends[split_backend_id];
     ggml_backend_t last_input_backend = nullptr;


### PR DESCRIPTION

Closes #2083 

#2083 reports corrupted results for GLM-5.2 when using `-ngl N` with `N` less than the number of model layers. This PR adds the ability to turn off the synchronization elision optimization when copying graph split inputs from other device(s) at compile time by adding
```
-DGGML_FORCE_SYNC
```
to the `cmake` command.  