### PR TITLE
ggml : fix vec_dot/vec_dot_type mismatch in non-IQK builds

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -968,10 +968,14 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_q4_K,
         .from_float_ref           = (ggml_from_float_t) quantize_row_q4_K_ref,
         .vec_dot                  = ggml_vec_dot_q4_K_q8_K,
+#if GGML_USE_IQK_MULMAT
 #ifdef __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
 #else
         .vec_dot_type             = GGML_TYPE_Q8_1_X4,
+#endif
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_K,
 #endif
         .nrows                    = 1,
         .row_meta_size            = 0,
@@ -998,10 +1002,14 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_q5_K,
         .from_float_ref           = (ggml_from_float_t) quantize_row_q5_K_ref,
         .vec_dot                  = ggml_vec_dot_q5_K_q8_K,
+#if GGML_USE_IQK_MULMAT
 #ifdef __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
 #else
         .vec_dot_type             = GGML_TYPE_Q8_1_X4,
+#endif
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_K,
 #endif
         .nrows                    = 1,
         .row_meta_size            = 0,
@@ -1028,10 +1036,14 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_q6_K,
         .from_float_ref           = (ggml_from_float_t) quantize_row_q6_K_ref,
         .vec_dot                  = ggml_vec_dot_q6_K_q8_K,
+#if GGML_USE_IQK_MULMAT
 #ifdef __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
 #else
         .vec_dot_type             = GGML_TYPE_Q8_0_X4,
+#endif
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_K,
 #endif
 //        .vec_dot_type             = GGML_TYPE_Q8_K,
         .nrows                    = 1,
@@ -1306,10 +1318,14 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_iq4_nl,
         .from_float_ref           = (ggml_from_float_t)quantize_row_iq4_nl_ref,
         .vec_dot                  = ggml_vec_dot_iq4_nl_q8_0,
+#if GGML_USE_IQK_MULMAT
 #if __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
 #else
         .vec_dot_type             = GGML_TYPE_Q8_0_X4,
+#endif
+#else
+        .vec_dot_type             = GGML_TYPE_Q8_0,
 #endif
         .nrows                    = 1,
         .row_meta_size            = 0,
@@ -1687,7 +1703,9 @@ static const ggml_type_traits_t type_traits[GGML_TYPE_COUNT] = {
         .from_float               = quantize_row_q1_0_g128,
         .from_float_ref           = (ggml_from_float_t)quantize_row_q1_0_g128_ref,
         .vec_dot                  = vec_dot_q1_0_g128_q8_0,
-#if defined __AVX2__
+#if !GGML_USE_IQK_MULMAT
+        .vec_dot_type             = GGML_TYPE_Q8_0_X4,
+#elif defined __AVX2__
         .vec_dot_type             = GGML_TYPE_Q8_2_X4,
 #else
         .vec_dot_type             = GGML_TYPE_Q8_0_X4,


### PR DESCRIPTION
Five `type_traits` entries in `ggml/src/ggml.c` pair a `.vec_dot` with a `.vec_dot_type` of a different block layout. The fix wraps the existing values in `#if GGML_USE_IQK_MULMAT`, so for these five entries an IQK build compiles to the same value it does today. Only the non-IQK path moves, and that is the one that is broken today. On a non-IQK Ivy Bridge build it fails without the change and passes with it: Gemma-4-12B Q4_K_M perplexity goes from `-nan` to `82.7454 +/- 20.72294`, against `93.9238 +/- 22.90` from upstream llama.cpp on the same CPU, model and corpus.

With IQK on, this change is a no-op: preprocessing `ggml.c` with `-DGGML_USE_IQK_MULMAT` before and after the change gives identical output, apart from the `__LINE__` values in assert strings. The patch adds lines, so those numbers shift, which is also why the object files differ.

Q4_K (962), Q5_K (992), Q6_K (1022) and IQ4_NL (1300) each declare a `.vec_dot` that reads `block_q8_K` (`block_q8_0` for IQ4_NL), then select the `.vec_dot_type` on `__AVX2__`:

```c
.vec_dot      = ggml_vec_dot_q4_K_q8_K,   // reads block_q8_K
#ifdef __AVX2__
.vec_dot_type = GGML_TYPE_Q8_2_X4,        // not q8_K
#else
.vec_dot_type = GGML_TYPE_Q8_1_X4,        // not q8_K either
#endif
```

Both branches disagree with the `vec_dot`. `__AVX2__` does not track whether `iqk_mul_mat` takes the multiplication. Q1_0_G128 is a fifth instance, mismatched only on AVX2. Q6_K has the matching value commented out one line below.

## The fix

```c
#if GGML_USE_IQK_MULMAT
#ifdef __AVX2__
    .vec_dot_type = GGML_TYPE_Q8_2_X4,
#else
    .vec_dot_type = GGML_TYPE_Q8_1_X4,
#endif
#else
    .vec_dot_type = GGML_TYPE_Q8_K,
#endif
```

That is Q4_K. The `#else` value is per entry, whatever that entry's `vec_dot` actually reads: `Q8_K` for the three `_K` types, `Q8_0` for IQ4_NL. Q1_0_G128 is the one case where the two ISAs disagree, so it takes a different shape. Its non-AVX2 arm already selects `Q8_0_X4` and is correct as written, so only the `__AVX2__` arm is redirected:

```c
#if !GGML_USE_IQK_MULMAT
    .vec_dot_type = GGML_TYPE_Q8_0_X4,
#elif defined __AVX2__
    .vec_dot_type = GGML_TYPE_Q8_2_X4,
#else
    .vec_dot_type = GGML_TYPE_Q8_0_X4,
#endif
```

This matches eleven other types in the table. `q4_0`, `q4_1`, `q5_0`, `q5_1`, `q6_0`, `q8_0`, `iq4_nl_r4`, `q4_0_r8`, `q8_0_r8`, `q5_0_r4` and `q6_0_r4` wrap the same move in `#if GGML_USE_IQK_MULMAT` and keep the legacy value in the `#else`.

## Repro

Xeon E5-2440 v2 (Ivy Bridge, `avx`, no `avx2`, no `fma`), Gemma-4-12B Q4_K_M, `-c 512`, 2 chunks, CPU only:

```
cmake -DGGML_IQK_MUL_MAT=OFF -DGGML_IQK_FLASH_ATTENTION=OFF \
      -DGGML_NATIVE=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF \
      -DGGML_ARCH_FLAGS="-march=ivybridge"
```

The base is PR #2138's branch, not main: main does not build on this CPU at all, which is what that PR fixes.

| build | PPL |
|---|---|
| #2138 branch | `-nan` |
| #2138 branch + this change | `82.7454 +/- 20.72294` |
| upstream llama.cpp, same CPU, same model and corpus | `93.9238 +/- 22.90` |

`-DGGML_FMA=OFF` is required on this hardware. Under `-DGGML_NATIVE=OFF`, `GGML_FMA` defaults ON and is not implied off by `GGML_AVX2=OFF`, so the build emits `-mfma` and dies with SIGILL inside `ggml_init`. Both binaries above contain zero `vfmadd`.

We also reproduced it with no model and no graph: on an AVX2 host (Xeon Platinum 8260, `GGML_IQK_MUL_MAT=OFF`, `GGML_NATIVE=OFF`, `GGML_AVX2=ON`), a standalone harness calling `vec_dot` directly against a reference dot product gives:

| type | #2138 branch | with this change |
|---|---|---|
| q4_K, q5_K, q6_K | wrong | ~1e-4 |
| iq4_nl, q1_0_g128 | NaN | ~1e-4 |

That path needs `GGML_NATIVE=OFF`: with `NATIVE=ON` on a VNNI host the non-IQK build does not compile, because `ggml-quants.c` uses `ggml_mm256_dpbusd_epi32` under a VNNI guard (`__AVXVNNI__ || (__AVX512VNNI__ && __AVX512VL__)`), while the `#include "iqk/iqk_config.h"` that defines the macro sits inside `#if GGML_USE_IQK_MULMAT`.

## Scope

Twelve entries in the table carry the same unguarded `#ifdef`. We left seven alone because a table change does not fix them: `mxfp4`, the four `iqN_kt`, `iq4_ks_r4` and `iq5_ks_r4` have no scalar `vec_dot` body, so in a non-IQK build they never write a result whatever the `vec_dot_type` says.

Thirteen types still fail in the harness after this change: four abort, eight never write a result, one segfaults. Those are the harness's symptoms, not diagnoses. This PR does not address them.

`tests/test-backend-ops` did not compile against this tree. I ported it and it builds and runs now, but it does not gate this change: a default build takes the IQK branch, which this change leaves identical.
