### PR TITLE
Disable quantized indexer cache

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1809,7 +1809,8 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         return true;
     }
     if (arg == "-ictk" || arg == "--indexer-cache-type-k") {
-        params.indexer_cache_type_k = argv[++i];
+        LLAMA_LOG_WARN("================== Quantized inexer cache has been disabled for now => argument '%s' ignored\n", arg.c_str());
+        //params.indexer_cache_type_k = argv[++i];
         return true;
     }
     if (arg == "-ctk-first" || arg == "--cache-type-k-first") {


### PR DESCRIPTION

I meant to disable it a while ago and then forgot.

There is either a bug when the indexer cache is quantized, or it simply does not work because of insufficient precision. I haven't come around to investigate, so for now the implementation is left behind, but the command line argument to use quantized indexer cache is disabled.