### PR TITLE
sampling: fix out-of-bounds logits read when the vocab has no newline token

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -655,15 +655,22 @@ static llama_token_data_array llama_sampling_prepare_impl(
     const auto& penalty_tokens = params.use_penalty_prompt_tokens ? params.penalty_prompt_tokens : prev;
     const int penalty_tokens_used_size = std::min((int)penalty_tokens.size(), penalty_last_n);
     if (penalty_tokens_used_size) {
-        const float nl_logit = logits[llama_token_nl(llama_get_model(ctx_main))];
+        // llama_token_nl() can legitimately return LLAMA_TOKEN_NULL (-1). Some vocabs (e.g. Falcon3's
+        // BPE tokenizer) tokenize "\n" to zero tokens, and the loader's fallback
+        // (llama-vocab.cpp, linefeed_id = special_pad_id) runs before LLM_KV_TOKENIZER_PAD_ID is read
+        // from the GGUF, so it copies the BPE default, which is itself LLAMA_TOKEN_NULL. Reading
+        // logits[-1] is then an out-of-bounds access one float before the current position's logit
+        // row, which segfaults when that address happens to be unmapped.
+        const llama_token nl_token = llama_token_nl(llama_get_model(ctx_main));
+        const float nl_logit = nl_token != LLAMA_TOKEN_NULL ? logits[nl_token] : 0.0f;
 
         llama_sample_repetition_penalties(ctx_main, &cur_p,
                 penalty_tokens.data() + penalty_tokens.size() - penalty_tokens_used_size,
                 penalty_tokens_used_size, penalty_repeat, penalty_freq, penalty_present);
 
-        if (!penalize_nl) {
+        if (!penalize_nl && nl_token != LLAMA_TOKEN_NULL) {
             for (size_t idx = 0; idx < cur_p.size; idx++) {
-                if (cur_p.data[idx].id == llama_token_nl(llama_get_model(ctx_main))) {
+                if (cur_p.data[idx].id == nl_token) {
                     cur_p.data[idx].logit = nl_logit;
                     break;
                 }


### PR DESCRIPTION
`common/sampling.cpp` reads one float before the start of the current logit row on any model whose vocab resolves the newline token to `LLAMA_TOKEN_NULL` (-1).

Falcon3 is one, and the two variants we tested reach it by different routes. Its BPE tokenizer maps `"\n"` to zero tokens, so the loader takes its fallback (`load: model vocab missing newline token, using special_pad_id instead`) and copies `special_pad_id` into `linefeed_id`. On Falcon3-7B-Instruct that copy runs before `LLM_KV_TOKENIZER_PAD_ID` is read from the GGUF, so what it copies is the BPE default, which is itself `LLAMA_TOKEN_NULL`, while the same load log goes on to print `PAD token = 2023 '<|pad|>'`. Falcon3-7B-Base carries no pad id at all, so it lands on null whatever the ordering. That is why a load-order fix alone would not close this: it would point Instruct at `<|pad|>` and leave Base where it is.

`llama_sampling_prepare_impl` then evaluates `logits[-1]`, inside the repetition-penalty block that runs whenever `penalty_last_n` is nonzero. Whether that address is mapped depends on allocation layout, so the crash is configuration-dependent rather than universal: 4/4 in the shape below, clean CPU-only. `llama-cli` and `llama-server` both reach it, through `llama_sampling_prepare`.

We reproduced it on Falcon3-7B-Instruct-Q4_K_M, four P100s with the layers split across all four, `-ngl 99 -fa 1 -c 8192`, one chat request per trial with a fresh server each trial:

| build | trials | result |
|---|---|---|
| main `de55d9e2` | 4 | Segmentation fault, 4/4 |
| this PR | 4 | HTTP 200, 4/4 |

All four main-arm faults appear in the kernel log as a user-mode read of a non-present page (`error 4`) at an address ending `ffc`, the last float of the page below, which is what `logits[-1]` looks like from the kernel side when the logit row is page-aligned. The PR arm produced none.

The fix caches the token once, skips the read when it is null, and skips the penalize-newline restore, since there is nothing to restore. For a vocab with a real newline token the block is unchanged. `common/sampling.cpp` is the only place in the tree that calls `llama_token_nl`.

### No regression across eight models

Greedy, `temperature 0`, fixed seed, 48 tokens from one prompt, so output is deterministic and any difference is attributable to the change. Both `--penalize-nl` polarities, because the guard adds a condition to the `!penalize_nl` branch. 26 comparisons of `llama-cli`, main `de55d9e2` against this PR: eight models under CUDA and five of them under CPU-only as well, both polarities each.

| vocab | models | result |
|---|---|---|
| newline token present | qwen2.5-1.5B, Qwen3.5-4B, Qwen3.5-27B, Qwen3-Coder-30B, mellum2-12B, DeepSeek-V2-Lite | generated text byte-identical, every case |
| newline token null | Falcon3-7B-Base (Q8_0), Falcon3-7B-Instruct (Q4_K_M) | main segfaults under CUDA, this PR runs |

Two variants and two quants land on null, so this is not one bad conversion. Under CPU-only main does not fault on either, takes the out-of-bounds read, and still produces output byte-identical to this PR. The four `llama-cli` faults land on the same instruction as the server ones.

Perplexity and KLD are not included because they cannot exercise this change: `llama-perplexity` never samples, and the whole diff is downstream of it in `common/sampling.cpp`.

This is a crash risk only; it cannot change output. The value is only ever written back to a candidate whose id equals `nl_token`, and no real candidate id is -1, so it never reaches the sampler. The CPU-only result above shows that directly.

The read is host-side, so it is not Pascal-specific, and it touches no ggml op.

Mainline carried this block verbatim until ggml-org/llama.cpp#9294 moved the penalty stage into the sampler chain, which dropped the raw read and handles the null id at sampler init instead. ggml-org/llama.cpp#10803 later removed `penalize_nl` entirely, so there is no upstream counterpart to port this to.
