### PR TITLE
Build the MROPE/IMROPE position sections in the legacy no-pos decode path

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -5953,9 +5953,22 @@ static int llama_decode_internal(
         // helpers for smoother batch API transition
         // after deprecating the llama_eval calls, these will be removed
         if (u_batch.pos == nullptr) {
-            pos.resize(n_tokens);
+            // MROPE/IMROPE models (e.g. Qwen3.5) read 4 position sections per token; the RoPE op indexes
+            // pos[i], pos[i+n], pos[i+2n], pos[i+3n]. Sizing this legacy fallback to only n_tokens (as for
+            // standard rope) made llama_set_inputs copy n_tokens*4 out of a n_tokens-sized vector -> an
+            // out-of-bounds read (UB) that fed garbage into the extra rope sections -> wrong, run-to-run
+            // non-deterministic RoPE. Build the 4 sections like the explicit-pos path above (text: t,t,t,0).
+            const int rope_pt = (hparams.rope_type == LLAMA_ROPE_TYPE_MROPE ||
+                                 hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE) ? 4 : 1;
+            pos.resize((size_t) n_tokens * rope_pt);
             for (uint32_t i = 0; i < n_tokens; i++) {
-                pos[i] = u_batch.all_pos_0 + i*u_batch.all_pos_1;
+                const int32_t p = u_batch.all_pos_0 + i*u_batch.all_pos_1;
+                pos[i] = p;
+                if (rope_pt == 4) {
+                    pos[    n_tokens + i] = p;
+                    pos[2 * n_tokens + i] = p;
+                    pos[3 * n_tokens + i] = 0;
+                }
             }
 
             u_batch.pos = pos.data();


### PR DESCRIPTION
We were chasing run to run nondeterminism on Qwen3.5: `llama-perplexity` run twice with the same binary and flags
disagreed on about 9 percent of top-1 tokens. A per tensor checksum diff of the two runs put the first divergence at
the RoPE op, and a standard rope model (qwen2.5) was bit identical through the same check, which pointed at the
position setup.

Qwen3.5 is IMROPE, so it uses four rope position sections per token and `llama_set_inputs` copies `n_tokens * 4` int32
into `inp_pos`. `llama_decode_internal` builds those positions in two places. The explicit pos path builds all four
sections. The legacy no-pos fallback (the `llama_batch_get_one` path used by perplexity, cli and eval-callback) only
sized the vector to `n_tokens`, so the copy read `3 * n_tokens` int32 past the end and fed garbage into the higher
rope sections: wrong angles, and different every run because the memory past the vector is not stable.

The fix builds the four sections in the fallback the same way the explicit pos path just above it does (for text,
t, t, t, 0). NEOX is byte identical to before, so standard rope models are unaffected; VL image input uses the
explicit pos path, not this fallback.

```cpp
if (u_batch.pos == nullptr) {
    const int rope_pt = (hparams.rope_type == LLAMA_ROPE_TYPE_MROPE ||
                         hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE) ? 4 : 1;
    pos.resize((size_t) n_tokens * rope_pt);
    for (uint32_t i = 0; i < n_tokens; i++) {
        const int32_t p = u_batch.all_pos_0 + i*u_batch.all_pos_1;
        pos[i] = p;
        if (rope_pt == 4) { pos[n_tokens+i] = p; pos[2*n_tokens+i] = p; pos[3*n_tokens+i] = 0; }
    }
    u_batch.pos = pos.data();
}
```

Qwen3.5-4B self vs self (same binary twice), same-top: 91 percent to 100 percent on CUDA and on single-thread CPU;
cli and server give the same greedy output after the fix. `llama_encode_internal` has the same unfixed shape; we
left it since no IMROPE encoder model we are aware of reaches it today.

This fallback may be ik specific, so there may be no direct upstream counterpart, but we have not checked mainline
closely. If we have misread how it is meant to work, we would appreciate the correction.
