### PR TITLE
CUDA: use fp32 flash-attention vec kernel on P100 (sm_60) decode, fixes silent fp16 accumulation error

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -96,7 +96,14 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
         }
         if (precision == GGML_PREC_DEFAULT) {
             if (Q->ne[1] <= 8 || Q->ne[0] == 256) {
-                ggml_cuda_flash_attn_ext_vec_f16(ctx, dst);
+                // P100 (sm_60/CC_PASCAL): the fp16 vec kernel accumulates the online-softmax
+                // denominator and the P*V product in fp16, flipping ~3-4% of decode top-1 tokens
+                // vs fp32 (llama.cpp#25593). Decode is bandwidth-bound on P100 so vec_f32 is free.
+                if (cc == CC_PASCAL && Q->ne[1] <= 8) {  // decode only (batch<=8); D=256 prefill stays vec_f16
+                    ggml_cuda_flash_attn_ext_vec_f32(ctx, dst);
+                } else {
+                    ggml_cuda_flash_attn_ext_vec_f16(ctx, dst);
+                }
             } else {
                 ggml_cuda_flash_attn_ext_tile_f16(ctx, dst);
             }
@@ -194,6 +201,9 @@ bool ggml_cuda_fattn_is_supported(ggml_backend_cuda_context & ctx, const ggml_te
         }
         if (precision == GGML_PREC_DEFAULT) {
             if (Q->ne[1] <= 8 || Q->ne[0] == 256) {
+                if (cc == CC_PASCAL && Q->ne[1] <= 8) {  // decode only (batch<=8); D=256 prefill stays vec_f16
+                    return ggml_cuda_fattn_vec_f32_is_supported(ctx, dst);
+                }
                 return ggml_cuda_fattn_vec_f16_is_supported(ctx, dst);
             } else {
                 return ggml_cuda_fattn_tile_f16_is_supported(ctx, dst);


### PR DESCRIPTION
On Tesla P100 (GP100, sm_60) the fp16 flash-attention vec kernel used for decode (batch <= 8) accumulates the
online-softmax sum and the P.V product in fp16. Against an all-fp32 reference we measured this flipping about 4
percent of decode top-1 tokens (mellum2-12B Q4_K_M, vec path forced with -ub 8: top-1 agreement 95.76% +/- 0.22%,
max KLD 0.95). In our tests that decode error did not grow with context the way the prefill error does.

This PR routes sm_60 decode to the in-tree fp32 vec kernel, and in our tests it came out free. From the P100
profiling, decode looks bound on streaming the model weights rather than on the attention kernel: nvprof showed
the vec kernel occupancy-limited (about 7 percent occupancy, roughly 22 GB/s of the 732 GB/s peak), so the extra
fp32 work appears to hide. tg128 was 96.79 (fp32) versus 96.61 (fp16), the same within noise, and stayed fast at
depth (tg128 @ pp8192 = 82.65). That is our read from single-token decode; we have not A/B'd batches 2 to 8, so if
we have the bottleneck wrong we would like to know.

Scope: sm_60 (P100) only, decode (vec, batch <= 8) only. The prefill fp16 tile path is unchanged here.

The full per-model data, the prefill side (its fp32 cost and two alternatives, one bounded-error and one exact),
and the relation to the upstream report are in the discussion: https://github.com/ikawrakow/ik_llama.cpp/discussions/2143. apollo-mg's fix in
ggml-org/llama.cpp #25593 (merged in two forks) excludes all of sm_60 from the fast fp16 path, both prefill and
decode; this PR is the decode (vec) slice of that, on its own because it is free, with the prefill slice and its
cost in the discussion.

- [x] I have read the contributing guidelines
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
