### PR TITLE
Fix build on macOS

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1102,7 +1102,9 @@ if (CMAKE_OSX_ARCHITECTURES      STREQUAL "arm64" OR
         endif()
         if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
             # else we fail on Gravitons and such
-            list(APPEND ARCH_FLAGS -march=native)
+            if (GGML_NATIVE)
+                list(APPEND ARCH_FLAGS -march=native)
+            endif()
             list(APPEND ARCH_FLAGS -flax-vector-conversions)
         endif()
     endif()

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1100,11 +1100,9 @@ if (CMAKE_OSX_ARCHITECTURES      STREQUAL "arm64" OR
         if (GGML_SVE)
             list(APPEND ARCH_FLAGS -march=armv8.6-a+sve)
         endif()
-        if (GGML_NATIVE)
-            list(APPEND ARCH_FLAGS -march=native)
-        endif()
         if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
             # else we fail on Gravitons and such
+            list(APPEND ARCH_FLAGS -march=native)
             list(APPEND ARCH_FLAGS -flax-vector-conversions)
         endif()
     endif()


### PR DESCRIPTION

#2094 added `-march=native` on ARM platforms, but this is only needed for GCC and breaks the macOS build with `clang`. This PR fixes it and should close #2135. 