### PR TITLE
Fix IQ4_NL_R4 GEMM on CPUs with FANCY_SIMD enabled

### DIFF
--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -868,12 +868,13 @@ static void mul_mat_iq4_nl_r4_q8_2(int n, const void * vx, size_t bx, const Data
         for (int ib = 4*(nb/4); ib < nb; ++ib) {
             auto scales = prepare(iq4l[ib], iq4h[ib]);
             for (int iy = 0; iy < nrc_y; ++iy) {
-                auto qy = (const block_q8_1 *)q8.y[iy];
+                auto qy = (const block_q8_2 *)q8.y[iy];
                 auto sumi = dot(_mm256_loadu_si256((const __m256i*)qy[ib].qs));
-                ggml_bf16_t d, s; d.bits = qy[ib].d; s.bits = qy[ib].s;
-                auto dy = _mm512_set1_ps(GGML_BF16_TO_FP32(d));
+                float   d = GGML_BF16_TO_FP32(ggml_bf16_t{qy[ib].d});
+                int16_t m = *(const int16_t *)&qy[ib].s;
+                auto dy = _mm512_set1_ps(d);
                 acc[2*iy+0] = _mm512_fmadd_ps(_mm512_mul_ps(scales, dy), _mm512_cvtepi32_ps(sumi), acc[2*iy+0]);
-                acc[2*iy+1] = _mm512_fmadd_ps(scales, _mm512_set1_ps(GGML_BF16_TO_FP32(s)), acc[2*iy+1]);
+                acc[2*iy+1] = _mm512_fmadd_ps(scales, _mm512_set1_ps(d*m), acc[2*iy+1]);
             }
         }
         for (int iy = 0; iy < nrc_y; ++iy) {


### PR DESCRIPTION

Nobody apart from @cora4 has used `IQ4_NL_R4` on CPUs with `HAVE_FANCY_SIMD` enabled?

The issue comes from the following chain of events
* On `AVX/AVX2/AVX512` the SIMD dot products require that the first operand is unsigned.
* When `HAVE_FANCY_SIMD` is defined, this is handled by adding 128 (or 127) to the quantized data to make it unisgned. One then needs to subtract `128 * sum(q8_0 quants)` from the dot product to obtain the correct result.
* Because of this, historically `Q8_1` was used as the vector dot type for `IQ4_NL` and several other quantization types. `Q8_1` stores the block scale and the sum of quants in the block as `fp16`.
* At some point I noticed that the sum of the `q8` quants can overflow the `fp16` range. So, I introduced `Q8_2`, where the scale and the sum are stored as `bf16`.
* But that also resulted in failure modes where the `bf16` sum of quants did not have enough precision (as `bf16` uses only 7 bits for the mantissa).
* Hence, I changed `Q8_2` to store a `bf16` scale and an `int16_t` sum of the `q8` quants in the block.
* For better efficiency the GEMM implementations process the dot product in chunks of 4 x `Q8_2` blocks. If the row size is not a multiple of 128 (`4 x 32`), then there is an epilogue that handles the tail.  
* In the adaptation of the GEMM implementation for the `Q8_2 {bf16, bf16} -> {bf16, int16_t}` change, the epilogue of the `IQ4_NL_R4` type was forgotten. As almost all models have row sizes that are a multiple of 128, the bug went unnoticed until @cora4 tried to repack the `IQ4_NL` quants in a Gemma4-26B model to `IQ4_NL_R4`.   