### PR TITLE
llama: disable fused up-gate when an offload backend lacks GGML_OP_FUSED_UP_GATE (fixes silent 3.5x Metal slowdown)

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7972,6 +7972,39 @@ struct llama_context * llama_init_from_model(
         }
         ctx->backends.push_back(ctx->backend_cpu);
 
+        // Fused up-gate nodes are emitted into the graph whenever the option is
+        // enabled, but not every backend implements GGML_OP_FUSED_UP_GATE (e.g. the
+        // Metal backend does not). The scheduler silently assigns those nodes to the
+        // CPU backend, forcing a device<->host round trip on every FFN layer when the
+        // rest of the graph is offloaded. Probe the offload backends and fall back to
+        // the decomposed ops (MUL_MAT + FUSED_MUL_UNARY) up front instead.
+        if (cparams.fused_up_gate) {
+            struct ggml_init_params probe_init = {
+                /*.mem_size   =*/ 8*ggml_tensor_overhead(),
+                /*.mem_buffer =*/ nullptr,
+                /*.no_alloc   =*/ true,
+            };
+            ggml_context * probe_ctx = ggml_init(probe_init);
+            ggml_tensor * up    = ggml_new_tensor_2d(probe_ctx, GGML_TYPE_Q4_0, 256, 16);
+            ggml_tensor * gate  = ggml_new_tensor_2d(probe_ctx, GGML_TYPE_Q4_0, 256, 16);
+            ggml_tensor * b     = ggml_new_tensor_2d(probe_ctx, GGML_TYPE_F32,  256, 1);
+            ggml_tensor * probe = ggml_fused_up_gate(probe_ctx, up, gate, b, GGML_UNARY_OP_SILU);
+            GGML_ASSERT(probe->op == GGML_OP_FUSED_UP_GATE);
+            for (auto * backend : ctx->backends) {
+                if (backend == ctx->backend_cpu) {
+                    continue;
+                }
+                if (!ggml_backend_supports_op(backend, probe)) {
+                    LLAMA_LOG_WARN("%s: backend %s does not implement %s - disabling fused up-gate "
+                            "(decomposing into mul_mat + fused_mul_unary)\n",
+                            __func__, ggml_backend_name(backend), ggml_op_name(probe->op));
+                    cparams.fused_up_gate = false;
+                    break;
+                }
+            }
+            ggml_free(probe_ctx);
+        }
+
         if (!llama_kv_cache_init(ctx->kv_self, ctx, type_k, type_v, params.idx_type_k, kv_size, cparams.offload_kqv,
                     params.type_k_first, params.type_k_last, params.type_v_first, params.type_v_last,
                     params.n_k_first, params.n_k_last, params.n_v_first, params.n_v_last)) {


### PR DESCRIPTION
## Problem

`GGML_OP_FUSED_UP_GATE` is implemented in the CUDA backend (`ggml_cuda_up_gate_unary`) but not in the Metal backend. With `-ngl 99` on Apple Silicon, the backend scheduler silently assigns every fused up-gate node to the CPU backend, forcing a GPU→CPU→GPU synchronization stall on every FFN layer — 24 times per token on Qwen 2.5-0.5B.

There is no error and no warning; inference is just silently slower. Measured on an M2 (Qwen 2.5-0.5B, Q5_0, full offload):

| | decode speed |
|---|---|
| default (`fused_up_gate = true`) | 36 tok/s |
| `--no-fused-up-gate` | **125 tok/s (3.5x)** |

This affects all standard transformer models (Qwen 2.5, Llama, DeepSeek, ...) on all Apple Silicon Macs (M1–M4). Hybrid DeltaNet models are unaffected (their FFN path doesn't emit this op).

## Fix

At context creation, after the backends are initialized, build a dummy `GGML_OP_FUSED_UP_GATE` node and probe each non-CPU backend with `ggml_backend_supports_op()`. If any offload backend lacks the op, disable `cparams.fused_up_gate` and log a warning. The graph then builds the decomposed form (`MUL_MAT` + `FUSED_MUL_UNARY`), which Metal handles natively, and the whole graph stays on GPU.

This deliberately does not special-case Metal: any backend without the kernel (Vulkan, SYCL, ...) gets the same fallback, and once someone adds a Metal kernel for the op the probe simply stops triggering.

`--no-fused-up-gate` still works as an explicit override; the probe only ever turns the option off, never on.

## Testing

- Linux x86-64 AVX2, CPU-only: builds clean; probe is a no-op when the only backend is CPU (fused path unchanged, verified `fused_up_gate = 1` in the context log and normal generation).
- The behavioral fix (forcing `fused_up_gate = false` under Metal full offload) is the same mitigation we have been running manually via an eval callback on M2 since April — that is where the 36→125 tok/s numbers come from.
- ~~I don't have Apple hardware in CI reach for this branch, so the probe path on Metal is verified by inspection.~~ **Update: we verified it on M2** (details in comment below): this branch built with `GGML_METAL=ON`, Qwen 2.5-0.5B Q4_K_M at `-ngl 99` — the probe warning fires at context creation and default decode runs at 112.5 t/s, matching the explicit `--no-fused-up-gate` run (115.3 t/s, identical output) instead of the previous ~36 t/s CPU-fallback behavior.
