### PR TITLE
Rename AVX-VNNI build to GGML_AVX_VNNI

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -82,7 +82,7 @@ option(GGML_CPU_HBM     "ggml: use memkind for CPU HBM" OFF)
 
 option(GGML_AVX         "ggml: enable AVX"              ${INS_ENB})
 option(GGML_AVX2        "ggml: enable AVX2"             ${INS_ENB})
-option(GGML_AVXVNNI     "ggml: enable AVX-VNNI"         OFF)
+option(GGML_AVX_VNNI     "ggml: enable AVX-VNNI"         OFF)
 option(GGML_AVX512      "ggml: enable AVX512"           OFF)
 option(GGML_AVX512_VBMI "ggml: enable AVX512-VBMI"      OFF)
 option(GGML_AVX512_VNNI "ggml: enable AVX512-VNNI"      OFF)

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1138,7 +1138,7 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
             endif()
         elseif (GGML_AVX2)
             list(APPEND ARCH_FLAGS /arch:AVX2)
-            if (GGML_AVXVNNI)
+            if (GGML_AVX_VNNI)
                 # clang-cl supports -m flags alongside /arch: flags.
                 # Using -mavxvnni enables the actual target feature for clang,
                 # which is required for intrinsic functions like _mm256_dpbusd_avx_epi32.
@@ -1168,7 +1168,7 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
         if (GGML_AVX2)
             list(APPEND ARCH_FLAGS -mavx2)
         endif()
-        if (GGML_AVXVNNI)
+        if (GGML_AVX_VNNI)
             list(APPEND ARCH_FLAGS -mavxvnni)
         endif()
         if (GGML_AVX512)


### PR DESCRIPTION
Renames GGML_AVXVNNI to `GGML_AVX_VNNI`

Similar to GGML_AVX512_VBMI, GGML_AVX512_VNNI, GGML_AVX512_BF16

Build script flag would need to be renamed `-DGGML_AVX_VNNI=ON`

- Self-reported review complexity:
  - [ x ] Low