### PR TITLE
Fix clang-cl AVX-VNNI always_inline target feature mismatch

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1139,8 +1139,15 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
         elseif (GGML_AVX2)
             list(APPEND ARCH_FLAGS /arch:AVX2)
             if (GGML_AVXVNNI)
-                add_compile_definitions($<$<COMPILE_LANGUAGE:C>:__AVXVNNI__>)
-                add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:__AVXVNNI__>)
+                # clang-cl supports -m flags alongside /arch: flags.
+                # Using -mavxvnni enables the actual target feature for clang,
+                # which is required for intrinsic functions like _mm256_dpbusd_avx_epi32.
+                if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+                    list(APPEND ARCH_FLAGS -mavxvnni)
+                else()
+                    add_compile_definitions($<$<COMPILE_LANGUAGE:C>:__AVXVNNI__>)
+                    add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:__AVXVNNI__>)
+                endif()
             endif()
         elseif (GGML_AVX)
             list(APPEND ARCH_FLAGS /arch:AVX)
@@ -1160,6 +1167,9 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
         endif()
         if (GGML_AVX2)
             list(APPEND ARCH_FLAGS -mavx2)
+        endif()
+        if (GGML_AVXVNNI)
+            list(APPEND ARCH_FLAGS -mavxvnni)
         endif()
         if (GGML_AVX512)
             list(APPEND ARCH_FLAGS -mavx512f)


### PR DESCRIPTION
When building with clang-cl (MSVC + Clang), the CMake MSVC branch defined __AVXVNNI__ as a preprocessor macro alongside /arch:AVX2, but clang-cl requires the actual -mavxvnni target feature flag to enable AVX-VNNI codegen. Without it, clang-cl refused to inline _mm256_dpbusd_avx_epi32 and _mm256_dpwssd_avx_epi32 into functions compiled under /arch:AVX2, causing 'requires target feature avxvnni' errors in:
  - ggml-quants.c (mul_sum_us8_pairs_float)
  - iqk_gemm_iquants.cpp (mul_mat_iq3_xxs_r4_q8_k)
  - iqk_gemm_kquants.cpp (mul_mat_q3_k_r4_q8_k)
  - iqk_gemm_legacy_quants.cpp (dot, accum_q4_0_quants, operator())

Fix: Detect clang-cl via CMAKE_CXX_COMPILER_ID STREQUAL 'Clang' and append -mavxvnni to ARCH_FLAGS instead of manual __AVXVNNI__ define.

Also add missing GGML_AVXVNNI handling for the non-MSVC (GCC/Clang on Linux) branch, passing -mavxvnni as expected.

Note: I use the MSVC compiler usually, and checked the Clang in my Visual Studio to see what's up. Didn't work. Thus this fix.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
