### PR TITLE
openpangu: use fused indexer top_k with -fidx (CPU-only op)

### DIFF
--- a/src/graphs/build_openpangu.cpp
+++ b/src/graphs/build_openpangu.cpp
@@ -408,7 +408,31 @@ ggml_tensor * llm_build_context::build_openpangu_attention(
                 !dsa_gather_allowed &&
                 openpangu_att_score_should_chunk(n_kv, hparams.param_sink_number, n_head, n_tokens,
                         OPENPANGU_ATT_SCORE_CHUNK, OPENPANGU_ATT_FULL_KQ_MAX_MIB);
-            if (chunk_scores) {
+            if (lctx.cparams.fused_idx_topk) {
+                // Fused indexer top-k (CPU-only op): one op computes sum_g w * relu(q.k) + causal
+                // mask -> top-k without materializing the [n_kv, n_ihead, T] score tensor, so no
+                // score chunking is needed. CUDA backends do not implement GGML_OP_INDEXER_TOPK;
+                // the scheduler runs it on CPU and copies the operands across the backend boundary.
+                // The op reads the mask row-strided, so the raw view suffices.
+                ggml_tensor * idx_mask = ggml_view_2d(ctx0, KQ_mask, n_kv, n_tokens,
+                                                      KQ_mask->nb[1], 0);
+                sel_idx = ggml_indexer_topk(ctx0, k_all_idx, q_idx, w_idx, idx_mask,
+                                            GGML_UNARY_OP_RELU, (int) topk);          // [topk, T] i32
+                if (il == 0) ggml_set_name(sel_idx, "opg0_idx_sel");
+                dsa_gather_engaged = dsa_gather_allowed;
+                if (dsa_gather_engaged) {
+                    GGML_ASSERT(n_kv >= topk + (int64_t) pad + n_tokens);
+                } else if (defer_sel_mask_to_att_chunks) {
+                    sel_mask = nullptr;
+                } else {
+                    ggml_tensor * base = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, 1, n_kv, n_tokens);
+                    base = ggml_fill(ctx0, base, -1e30f);
+                    ggml_tensor * zeros = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, 1, topk, n_tokens);
+                    zeros = ggml_fill(ctx0, zeros, 0.0f);
+                    sel_mask = ggml_set_rows(ctx0, base, zeros, sel_idx);
+                    sel_mask = ggml_reshape_2d(ctx0, sel_mask, n_kv, n_tokens);
+                }
+            } else if (chunk_scores) {
                 ggml_tensor * sel_mask_parts = nullptr;
                 for (int64_t c0 = 0; c0 < n_tokens; c0 += OPENPANGU_IDX_SCORE_CHUNK) {
                     const int64_t tc = std::min<int64_t>(OPENPANGU_IDX_SCORE_CHUNK, n_tokens - c0);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7772,6 +7772,12 @@ struct llama_context * llama_init_from_model(
             LLAMA_LOG_INFO("%s: dsa_top_k     = %d\n",     __func__, cparams.dsa_top_k);
         }
     }
+    if (model->arch == LLM_ARCH_OPENPANGU) {
+        LLAMA_LOG_INFO("%s: dsa_idx_topk  = %d\n",     __func__, cparams.fused_idx_topk);
+        if (cparams.dsa_top_k > 0) {
+            LLAMA_LOG_INFO("%s: dsa_top_k     = %d\n",     __func__, cparams.dsa_top_k);
+        }
+    }
     LLAMA_LOG_INFO("%s: k_cache_hadam = %d\n",     __func__, cparams.k_cache_hadamard);
     LLAMA_LOG_INFO("%s: v_cache_hadam = %d\n",     __func__, cparams.v_cache_hadamard);
     LLAMA_LOG_INFO("%s: split_mode_graph_scheduling = %d\n",   __func__, cparams.split_mode_graph_scheduling);


### PR DESCRIPTION
openPangu's indexer scoring is exactly the shape #2098's `GGML_OP_INDEXER_TOPK` computes, so this PR routes openPangu's DSA selection through the op when `-fidx` is set. One branch in `build_openpangu.cpp`, off by default, unfused paths unchanged. It composes with the gathered DSA decode path, the deferred attention-chunk masks, and the `set_rows` mask path, and the loader now echoes `dsa_idx_topk` for openPangu the way it does for GLM-DSA. The op is CPU-only, so on a CUDA rig the scheduler places it on CPU and its operands cross the backend boundary each eval.

The point on a hybrid rig is the compute-buffer ceiling. Measured on a 12 GB RTX 4070 (the #2065 Q4_K_M, `-fa off -ngl 999 -ot exps=CPU -ub 2048`, q8_0 caches):

<img width="1540" height="935" alt="fidx-cpu-pr-graph" src="https://github.com/user-attachments/assets/89ee5a8e-24ef-44b0-8d60-262cc65653ed" />

| ctx | -fidx | load | CUDA0 compute buffer | CUDA_Host compute buffer | peak VRAM |
|--:|--|--|--:|--:|--:|
| 32768 | off | FIT | 2808.27 MiB | 350.16 MiB | 6687 MiB |
| 32768 | on | FIT | 2808.27 MiB | 320.72 MiB | 6685 MiB |
| 65536 | off | FIT | 3945.52 MiB | 663.80 MiB | 8771 MiB |
| 65536 | on | FIT | 2808.27 MiB | 580.97 MiB | 7633 MiB |
| 131072 | off | OOM | allocation fails | - | - |
| 131072 | on | FIT | 2808.27 MiB | 1101.47 MiB | 9527 MiB |

The paths diverge at 64K, and at 128K the unfused path fails to allocate while `-fidx` holds the CUDA0 buffer at its 32K floor, because the score tensors never exist on the GPU. The cost is throughput: with the op on CPU and attention on CUDA, the warm A/B sweep (figure, right panels) runs S_PP -8% at N_KV 2048 growing to -44% at 32K, and S_TG -4% to -26%. A `-ngl 0` probe on this 8-core desktop showed S_TG at parity and S_PP 3 to 12 percent behind, so on this class of CPU the flag is not a throughput feature, and can be left off when the unfused path fits.

Correctness is output-level: a 4.7K-token needle at temp 0 (past top_k 2048, so selection prunes) returns identically with `-fidx` off and on across the base graph, MTP speculative decode, the deferred-chunk regime, and all four accepted indexer cache types (12/12 arms; top-k tie-break identity is not asserted).

The branch leaves op placement to the scheduler, so if a CUDA implementation of the op lands (the direction #2103 is exploring), openPangu picks it up here with no further arch changes, and the round-trip cost above disappears. And the op carries #2098's platform contract (AVX2 and ARM dotprod builds); other builds should leave `-fidx` off, same as GLM-DSA today.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High