### PR TITLE
Add /models and /responses endpoints

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2129,12 +2129,14 @@ int main(int argc, char ** argv) {
     svr->Get ("/props",               handle_props);
     svr->Get("/v1/props",             handle_props_simple);
     svr->Get ("/v1/models",           handle_models);
+    svr->Get ("/models",              handle_models);
     svr->Post("/completion",          handle_completions); // legacy
     svr->Post("/completions", handle_completions); // legacy
     svr->Post("/v1/completions",     handle_completions_oai);
     svr->Post("/chat/completions",    handle_chat_completions);
     svr->Post("/v1/chat/completions", handle_chat_completions);
     svr->Post("/v1/responses",        handle_responses);
+    svr->Post("/responses",           handle_responses);
     svr->Post("/v1/messages",         handle_anthropic_messages);
     svr->Post("/v1/messages/count_tokens", handle_anthropic_count_tokens);
     svr->Post("/infill",              handle_infill);


### PR DESCRIPTION
Add bare `/models` and `/responses` routes to match mainline's endpoints. Some harnesses with llama.cpp support expect these.