### PR TITLE
CUDA: update captured graph when a source tensor's shape changes

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4421,6 +4421,10 @@ static void set_ggml_graph_node_properties(ggml_tensor * node, ggml_graph_node_p
     }
     for (int i = 0; i < GGML_MAX_SRC; i++) {
         graph_node_properties->src_address[i] = node->src[i] ? node->src[i]->data : nullptr;
+        for (int j = 0; j < GGML_MAX_DIMS; j++) {
+            graph_node_properties->src_ne[i][j] = node->src[i] ? node->src[i]->ne[j] : 0;
+            graph_node_properties->src_nb[i][j] = node->src[i] ? node->src[i]->nb[j] : 0;
+        }
     }
     memcpy(graph_node_properties->op_params, node->op_params, GGML_MAX_OP_PARAMS);
 }
@@ -4453,10 +4457,25 @@ static bool ggml_graph_node_has_matching_properties(ggml_tensor * node, ggml_gra
         ) {
             return false;
         }
+        // A source's data address can legitimately stay the same across tokens while its
+        // shape/strides change (e.g. the KV-cache views feeding the attention matmuls as
+        // n_kv grows). The consuming node's own ne/nb may be n_kv-independent (the V*softmax
+        // "kqv" matmul is the canonical case), so relying on the node's own ne/nb is not
+        // enough: we must also detect changes in each source's ne/nb, otherwise a stale
+        // captured kernel (with the old n_kv baked in) gets replayed and produces garbage.
+        if (node->src[i]) {
+            for (int j = 0; j < GGML_MAX_DIMS; j++) {
+                if (node->src[i]->ne[j] != graph_node_properties->src_ne[i][j] ||
+                    node->src[i]->nb[j] != graph_node_properties->src_nb[i][j]) {
+                    return false;
+                }
+            }
+        }
     }
 
-    if (node->op == GGML_OP_SCALE &&
-        memcmp(graph_node_properties->op_params, node->op_params, GGML_MAX_OP_PARAMS) != 0) {
+    // Compare op_params for every op (not just SCALE): a change in op_params means a
+    // different computation and must force a graph update.
+    if (memcmp(graph_node_properties->op_params, node->op_params, GGML_MAX_OP_PARAMS) != 0) {
         return false;
     }
 

--- a/ggml/src/ggml-cuda/graph.cuh
+++ b/ggml/src/ggml-cuda/graph.cuh
@@ -8,6 +8,8 @@ struct ggml_graph_node_properties {
     int64_t ne[GGML_MAX_DIMS];
     size_t nb[GGML_MAX_DIMS];
     void * src_address[GGML_MAX_SRC];
+    int64_t src_ne[GGML_MAX_SRC][GGML_MAX_DIMS];
+    size_t  src_nb[GGML_MAX_SRC][GGML_MAX_DIMS];
     int32_t op_params[GGML_MAX_OP_PARAMS / sizeof(int32_t)];
 };
 


### PR DESCRIPTION
ggml_graph_node_has_matching_properties only compared each node's own
ne/nb, the source data pointers, and op_params (for SCALE only). It never
looked at the sources' ne/nb. During decode n_kv grows, so the KV-cache
views feeding attention change shape while keeping the same data pointer.
For the V*softmax matmul the output shape is independent of n_kv, so
nothing the check looked at changed and the stale captured graph got
replayed with the old n_kv baked into the kernel, producing garbage
output (seen with MiniMax-M2).

Store each source's ne/nb in the node properties and compare them, and
compare op_params for every op instead of only SCALE. This forces a graph
update only when a source shape or op params actually change (i.e. when
the KV length crosses a padding boundary), so steady-state decode still
reuses the graph. The CPY/VIEW data-pointer exclusion is kept so copy
indirection is unaffected.

Tested on 3x RTX A6000, CUDA 13.1, MiniMax-M2 Q8_0, experts split across the 3 GPUs + CPU, FA on, q8_0 KV:
- before: `The capital of France is` -> `a,8 conmem conmem...` (garbage), only usable with GGML_CUDA_DISABLE_GRAPHS=1
- after: `Paris.`, coherent output incl. non-English, 320-token generations stay clean across padding boundaries
- perplexity matches the graphs-disabled run exactly (2.7618)
- speed unchanged in this layout (~290 t/s PP, ~21.7 t/s TG with or without graphs)

Not specific to MiniMax — it affects any model where an attention matmul's output shape is independent of the growing KV length.

Likely fixes the gibberish reported in #1642.
