### PR TITLE
Fix IQ3_XXS CPU GEMM on AVX2/AVX512

### DIFF
--- a/ggml/src/iqk/iqk_gemm_iquants.cpp
+++ b/ggml/src/iqk/iqk_gemm_iquants.cpp
@@ -550,7 +550,7 @@ struct DequantizerIQ3XXS final : public BaseDequantizer<block_iq3_xxs> {
         make4_unsigned(qs, bits.values);
         sign_2_values(signs+0, bits.values+0);
         sign_2_values(signs+4, bits.values+2);
-        for (int k = 0; k < 4; ++k) bits.values[k] = _mm256_add_epi32(bits.values[k], min_value);
+        for (int k = 0; k < 4; ++k) bits.values[k] = _mm256_add_epi8(bits.values[k], min_value);
     }
     inline void prepare(int i, int j, const Q8<1>& q8, __m256i * q8_quants) {
         for (int k = 0; k < 4; ++k) q8_quants[k] = q8.load_quants(0, i, 4*j+k);


### PR DESCRIPTION

The PR fixes a bug in the `IQ3_XXS` matrix multiplication implementation. The bug has been there since the beginning of IQK GEMM kernels, so it is really strange that it did not manifest itself for so long. The Unsloth DeepSeek-V4-Flash `IQ3_XXS` model triggers it, and we get gibberish output.

Closes #2214 