### PR TITLE
ggml : fix build and MoE inference on CPUs without AVX2 (AVX1-only) 

### DIFF
--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -708,8 +708,11 @@ void quantize_row_q4_0_ref(const float * restrict x, block_q4_0 * restrict y, in
 }
 
 void quantize_row_q4_0(const float * restrict x, void * restrict y, int64_t k) {
+#if GGML_USE_IQK_MULMAT
     iqk_quantize_q4_0(x, y, k);
-    //quantize_row_q4_0_ref(x, y, k);
+#else
+    quantize_row_q4_0_ref(x, y, k);
+#endif
 }
 
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -7916,6 +7916,54 @@ struct ggml_tensor * ggml_mul_mat_id(
     return result;
 }
 
+#if !GGML_USE_IQK_MULMAT
+// Without IQK the fused MOE_FUSED_UP_GATE op has no compute path, so
+// ggml_moe_up_gate / ggml_moe_up_gate_ext express the same computation with
+// mul_mat_id + add_id + fused_mul_unary instead.
+static struct ggml_tensor * ggml_moe_up_gate_fallback(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * as_up,
+            struct ggml_tensor  * as_gate,
+            struct ggml_tensor  * b,
+            struct ggml_tensor  * ids,
+            struct ggml_tensor  * as_up_b,
+            struct ggml_tensor  * as_gate_b,
+            enum   ggml_unary_op  op) {
+    if (as_gate == NULL) {
+        // Combined weight: as_up has ne[1] = 2*n_ff, gate first / up second
+        // (see the combined-tensor handling in
+        // ggml_compute_forward_mul_mat_id_up_gate, where src0_2_cur = base =
+        // gate and src0_1_cur = base + nb02/2 = up). Split the weight tensor
+        // into two views and do two separate mul_mat_ids. The combined bias
+        // in as_up_b uses the same layout, and as_gate_b must be null.
+        GGML_ASSERT(!as_gate_b);
+        GGML_ASSERT(as_up->ne[1] % 2 == 0);
+        const int64_t n_ff = as_up->ne[1] / 2;
+        struct ggml_tensor * gate_w = ggml_view_3d(ctx, as_up, as_up->ne[0], n_ff, as_up->ne[2], as_up->nb[1], as_up->nb[2], 0);
+        struct ggml_tensor * up_w   = ggml_view_3d(ctx, as_up, as_up->ne[0], n_ff, as_up->ne[2], as_up->nb[1], as_up->nb[2], n_ff * as_up->nb[1]);
+        struct ggml_tensor * result_gate = ggml_mul_mat_id(ctx, gate_w, b, ids);
+        struct ggml_tensor * result_up   = ggml_mul_mat_id(ctx, up_w,   b, ids);
+        if (as_up_b) {
+            GGML_ASSERT(as_up_b->ne[0] == 2*n_ff);
+            struct ggml_tensor * gate_bias = ggml_view_2d(ctx, as_up_b, n_ff, as_up_b->ne[1], as_up_b->nb[1], 0);
+            struct ggml_tensor * up_bias   = ggml_view_2d(ctx, as_up_b, n_ff, as_up_b->ne[1], as_up_b->nb[1], n_ff * as_up_b->nb[0]);
+            result_gate = ggml_add_id(ctx, result_gate, gate_bias, ids);
+            result_up   = ggml_add_id(ctx, result_up,   up_bias,   ids);
+        }
+        return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
+    }
+    struct ggml_tensor * result_up   = ggml_mul_mat_id(ctx, as_up,   b, ids);
+    if (as_up_b) {
+        result_up = ggml_add_id(ctx, result_up, as_up_b, ids);
+    }
+    struct ggml_tensor * result_gate = ggml_mul_mat_id(ctx, as_gate, b, ids);
+    if (as_gate_b) {
+        result_gate = ggml_add_id(ctx, result_gate, as_gate_b, ids);
+    }
+    return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
+}
+#endif
+
 struct ggml_tensor * ggml_moe_up_gate(
             struct ggml_context * ctx,
             struct ggml_tensor  * as_up,
@@ -7928,6 +7976,9 @@ struct ggml_tensor * ggml_moe_up_gate(
         struct ggml_tensor * result_gate = ggml_mul_mat_id(ctx, as_gate, b, ids);
         return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
     }
+#if !GGML_USE_IQK_MULMAT
+    return ggml_moe_up_gate_fallback(ctx, as_up, as_gate, b, ids, NULL, NULL, op);
+#endif
     GGML_ASSERT(!ggml_is_transposed(as_up));
     GGML_ASSERT(!as_gate || !ggml_is_transposed(as_gate));
     GGML_ASSERT(ids->type == GGML_TYPE_I32);
@@ -7987,6 +8038,9 @@ struct ggml_tensor * ggml_moe_up_gate_ext(
         }
         return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
     }
+#if !GGML_USE_IQK_MULMAT
+    return ggml_moe_up_gate_fallback(ctx, as_up, as_gate, b, ids, as_up_b, as_gate_b, op);
+#endif
 
     GGML_ASSERT(!ggml_is_transposed(as_up));
     GGML_ASSERT(!as_gate || !ggml_is_transposed(as_gate));
@@ -8031,6 +8085,14 @@ struct ggml_tensor * ggml_fused_up_gate(
         struct ggml_tensor * result_gate = ggml_mul_mat(ctx, gate, b);
         return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
     }
+#if !GGML_USE_IQK_MULMAT
+    // FUSED_UP_GATE has no compute path without IQK; always use the unfused fallback.
+    {
+        struct ggml_tensor * result_up   = ggml_mul_mat(ctx, up,   b);
+        struct ggml_tensor * result_gate = ggml_mul_mat(ctx, gate, b);
+        return ggml_fused_mul_unary(ctx, result_gate, result_up, op);
+    }
+#endif
     GGML_ASSERT(!ggml_is_transposed(up));
     GGML_ASSERT(!ggml_is_transposed(gate));
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -17212,6 +17212,10 @@ static int ggml_compute_forward_mul_mat(
     const struct ggml_tensor * src0 = dst->src[0];
     const struct ggml_tensor * src1 = dst->src[1];
 
+#if !GGML_USE_IQK_MULMAT
+    GGML_UNUSED(cgraph); // only used for the IQK mul_mat fusion
+#endif
+
     GGML_TENSOR_BINARY_OP_LOCALS
 
     const int ith = params->ith;
@@ -17313,9 +17317,9 @@ static int ggml_compute_forward_mul_mat(
 
     }
 
-    const void * wdata    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
-
     if (src1->type != vec_dot_type && dst->type == GGML_TYPE_F32) {
+#if GGML_USE_IQK_MULMAT
+        const void * wdata    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
         const size_t row_size = ggml_row_size(vec_dot_type, ne10);
         if (iqk_mul_mat_4d(ne01, ne11, ne00,
                     ne02, ne03, ne12, ne13, nb02, nb03, row_size*ne11, row_size*ne11*ne12,
@@ -17332,7 +17336,6 @@ static int ggml_compute_forward_mul_mat(
                 struct ggml_tensor * src0_next = dst_next->src[0];
                 GGML_ASSERT(dst_next->type == GGML_TYPE_F32);
                 GGML_ASSERT(src0_next->ne[0] == ne00);
-                //if (ith == 0) printf("Fusing %s\n", src0_next->name);
                 if (!iqk_mul_mat_4d(src0_next->ne[1], ne11, ne00,
                     src0_next->ne[2], src0_next->ne[3], ne12, ne13, src0_next->nb[2], src0_next->nb[3], row_size*ne11, row_size*ne11*ne12,
                     dst_next->nb[2]/sizeof(float), dst_next->nb[3]/sizeof(float),
@@ -17343,6 +17346,7 @@ static int ggml_compute_forward_mul_mat(
             }
         }
         return node_n;
+#endif
     }
 
     if (ith == 0) {
@@ -23025,12 +23029,14 @@ static void ggml_compute_forward_delta_net_f32(
         GGML_ASSERT(src6->ne[0] >= (n_tokens - 1)*state_step_stride);
     }
 
+#if GGML_USE_IQK_MULMAT
     if (iqk_fused_delta_net(head_dim, n_heads, gqa_ratio, repeat_type, n_tokens, n_seqs,
                 src2->nb[1]/sizeof(float), src2->nb[2]/sizeof(float), src2->nb[3]/sizeof(float),
                 q_data, k_data, v_data, g_data, beta_data, state_in,
                 out_data, state_working, saved_steps, (int) state_step_stride, ith, nth)) {
         return;
     }
+#endif
 
     const int64_t total_heads = n_heads * n_seqs;
     const int64_t heads_per_thread = (total_heads + nth - 1) / nth;
@@ -24727,11 +24733,21 @@ static int ggml_compute_forward(struct ggml_compute_params * params, struct ggml
             } break;
         case GGML_OP_MOE_FUSED_UP_GATE:
             {
+#if GGML_USE_IQK_MULMAT
                 ggml_compute_forward_mul_mat_id_up_gate(params, tensor);
+#else
+                // never emitted by the graph builders in this configuration
+                GGML_ABORT("MOE_FUSED_UP_GATE requires a build with GGML_IQK_MUL_MAT");
+#endif
             } break;
         case GGML_OP_FUSED_UP_GATE:
             {
+#if GGML_USE_IQK_MULMAT
                 ggml_compute_forward_mul_mat_up_gate(params, tensor);
+#else
+                // never emitted by the graph builders in this configuration
+                GGML_ABORT("FUSED_UP_GATE requires a build with GGML_IQK_MUL_MAT");
+#endif
             } break;
         case GGML_OP_OUT_PROD:
             {
@@ -24813,7 +24829,8 @@ static int ggml_compute_forward(struct ggml_compute_params * params, struct ggml
             } break;
         case GGML_OP_SOFT_MAX:
             {
-                if (fusion && i + 4 < cgraph->n_nodes &&
+    #if GGML_USE_IQK_MULMAT
+            if (fusion && i + 4 < cgraph->n_nodes &&
                     cgraph->nodes[i+1]->op == GGML_OP_RESHAPE  &&
                     cgraph->nodes[i+2]->op == GGML_OP_ARGSORT  &&
                     cgraph->nodes[i+3]->op == GGML_OP_VIEW     &&
@@ -24825,9 +24842,11 @@ static int ggml_compute_forward(struct ggml_compute_params * params, struct ggml
                             (const float *)cgraph->nodes[i]->data, (float *)cgraph->nodes[i+4]->data, (int32_t *)cgraph->nodes[i+3]->data,
                             params->ith, params->nth);
                     i += 4;
-                } else {
-                    ggml_compute_forward_soft_max(params, tensor);
-                }
+                } else
+#endif
+            {
+                ggml_compute_forward_soft_max(params, tensor);
+            }
             } break;
         case GGML_OP_SOFT_MAX_BACK:
             {
@@ -24964,9 +24983,13 @@ static int ggml_compute_forward(struct ggml_compute_params * params, struct ggml
             } break;
         case GGML_OP_INDEXER_TOPK:
             {
+#if GGML_USE_IQK_MULMAT
                 if (!iqk_indexer_topk(tensor, params->wdata, (barrier_t)ggml_barrier, (void *)params->shared, params->ith, params->nth)) {
                     GGML_ABORT("Fatal error");
                 }
+#else
+                GGML_ABORT("INDEXER_TOPK requires a build with GGML_IQK_MUL_MAT");
+#endif
             } break;
         case GGML_OP_MASK_TOPK:
             {
@@ -27101,8 +27124,10 @@ struct ggml_cplan ggml_graph_plan(const struct ggml_cgraph * cgraph, int n_threa
                 } break;
             case GGML_OP_INDEXER_TOPK:
                 {
+#if GGML_USE_IQK_MULMAT
                     size_t size = iqk_idx_topk_work_buffer_size(node, n_tasks);
                     cur = MAX(cur, size);
+#endif
                 } break;
             case GGML_OP_CROSS_ENTROPY_LOSS:
                 {

--- a/ggml/src/iqk/iqk_common.h
+++ b/ggml/src/iqk/iqk_common.h
@@ -11,12 +11,15 @@
 
 #include "iqk_config.h"
 
+// needed by the popcount() helpers below, which live outside the
+// IQK_IMPLEMENT block
+#include <cstdint>
+
 #if defined IQK_IMPLEMENT
 
 #include <cstring>
 #include <type_traits>
 #include <vector>
-#include <cstdint>
 
 #include "ggml-impl.h"
 #include "ggml-quants.h"

--- a/ggml/src/iqk/iqk_cpu_ops.cpp
+++ b/ggml/src/iqk/iqk_cpu_ops.cpp
@@ -619,10 +619,10 @@ float iqk_exp_with_thresh(int n, float * logits, float max, float min) {
     //return result[0] + result[1];
 }
 
-bool iqk_ssm_conv4(int nr, int nc, int nt,
-        uint64_t nb01, uint64_t nb10, uint64_t nb11, uint64_t nb21,
-        const float * x0_in, const float * s0_in, const float * c_in,
-        float * dst, float * dst_silu, int ith, int nth) {
+bool iqk_ssm_conv4([[maybe_unused]] int nr, [[maybe_unused]] int nc, [[maybe_unused]] int nt,
+        [[maybe_unused]] uint64_t nb01, [[maybe_unused]] uint64_t nb10, [[maybe_unused]] uint64_t nb11, [[maybe_unused]] uint64_t nb21,
+        [[maybe_unused]] const float * x0_in, [[maybe_unused]] const float * s0_in, [[maybe_unused]] const float * c_in,
+        [[maybe_unused]] float * dst, [[maybe_unused]] float * dst_silu, [[maybe_unused]] int ith, [[maybe_unused]] int nth) {
 #if defined __AVX2__
     if (nt <= 32 || nc != 4 || nr%16 != 0) {
         return false;

--- a/ggml/src/iqk/iqk_cpu_ops.cpp
+++ b/ggml/src/iqk/iqk_cpu_ops.cpp
@@ -7,6 +7,11 @@
 #define IQK_IMPLEMENT
 
 #include "iqk_cpu_ops.h"
+
+#define GGML_COMMON_DECL_C
+#include "ggml-common.h"
+#include "ggml-impl.h"
+
 #include "iqk_utils.h"
 #include "iqk_common.h"
 #include "ggml.h"

--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -568,6 +568,7 @@ bool iqk_flash_attn_noalibi([[maybe_unused]] int type_q, [[maybe_unused]] int ty
                             [[maybe_unused]] const void  * k,        // k matrix. Assumed to be fp16, nq x nk elements
                             [[maybe_unused]] const void  * v,        // v matrix. Assumed to be fp16, nq x nk elements
                             [[maybe_unused]] const void  * mask,     // mask. If not null, assumed to be fp16. nq x nk elements
+                            [[maybe_unused]] const void  * sinks,    // mask. If not null, assumed to be fp16. nq x nk elements
                             [[maybe_unused]] float         scale,    // scale applied before softmax
                             [[maybe_unused]] float         softcap,  // if > 0, a "soft-cap" operation is applied before softmax
                             [[maybe_unused]] float       * qkv,      // v*softmax(scale*(k*q))

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -1934,8 +1934,16 @@ bool iqk_indexer_topk(struct ggml_tensor * dst, void * work_buffer, barrier_t ba
 #else  // IQK_IMPLEMENT
 
 #include "ggml-impl.h"
+#include "iqk_mul_mat.h"
 
-extern "C" IQK_API bool iqk_mul_mat(int, long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
+// These stubs abort unconditionally, but they implement interfaces that do
+// return on supported CPUs, so the noreturn suggestion does not apply.
+#if defined __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif
+
+extern "C" IQK_API bool iqk_mul_mat(long, long, long, int, const void *, long, int, const void *, long, float *, long, int, int) {
     GGML_ABORT("Unsupported CPU. You may need to manually set compilation flags\n");
     return false;
 }
@@ -1959,7 +1967,8 @@ extern "C" IQK_API bool iqk_mul_mat_moe(long, long, long, int, int, const void *
 extern "C" IQK_API bool iqk_moe_fused_up_gate(long /*Nx*/, long /*Ny*/, long /*ne00*/, int /*ne11*/, int /*unary_op*/,
         int /*typeA*/, const void * /*Aup*/, const void * /*Agate*/, long /*strideA*/,
         int /*typeB*/, const void * /*B*/, long /*strideB*/,
-        float * /*C*/, long /*nb1*/, long /*nb2*/, const void * /*vrow_mapping*/, float, int /*ith*/, int /*nth*/) {
+        const char * /*up_b*/, const char * /*gate_b*/,
+        float * /*C*/, long /*nb1*/, long /*nb2*/, const void * /*vrow_mapping*/, float /*limit*/, int /*ith*/, int /*nth*/) {
     GGML_ABORT("Unsupported CPU. You may need to manually set compilation flags\n");
     return false;
 }
@@ -1978,5 +1987,17 @@ bool iqk_indexer_topk(struct ggml_tensor *, void *, barrier_t, void *, int, int)
 size_t iqk_idx_topk_work_buffer_size(const struct ggml_tensor *, int) {
     return 0;
 }
+
+extern "C" IQK_API size_t iqk_fa_work_buffer_size(const struct ggml_tensor *, int) {
+    return 0;
+}
+
+extern "C" IQK_API void iqk_topk_moe(int, int, int, const float *, float *, int32_t *, int, int) {
+    GGML_ABORT("Unsupported CPU. You may need to manually set compilation flags\n");
+}
+
+#if defined __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -934,7 +934,7 @@ void quantize_row_q8_0_x4(const float * x, void * vy, int64_t k) {
             }
         }
     }
-#else
+#elif defined(__AVX2__)
     for (int i = 0; i < nb; i++) {
         int i4 = i/4, ir = i%4;
         // Load elements into 4 AVX vectors
@@ -980,14 +980,10 @@ void quantize_row_q8_0_x4(const float * x, void * vy, int64_t k) {
         __m256i i3 = _mm256_cvtps_epi32( v3 );
 
         // Convert int32 to int16
-        i0 = _mm256_packs_epi32( i0, i1 );  // 0, 1, 2, 3,  8, 9, 10, 11,  4, 5, 6, 7, 12, 13, 14, 15
-        i2 = _mm256_packs_epi32( i2, i3 );  // 16, 17, 18, 19,  24, 25, 26, 27,  20, 21, 22, 23, 28, 29, 30, 31
-                                            // Convert int16 to int8
-        i0 = _mm256_packs_epi16( i0, i2 );  // 0, 1, 2, 3,  8, 9, 10, 11,  16, 17, 18, 19,  24, 25, 26, 27,  4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
+        i0 = _mm256_packs_epi32( i0, i1 );
+        i2 = _mm256_packs_epi32( i2, i3 );
+        i0 = _mm256_packs_epi16( i0, i2 );
 
-        // We got our precious signed bytes, but the order is now wrong
-        // These AVX2 pack instructions process 16-byte pieces independently
-        // The following instruction is fixing the order
         const __m256i perm = _mm256_setr_epi32( 0, 4, 1, 5, 2, 6, 3, 7 );
         i0 = _mm256_permutevar8x32_epi32( i0, perm );
 
@@ -995,6 +991,32 @@ void quantize_row_q8_0_x4(const float * x, void * vy, int64_t k) {
             _mm256_storeu_si256((__m256i *)y4[i4].qs + ir, i0);
         } else {
             _mm256_storeu_si256((__m256i *)y[i].qs, i0);
+        }
+    }
+#else
+    for (int i = 0; i < nb; i++) {
+        int i4 = i/4, ir = i%4;
+        float amax = 0.0f;
+        for (int j = 0; j < QK8_0; j++) {
+            float a = fabsf(x[i*QK8_0 + j]);
+            if (a > amax) amax = a;
+        }
+        const float d = amax / 127.0f;
+        const float id = d > 0 ? 1.0f/d : 0.0f;
+        if (i < nb4) {
+            y4[i4].d[ir] = GGML_FP32_TO_FP16(d);
+        } else {
+            y[i].d = GGML_FP32_TO_FP16(d);
+        }
+        for (int j = 0; j < QK8_0; j++) {
+            int val = (int)roundf(x[i*QK8_0 + j] * id);
+            if (val > 127) val = 127;
+            if (val < -128) val = -128;
+            if (i < nb4) {
+                y4[i4].qs[ir*QK8_0 + j] = (int8_t)val;
+            } else {
+                y[i].qs[j] = (int8_t)val;
+            }
         }
     }
 #endif
@@ -1068,7 +1090,7 @@ void quantize_row_q8_1_x4_T(const float * x, Block * y, int64_t k) {
             }
         }
     }
-#else
+#elif defined(__AVX2__)
     for (int i = 0; i < nb; i++) {
         int i4 = i/4, ir = i%4;
         // Load elements into 4 AVX vectors
@@ -1147,14 +1169,10 @@ void quantize_row_q8_1_x4_T(const float * x, Block * y, int64_t k) {
         }
 
         // Convert int32 to int16
-        i0 = _mm256_packs_epi32( i0, i1 );  // 0, 1, 2, 3,  8, 9, 10, 11,  4, 5, 6, 7, 12, 13, 14, 15
-        i2 = _mm256_packs_epi32( i2, i3 );  // 16, 17, 18, 19,  24, 25, 26, 27,  20, 21, 22, 23, 28, 29, 30, 31
-                                            // Convert int16 to int8
-        i0 = _mm256_packs_epi16( i0, i2 );  // 0, 1, 2, 3,  8, 9, 10, 11,  16, 17, 18, 19,  24, 25, 26, 27,  4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
+        i0 = _mm256_packs_epi32( i0, i1 );
+        i2 = _mm256_packs_epi32( i2, i3 );
+        i0 = _mm256_packs_epi16( i0, i2 );
 
-        // We got our precious signed bytes, but the order is now wrong
-        // These AVX2 pack instructions process 16-byte pieces independently
-        // The following instruction is fixing the order
         const __m256i perm = _mm256_setr_epi32( 0, 4, 1, 5, 2, 6, 3, 7 );
         i0 = _mm256_permutevar8x32_epi32( i0, perm );
 
@@ -1162,6 +1180,59 @@ void quantize_row_q8_1_x4_T(const float * x, Block * y, int64_t k) {
             _mm256_storeu_si256((__m256i *)y4[i4].qs + ir, i0);
         } else {
             _mm256_storeu_si256((__m256i *)y[i].qs, i0);
+        }
+    }
+#else
+    for (int i = 0; i < nb; i++) {
+        int i4 = i/4, ir = i%4;
+        float amax = 0.0f;
+        for (int j = 0; j < QK8_1; j++) {
+            float a = fabsf(x[i*QK8_1 + j]);
+            if (a > amax) amax = a;
+        }
+        float d = amax / 127.0f;
+        if constexpr (std::is_same_v<Block, block_q8_1>) {
+            if (i < nb4) {
+                y4[i4].d[ir] = GGML_FP32_TO_FP16(d);
+            } else {
+                y[i].d = GGML_FP32_TO_FP16(d);
+            }
+        } else {
+            auto t = GGML_FP32_TO_BF16(d);
+            d = ggml_bf16_to_fp32(t);
+            if (i < nb4) {
+                y4[i4].d[ir] = t.bits;
+            } else {
+                y[i].d = t.bits;
+            }
+        }
+        const float id = d > 0 ? 1.0f/d : 0.0f;
+        int sum = 0;
+        for (int j = 0; j < QK8_1; j++) {
+            int val = (int)roundf(x[i*QK8_1 + j] * id);
+            if (val > 127) val = 127;
+            if (val < -128) val = -128;
+            if (i < nb4) {
+                y4[i4].qs[ir*QK8_1 + j] = (int8_t)val;
+            } else {
+                y[i].qs[j] = (int8_t)val;
+            }
+            sum += val;
+        }
+        if constexpr (std::is_same_v<Block, block_q8_1>) {
+            if (i < nb4) {
+                y4[i4].d[ir+4] = GGML_FP32_TO_FP16(d * sum);
+            } else {
+                y[i].s = GGML_FP32_TO_FP16(d * sum);
+            }
+        } else {
+            if (i < nb4) {
+                auto i16 = (int16_t *)y4[i4].d;
+                i16[ir+4] = sum;
+            } else {
+                auto i16 = (int16_t *)&y[i].s;
+                i16[0] = sum;
+            }
         }
     }
 #endif
@@ -7169,11 +7240,11 @@ static void repack_q8_KV(int nrows, int n_per_row, const char * cx, char * cy, [
             vst1q_s8_x2(qy + 64 + 128*ib, m2);
             vst1q_s8_x2(qy + 96 + 128*ib, m3);
 #else
-            // TODO
             for (int l = 0; l < 4; ++l) {
-                for (int k = 0; k < 8; ++k) for (int i = 0; i < 4; ++i) {
-                    y[ib].qs[32*l+4*k+i+  0] = x8[k][ib].qs[i+4*l+ 0];
-                    y[ib].qs[32*l+4*k+i+128] = x8[k][ib].qs[i+4*l+16];
+                for (int k = 0; k < 8; ++k) {
+                    for (int i = 0; i < 4; ++i) {
+                        qy[128*ib + 32*l + 4*k + i] = x8[k][16*ib + 4*l + i];
+                    }
                 }
             }
 #endif


### PR DESCRIPTION
This PR makes ik_llama.cpp build and run correctly on x86-64 CPUs without
AVX2 (e.g. Ivy Bridge / Sandy Bridge Xeons). Tested end-to-end on a Xeon
E5-2690 v2 (2013, AVX1 only) running gemma-4-26B-A4B-it Q8_0 at ~5 tok/s.

### Commit 1 — `ggml: make non-IQK builds compile on AVX1-only CPUs`

The iqk_* kernels are AVX2+, so non-AVX2 CPUs need
`GGML_IQK_MUL_MAT=OFF` — but that configuration no longer compiles:
several `iqk_*` calls in `ggml.c` / `ggml-quants.c` are unguarded
(including the new `iqk_indexer_topk` sites), `iqk_cpu_ops.cpp` doesn't
compile standalone, and the non-AVX2 `#else` branch of
`quantize_row_q8_0_x4` / `quantize_row_q8_1_x4_T` references AVX2-only
helpers. This commit adds the missing `#if` guards and a portable scalar
fallback. No-op for AVX2+ builds.

### Commit 2 — `ggml: add non-IQK fallback for MOE_FUSED_UP_GATE / FUSED_UP_GATE`

**This one is the correctness fix.** With `GGML_IQK_MUL_MAT=OFF`, the
compute dispatch cases for `GGML_OP_MOE_FUSED_UP_GATE` /
`GGML_OP_FUSED_UP_GATE` are compiled out — but the graph builders
(`ggml_moe_up_gate`, `ggml_moe_up_gate_ext`, `ggml_fused_up_gate`) still
emit those ops unconditionally. The dst tensors are silently never
computed, and the model consumes uninitialized memory → deterministic
catastrophic gibberish on every MoE model.

The fix makes the graph builders (under `#if !GGML_USE_IQK_MULMAT`)
express the same computation with ops that always have compute paths:
`ggml_mul_mat_id` (+ `ggml_add_id` for the `_ext` bias variant) +
`ggml_fused_mul_unary`, splitting combined `up_gate` tensors with views
using the same gate-first layout as the IQK kernels.

Before: `"Write a short paragraph about the history of computers."` →
`"การ์ตูน-การ์ตูน-การ์ตูน..."`.
After: coherent output at temp 0 and ~5.2 tok/s decode / ~16 tok/s pp
on the 2013 Xeon.

### Commit 3 — `iqk: fix non-AVX2 stub path so ci/run.sh builds on AVX1-only CPUs`

`bash ci/run.sh` (default config: IQK **ON**, `-march=native`,
`-DLLAMA_FATAL_WARNINGS=ON`) fails on non-AVX2 hardware because the
`#else`-path stubs have drifted from `iqk_mul_mat.h`:

* `iqk_common.h`: `popcount()` helpers sit outside the `IQK_IMPLEMENT`
  block but `<cstdint>` was only included inside it
* `iqk_flash_attn_noalibi` stub missing the `sinks` parameter (defines a
  different C++ overload → undefined reference at link)
* `iqk_mul_mat` stub has an extra leading `int` parameter;
  `iqk_moe_fused_up_gate` stub missing `up_b`/`gate_b`
* no stubs at all for `iqk_fa_work_buffer_size` / `iqk_topk_moe`
  (undefined references)
* assorted fatal warnings (`-Wmissing-declarations`,
  `-Wunused-parameter`, `-Wsuggest-attribute=noreturn`)

### Testing

* `bash ci/run.sh ./tmp/results ./tmp/mnt` on the AVX1 Xeon: debug build
  now compiles and links cleanly (pristine `main` @ `7937465f` fails at
  compile on this hardware with 125 error lines). ctest: **17/19 pass**.
  The 2 failures (`test-tokenizer-0-bert-bge`, `test-chat-template` — a
  ChatGLM-template expected-output mismatch) are pre-existing: a baseline
  of `main` + only the build-enablement commits (without the MoE runtime
  fix) produces the identical 17/19 result with the same 2 failures.
  They are in arch-independent text-processing code untouched by this PR,
  and both reproduce byte-identically on a second machine (AVX2+,
  GCC 16.1.1, CPU-only): same 17/19, same two failures — a WPM tokenizer
  case-folding gap for certain uppercase Unicode, and a trailing-newline
  mismatch in the ChatGLM4 `[gMASK]<sop>` template case.
* `ci/run.sh` on the AVX2+ machine also confirms the branch builds clean
  under `-DLLAMA_FATAL_WARNINGS=ON` with the IQK kernels enabled, i.e.
  the changes are no-ops for supported CPUs.
* IQK-OFF build (`-DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_IQK_MUL_MAT=OFF`):
  compiles warning-clean; gemma-4-26B-A4B-it Q8_0 produces correct,
  coherent output (greedy sampling), including with
  `--cpu-moe --merge-up-gate-experts --flash-attn on --mla-use 3` and MTP
  speculative decoding with the assistant draft model.

### Known limitations (out of scope)

* `--run-time-repack` repacks Q8_0 → Q8_0_R8 (an AVX2 interleaved
  layout) and still produces garbage on AVX1; omit it on such CPUs.
* An IQK-**ON** build on non-AVX2 hardware now compiles and links, but
  the mul_mat/MoE stubs intentionally keep upstream's
  `GGML_ABORT("Unsupported CPU...")` behavior at runtime. AVX1 users
  should build with `-DGGML_IQK_MUL_MAT=OFF`.
* `tests/test-backend-ops` (named in CONTRIBUTING.md) is not wired into
  this repo's CMake, so it cannot be run; the full local `ci/run.sh` was
  used instead, on both machines.

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/main/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [x] High

**NOTE:** These commits were authored by Claude Code at my direction. I am
not a C++ developer.
