### PR TITLE
GLM-DSA: Fix token corruption due to incorrect RoPE type

### DIFF
--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -396,7 +396,7 @@ ggml_tensor * llm_build_context::build_deepseek2_dsa_indexer(
                 ggml_row_size(indexer_q->type, rope_dim));
 
         indexer_q_pe = ggml_rope_ext(ctx0, indexer_q_pe, inp_pos, nullptr, n_rot,
-                LLAMA_ROPE_TYPE_NEOX, n_ctx_orig, freq_base, freq_scale,
+                rope_type, n_ctx_orig, freq_base, freq_scale,
                 ext_factor, attn_factor, beta_fast, beta_slow);
 
         // {head_size, n_ihead, n_tokens}
@@ -419,7 +419,7 @@ ggml_tensor * llm_build_context::build_deepseek2_dsa_indexer(
             ggml_row_size(indexer_k->type, rope_dim));
 
     indexer_k_pe = ggml_rope_ext(ctx0, indexer_k_pe, inp_pos, nullptr, n_rot,
-            LLAMA_ROPE_TYPE_NEOX, n_ctx_orig, freq_base, freq_scale,
+            rope_type, n_ctx_orig, freq_base, freq_scale,
             ext_factor, attn_factor, beta_fast, beta_slow);
 
     // {head_size, 1, n_tokens}


### PR DESCRIPTION
The DSA lightning indexer hardcoded LLAMA_ROPE_TYPE_NEOX for indexer Q/K positional encoding, but the GLM-5.2 model config.json explicitly sets "indexer_rope_interleave": true, meaning the indexer uses interleaved RoPE (LLAMA_ROPE_TYPE_NORM).

GLM-5.1 config.json also sets "rope_interleave": true.

The mismatch caused incorrect indexer scores, wrong top-k key selection, giving single-character/token errors and other corruption that could grow worse with context length.

Here the setup is changed to use the model's given rope_type instead of hardcoding NEOX. This fixes GLM-5.2, GLM-5.1, and should be less brittle for future GLM variants.

Closes #2083 


- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
