### PR TITLE
hc_post: sum the comb terms before adding x*post

### DIFF
--- a/ggml/src/ggml-cuda/sinkhorn.cu
+++ b/ggml/src/ggml-cuda/sinkhorn.cu
@@ -158,13 +158,14 @@ static __global__ void k_hc_post(int ne0, const float * __restrict__ x, const fl
 
     #pragma unroll
     for (int i = 0; i < S; ++i) {
-        float sum = x_r[i0] * post_r[i];
+        // fold x*post in last: seeding with it costs the comb terms their low bits
+        float sum = comb_r[i] * r[0];
         #pragma unroll
-        for (int j = 0; j < S; ++j) {
+        for (int j = 1; j < S; ++j) {
             sum += comb_r[j*S + i] * r[j];
         }
         float * dst_r = (float *)((char *)dst + i1*nb2 + i*nb1);
-        dst_r[i0] = sum;
+        dst_r[i0] = x_r[i0] * post_r[i] + sum;
     }
 
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -24264,12 +24264,12 @@ static void ggml_compute_forward_hc_post_f32(
                     r[j] = res_r[i0];
                 }
                 for (int i = 0; i < S; ++i) {
-                    float sum = x_r[i0] * post_r[i];
-                    for (int j = 0; j < S; ++j) {
+                    float sum = comb_r[i] * r[0];
+                    for (int j = 1; j < S; ++j) {
                         sum += comb_r[j*S + i] * r[j];
                     }
                     float * dst_r = (float *)((char *)dst->data + i*dst->nb[1]);
-                    dst_r[i0] = sum;
+                    dst_r[i0] = x_r[i0] * post_r[i] + sum;
                 }
             }
         }
@@ -24293,13 +24293,13 @@ static void ggml_compute_forward_hc_post_f32(
                 r[j] = res_r[i0];
             }
             for (int i = 0; i < S; ++i) {
-                float sum = x_r[i0] * post_r[i];
-                for (int j = 0; j < S; ++j) {
+                float sum = comb_r[i] * r[0];
+                for (int j = 1; j < S; ++j) {
                     //sum += comb_r[i*S + j] * r[j];
                     sum += comb_r[j*S + i] * r[j];
                 }
                 float * dst_r = (float *)((char *)dst->data + t*dst->nb[2] + i*dst->nb[1]);
-                dst_r[i0] = sum;
+                dst_r[i0] = x_r[i0] * post_r[i] + sum;
             }
         }
     }


### PR DESCRIPTION
While slowly moving openPangu toward the shared mHC machinery I ran into some confusing numbers that ended up here. It looks like `ggml_hc_post` disagrees between CPU and CUDA by more than the unfused chain it replaced, and testing points at the accumulation order: the kernel seeds its accumulator with the `x*post` term, which is usually the largest, so the comb products added after it lose their low bits. Summing the comb terms first and folding `x*post` in at the store comes out closer to a double-precision evaluation of the same formula on both backends, with the same instruction mix where FP contraction is on (one multiply plus four FMAs, as before).

There may be a reason for the current order that I'm missing.

Numbers below are from an isolated harness running just the fused op pair (S=4, H=2560, fp32 inputs, RTX 4070 and 8-thread CPU; T=2048 is the prefill shape at `-ub 2048`).

Max abs CPU-vs-CUDA difference for the fused op, with the unfused chain as a scale reference:

| T | unfused chain | fused, main | fused, this PR |
| --- | --- | --- | --- |
| 1 | 2.384e-07 | 3.576e-07 | 2.980e-07 |
| 6 | 2.980e-07 | 3.576e-07 | 2.980e-07 |
| 512 | 4.768e-07 | 5.960e-07 | 3.576e-07 |
| 2048 | 4.768e-07 | 5.960e-07 | 4.768e-07 |

Error against an fp64 evaluation of the same formula from the same fp32 inputs, with the unfused chain again as a scale reference (the fp64 reference accumulates in main's order, so if it leans either way it leans toward main):

| backend | shape | unfused chain, max / rms | fused main, max / rms | fused this PR, max / rms |
| --- | --- | --- | --- | --- |
| CUDA | T=512 | 3.812e-07 / 4.940e-08 | 3.967e-07 / 5.165e-08 | 3.662e-07 / 4.528e-08 |
| CUDA | T=2048 | 3.834e-07 / 4.924e-08 | 4.147e-07 / 5.185e-08 | 3.662e-07 / 4.545e-08 |
| CPU | T=512 | 3.677e-07 / 4.682e-08 | 4.288e-07 / 5.290e-08 | 3.246e-07 / 4.339e-08 |
| CPU | T=2048 | 3.797e-07 / 4.710e-08 | 4.379e-07 / 5.308e-08 | 3.246e-07 / 4.357e-08 |

The unfused chain currently sits between the two: fusing gives up a little accuracy today, and comes out ahead of it with this change.

That `x*post` is the larger term looks like an assumption about the inputs, but it follows from the operation: sinkhorn drives `comb` toward doubly stochastic, so the comb weights are non-negative and sum to roughly one, which puts each product at about `1/S` of a residual stream while `x*post` is a full one. For completeness, scaling `x` alone moves that ratio with everything else held fixed (T=512, CPU, rms):

| x scale | main | this PR | main - this PR |
| --- | --- | --- | --- |
| 0.01 | 3.322e-08 | 3.361e-08 | -3.9e-10 (PR worse) |
| 0.1 | 3.351e-08 | 3.371e-08 | -2.0e-10 (PR worse) |
| 1 | 5.290e-08 | 4.339e-08 | +9.5e-09 (PR better) |
| 32 | 1.304e-06 | 8.827e-07 | +4.2e-07 (PR better) |

The outer rows are well outside what a residual stream should do, since `x` and the mixed streams are the same kind of activation at the same layer. Where the change loses it loses on the smallest errors in the table, by an absolute margin about 24x smaller than what it gains at ratio 1.

Cost, measured on a 32-deep chain of `hc_pre`+`hc_post` with arms interleaved: CUDA is unchanged at both shapes (T=512 medians 3.428 vs 3.427 ms per graph, T=2048 13.192 vs 13.191), and eight CPU rounds straddle zero within a few percent of noise. End-to-end I can't measure: DS4 is the only arch that reaches these ops, and the smallest GGUF is 82 GB against 64 GB of RAM, so `llama-bench` mostly measures the page cache. I'd appreciate confirmation that this is throughput-neutral on a machine that runs DS4 comfortably, particularly on Ampere, since my timings are all from one Ada card.

Output changes bit-wise on DS4, expected from any change to these kernels. My four usual test prompts stay coherent and finish normally on both builds at UD-IQ1_S.

*Adversarial code review and tedious composition of tables above performed by GPT-5.6.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [X] Low
  - [ ] Medium
  - [ ] High

_______________

I meant to close with the following comment but hit the wrong button; editing instead.  I measured the premise on a real forward pass and it does not hold.

The argument here was that `x*post` is usually the largest term, which is what makes folding it in last worth doing. Sampling `hc_post`'s inputs across a DeepSeek-V4-Flash forward pass (UD-IQ1_S, fully offloaded), the ratio of `rms(x*post)` to the rms of a single `comb*res` product has a median of 0.10, and close to 90% of calls sit below the point where the reorder starts to help. The accumulated hyper-connection streams grow with depth while the per-layer contribution does not, so `x*post` is normally the smaller term rather than the larger one.

At that ratio the numbers in the description do not reproduce. The error against fp64 changes sign, about 2% worse on CUDA and 1% worse on CPU, and the CPU vs CUDA gap I opened with is identical for main, the unfused chain and this branch, so there is nothing there to fix. Both tables were taken at a term ratio roughly 35 times the model's median. The reorder does still help in the 10% or so of calls above the crossover, but that is not enough to justify changing every DS4 `hc_post` call.

Everything involved is around 1e-9 absolute, but the forward pass totally invalidated the case for it.