### PR TITLE
Set GGML_AVXVNNI to OFF by default

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -82,7 +82,7 @@ option(GGML_CPU_HBM     "ggml: use memkind for CPU HBM" OFF)
 
 option(GGML_AVX         "ggml: enable AVX"              ${INS_ENB})
 option(GGML_AVX2        "ggml: enable AVX2"             ${INS_ENB})
-option(GGML_AVXVNNI     "ggml: enable AVX-VNNI"         ${INS_ENB})
+option(GGML_AVXVNNI     "ggml: enable AVX-VNNI"         OFF)
 option(GGML_AVX512      "ggml: enable AVX512"           OFF)
 option(GGML_AVX512_VBMI "ggml: enable AVX512-VBMI"      OFF)
 option(GGML_AVX512_VNNI "ggml: enable AVX512-VNNI"      OFF)


### PR DESCRIPTION
## Summary
This PR updates the CMakeLists to prevent `Illegal instruction` error.

### Related Issues
Fixes #2113

- Self-reported review complexity:
  - [ x ] Low
