### PR TITLE
cuda: decline unsupported indexer top_k cache types in supports_op

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -5040,8 +5040,15 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                    op->src[1]->ne[0] == op->src[0]->ne[1] &&
                    op->src[3]->ne[0] == op->src[0]->ne[2];
         case GGML_OP_DELTA_NET:
-        case GGML_OP_INDEXER_TOPK:
             return true;
+        case GGML_OP_INDEXER_TOPK:
+            // f16 k goes through cuBLAS; quantized k needs an MMQ kernel for the type on
+            // this device. Anything else falls back to the CPU op via the scheduler.
+            return (op->src[0]->type == GGML_TYPE_F16 ||
+                    (ggml_is_quantized(op->src[0]->type) &&
+                     ggml_cuda_should_use_mmq(op->src[0]->type, ggml_cuda_info().devices[cuda_ctx->device].cc, 8))) &&
+                   op->src[1]->type == GGML_TYPE_F32 && op->src[2]->type == GGML_TYPE_F32 &&
+                   (op->src[3]->type == GGML_TYPE_F32 || op->src[3]->type == GGML_TYPE_F16);
         case GGML_OP_SINKHORN: {
             const int sink_s = op->op_params[0];
             return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 &&

--- a/src/graphs/build_openpangu.cpp
+++ b/src/graphs/build_openpangu.cpp
@@ -376,10 +376,10 @@ ggml_tensor * llm_build_context::build_openpangu_attention(
                 openpangu_att_score_should_chunk(n_kv, hparams.param_sink_number, n_head, n_tokens,
                         OPENPANGU_ATT_SCORE_CHUNK, OPENPANGU_ATT_FULL_KQ_MAX_MIB);
             if (lctx.cparams.fused_idx_topk) {
-                // Fused indexer top-k (CPU-only op): one op computes sum_g w * relu(q.k) + causal
+                // Fused indexer top-k: one op computes sum_g w * relu(q.k) + causal
                 // mask -> top-k without materializing the [n_kv, n_ihead, T] score tensor, so no
-                // score chunking is needed. CUDA backends do not implement GGML_OP_INDEXER_TOPK;
-                // the scheduler runs it on CPU and copies the operands across the backend boundary.
+                // score chunking is needed. The CUDA op handles f16/quantized k; other indexer
+                // cache types fall back to the CPU op through the scheduler.
                 // The op reads the mask row-strided, so the raw view suffices.
                 ggml_tensor * idx_mask = ggml_view_2d(ctx0, KQ_mask, n_kv, n_tokens,
                                                       KQ_mask->nb[1], 0);


### PR DESCRIPTION
`-fidx -ictk f32` on a CUDA build aborts at eval: the indexer top_k kernel asserts `k->type == F16 || ggml_is_quantized(k->type)` (indexer_topk.cu:72) while supports_op returns true unconditionally, so the scheduler keeps the op on CUDA. Because the op only engages once n_kv exceeds top_k, the server loads clean and serves short requests, then aborts on the first one past 2048 tokens. On main at `8e2d83cfe`:

```
./llama-server -m openPangu-2.0-Flash-Q4_K_M.gguf -c 8192 -fa off -ngl 999 -ot exps=CPU -ctk q8_0 -fidx -ictk f32
# first request > 2048 tokens:
ggml/src/ggml-cuda/indexer_topk.cu:72: GGML_ASSERT(k->type == GGML_TYPE_F16 || ggml_is_quantized(k->type)) failed
```

This patch makes supports_op mirror what the kernel can execute: f16 k (the cuBLAS path), or quantized k that has an MMQ kernel for the type on the device (`ggml_cuda_should_use_mmq`), plus the operand types the kernel asserts. Everything else falls back through the scheduler to the CPU op, which handles all four openPangu `-ictk` types on AVX2 and ARM-dotprod builds (its existing platform contract from #2111). Checking `ggml_is_quantized` alone would over-accept: quantized types with no MMQ case would still hit the dispatch abort, and the GLM `-ictk` path does not restrict cache types.

With the fix, the same f32 configuration answers a 6.5K-token needle correctly with every INDEXER_TOPK node on CPU (GGML_SCHED_DEBUG); `-ictk q8_0` and the default f16 keep their main placement (identical scheduler split before and after the fix). bf16, which the kernel also cannot execute, did not abort on main because the scheduler happened to route it to CPU already; it now lands there by explicit decline, with the same needle result.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High