### PR TITLE
state: fix V cache compatibility check for models with no V cache

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -9921,9 +9921,14 @@ struct llama_data_read {
             return false;
         }
 
-	// Currently the only way there is no V cache (and thus v_state is 2) requires flash_attn, and flash_attn sets kv_self.v_trans to false
-        if (kv_self.v_trans != (v_state == 1)) {
-            LLAMA_LOG_ERROR("%s: incompatible V transposition\n", __func__);
+        // v_state == 2 means the writer had no V cache at all. Transposition is meaningless in that
+        // case, and kv_self.v_trans is independent of whether v_l was ever allocated, so it says
+        // nothing about compatibility here. V cache presence has to match in both directions;
+        // transposition only has to match when there actually is a V cache on both sides.
+        if (((v_state == 2) != kv_self.v_l.empty()) ||
+            (v_state != 2 && kv_self.v_trans != (v_state == 1))) {
+            LLAMA_LOG_ERROR("%s: incompatible V cache state (v_state = %u, v_l %s, v_trans = %d)\n",
+                    __func__, v_state, kv_self.v_l.empty() ? "empty" : "present", (int) kv_self.v_trans);
             return false;
         }
 


### PR DESCRIPTION
In current main, state restore is refused for models with no V cache when flash attention is off.

`read_kv_cache_data` gates the restore on `kv_self.v_trans != (v_state == 1)`. `v_state == 2` records that the writer had no V cache, while `v_trans` comes from `!recurrent && !flash_attn && !hybrid` and so tracks flash attention rather than V allocation. With `-fa 0` on a K-only or MLA cache the two disagree, and the restore is rejected even though both sides agree there is no V cache to compare.

```diff
-	// Currently the only way there is no V cache (and thus v_state is 2) requires flash_attn, and flash_attn sets kv_self.v_trans to false
-        if (kv_self.v_trans != (v_state == 1)) {
-            LLAMA_LOG_ERROR("%s: incompatible V transposition\n", __func__);
+        // v_state == 2 means the writer had no V cache at all. Transposition is meaningless in that
+        // case, and kv_self.v_trans is independent of whether v_l was ever allocated, so it says
+        // nothing about compatibility here. V cache presence has to match in both directions;
+        // transposition only has to match when there actually is a V cache on both sides.
+        if (((v_state == 2) != kv_self.v_l.empty()) ||
+            (v_state != 2 && kv_self.v_trans != (v_state == 1))) {
+            LLAMA_LOG_ERROR("%s: incompatible V cache state (v_state = %u, v_l %s, v_trans = %d)\n",
+                    __func__, v_state, kv_self.v_l.empty() ? "empty" : "present", (int) kv_self.v_trans);
             return false;
         }
```

With this PR, presence is compared in both directions, and transposition only when a V cache exists on both sides. The mirror case, serialized V data restored into a context without a V cache, previously passed this guard and reached an empty `v_l`; it is now refused.

Affected today: `deepseek2`, `mistral4` and `glm_dsa` at `mla_attn >= 2`, and `deepseek4`. openPangu reaches the same state but is refused state I/O earlier. All of them are non-recurrent and non-hybrid, which is why flash attention is the only varying input.

The write path, the serialized layout and the emitted byte counts are untouched, so existing session files remain readable and no version bump is involved. For `v_state` 0 or 1 with a V cache present the predicate reduces to the previous comparison, and the flash-attention-on path is unaffected. The guard is not gated by `need_kv`, which controls only the per-layer payloads, so full, sequence and `PARTIAL_ONLY` restores all pick up the fix without any of them changing shape.

Validation

Base `52836917a` (`libllama.so` `a185225d`) against `368845f54` (`libllama.so` `3ff016d7`). The changed code is in `libllama.so`, and arms were run by swapping that library. CUDA build, RTX 4070, `Release`, CPU-only runs (`-ngl 0`), greedy.

```
llama-save-load-state -m <model.gguf> -c 512 -ngl 0 -fa 0 -n 16 --temp 0
```

| model | arch | `-fa` | base | patched |
| --- | --- | --- | --- | --- |
| DeepSeek-V2-Lite-Chat Q4_K_M | deepseek2 | off | exit 1 | exit 0 |
| DeepSeek-V2-Lite-Chat Q4_K_M | deepseek2 | on | exit 0 | exit 0 |
| GLM-4.7-Flash-APEX | deepseek2 | off | exit 1 | exit 0 |
| Mistral-Small-4-119B-2603 i1-IQ1_S | mistral4 | off | exit 1 | exit 0 |
| Mistral-Small-4-119B-2603 i1-IQ1_S | mistral4 | on | exit 0 | exit 0 |
| DeepSeek-V4-Flash UD-IQ1_S | deepseek4 | off | exit 1 | exit 0 |
| DeepSeek-V4-Flash UD-IQ1_S | deepseek4 | on | exit 0 | exit 0 |

The DeepSeek4 and Mistral4 rows use `-c 256 -n 4 -np 2`, since the example's third phase restores into sequence 1 and DeepSeek4 sizes its per-stream state by the parallel count. The flash-attention-on rows are the non-regression control. Failing rows report `read_kv_cache_data: incompatible V transposition`; on the patched build DeepSeek4 deserializes 49361251 of 49361251 bytes.

Same through the server, DeepSeek-V2-Lite with `-fa 0` and `--slot-save-path`:

| arm | `POST /slots/0?action=save` | `POST /slots/0?action=restore` |
| --- | --- | --- |
| base | 13 tokens, 404864 bytes | no HTTP response within 120 s |
| patched | 13 tokens, 404864 bytes | 13 restored, 404864 bytes, 0.14 ms |

`glm_dsa` is listed from the allocation code rather than measured, since the smallest 5.2 GGUF available is far beyond this machine's capacity.

Three unrelated pre-existing issues turned up while testing and are left alone here: saving a session with `-mla 1 -fa 0` trips an out of bounds assert in `ggml-backend.cpp`; DeepSeek4 with `-fa 0` aborts at graph build on `GGML_ASSERT(ggml_is_contiguous(mask))` in `ggml.c`; and a failed `/slots` restore sends no HTTP response at all rather than an error. Each would need its own repro and fix.

This unblocks a follow-up PR extending #2195's context checkpoints to openPangu, which runs with flash attention off and would meet this same guard once its state I/O is enabled.  I've split it here because it reaches these other arches.

This PR was drafted with the aid of Opus 5, primarily to verify code correctness before testing, and the accuracy of this description.

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
