### PR TITLE
GLM DSA: reduce indexer cache size

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1030,7 +1030,7 @@ static bool llama_kv_cache_init(
             cache.k_l.push_back(kv);
             // DSA lightning-indexer key cache (MQA, single head). Store the Hadamard-rotated
             // indexer keys in F16 so a decoded token can score against ALL past keys.
-            if (has_dsa_indexer && model.layers[i].indexer_attn_k && !is_mtp_tail_layer) {
+            if (has_dsa_indexer && model.layers[i].indexer_attn_k && hparams.indexer_is_full[i] && !is_mtp_tail_layer) {
                 ggml_tensor * kr = ggml_new_tensor_2d(ctx, idx_type_k, hparams.indexer_head_size, kv_size);
                 ggml_format_name(kr, "cache_kr_l%d", i);
                 cache.kr_l[i] = kr;


### PR DESCRIPTION

The GLM-5 indexer only operates in a subset of the model layers, the other layers reuse the indexer result from a preceding "full" layer. This is taken into account when preparing the compute graph, but not when allocating memory for the indexer cache.

This PR avoids the unnecessary cache allocation. For a context of 128k tokens and `f16` indexer cache, cache size drops from 2.5 GiB to 672 MiB.