### PR TITLE
speculative : fix MTP warmup conditioning row 0 on a future hidden state

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2872,6 +2872,15 @@ int32_t common_speculative_on_target_batch(
         return -1;
     }
 
+    // snapshot the previous call's last hidden before the store below overwrites it (row-0 conditioning needs it)
+    std::vector<float> prev_call_last_hidden;
+    {
+        const auto prev_it = mtp_state->target_hidden_by_seq.find(seq_id);
+        if (prev_it != mtp_state->target_hidden_by_seq.end()) {
+            prev_call_last_hidden = prev_it->second;
+        }
+    }
+
     const float * last_hidden = hidden_rows_storage.data() + (size_t) (batch.n_tokens - 1) * features.width;
     mtp_store_target_hidden(*mtp_state, seq_id, last_hidden, features.width);
 
@@ -2899,9 +2908,8 @@ int32_t common_speculative_on_target_batch(
     const bool uses_shifted_hidden_rows = mtp_model_uses_recurrent_conditioning(*mtp_state);
     std::vector<float> previous_hidden_storage;
     if (uses_shifted_hidden_rows) {
-        const auto hidden_it = mtp_state->target_hidden_by_seq.find(seq_id);
-        if (hidden_it != mtp_state->target_hidden_by_seq.end() && (int32_t) hidden_it->second.size() == features.width) {
-            previous_hidden_storage = hidden_it->second;
+        if ((int32_t) prev_call_last_hidden.size() == features.width) {
+            previous_hidden_storage = std::move(prev_call_last_hidden);
         } else {
             previous_hidden_storage.assign(features.width, 0.0f);
         }


### PR DESCRIPTION
In `common_speculative_on_target_batch`, `mtp_store_target_hidden(...)` writes this batch's last hidden into `target_hidden_by_seq[seq]` **before** the shifted warmup conditioning reads that map back. So the first conditioned row (row 0) is fed this batch's *last* hidden — a state up to `n_tokens-1` positions in the future — instead of the previous call's last hidden, and the position-0 zeros fallback becomes unreachable (the store always fills the slot the emptiness check tests).

On a multi-chunk prompt warmup this mis-seeds the recurrent companion at each chunk boundary and lowers NextN draft acceptance. Prompts that fit in a single warmup chunk (one call) don't hit it, which is likely why it went unnoticed. Output is unaffected — the target verifies every drafted token — so the only cost is draft acceptance.

Fix: snapshot the previous call's last hidden before the store, and condition row 0 on that; the store is left unchanged so other readers of the map are unaffected. A fresh position-0 warmup now correctly takes the zeros branch.

Measured on Qwen3.5-4B (single NextN head): ~+0.2% acceptance with no regression — small on typical prompts, larger as the warmup chunk size grows. Verified with a multi-chunk-warmup differential acceptance test in the downstream binding `ik-llama-cpp-2`.

---

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/main/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

Disclosure (per CONTRIBUTING): prepared with AI assistance; I reviewed and understand the change, and it has been running and tested in the downstream binding noted above.
