### PR TITLE
CUDA sm_60: bound the fp16 flash-attention error on P100 prefill instead of disabling the fast path

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f16.cu
@@ -37,11 +37,12 @@ static_assert(FABSUM_PV_BLOCK % 2 == 0 && FATTN_KQ_STRIDE_TILE_F16 % FABSUM_PV_B
 // chain then never exceeds QK_FLUSH_BLOCK fused-FMA roundings, independent of D; the fp32 seam adds
 // only (D/2)/QK_FLUSH_BLOCK exact promotions per score. An explicit value MUST evenly divide D/2 for
 // EVERY instantiated head size (D=64 and D=128 are both compiled, so it must divide 32: one of
-// {8, 16, 32}; enforced by a static_assert inside the kernel). Unset (default) it expands to D/2 ==
-// exactly one fold at the end of the chain: the flush compiles out and the kernel's arithmetic is
-// identical to the flush-less original.
-// Composition default 8 (pairs with FABSUM_PV_BLOCK=16 above): 8 divides D/2 for both compiled head
-// sizes (32 at D=64, 64 at D=128). Set to (D/2) for the flush-less, bitwise-base behavior.
+// {8, 16, 32}; enforced by a static_assert inside the kernel). The default is 8, the composition
+// operating point (pairs with FABSUM_PV_BLOCK=16). Setting it to (D/2) collapses the K.Q flush to a
+// single fold at the end of the chain, recovering the flush-less FABsum base. NOTE: that base is NOT
+// bit-identical to the upstream stock tile_f16 kernel -- the FABsum rewrite already keeps the softmax
+// max/sum and the P.V/K.Q reductions in float (float adds vs the stock fp16 half-adds), so "flush off"
+// restores the FABsum base, not the current upstream kernel.
 #ifndef QK_FLUSH_BLOCK
 #define QK_FLUSH_BLOCK 8
 #endif

--- a/ggml/src/ggml-cuda/fattn-tile-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-tile-f16.cu
@@ -11,6 +11,41 @@
 
 #define FATTN_KQ_STRIDE_TILE_F16 64
 
+// FABsum P.V flush granularity, in KEYS. MUST evenly divide FATTN_KQ_STRIDE_TILE_F16 (=64) and be even
+// (the P.V loop advances k0 by 2), i.e. one of {64, 32, 16}. 64 == one flush per tile at the natural
+// per-tile online-softmax seam (near-free). 32 == two flushes per tile (higher accuracy, one extra
+// fold+zero per tile). Error bound of the two-level accumulator is ~(FABSUM_PV_BLOCK+1)*u_fp16 and is
+// INDEPENDENT of context length (the fp16 partial never accumulates more than FABSUM_PV_BLOCK keys).
+// Composition operating point: PV=16 pairs with QK_FLUSH_BLOCK=8 (below) for the best measured
+// accuracy-per-speed FABsum point on mellum2-12B: same-top 98.81% at 744 tok/s prefill (vs the
+// PV=64/QK=D/2 base 98.19% @ 752, and vs the exact-QK reference 98.83% @ 695). Override to 64 for
+// the max-speed base point, or 32 for an intermediate.
+#ifndef FABSUM_PV_BLOCK
+#define FABSUM_PV_BLOCK 16
+#endif
+// The flush-vs-rescale seam is only safe when FABSUM_PV_BLOCK evenly divides the tile stride and is even
+// (the P.V loop advances k0 by 2); an odd or non-dividing override reintroduces the O(n) fp16 accumulation
+// across a tile boundary -> silent degradation. Enforce the contract at compile time.
+static_assert(FABSUM_PV_BLOCK % 2 == 0 && FATTN_KQ_STRIDE_TILE_F16 % FABSUM_PV_BLOCK == 0,
+              "FABSUM_PV_BLOCK must be even and evenly divide FATTN_KQ_STRIDE_TILE_F16 (64): one of {64,32,16}");
+
+// FABsum-for-QK flush granularity, in K-STEPS of the K.Q dot product's inner loop (one k-step = one
+// half2 = 2 head-dim elements; the chain is D/2 = 64 steps at D=128, 32 at D=64). The half2 lane
+// accumulator sum2 runs at full HFMA2 rate and, every QK_FLUSH_BLOCK k-steps, is folded into the
+// persistent fp32 score accumulator KQ_acc (exact widening promotion + fp32 add) and zeroed -- the
+// P.V FABSUM_PV_BLOCK mechanism applied to the kernel's SECOND fp16 accumulation chain. The fp16 QK
+// chain then never exceeds QK_FLUSH_BLOCK fused-FMA roundings, independent of D; the fp32 seam adds
+// only (D/2)/QK_FLUSH_BLOCK exact promotions per score. An explicit value MUST evenly divide D/2 for
+// EVERY instantiated head size (D=64 and D=128 are both compiled, so it must divide 32: one of
+// {8, 16, 32}; enforced by a static_assert inside the kernel). Unset (default) it expands to D/2 ==
+// exactly one fold at the end of the chain: the flush compiles out and the kernel's arithmetic is
+// identical to the flush-less original.
+// Composition default 8 (pairs with FABSUM_PV_BLOCK=16 above): 8 divides D/2 for both compiled head
+// sizes (32 at D=64, 64 at D=128). Set to (D/2) for the flush-less, bitwise-base behavior.
+#ifndef QK_FLUSH_BLOCK
+#define QK_FLUSH_BLOCK 8
+#endif
+
 template<int D, int ncols, int nwarps, int parallel_blocks, bool use_softcap> // D == head size
 #if !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__))
 __launch_bounds__(nwarps*WARP_SIZE, 1)
@@ -78,23 +113,42 @@ static __global__ void flash_attn_tile_ext_f16(
     const int stride_KV2 = nb11 / sizeof(half2);
 
     const float slopef = get_alibi_slope(max_bias, blockIdx.y, n_head_log2, m0, m1);
-    const half  slopeh = __float2half(slopef);
 
     static_assert(D % (2*WARP_SIZE) == 0, "D not divisible by 2*WARP_SIZE == 64.");
+
+    // QK_FLUSH_BLOCK contract (see the #define above): it must evenly divide the K.Q chain length D/2,
+    // or the final flush misses the end of the chain and the k-steps after the last flush are silently
+    // DROPPED from the score (the reduction below reads only KQ_acc when the flush is active). Checked
+    // here, per instantiation, because D is a template parameter: an explicit -DQK_FLUSH_BLOCK must
+    // divide both compiled chain lengths (32 at D=64, 64 at D=128), i.e. be one of {8, 16, 32}.
+    static_assert((QK_FLUSH_BLOCK) >= 1 && (D/2) % (QK_FLUSH_BLOCK) == 0,
+                  "QK_FLUSH_BLOCK must be >= 1 and evenly divide D/2 for every compiled head size "
+                  "(D=64 and D=128): one of {8,16,32}, or leave unset for the flush-once default");
 
     __shared__ half KQ[ncols*FATTN_KQ_STRIDE_TILE_F16];
     half2 * KQ2 = (half2 *) KQ;
 
     __shared__ half2 KV_tmp[FATTN_KQ_STRIDE_TILE_F16][D/2 + 1]; // Pad D to avoid memory bank conflicts.
 
-    half kqmax[ncols/nwarps];
+    // KQ scores and the online-softmax statistics (max/sum) are kept in float (upstream precision split).
+    // Level-3 additionally promotes the VKQ (P.V) accumulator to float2 (see below).
+    float kqmax[ncols/nwarps];
 #pragma unroll
     for (int j0 = 0; j0 < ncols; j0 += nwarps) {
-        kqmax[j0/nwarps] = -HALF_MAX_HALF;
+        kqmax[j0/nwarps] = -FLT_MAX/2.0f;
     }
-    half2 kqsum[ncols/nwarps] = {{0.0f, 0.0f}};
+    float kqsum[ncols/nwarps] = {0.0f};
 
-    half2 VKQ[ncols/nwarps][(D/2)/WARP_SIZE] = {{{0.0f, 0.0f}}};
+    // FABsum two-level P.V accumulator (P100). VKQ is the PERSISTENT cross-block accumulator and stays
+    // float2 -- it is what kills the O(n_keys) growth and it is the ONLY accumulator the online-softmax
+    // KQ_max_scale rescale, the sinks term, and the epilogue ever touch. VKQ_h2 is a per-tile HALF2 PARTIAL
+    // that accumulates the P.V products at full HFMA2 rate (identical to the stock kernel's inner loop) and
+    // is FLUSHED into VKQ and zeroed every FABSUM_PV_BLOCK keys. Within a block |acc|/|term| <= block size
+    // << 2^11, so the fp16 partial never swamps; the float2 sum across blocks removes the context-length
+    // growth. VKQ_h2 is guaranteed zero at every rescale seam (the last flush of each tile lands at the
+    // tile boundary), so the rescale never sees un-flushed, mis-scaled fp16 mass.
+    float2 VKQ   [ncols/nwarps][(D/2)/WARP_SIZE] = {{{0.0f, 0.0f}}};
+    half2  VKQ_h2[ncols/nwarps][(D/2)/WARP_SIZE] = {{{0.0f, 0.0f}}};
 
     // Convert Q to half2 and store in registers:
     __shared__ half2 Q_h2[ncols][D/2];
@@ -107,6 +161,10 @@ static __global__ void flash_attn_tile_ext_f16(
             const int i = i0 + threadIdx.x;
 
             const float2 tmp = ic0 + j < ne01 ? Q_f2[j*(nb01/sizeof(float2)) + i] : make_float2(0.0f, 0.0f);
+            // Full-speed QK revert: Q is stored at full scale (stock path). The K.Q dot product accumulates in
+            // half2 (below) at full HFMA2 rate; stock ships this scale with no overflow, so the C' 0.25x / x4
+            // guard is dropped. (If any model NaNs, restore the guard: use scale*0.25f here and multiply the
+            // reduced score by 4.0f at the reduction below -- same speed, 4x fp16 headroom, one extra float mul.)
             Q_h2[j][i] = make_half2(scale, scale) * make_half2(tmp.x, tmp.y);
         }
     }
@@ -117,7 +175,7 @@ static __global__ void flash_attn_tile_ext_f16(
     for (int k_VKQ_0 = k_start; k_VKQ_0 < ne11; k_VKQ_0 += parallel_blocks*FATTN_KQ_STRIDE_TILE_F16) {
         // Calculate KQ tile and keep track of new maximum KQ values:
 
-        half kqmax_new[ncols/nwarps];
+        float kqmax_new[ncols/nwarps];
 #pragma unroll
         for (int j = 0; j < ncols/nwarps; ++j) {
             kqmax_new[j] = kqmax[j];
@@ -137,7 +195,20 @@ static __global__ void flash_attn_tile_ext_f16(
 
         __syncthreads();
 
+        // Full-speed QK: accumulate the K.Q dot product in a HALF2 register at full HFMA2 rate (stock path).
+        // sum2 spans only D/2 (<=64) terms within THIS tile and never carries across tiles, so the fp16
+        // accumulation is bounded and context-length-independent -- the proven O(n) error was the P.V
+        // accumulator, which FABsum still fixes with its two-level half2->float2 flush. KQ_acc keeps the
+        // FLOAT reduced score (written in the reduction block below) so the online-softmax stats stay float.
+        //
+        // FABsum-for-QK (QK_FLUSH_BLOCK < D/2): KQ_acc doubles as the PERSISTENT fp32 half of a two-level
+        // QK accumulator. Zero-initialized here, it absorbs sum2 every QK_FLUSH_BLOCK k-steps (flush block
+        // in the k-loop below), so the fp16 fused-FMA chain never exceeds QK_FLUSH_BLOCK roundings. No new
+        // variable exists: the same registers later hold the post-softcap/mask score, exactly as before.
+        // At the flush-once default (QK_FLUSH_BLOCK == D/2) the flush compiles out, the reduction below
+        // selects the stock lane-reduction expression, and this initializer is a dead store.
         half2 sum2[FATTN_KQ_STRIDE_TILE_F16/WARP_SIZE][ncols/nwarps] = {{{0.0f, 0.0f}}};
+        float KQ_acc[FATTN_KQ_STRIDE_TILE_F16/WARP_SIZE][ncols/nwarps] = {{0.0f}};
 
 #pragma unroll
         for (int k_KQ = 0; k_KQ < D/2; ++k_KQ) {
@@ -161,7 +232,33 @@ static __global__ void flash_attn_tile_ext_f16(
             for (int i_KQ_0 = 0; i_KQ_0 < FATTN_KQ_STRIDE_TILE_F16; i_KQ_0 += WARP_SIZE) {
 #pragma unroll
                 for (int j_KQ_0 = 0; j_KQ_0 < ncols; j_KQ_0 += nwarps) {
+                    // Full-speed QK: fused half2 multiply-add (stock path). Issues as HFMA2 at full fp16 rate;
+                    // the two lanes hold the partial dot product and are summed in float at the reduction below.
                     sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] += K_k[i_KQ_0/WARP_SIZE]*Q_k[j_KQ_0/nwarps];
+                }
+            }
+
+            // FABsum-for-QK flush: every QK_FLUSH_BLOCK k-steps, fold the half2 dot-product partial into
+            // the persistent fp32 KQ_acc (half->float promotion is exact; the adds are fp32) and zero it --
+            // the P.V flush below, applied to the QK chain. k_KQ is fully unrolled and QK_FLUSH_BLOCK is a
+            // compile-time constant, so the guard folds away and the flush body is emitted ONLY at block
+            // boundaries (e.g. k_KQ = 15,31,47,63 for -DQK_FLUSH_BLOCK=16 at D=128). All flush state is
+            // thread-private registers: no sync, no smem traffic, no cross-thread coordination. The
+            // static_assert above guarantees the last flush lands exactly at k_KQ == D/2-1, so sum2 is zero
+            // when the loop exits and the reduction below reads KQ_acc alone -- a tail cannot exist (the
+            // QK mirror of the P.V tile-boundary invariant). Overflow headroom strictly improves: the fp16
+            // partial now spans <= QK_FLUSH_BLOCK of the same full-scale terms stock already ships over the
+            // whole D/2 chain. At the default QK_FLUSH_BLOCK == D/2 the guard is compile-time false and NO
+            // flush code is emitted -- the k-loop body is the current kernel's, unchanged.
+            if ((QK_FLUSH_BLOCK) < D/2 && (k_KQ + 1) % (QK_FLUSH_BLOCK) == 0) {
+#pragma unroll
+                for (int i_KQ_0 = 0; i_KQ_0 < FATTN_KQ_STRIDE_TILE_F16; i_KQ_0 += WARP_SIZE) {
+#pragma unroll
+                    for (int j_KQ_0 = 0; j_KQ_0 < ncols; j_KQ_0 += nwarps) {
+                        KQ_acc[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] += __low2float(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps])
+                                                                 + __high2float(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
+                        sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] = make_half2(0.0f, 0.0f);
+                    }
                 }
             }
         }
@@ -174,18 +271,24 @@ static __global__ void flash_attn_tile_ext_f16(
             for (int j_KQ_0 = 0; j_KQ_0 < ncols; j_KQ_0 += nwarps) {
                 const int j_KQ = j_KQ_0 + threadIdx.y;
 
-                half sum;
+                // Reduce the two half2 lanes of the K.Q dot product in FLOAT (stock reduces in half; we keep it
+                // float to feed the float online-softmax). Q is at full scale, so no x4 rescale is applied.
+                // With FABsum-for-QK active (QK_FLUSH_BLOCK < D/2) the k-loop's final flush has already folded
+                // the whole chain into KQ_acc and zeroed sum2, so the score is read from KQ_acc; at the
+                // flush-once default this selects the stock lane-reduction expression, unchanged. The
+                // condition is compile-time constant -- exactly one side is ever emitted.
+                float sum = (QK_FLUSH_BLOCK) < D/2
+                    ? KQ_acc[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]
+                    : __low2float(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]) + __high2float(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
                 if (use_softcap) {
-                    const float2 tmp = __half22float2(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
-                    sum = softcap * tanhf(tmp.x + tmp.y);
-                } else {
-                    sum = __low2half(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]) + __high2half(sum2[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps]);
+                    sum = softcap * tanhf(sum);
                 }
-                sum += mask ? slopeh*maskh[j_KQ*stride_mask + k_VKQ_0 + i_KQ] : __float2half(0.0f);
+                sum += mask ? slopef*__half2float(maskh[j_KQ*stride_mask + k_VKQ_0 + i_KQ]) : 0.0f;
 
-                kqmax_new[j_KQ_0/nwarps] = ggml_cuda_hmax(kqmax_new[j_KQ_0/nwarps], sum);
+                kqmax_new[j_KQ_0/nwarps] = fmaxf(kqmax_new[j_KQ_0/nwarps], sum + FATTN_KQ_MAX_OFFSET);
 
-                KQ[j_KQ*FATTN_KQ_STRIDE_TILE_F16 + i_KQ] = sum;
+                // Keep the score in registers; the raw (pre-exp) value is no longer stored to shared KQ.
+                KQ_acc[i_KQ_0/WARP_SIZE][j_KQ_0/nwarps] = sum;
             }
         }
 
@@ -196,22 +299,27 @@ static __global__ void flash_attn_tile_ext_f16(
             const int j = j0 + threadIdx.y;
 
             kqmax_new[j0/nwarps] = warp_reduce_max(kqmax_new[j0/nwarps]);
-            const half2 KQ_max_scale = __half2half2(hexp(kqmax[j0/nwarps] - kqmax_new[j0/nwarps]));
+            const float KQ_max_scale = expf(kqmax[j0/nwarps] - kqmax_new[j0/nwarps]);
             kqmax[j0/nwarps] = kqmax_new[j0/nwarps];
 
+            float kqsum_add = 0.0f;
 #pragma unroll
-            for (int i0 = 0; i0 < FATTN_KQ_STRIDE_TILE_F16/2; i0 += WARP_SIZE) {
+            for (int i0 = 0; i0 < FATTN_KQ_STRIDE_TILE_F16; i0 += WARP_SIZE) {
                 const int i = i0 + threadIdx.x;
 
-                const half2 diff = KQ2[j*(FATTN_KQ_STRIDE_TILE_F16/2) + i] - __half2half2(kqmax[j0/nwarps]);
-                const half2 val = h2exp(diff);
-                kqsum[j0/nwarps] = kqsum[j0/nwarps]*KQ_max_scale + val;
-                KQ2[j*(FATTN_KQ_STRIDE_TILE_F16/2) + i] = val;
+                const float val = expf(KQ_acc[i0/WARP_SIZE][j0/nwarps] - kqmax[j0/nwarps]);
+                kqsum_add += val;
+                // Store the post-exp probability as half (not float) to keep shared usage at 2 blocks/SM on P100.
+                // Ownership (i = i0 + threadIdx.x) matches the V-loop read of KQ below.
+                KQ[j*FATTN_KQ_STRIDE_TILE_F16 + i] = __float2half(val);
             }
+            kqsum[j0/nwarps] = kqsum[j0/nwarps]*KQ_max_scale + kqsum_add;
 
+            // Rescale the running float2 VKQ accumulator by the (float) online-softmax correction.
 #pragma unroll
             for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
-                VKQ[j0/nwarps][i0/WARP_SIZE] *= KQ_max_scale;
+                VKQ[j0/nwarps][i0/WARP_SIZE].x *= KQ_max_scale;
+                VKQ[j0/nwarps][i0/WARP_SIZE].y *= KQ_max_scale;
             }
         }
 
@@ -254,8 +362,34 @@ static __global__ void flash_attn_tile_ext_f16(
             for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
 #pragma unroll
                 for (int j0 = 0; j0 < ncols; j0 += nwarps) {
-                    VKQ[j0/nwarps][i0/WARP_SIZE] += V_k[i0/WARP_SIZE][0]* __low2half2(KQ_k[j0/nwarps]);
-                    VKQ[j0/nwarps][i0/WARP_SIZE] += V_k[i0/WARP_SIZE][1]*__high2half2(KQ_k[j0/nwarps]);
+                    // FABsum inner: accumulate the two P.V products in the HALF2 partial at full HFMA2 rate.
+                    // This is bit-for-bit the stock kernel's inner loop (no per-key float conversion), so it
+                    // issues as HFMA2, not FFMA. __low2half2/__high2half2 splat p(k0)/p(k0+1) across both
+                    // head-dim lanes carried in each V_k half2.
+                    VKQ_h2[j0/nwarps][i0/WARP_SIZE] += V_k[i0/WARP_SIZE][0]* __low2half2(KQ_k[j0/nwarps]);
+                    VKQ_h2[j0/nwarps][i0/WARP_SIZE] += V_k[i0/WARP_SIZE][1]*__high2half2(KQ_k[j0/nwarps]);
+                }
+            }
+
+            // FABsum flush: every FABSUM_PV_BLOCK keys, fold the half2 partial into the persistent float2
+            // accumulator and zero it. k0 advances by 2, so (k0+2) keys of this tile have been processed
+            // after this iteration. FABSUM_PV_BLOCK divides 64 and k0 is fully unrolled, so (k0+2) %
+            // FABSUM_PV_BLOCK is a compile-time constant and the flush body is emitted ONLY at block
+            // boundaries (e.g. once, at k0==62, for the K=64 default). All keys in a tile share a single
+            // kqmax (the online rescale ran before this loop), so there is no mid-tile rescale and the
+            // partial is at one consistent scale between flushes. Because 64 % FABSUM_PV_BLOCK == 0 the final
+            // block boundary always coincides with the tile boundary, so VKQ_h2 is zero on exit -> the next
+            // tile's KQ_max_scale rescale (and the sinks term and the epilogue) see only the flushed VKQ.
+            if ((k0 + 2) % FABSUM_PV_BLOCK == 0) {
+#pragma unroll
+                for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
+#pragma unroll
+                    for (int j0 = 0; j0 < ncols; j0 += nwarps) {
+                        const float2 fh = __half22float2(VKQ_h2[j0/nwarps][i0/WARP_SIZE]);
+                        VKQ[j0/nwarps][i0/WARP_SIZE].x += fh.x;
+                        VKQ[j0/nwarps][i0/WARP_SIZE].y += fh.y;
+                        VKQ_h2[j0/nwarps][i0/WARP_SIZE] = make_half2(0.0f, 0.0f);
+                    }
                 }
             }
         }
@@ -269,23 +403,24 @@ static __global__ void flash_attn_tile_ext_f16(
     // parallel_blocks KV split. Ported from fattn-vec-f16.cuh. kqmax is warp-uniform here (already
     // warp_reduce_max'd in the KV loop), so no shared-mem reduction is needed.
     if (sinksf && ip == 0) {
-        const half sink = __float2half(sinksf[blockIdx.y]);
+        const float sink = sinksf[blockIdx.y];
 
 #pragma unroll
         for (int j0 = 0; j0 < ncols; j0 += nwarps) {
-            const half kqmax_new_j = ggml_cuda_hmax(kqmax[j0/nwarps], sink);
-            const half2 KQ_max_scale = __half2half2(hexp(kqmax[j0/nwarps] - kqmax_new_j));
+            const float kqmax_new_j = fmaxf(kqmax[j0/nwarps], sink);
+            const float KQ_max_scale = expf(kqmax[j0/nwarps] - kqmax_new_j);
             kqmax[j0/nwarps] = kqmax_new_j;
 
             kqsum[j0/nwarps] = kqsum[j0/nwarps]*KQ_max_scale;
             if (threadIdx.x == 0) {
-                // Add the sink term to only the low half; the epilogue sums low+high once per lane.
-                kqsum[j0/nwarps].x += hexp(sink - kqmax[j0/nwarps]);
+                // kqsum holds per-lane partials reduced in the epilogue, so add the sink term on a single lane.
+                kqsum[j0/nwarps] += expf(sink - kqmax[j0/nwarps]);
             }
 
 #pragma unroll
             for (int i0 = 0; i0 < D/2; i0 += WARP_SIZE) {
-                VKQ[j0/nwarps][i0/WARP_SIZE] *= KQ_max_scale;
+                VKQ[j0/nwarps][i0/WARP_SIZE].x *= KQ_max_scale;
+                VKQ[j0/nwarps][i0/WARP_SIZE].y *= KQ_max_scale;
             }
         }
     }
@@ -298,20 +433,21 @@ static __global__ void flash_attn_tile_ext_f16(
             return;
         }
 
-        half kqsum_j = __low2half(kqsum[j_VKQ_0/nwarps]) + __high2half(kqsum[j_VKQ_0/nwarps]);
+        float kqsum_j = kqsum[j_VKQ_0/nwarps];
         kqsum_j = warp_reduce_sum(kqsum_j);
 
 #pragma unroll
         for (int i00 = 0; i00 < D; i00 += 2*WARP_SIZE) {
             const int i0 = i00 + 2*threadIdx.x;
 
-            half2 dst_val = VKQ[j_VKQ_0/nwarps][i0/(2*WARP_SIZE)];
+            float2 dst_val = VKQ[j_VKQ_0/nwarps][i0/(2*WARP_SIZE)];
             if (parallel_blocks == 1) {
-                dst_val /= __half2half2(kqsum_j);
+                dst_val.x /= kqsum_j;
+                dst_val.y /= kqsum_j;
             }
             const int j_dst = (ic0 + j_VKQ)*parallel_blocks + ip;
-            dst[j_dst*D*gridDim.y + D*blockIdx.y + i0 + 0] =  __low2float(dst_val);
-            dst[j_dst*D*gridDim.y + D*blockIdx.y + i0 + 1] = __high2float(dst_val);
+            dst[j_dst*D*gridDim.y + D*blockIdx.y + i0 + 0] = dst_val.x;
+            dst[j_dst*D*gridDim.y + D*blockIdx.y + i0 + 1] = dst_val.y;
         }
 
         if (parallel_blocks != 1 && threadIdx.x == 0) {


### PR DESCRIPTION
On P100 (sm_60) the fast fp16 flash-attention path loses prefill accuracy: llama.cpp #25593 (apollo-mg) shows a
measurable KL and same-top hit because score and accumulator math that should be fp32 is done in fp16. On current
main, P100 prefill still runs that stock fp16 tile kernel (our earlier decode fix only rerouted decode). The standard
correctness fix carves sm_60 out to the fp32 tile kernel, but a tester in that thread (rankaiyx) measured the carve-out
costing up to 27 percent of prefill in GEMM-heavy shapes. On our P100 boxes prefill matters, so this keeps the fast
path and bounds its error instead of turning it off.

The change is to the two fp16 accumulation chains in `fattn-tile-f16` (the K.Q dot product and the P.V accumulation).
Each runs a packed-half2 partial at full HFMA2 rate, and every B keys folds that partial into a persistent fp32
accumulator and zeroes it. The fp16 partial then never accumulates more than B terms, so its error stays on the order
of (B+1) times the fp16 unit roundoff and does not grow with context the way the stock path does. Softmax stats were
already kept in float. Block sizes are compile-time (B=16 for P.V, 8 for K.Q), with a `static_assert` on the flush
divisibility.

Numbers on mellum2-12B (D=128), Tesla P100-PCIE-16GB, sm_60, clean back-to-back (`llama-bench`, 3 reps).

Prefill throughput (t/s), across context:

| variant | pp4096 | pp8192 | pp16384 | pp32768 |
|---|---|---|---|---|
| stock fp16 (current main) | 768 | 758 | 728 | 678 |
| FABsum (this PR) | 763 | 750 | 717 | 663 |
| exact fp32 tile (main, includes #2142) | 728 | 705 | 657 | 582 |

FABsum costs 1 to 2 percent against the stock fp16 path P100 runs today (0.7 percent at 4k, 2.2 percent at 32k), and
runs 5 to 14 percent faster than the exact fp32 path (5 percent at 4k, 14 percent at 32k). Both gaps widen with context.

Same-top agreement with the fp32 reference, across context:

| context | stock fp16 (same-top / max KLD) | FABsum (same-top / max KLD) |
|---|---|---|
| 4k | 96.35% / 2.7 | 98.09% / 2.1 |
| 8k | 96.60% / 2.8 | 98.64% / 0.9 |
| 16k | 96.46% / 4.0 | 98.74% / 2.5 |
| 32k | 95.89% / 19.6 | 98.73% / 2.8 |

FABsum sits about 2 points above stock in same-top at every context. The bounded chain shows in the worst-token KL:
FABsum stays near 1 to 3 across the range, while the stock path's is fine at short context and grows to 19.6 at 32k.
That is the accuracy FABsum recovers at long context, at the throughput cost above.

It is a more-accurate fp16, not bit-exact fp32, and how much it recovers is model-dependent (it tracks how fp16-sensitive
the model already is). The mellum2 numbers above are the re-verified case. In our earlier characterization across the
other D=128 models (same kernel, not re-stamped on this base), the recovery was near-lossless on the less fp16-sensitive
dense models (Qwen3-32B, Llama-3.3-70B, Devstral-24B all stayed above 99.7 percent same-top with FABsum) and largest on
the more sensitive mellum2.

If you need exact output, the fp32 path is there: main's `tile_f32` kernel (already includes the #2142 retile).

Scope and limits:
- This only affects the `tile_f16` kernel, the fast-fp16 prefill path (D=128 in these models). D=256 models route to
  the vec kernel and are untouched.
- Measured on P100 (sm_60) only. We are following up with P40 (sm_61) numbers.
- In earlier runs it held up under `-sm graph` (tensor parallel) at 2/3/4 GPUs: coherent, no crashes, same-top on par
  with `-sm layer`.
- The block sizes (B) are a speed/accuracy knob we have not swept exhaustively.

We left the bounded path always-on for tile_f16 because it was more accurate than the stock fp16 path on every model we
measured, at nearly the same speed. If you would rather have it behind a flag (off by default), or keep the fp32
carve-out, either is a one-line change.
