### PR TITLE
Fix race in indexer topk on CUDA

### DIFF
--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -240,7 +240,9 @@ static __global__ void k_indexer_mask(int ne0, int ne1, int ne2, int ntopk, int 
 
     if (i1 < ne11) {
         for (int j = threadIdx.x; j < ne0;   j += blockDim.x) d[j] = inf;
+        __syncthreads();
         for (int j = threadIdx.x; j < ntopk; j += blockDim.x) d[i[j]] = zero;
+        __syncthreads();
         for (int j = threadIdx.x; j < ne0;   j += blockDim.x) d[j] += m[j];
     } else {
         for (int j = threadIdx.x; j < ne0;   j += blockDim.x) d[j] = m[j];


### PR DESCRIPTION

Missing synchronization noted by @joelfarthing, see #2139.

Closes #2139 