### PR TITLE
Apply helper functions to the MTP graph

### DIFF
--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -1285,17 +1285,7 @@ ggml_cgraph * llm_build_context::build_deepseek2() {
             GGML_ABORT("MTP tail is only wired for GLM_DSA models with NextN layers enabled");
         }
 
-        ggml_tensor * hidden_states_from_main_model;
-
-        if (cparams.mtp_op_type == MTP_OP_WARMUP || cparams.mtp_op_type == MTP_OP_UPDATE_ACCEPTED) {
-            hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-        } else {
-            hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
-        }
-        ggml_set_name(hidden_states_from_main_model, "inp_mtp_states");
-        ggml_set_input(hidden_states_from_main_model);
-
-        lctx.inp_mtp_states = hidden_states_from_main_model;
+        ggml_tensor * hidden_states_from_main_model = build_inp_mtp_states(hparams.n_embd);
 
         const int il_mtp = hparams.n_layer - 1;
         const auto & mtp_layer = model.layers[il_mtp];
@@ -1452,17 +1442,11 @@ struct ggml_tensor * llm_build_context::build_deepseek2_mtp(
     }
     ggml_tensor * token_emb = build_inp_embd_mtp(mtp_embd_weights);
 
-    // Normalize and project
-    ggml_tensor * token_emb_norm = llm_build_norm(ctx0, token_emb, hparams, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, cb, il);
-    ggml_tensor * hidden_state_norm = llm_build_norm(ctx0, prev_embeddings, hparams, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, cb, il);
-
     if (mtp_layer.nextn.eh_proj == nullptr) {
         GGML_ABORT("GLM_DSA MTP requires nextn.eh_proj");
     }
 
-    ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
-    cb(combined, "mtp_concat", il);
-    ggml_tensor * cur = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, combined);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, nullptr);
 
     struct ggml_tensor * inpSA = cur;
 

--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -1446,7 +1446,7 @@ struct ggml_tensor * llm_build_context::build_deepseek2_mtp(
         GGML_ABORT("GLM_DSA MTP requires nextn.eh_proj");
     }
 
-    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, nullptr);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, nullptr);
 
     struct ggml_tensor * inpSA = cur;
 

--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -1276,7 +1276,17 @@ ggml_cgraph * llm_build_context::build_deepseek4() {
         const int il_mtp = n_layer - hparams.nextn_predict_layers;
         const auto & mtp_layer = model.layers[il_mtp];
 
-        inpL = build_mtp_input(mtp_layer, hidden_state, tok_embd, il_mtp, hc);
+        hidden_state = ggml_reshape_2d(ctx0, hidden_state, n_embd, hc * n_tokens);
+        tok_embd = ggml_reshape_3d(ctx0, tok_embd, n_embd, 1, n_tokens);
+        tok_embd = ggml_repeat_4d(ctx0, tok_embd, n_embd, hc, n_tokens, 1);
+        tok_embd = ggml_reshape_2d(ctx0, tok_embd, n_embd, hc * n_tokens);
+        inpL = build_mtp_input(mtp_layer, hidden_state, tok_embd, il_mtp);
+        GGML_ASSERT(inpL->ne[0] == n_embd);
+        GGML_ASSERT(inpL->ne[1] == hc * n_tokens);
+        GGML_ASSERT(inpL->ne[2] == 1);
+        GGML_ASSERT(inpL->ne[3] == 1);
+        inpL = ggml_reshape_3d(ctx0, inpL, n_embd, hc, n_tokens);
+        cb(inpL, "mtp_eh_proj", il_mtp);
     } else {
         ggml_tensor * inp = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
         inpL = ggml_reshape_3d(ctx0, inp, n_embd, 1, n_tokens);

--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -1270,36 +1270,13 @@ ggml_cgraph * llm_build_context::build_deepseek4() {
         GGML_ASSERT(n_layer > hparams.nextn_predict_layers);
 
         const int64_t n_hidden = n_embd * hc;
-        ggml_tensor * hidden_state = nullptr;
-        if (lctx.cparams.mtp_op_type == MTP_OP_WARMUP || lctx.cparams.mtp_op_type == MTP_OP_UPDATE_ACCEPTED) {
-            hidden_state = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_hidden, n_tokens);
-        } else {
-            hidden_state = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, n_hidden);
-        }
-        ggml_set_name(hidden_state, "inp_mtp_states");
-        ggml_set_input(hidden_state);
-        lctx.inp_mtp_states = hidden_state;
+        ggml_tensor * hidden_state = build_inp_mtp_states(n_hidden);
 
         ggml_tensor * tok_embd = build_inp_embd_mtp(model.tok_embd);
         const int il_mtp = n_layer - hparams.nextn_predict_layers;
         const auto & mtp_layer = model.layers[il_mtp];
 
-        ggml_tensor * h_state = ggml_reshape_3d(ctx0, hidden_state, n_embd, hc, n_tokens);
-        cb(h_state, "mtp_h_state", il_mtp);
-        ggml_tensor * h_norm = llm_build_norm(ctx0, h_state, hparams, mtp_layer.nextn.hnorm,
-                nullptr, LLM_NORM_RMS, cb, il_mtp);
-        cb(h_norm, "mtp_hnorm", il_mtp);
-
-        ggml_tensor * e_norm = llm_build_norm(ctx0, tok_embd, hparams, mtp_layer.nextn.enorm,
-                nullptr, LLM_NORM_RMS, cb, il_mtp);
-        e_norm = ggml_reshape_3d(ctx0, e_norm, n_embd, 1, n_tokens);
-        e_norm = ggml_repeat_4d(ctx0, e_norm, n_embd, hc, n_tokens, 1);
-        cb(e_norm, "mtp_enorm", il_mtp);
-
-        ggml_tensor * concat = ggml_concat(ctx0, e_norm, h_norm, 0);
-        cb(concat, "mtp_concat", il_mtp);
-        inpL = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, concat);
-        cb(inpL, "mtp_eh_proj", il_mtp);
+        inpL = build_mtp_input(mtp_layer, hidden_state, tok_embd, il_mtp, hc);
     } else {
         ggml_tensor * inp = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
         inpL = ggml_reshape_3d(ctx0, inp, n_embd, 1, n_tokens);

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -541,10 +541,7 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
 
     GGML_ASSERT(n_backbone > 0);
 
-    ggml_tensor * hidden_state = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_backbone, n_tokens);
-    ggml_set_name(hidden_state, "inp_mtp_states");
-    ggml_set_input(hidden_state);
-    lctx.inp_mtp_states = hidden_state;
+    ggml_tensor * hidden_state = build_inp_mtp_states(n_backbone);
 
     if (!has_target_ctx || !batch.token) {
         ggml_tensor * cur = ggml_view_2d(ctx0, hidden_state, n_embd, n_tokens,

--- a/src/graphs/build_glm4.cpp
+++ b/src/graphs/build_glm4.cpp
@@ -18,17 +18,7 @@ ggml_cgraph * llm_build_context::build_glm4_moe() {
             ext_factor, attn_factor, beta_fast, beta_slow) : nullptr;
 
     if (cparams.mtp_op_type != MTP_OP_NONE) {
-        ggml_tensor* hidden_states_from_main_model;
-
-        if (cparams.mtp_op_type == MTP_OP_WARMUP || cparams.mtp_op_type == MTP_OP_UPDATE_ACCEPTED) {
-            hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-        } else {
-            hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
-        }
-        ggml_set_name(hidden_states_from_main_model, "inp_mtp_states");
-        ggml_set_input(hidden_states_from_main_model);
-
-        lctx.inp_mtp_states = hidden_states_from_main_model;
+        ggml_tensor * hidden_states_from_main_model = build_inp_mtp_states(hparams.n_embd);
 
         const int il_mtp = hparams.n_layer - 1;
         const auto & mtp_layer = model.layers[il_mtp];
@@ -307,12 +297,7 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
     }
     ggml_tensor * token_emb = build_inp_embd_mtp(mtp_embd_weights);
 
-    ggml_tensor * token_emb_norm = llm_build_norm(ctx0, token_emb, hparams, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, cb, il);
-    ggml_tensor * hidden_state_norm = llm_build_norm(ctx0, prev_embeddings, hparams, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, cb, il);
-
-    ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
-    cb(combined, "mtp_concat", il);
-    ggml_tensor* cur = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, combined);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, nullptr);
 
     // Self-Attention
     const float kq_scale = 1.0f / sqrtf(float(n_embd_head));

--- a/src/graphs/build_glm4.cpp
+++ b/src/graphs/build_glm4.cpp
@@ -297,7 +297,7 @@ struct ggml_tensor * llm_build_context::build_glm4_moe_mtp(
     }
     ggml_tensor * token_emb = build_inp_embd_mtp(mtp_embd_weights);
 
-    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, nullptr);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, nullptr);
 
     // Self-Attention
     const float kq_scale = 1.0f / sqrtf(float(n_embd_head));

--- a/src/graphs/build_openpangu.cpp
+++ b/src/graphs/build_openpangu.cpp
@@ -922,7 +922,7 @@ ggml_tensor * llm_build_context::build_openpangu_mtp(
     ggml_tensor * token_emb = ggml_get_rows(ctx0, mtp_embd_weights, inp_tokens);
     cb(token_emb, "inp_embd", il);
 
-    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, nullptr);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, nullptr);
     cb(cur, "mtp_eh_proj", il);
 
     // --- attention sublayer (plain residual) ---

--- a/src/graphs/build_openpangu.cpp
+++ b/src/graphs/build_openpangu.cpp
@@ -922,12 +922,7 @@ ggml_tensor * llm_build_context::build_openpangu_mtp(
     ggml_tensor * token_emb = ggml_get_rows(ctx0, mtp_embd_weights, inp_tokens);
     cb(token_emb, "inp_embd", il);
 
-    ggml_tensor * emb_norm = llm_build_norm(ctx0, token_emb,       hparams, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, cb, il);
-    ggml_tensor * hid_norm = llm_build_norm(ctx0, prev_embeddings, hparams, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, cb, il);
-
-    // reference order: cat([inputs_embeds, previous_hidden_states], -1)
-    ggml_tensor * combined = ggml_concat(ctx0, emb_norm, hid_norm, 0);
-    ggml_tensor * cur = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, combined);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, nullptr);
     cb(cur, "mtp_eh_proj", il);
 
     // --- attention sublayer (plain residual) ---
@@ -1022,15 +1017,7 @@ ggml_cgraph * llm_build_context::build_openpangu() {
                     "OpenPangu MTP graph requested without NextN layers loaded");
         GGML_ASSERT(batch.token && "openPangu MTP graphs decode token batches");
 
-        ggml_tensor * hidden_states_from_main_model;
-        if (cparams.mtp_op_type == MTP_OP_WARMUP || cparams.mtp_op_type == MTP_OP_UPDATE_ACCEPTED) {
-            hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-        } else {
-            hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
-        }
-        ggml_set_name(hidden_states_from_main_model, "inp_mtp_states");
-        ggml_set_input(hidden_states_from_main_model);
-        lctx.inp_mtp_states = hidden_states_from_main_model;
+        ggml_tensor * hidden_states_from_main_model = build_inp_mtp_states(hparams.n_embd);
 
         // shared batch inputs, created exactly once per graph (see build_openpangu_mtp)
         ggml_tensor * inp_pos = build_inp_pos();

--- a/src/graphs/build_qwen35.cpp
+++ b/src/graphs/build_qwen35.cpp
@@ -15,15 +15,7 @@ ggml_cgraph * llm_build_context::build_qwen35moe() {
     ggml_tensor * cur = nullptr;
 
     if (cparams.mtp_op_type != MTP_OP_NONE) {
-        ggml_tensor * hidden_states_from_main_model;
-        if (cparams.mtp_op_type == MTP_OP_WARMUP || cparams.mtp_op_type == MTP_OP_UPDATE_ACCEPTED) {
-            hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-        } else {
-            hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
-        }
-        ggml_set_name(hidden_states_from_main_model, "inp_mtp_states");
-        ggml_set_input(hidden_states_from_main_model);
-        lctx.inp_mtp_states = hidden_states_from_main_model;
+        ggml_tensor * hidden_states_from_main_model = build_inp_mtp_states(hparams.n_embd);
 
         const int il_mtp = hparams.n_layer - 1;
         const auto & mtp_layer = model.layers[il_mtp];
@@ -99,15 +91,7 @@ ggml_cgraph * llm_build_context::build_qwen35() {
 
     if (cparams.mtp_op_type != MTP_OP_NONE) {
         // MTP tail-only graph
-        ggml_tensor * hidden_states_from_main_model;
-        if (cparams.mtp_op_type == MTP_OP_WARMUP || cparams.mtp_op_type == MTP_OP_UPDATE_ACCEPTED) {
-            hidden_states_from_main_model = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
-        } else {
-            hidden_states_from_main_model = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_embd);
-        }
-        ggml_set_name(hidden_states_from_main_model, "inp_mtp_states");
-        ggml_set_input(hidden_states_from_main_model);
-        lctx.inp_mtp_states = hidden_states_from_main_model;
+        ggml_tensor * hidden_states_from_main_model = build_inp_mtp_states(hparams.n_embd);
 
         const int il_mtp = hparams.n_layer - 1;
         const auto & mtp_layer = model.layers[il_mtp];
@@ -182,18 +166,7 @@ struct ggml_tensor * llm_build_context::build_qwen35moe_mtp(
 
     ggml_tensor * token_emb = build_inp_embd_mtp(model.tok_embd);
 
-    ggml_tensor * token_emb_norm = llm_build_norm(ctx0, token_emb, hparams, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, cb, il);
-    ggml_tensor * hidden_state_norm = llm_build_norm(ctx0, prev_embeddings, hparams, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, cb, il);
-
-    ggml_tensor * cur;
-    if (mtp_layer.nextn.eh_proj != nullptr) {
-        ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
-        cb(combined, "mtp_concat", il);
-        cur = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, combined);
-    } else {
-        cur = ggml_add(ctx0, token_emb_norm, hidden_state_norm);
-    }
-    cb(cur, "mtp_fused", il);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, "mtp_fused");
 
     GGML_ASSERT(il < (int)kv_self.k_l.size() && il < (int)kv_self.v_l.size());
     if (!kv_self.k_l[il] || !kv_self.v_l[il]) {
@@ -259,20 +232,7 @@ struct ggml_tensor * llm_build_context::build_qwen35_mtp(
 
     ggml_tensor * token_emb = build_inp_embd_mtp(model.tok_embd);
 
-    ggml_tensor * token_emb_norm = llm_build_norm(ctx0, token_emb, hparams, mtp_layer.nextn.enorm, NULL, LLM_NORM_RMS, cb, il);
-    ggml_tensor * hidden_state_norm = llm_build_norm(ctx0, prev_embeddings, hparams, mtp_layer.nextn.hnorm, NULL, LLM_NORM_RMS, cb, il);
-
-    ggml_tensor * cur;
-    if (mtp_layer.nextn.eh_proj != nullptr) {
-        // Full fusion: concat + project (27B, 4B, 2B, 0.8B)
-        ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
-        cb(combined, "mtp_concat", il);
-        cur = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, combined);
-    } else {
-        // 9B — no fc/eh_proj
-        cur = ggml_add(ctx0, token_emb_norm, hidden_state_norm);
-    }
-    cb(cur, "mtp_fused", il);
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, "mtp_fused");
 
     // Self-Attention (wq may be shared from main model's last layer)
     GGML_ASSERT(il < (int)kv_self.k_l.size() && il < (int)kv_self.v_l.size());

--- a/src/graphs/build_qwen35.cpp
+++ b/src/graphs/build_qwen35.cpp
@@ -166,7 +166,7 @@ struct ggml_tensor * llm_build_context::build_qwen35moe_mtp(
 
     ggml_tensor * token_emb = build_inp_embd_mtp(model.tok_embd);
 
-    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, "mtp_fused");
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, "mtp_fused");
 
     GGML_ASSERT(il < (int)kv_self.k_l.size() && il < (int)kv_self.v_l.size());
     if (!kv_self.k_l[il] || !kv_self.v_l[il]) {
@@ -232,7 +232,7 @@ struct ggml_tensor * llm_build_context::build_qwen35_mtp(
 
     ggml_tensor * token_emb = build_inp_embd_mtp(model.tok_embd);
 
-    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, 1, "mtp_fused");
+    ggml_tensor * cur = build_mtp_input(mtp_layer, prev_embeddings, token_emb, il, "mtp_fused");
 
     // Self-Attention (wq may be shared from main model's last layer)
     GGML_ASSERT(il < (int)kv_self.k_l.size() && il < (int)kv_self.v_l.size());

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -467,6 +467,49 @@ struct ggml_tensor * llm_build_context::build_inp_embd_mtp(struct ggml_tensor * 
     return cur;
 }
 
+struct ggml_tensor * llm_build_context::build_inp_mtp_states(int64_t n_hidden) {
+    struct ggml_tensor * hidden_state = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_hidden, n_tokens);
+    cb(hidden_state, "inp_mtp_states", -1);
+    ggml_set_input(hidden_state);
+    lctx.inp_mtp_states = hidden_state;
+    return hidden_state;
+}
+
+struct ggml_tensor * llm_build_context::build_mtp_input(
+        const struct llama_layer & mtp_layer,
+        struct ggml_tensor * hidden_state,
+        struct ggml_tensor * token_embd,
+        int il,
+        int64_t n_streams,
+        const char * output_name) {
+    if (n_streams > 1) {
+        hidden_state = ggml_reshape_3d(ctx0, hidden_state, n_embd, n_streams, n_tokens);
+    }
+
+    struct ggml_tensor * hidden_state_norm = llm_build_norm(ctx0, hidden_state, hparams,
+            mtp_layer.nextn.hnorm, nullptr, LLM_NORM_RMS, cb, il);
+    struct ggml_tensor * token_emb_norm = llm_build_norm(ctx0, token_embd, hparams,
+            mtp_layer.nextn.enorm, nullptr, LLM_NORM_RMS, cb, il);
+
+    if (n_streams > 1) {
+        token_emb_norm = ggml_reshape_3d(ctx0, token_emb_norm, n_embd, 1, n_tokens);
+        token_emb_norm = ggml_repeat_4d(ctx0, token_emb_norm, n_embd, n_streams, n_tokens, 1);
+    }
+
+    struct ggml_tensor * result;
+    if (mtp_layer.nextn.eh_proj != nullptr) {
+        struct ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);
+        cb(combined, "mtp_concat", il);
+        result = llm_build_lora_mm(lctx, ctx0, mtp_layer.nextn.eh_proj, combined);
+    } else {
+        result = ggml_add(ctx0, token_emb_norm, hidden_state_norm);
+    }
+    if (output_name != nullptr) {
+        cb(result, output_name, il);
+    }
+    return result;
+}
+
 ggml_tensor * llm_build_context::build_inp_pos() {
     int n_pos_per_embd = hparams.rope_type == LLAMA_ROPE_TYPE_MROPE || hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE ? 4 : 1;
     lctx.inp_pos = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, int64_t(n_tokens)*n_pos_per_embd);

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -480,22 +480,14 @@ struct ggml_tensor * llm_build_context::build_mtp_input(
         struct ggml_tensor * hidden_state,
         struct ggml_tensor * token_embd,
         int il,
-        int64_t n_streams,
-        const char * output_name) {
-    if (n_streams > 1) {
-        hidden_state = ggml_reshape_3d(ctx0, hidden_state, n_embd, n_streams, n_tokens);
-    }
+    const char * output_name) {
+    GGML_ASSERT(hidden_state->ne[0] == n_embd);
+    GGML_ASSERT(ggml_are_same_shape(hidden_state, token_embd));
 
     struct ggml_tensor * hidden_state_norm = llm_build_norm(ctx0, hidden_state, hparams,
             mtp_layer.nextn.hnorm, nullptr, LLM_NORM_RMS, cb, il);
     struct ggml_tensor * token_emb_norm = llm_build_norm(ctx0, token_embd, hparams,
             mtp_layer.nextn.enorm, nullptr, LLM_NORM_RMS, cb, il);
-
-    if (n_streams > 1) {
-        token_emb_norm = ggml_reshape_3d(ctx0, token_emb_norm, n_embd, 1, n_tokens);
-        token_emb_norm = ggml_repeat_4d(ctx0, token_emb_norm, n_embd, n_streams, n_tokens, 1);
-    }
-
     struct ggml_tensor * result;
     if (mtp_layer.nextn.eh_proj != nullptr) {
         struct ggml_tensor * combined = ggml_concat(ctx0, token_emb_norm, hidden_state_norm, 0);

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -129,6 +129,16 @@ struct llm_build_context {
 
     struct ggml_tensor * build_inp_embd_mtp(struct ggml_tensor * mtp_tok_embd);
 
+    struct ggml_tensor * build_inp_mtp_states(int64_t n_hidden);
+
+    struct ggml_tensor * build_mtp_input(
+            const struct llama_layer & mtp_layer,
+            struct ggml_tensor * hidden_state,
+            struct ggml_tensor * token_embd,
+            int il,
+            int64_t n_streams = 1,
+            const char * output_name = "mtp_eh_proj");
+
     ggml_tensor * build_inp_pos();
 
     ggml_tensor * build_input_scale(int n_tokens);

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -136,7 +136,6 @@ struct llm_build_context {
             struct ggml_tensor * hidden_state,
             struct ggml_tensor * token_embd,
             int il,
-            int64_t n_streams = 1,
             const char * output_name = "mtp_eh_proj");
 
     ggml_tensor * build_inp_pos();


### PR DESCRIPTION
Moved some repetitive methods from the MTP graph to helper functions following the review in PR #2216.

To validate this, I ran smoke tests and benchmarks using llama-spec-bench.

## Test configuration

- Tasks: built-in code, extraction, and story prompts
- Generation: 2000 tokens, `n_max=3`, `p_min=0.0`
- Sampling: seed 42, temperature 0, Jinja enabled
- Runtime: Flash Attention (except OpenPangu), `GGML_CUDA_NO_PINNED=1`, 24 threads, 48 batch threads
- Standard repetitions: 11 per task/build, with one warm-up and ten measured runs
- DSV4 repetitions: 6 per task/build, with one warm-up and five measured runs

The only one I didn’t test was GLM 4 because I no longer had the model on disk.

## Throughput and acceptance

| Model | Prompt | Runs/build | Parent decode | PR decode | Change | Acceptance |
|---|---|---:|---:|---:|---:|---:|
| Qwen3.6 27B | Code | 11 | 65.383 | 63.507 | -2.87% | 510/624 (81.73%) |
| Qwen3.6 27B | Extraction | 11 | 62.113 | 61.633 | -0.77% | 1404/1780 (78.88%) |
| Qwen3.6 27B | Story | 11 | 51.866 | 51.316 | -1.06% | 1286/2133 (60.29%) |
| Gemma4 26B-A4B | Code | 11 | 121.281 | 119.616 | -1.37% | 770/1002 (76.85%) |
| Gemma4 26B-A4B | Extraction | 11 | 120.429 | 119.557 | -0.72% | 1207/1557 (77.52%) |
| Gemma4 26B-A4B | Story | 11 | 87.028 | 87.739 | +0.82% | 1126/2406 (46.80%) |
| OpenPangu | Code | 11 | 8.093 | 7.913 | -2.23% | 447/633 (70.62%) |
| OpenPangu | Extraction | 11 | 9.354 | 9.249 | -1.12% | 1414/1749 (80.85%) |
| OpenPangu | Story | 11 | 6.304 | 6.171 | -2.10% | 1249/2244 (55.66%) |
| DSV4 Flash | Code | 6 | 14.114 | 13.799 | -2.23% | 198/318 (62.26%) |
| DSV4 Flash | Extraction | 6 | 13.946 | 14.503 | +3.99% | 282/447 (63.09%) |
| DSV4 Flash | Story | 6 | 11.232 | 11.293 | +0.54% | 459/1016 (45.18%) |

I used a difference greater than 2% as the regression criterion, especially since the machine was in use, two models reached this threshold, so I reversed the order of each branch to run the benchmark again:

- Qwen3.6: The refactor branch remained 0.45%, 0.10%, and 0.79% slower for code, extraction, and story respectively.
- OpenPangu: reduced refactor-first control for code and story, four measured runs per task. The refactor remained 0.27% to 0.74% slower.

Regarding DSV4, I ran tests with fewer repetitions due to the total time required to complete them. This pattern repeated when I re-ran the Openpangu benchmark. Some models initially showed regression, but after performing double validation with new benchmarks, I was able to confirm that there was no regression beyond what I considered to be noise. As for GLM 5.1, I ran smoke tests.