### PR TITLE
Chunked experts (CPU)

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -95,6 +95,7 @@ option(GGML_LASX        "ggml: enable lasx"             ON)
 option(GGML_LSX         "ggml: enable lsx"              ON)
 option(GGML_SVE         "ggml: enable SVE"              OFF)
 option(GGML_NCCL        "ggml: enable NCCL"             ON)
+option(GGML_EXPERT_CHUNKING "ggml: enable expert chunking" ON)
 
 if (WIN32)
     # Default to Windows 10 (0x0A00). Windows 8 / 8.1 reached end of support in

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -219,6 +219,10 @@ if (GGML_IQK_MUL_MAT)
     endif()
 endif()
 
+if (GGML_EXPERT_CHUNKING)
+    add_compile_definitions(GGML_EXPERT_CHUNKING)
+endif()
+
 if (GGML_CUDA)
     cmake_minimum_required(VERSION 3.18)  # for CMAKE_CUDA_ARCHITECTURES
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -18200,7 +18200,58 @@ static void ggml_compute_forward_mul_mat_id(
         }
     }
 
+    if (ith == 0) {
+        atomic_store(&params->shared->current_chunk, nth);
+    }
+
     ggml_barrier(params->shared);
+
+#if GGML_USE_IQK_MULMAT
+    if (ne13 == 1 && dst->type == GGML_TYPE_F32) {
+        const void * wdata_mm    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
+        const size_t row_size_mm = ggml_row_size(vec_dot_type, ne10);
+
+        const int chunks_per_expert = MAX(1, MIN(nth, (int)(ne01 / 32)));
+
+        int total_chunks = 0;
+        for (int a = 0; a < n_as; a++) {
+            if (matrix_row_counts[a] > 0) total_chunks += chunks_per_expert;
+        }
+
+        int chunk_id = ith;
+        while (chunk_id < total_chunks) {
+            // Map global chunk_id to (expert_index, local_chunk_index)
+            int acc = 0, cur_a = -1, local_chunk = 0;
+            for (int a = 0; a < n_as; a++) {
+                if (matrix_row_counts[a] == 0) continue;
+                if (chunk_id < acc + chunks_per_expert) {
+                    cur_a = a;
+                    local_chunk = chunk_id - acc;
+                    break;
+                }
+                acc += chunks_per_expert;
+            }
+
+            const char * src0_cur = (const char *) src0->data + cur_a*nb02;
+
+            if (!iqk_mul_mat_moe(ne01, matrix_row_counts[cur_a], ne00, ne11,
+                        src0->type, src0_cur, nb01,
+                        vec_dot_type, (const char *)wdata_mm, row_size_mm,
+                        (float *)dst->data, nb1, nb2,
+                        matrix_rows + cur_a*ne12, local_chunk, chunks_per_expert)) goto IQK_MulMat_Not_Available0;
+
+            chunk_id = atomic_fetch_add(&params->shared->current_chunk, 1);
+        }
+        return;
+    }
+IQK_MulMat_Not_Available0:;
+
+    // Reset counter for fallback path
+    if (ith == 0) {
+        atomic_store(&params->shared->current_chunk, 0);
+    }
+    ggml_barrier(params->shared);
+#endif
 
     // compute each matrix multiplication in sequence
     for (int cur_a = 0; cur_a < n_as; ++cur_a) {
@@ -18476,6 +18527,75 @@ static void ggml_compute_forward_mul_mat_id_up_gate(
         }
     }
 
+#if 1
+
+    if (ith == 0) {
+        atomic_store(&params->shared->current_chunk, nth);
+    }
+
+    ggml_barrier(params->shared);
+
+    const float limit = *(const float *)(dst->op_params + 1);
+
+    const void * wdata_ug    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
+    const size_t row_size_ug = ggml_row_size(vec_dot_type, ne10);
+    const int64_t nr0_base = src0_2 ? ne01 : ne01/2;
+
+    const int chunks_per_expert_ug = MAX(1, MIN(nth, (int)(nr0_base / 32)));
+
+    int total_chunks_ug = 0;
+    for (int a = 0; a < n_as; a++) {
+        if (matrix_row_counts[a] > 0) total_chunks_ug += chunks_per_expert_ug;
+    }
+
+    int last_a = 0;
+    int last_acc = 0;
+    int chunk_id_ug = ith;
+    while (chunk_id_ug < total_chunks_ug) {
+        int acc = last_acc, cur_a = -1, local_chunk = 0;
+        for (int a = last_a; a < n_as; a++) {
+            if (matrix_row_counts[a] == 0) continue;
+            if (chunk_id_ug < acc + chunks_per_expert_ug) {
+                cur_a = a;
+                local_chunk = chunk_id_ug - acc;
+                break;
+            }
+            acc += chunks_per_expert_ug;
+        }
+        if (cur_a < 0) {
+            return;
+        }
+        last_a = cur_a;
+        last_acc = acc;
+
+        const char *src0_1_cur, *src0_2_cur, *up_b_cur = NULL, *gate_b_cur = NULL;
+        if (src0_2) {
+            src0_1_cur = (const char *) src0_1->data + cur_a*nb02;
+            src0_2_cur = (const char *) src0_2->data + cur_a*nb02;
+            up_b_cur   = up_b   ? (const char *)up_b->data + cur_a*nb41 : NULL;
+            gate_b_cur = gate_b ? (const char *)gate_b->data + cur_a*nb51 : NULL;
+        } else {
+            src0_2_cur = (const char *) src0_1->data + cur_a*nb02;
+            src0_1_cur = src0_2_cur + nb02/2;
+            if (up_b) {
+                GGML_ASSERT(!gate_b);
+                gate_b_cur = (const char *)up_b->data + cur_a*nb41;
+                up_b_cur   = gate_b_cur + nb41/2;
+            }
+        }
+
+        if (!iqk_moe_fused_up_gate(nr0_base, matrix_row_counts[cur_a], ne00, ne11, dst->op_params[0],
+                            type, src0_1_cur, src0_2_cur, nb01,
+                            vec_dot_type, (const char *)wdata_ug, row_size_ug,
+                            up_b_cur, gate_b_cur,
+                            (float *)dst->data, nb1, nb2,
+                            matrix_rows + cur_a*ne12, limit, local_chunk, chunks_per_expert_ug)) GGML_ABORT("fatal error");
+
+        chunk_id_ug = atomic_fetch_add(&params->shared->current_chunk, 1);
+    }
+
+#else
+
     ggml_barrier(params->shared);
 
     const float limit = *(const float *)(dst->op_params + 1);
@@ -18520,7 +18640,7 @@ static void ggml_compute_forward_mul_mat_id_up_gate(
                             matrix_rows + cur_a*ne12, limit, ith, nth)) GGML_ABORT("fatal error");
 
     }
-
+#endif
 #undef MMID_MATRIX_ROW
 }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -18207,6 +18207,7 @@ static void ggml_compute_forward_mul_mat_id(
     ggml_barrier(params->shared);
 
 #if GGML_USE_IQK_MULMAT
+#if defined GGML_EXPERT_CHUNKING
     if (ne13 == 1 && dst->type == GGML_TYPE_F32) {
         const void * wdata_mm    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
         const size_t row_size_mm = ggml_row_size(vec_dot_type, ne10);
@@ -18251,6 +18252,7 @@ IQK_MulMat_Not_Available0:;
         atomic_store(&params->shared->current_chunk, 0);
     }
     ggml_barrier(params->shared);
+#endif
 #endif
 
     // compute each matrix multiplication in sequence
@@ -18527,7 +18529,7 @@ static void ggml_compute_forward_mul_mat_id_up_gate(
         }
     }
 
-#if 1
+#if defined GGML_EXPERT_CHUNKING
 
     if (ith == 0) {
         atomic_store(&params->shared->current_chunk, nth);

--- a/ggml/src/iqk/iqk_mul_mat.cpp
+++ b/ggml/src/iqk/iqk_mul_mat.cpp
@@ -1928,7 +1928,9 @@ bool iqk_indexer_topk(struct ggml_tensor * dst, void * work_buffer, barrier_t ba
             std::partial_sort(sorted, sorted + n_top_k, sorted + k->ne[1], [score] (int32_t l, int32_t r) -> bool { return score[l] > score[r]; });
             std::memcpy((char *)dst->data + dst->nb[1]*iq, sorted, n_top_k*sizeof(int32_t));
         }
-        barrier(barrier_data);
+        if (iq + 1 < q->ne[2]) {
+            barrier(barrier_data);
+        }
     }
 
     return true;


### PR DESCRIPTION

This PR basically resurrects #1485 with some relatively minor modifications.

The author of #1485 closed it claiming that they saw a performance regression for some model. I did not find any regressions myself back then, but performance gains were minor, so I did not object to shelving the PR.

So, why bring it back now?

This is best explained with the following graph. The graph shows TG performance as a function of `N_KV`, the number of tokens in the cache, for DS4-MXFP4 using hybrid GPU/CPU inference with all experts left in RAM (`--cpu-moe`) on a 2x3090+Ryzen-3995WX system. The main branch in in black, `llama.cpp @ f5b9bd39b56c7a7839a9795a100b6a00b84ac961` is in red, and the PR is shown in green. There is a lot of wiggle on the main branch, with performance kind of fluctuating around `llama.cpp` (but being about 1.6% lower on average). The PR is clearly better than the main branch and `llama.cpp` (on average 4.4% better than main, 2.7% better than `llama.cpp`) with much less fluctuations around the main trend. 

<img width="792" height="612" alt="ds4_hybrid_tg" src="https://github.com/user-attachments/assets/42602329-278f-4e92-b8ee-36295fcc7baf" />

So, how come `llama.cpp` is so much smoother? The difference comes from the fact that `llama.cpp` maintains a thread pool, while `ik_llama.cpp` starts new threads for every graph split. In the case of hybrid CPU/GPU inference with all experts left in RAM this basically means launching new threads `n_layer` times **per token** (i.e., 43 times for DS4). At ~20 t/s we have ~50 ms per token, so ~1.1 ms per layer, so cost for launching and joining threads is not negligible (but neither is the cost of waking up threads in the thread pool waiting on a condition variable in the case of `llama.cpp`). More importantly, if a thread gets delayed by the OS, because the work is split evenly between threads on the main branch, all threads need to wait for the delayed thread(s) before being able to continue. My guess is that this leads to the strong functions in the black curve. The PR reduces the issue by using what is typically known as "work stealing". Instead of having each thread compute a fixed fraction of each expert, experts are split into chunks of 32 rows, and threads "steal" work chunks from a common work pool.

For CPU-only inference the PR has a negligible performance impact for DS4 (<1%). But in that case the situation is different as we have a single launch of all threads for the entire compute graph (token decode), so thread launch delays are much less important.

Thread pools always lead to a higher complexity and more bugs (it took months to have all bugs ironed out in `llama.cpp` when they introduced a thread pool), so I have been reluctant to use a thread pool in `ik_llama.cpp`. Let's see if this experiment will finally convince me to do it.

I have no NUMA system to test, so it would be interesting to hear if this PR has a performance impact on NUMA systems. The work stealing approach results in threads possibly processing different portions of the experts tensors on each invocation, so that may be detrimental to memory bound inference.

**Update** I have added the ability to turn off the chunking in case it results in a lower performance. To do so, add `-DGGML_EXPERT_CHUNKING=OFF` to the `cmake` command.
