### PR TITLE
Scope split-mode graph mmap to the tensor being loaded. Prevents memory leak

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1078,10 +1078,6 @@ bool llama_model_loader::load_all_data(
     std::vector<void*> host_ptrs;
     std::vector<ggml_backend_event_t> events;
 
-#if !defined(_WIN32)
-    std::vector<std::unique_ptr<llama_mmap>> split_mappings(files.size());
-#endif
-
     ggml_backend_t cuda_backend = nullptr;
     if (!use_mmap && !check_tensors) {
         // When not using mmaped io use async uploads from pinned memory to GPU memory.
@@ -1201,37 +1197,13 @@ bool llama_model_loader::load_all_data(
         const char * buffer_name = ggml_backend_buffer_name(cur->buffer);
         const bool   is_probably_split_mode_graph = std::strncmp(buffer_name, GGML_CUDA_NAME, strlen(GGML_CUDA_NAME)) == 0;
         if (is_probably_split_mode_graph) {
-#if !defined(_WIN32)
-            llama_mmap * mapping;
-            {
-                std::lock_guard<std::mutex> lock(load_mutex);
-                auto & m = split_mappings[weight->idx];
-                if (!m) {
-                    m.reset(new llama_mmap(files.at(weight->idx).get(), 0, ggml_is_numa()));
-                }
-                mapping = m.get();
-            }
-            uint8_t * data = (uint8_t *) mapping->addr() + weight->offs;
+            llama_mmap mapping(file.get(), 0);
+            uint8_t * data = (uint8_t *) mapping.addr() + weight->offs;
             ggml_backend_tensor_set(cur, data, 0, n_size);
             if (check_tensors && !ggml_validate_row_data(cur->type, data, n_size)) {
                 throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
             }
-            mapping->dontneed_fragment(weight->offs, weight->offs + n_size);
             return n_size;
-#else
-            auto & read_buf = read_bufs[thread_idx];
-            if (read_buf.capacity() > n_size) {
-                read_buf = std::vector<no_init<uint8_t>>();
-            }
-            read_buf.resize(n_size);
-            file->seek(weight->offs, SEEK_SET);
-            file->read_raw(read_buf.data(), n_size);
-            ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
-            if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {
-                throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
-            }
-            return n_size;
-#endif
         }
 #endif
         // rest. Serialized.


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

#2102 introduced a change where staging buffers for tensor reads were swapped from anonymous memory to mmaped memory. For some reason (read: "I failed at devibing the prototype") these allocations were freed using `llama_mmap::dontneed_fragment` which delegates to posix `MADV_DONTNEED` instead of just letting them drop out of scope

llama_mmap::dontneed_fragment is a no-op on windows and this caused memory pressure and a regression in model load times.

Fix is to let the mmaps drop out of scope. This also removes the need for the windows workaround introduced in #2121, as this fixes the issue at the root cause.

The change is complete but I will flip to ready once I have tested on Windows.