### PR TITLE
sampling : fix use-after-scope in grammar trigger_words path

### DIFF
--- a/src/llama-sampling.cpp
+++ b/src/llama-sampling.cpp
@@ -1367,11 +1367,13 @@ struct llama_grammar* llama_sampler_init_grammar_impl(
     size_t num_trigger_patterns) {
     // Huh? this is not used and leaks. auto* ctx = new llama_sampler_grammar;
     struct llama_grammar* grammar;
+    std::string trigger_pattern;
+    const char * trigger_pattern_c = nullptr;
     if (grammar_str != nullptr && grammar_str[0] != '\0') {
         // TODO: remove trigger_words support.
         if (trigger_words != nullptr && num_trigger_words > 0) {
             GGML_ASSERT(trigger_patterns == nullptr && num_trigger_patterns == 0);
-            std::string trigger_pattern("[\\s\\S]*?(");
+            trigger_pattern = "[\\s\\S]*?(";
             for (size_t i = 0; i < num_trigger_words; ++i) {
                 static const std::regex special_chars("[.^$|()*+?\\[\\]{}\\\\]");
                 if (i > 0) {
@@ -1380,7 +1382,7 @@ struct llama_grammar* llama_sampler_init_grammar_impl(
                 trigger_pattern += std::regex_replace(trigger_words[i], special_chars, "\\$0");
             }
             trigger_pattern += ")[\\s\\S]*";
-            auto trigger_pattern_c = trigger_pattern.c_str();
+            trigger_pattern_c = trigger_pattern.c_str();
             trigger_patterns = &trigger_pattern_c;
             num_trigger_patterns = 1;
         }


### PR DESCRIPTION
In `llama_sampler_init_grammar_impl`, the `trigger_words` branch builds the trigger pattern in a block-scoped `std::string`, saves `trigger_pattern.c_str()` into a local `trigger_pattern_c`, points `trigger_patterns` at it, then the block ends — destroying both locals — before `llama_grammar_init_impl` dereferences `trigger_patterns`. That's a read through a dangling pointer into freed `std::string` storage (undefined behavior; it only "works" when the freed bytes happen to survive until the read).

Fix: hoist `trigger_pattern` and `trigger_pattern_c` to function scope so both outlive the `llama_grammar_init_impl` call. Pattern-building logic is unchanged.

Tested via a downstream Rust binding (`ik-llama-cpp-2`) that arms a lazy grammar through `trigger_words` and asserts it fires.

---

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/main/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Disclosure (per CONTRIBUTING): prepared with AI assistance; I reviewed and understand the change, and it has been running and tested in the downstream binding noted above.
