### PR TITLE
use mmap to reduce unbounded memory usage for split-tensor graph parallel loading

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1078,6 +1078,8 @@ bool llama_model_loader::load_all_data(
     std::vector<void*> host_ptrs;
     std::vector<ggml_backend_event_t> events;
 
+    std::vector<std::unique_ptr<llama_mmap>> split_mappings(files.size());
+
     ggml_backend_t cuda_backend = nullptr;
     if (!use_mmap && !check_tensors) {
         // When not using mmaped io use async uploads from pinned memory to GPU memory.
@@ -1197,17 +1199,21 @@ bool llama_model_loader::load_all_data(
         const char * buffer_name = ggml_backend_buffer_name(cur->buffer);
         const bool   is_probably_split_mode_graph = std::strncmp(buffer_name, GGML_CUDA_NAME, strlen(GGML_CUDA_NAME)) == 0;
         if (is_probably_split_mode_graph) {
-            auto & read_buf = read_bufs[thread_idx];
-            if (read_buf.capacity() > n_size) {
-                read_buf = std::vector<no_init<uint8_t>>();
+            llama_mmap * mapping;
+            {
+                std::lock_guard<std::mutex> lock(load_mutex);
+                auto & m = split_mappings[weight->idx];
+                if (!m) {
+                    m.reset(new llama_mmap(files.at(weight->idx).get(), 0, ggml_is_numa()));
+                }
+                mapping = m.get();
             }
-            read_buf.resize(n_size);
-            file->seek(weight->offs, SEEK_SET);
-            file->read_raw(read_buf.data(), n_size);
-            ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
-            if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {
+            uint8_t * data = (uint8_t *) mapping->addr() + weight->offs;
+            ggml_backend_tensor_set(cur, data, 0, n_size);
+            if (check_tensors && !ggml_validate_row_data(cur->type, data, n_size)) {
                 throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
             }
+            mapping->dontneed_fragment(weight->offs, weight->offs + n_size);
             return n_size;
         }
 #endif


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  
Change an allocation in the model loader to mmap to reduce memory pressure during graph split tensor loading. This is a free win, but not  a long term fix for unbounded use during this phase of loading.

----
  
With the merging of #2057 to parallelize weight loading, for tensors that are allocated to GPU with sm graph, the 8 loading threads will pull entire tensors into host memory. This causes memory pressure and possible OOM.

I am experiencing this with kimi k2.7, as the loader attempts to grab 40GiB of host memory, which isn't available because the majority of host ram is allocated for pinned host tensors.

I considered several fixes:
* **Revert #2057**. I don't want to do this. I like it when model loading doesn't take 15 minutes
* **Change the split tensor loading code to be chunked **: No. I looked at the code and then I changed my mind 🤯
* **Ask the host how much memory is available and then dispatch the threads to avoid OOM**: This is my plan, and I have a draft patch in the works.

But until then, this is a stopgap that will more than half host memory use during this loading phase.