### PR TITLE
llama: fix GGML_METAL=ON build - missing ggml-metal.h include in llama-dflash.cpp

### DIFF
--- a/src/llama-dflash.cpp
+++ b/src/llama-dflash.cpp
@@ -9,6 +9,10 @@
 #include "ggml.h"
 #include "ggml-backend.h"
 
+#ifdef GGML_USE_METAL
+#  include "ggml-metal.h"
+#endif
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>


### PR DESCRIPTION
## Problem

Any build configured with `GGML_METAL=ON` currently fails to compile on `main`:

`src/llama-dflash.cpp` calls `ggml_backend_is_metal()` and `ggml_backend_metal_set_n_cb()` inside an `#ifdef GGML_USE_METAL` block (around line 203), but the file never includes `ggml-metal.h`, so the declarations are missing exactly when that block is compiled.

Found while verifying #2133 on an Apple M2.

## Fix

Add the same guarded include `llama.cpp` already uses:

```cpp
#ifdef GGML_USE_METAL
#  include "ggml-metal.h"
#endif
```

## Testing

- macOS / Apple M2, Xcode clang 21, `GGML_METAL=ON`: `main` fails to compile at `llama-dflash.cpp` without this change; with it the build completes and full-offload inference runs normally (this is the patch we ran for the #2133 verification).
- Linux x86-64, Metal off: build unaffected (the include is behind the guard).
