### PR TITLE
fix: adjust token count for MTP draft generation in kv cache update

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6949,6 +6949,10 @@ static int32_t llama_kv_cache_update_internal(struct llama_context & lctx) {
         // TODO: extract to a function
         // build worst-case graph
         int n_tokens = (int)std::min(lctx.cparams.n_ctx, lctx.cparams.n_ubatch);
+        // MTP draft generation consumes one token and one hidden-state vector per decode step.
+        if (lctx.cparams.mtp_op_type == MTP_OP_DRAFT_GEN) {
+            n_tokens = 1;
+        }
         int n_past = lctx.cparams.n_ctx - n_tokens;
         llama_token token = llama_token_bos(&lctx.model); // not actually used by llama_build_graph, but required to choose between token and embedding inputs graph
         llama_batch reserve_batch = llama_batch_get_one(&token, n_tokens, n_past, 0);


### PR DESCRIPTION
Closes #2157

Using the `--defrag-thold` argument in conjunction with MTP can trigger an assert in `ggml_concat`. This occurs because defrag enables KV defragmentation and forces the construction of the worst-case graph for N tokens depending on your batch size. For example, with batch = 256, you’ll have a `token embedding: [5120, 256]`, which is fine for prompt processing, but for MTP to generate a token, it expects `hidden state: [5120, 1]` which triggers the assert.

The simplest way to fix this is to allocate only 1 token in the worst-case graph for MTP when drafting the token.