### PR TITLE
deepseek4: add --dsv4-cache-cpu to keep compressed-attention K caches in host memory

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2209,6 +2209,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.k_cache_hadamard = true;
         return true;
     }
+    if (arg == "-dsv4cc" || arg == "--dsv4-cache-cpu") {
+        params.dsv4_cache_cpu = true;
+        return true;
+    }
     if (arg == "-vhad" || arg == "--v-cache-hadamard") {
         params.v_cache_hadamard = true;
         return true;
@@ -3065,6 +3069,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",         "-mqkv,  --merge-qkv",            "merge Q,K,V (default: %d)", params.merge_qkv});
     options.push_back({ "*",         "-muge,  --merge-up-gate-experts","merge ffn_up/gate_exps (default: %d)", params.merge_up_gate_exps});
     options.push_back({ "*",         "-khad,  --k-cache-hadamard",     "Use Hadamard transform for K-cache (default: %d)", params.k_cache_hadamard});
+    options.push_back({ "*",         "-dsv4cc, --dsv4-cache-cpu",      "Keep DeepSeek-V4 compressed-attention K caches in host memory (default: %d)", params.dsv4_cache_cpu});
     options.push_back({ "*",         "-vhad,  --v-cache-hadamard",     "Use Hadamard transform for V-cache (default: %d)", params.v_cache_hadamard});
     options.push_back({ "*",         "-smf16, --split-mode-f16",       "Use f16 for data exchange between GPUs (default: %d)", true});
     options.push_back({ "*",         "-smf32, --split-mode-f32",       "Use f32 for data exchange between GPUs (default: %d)", false});
@@ -4331,6 +4336,7 @@ struct llama_context_params common_context_params_to_llama(const gpt_params & pa
     cparams.fused_idx_topk    = params.fused_idx_topk;
     cparams.dsa_top_k         = params.dsa_top_k;
     cparams.k_cache_hadamard  = params.k_cache_hadamard;
+    cparams.dsv4_cache_cpu    = params.dsv4_cache_cpu;
     cparams.v_cache_hadamard  = params.v_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
     //cparams.split_mode_f16    = params.split_mode_f16;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2213,6 +2213,10 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.dsv4_cache_cpu = true;
         return true;
     }
+    if (arg == "-dsv4lcc" || arg == "--dsv4-lid-cache-cpu") {
+        params.dsv4_lid_cache_cpu = true;
+        return true;
+    }
     if (arg == "-vhad" || arg == "--v-cache-hadamard") {
         params.v_cache_hadamard = true;
         return true;
@@ -3069,7 +3073,8 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "*",         "-mqkv,  --merge-qkv",            "merge Q,K,V (default: %d)", params.merge_qkv});
     options.push_back({ "*",         "-muge,  --merge-up-gate-experts","merge ffn_up/gate_exps (default: %d)", params.merge_up_gate_exps});
     options.push_back({ "*",         "-khad,  --k-cache-hadamard",     "Use Hadamard transform for K-cache (default: %d)", params.k_cache_hadamard});
-    options.push_back({ "*",         "-dsv4cc, --dsv4-cache-cpu",      "Keep DeepSeek-V4 compressed-attention K caches in host memory (default: %d)", params.dsv4_cache_cpu});
+    options.push_back({ "*",         "-dsv4cc, --dsv4-cache-cpu",      "Keep DeepSeek-V4 compressed-attention K caches (CSA/HCA) in host memory (default: %d)", params.dsv4_cache_cpu});
+    options.push_back({ "*",         "-dsv4lcc, --dsv4-lid-cache-cpu", "Also keep the DeepSeek-V4 indexer (LID) K cache in host memory (default: %d)", params.dsv4_lid_cache_cpu});
     options.push_back({ "*",         "-vhad,  --v-cache-hadamard",     "Use Hadamard transform for V-cache (default: %d)", params.v_cache_hadamard});
     options.push_back({ "*",         "-smf16, --split-mode-f16",       "Use f16 for data exchange between GPUs (default: %d)", true});
     options.push_back({ "*",         "-smf32, --split-mode-f32",       "Use f32 for data exchange between GPUs (default: %d)", false});
@@ -4337,6 +4342,7 @@ struct llama_context_params common_context_params_to_llama(const gpt_params & pa
     cparams.dsa_top_k         = params.dsa_top_k;
     cparams.k_cache_hadamard  = params.k_cache_hadamard;
     cparams.dsv4_cache_cpu    = params.dsv4_cache_cpu;
+    cparams.dsv4_lid_cache_cpu = params.dsv4_lid_cache_cpu;
     cparams.v_cache_hadamard  = params.v_cache_hadamard;
     cparams.split_mode_graph_scheduling = params.split_mode_graph_scheduling;
     //cparams.split_mode_f16    = params.split_mode_f16;

--- a/common/common.h
+++ b/common/common.h
@@ -450,6 +450,7 @@ struct gpt_params {
     int  prefetch_experts_threads = 0; // number of expert prefetch workers (<=0 = auto)
     bool k_cache_hadamard  = false; // if true, use Hadamard transform for the K-cache (only makes sense with quantized cache)
     bool v_cache_hadamard  = false; // if true, use Hadamard transform for the V-cache (only makes sense with quantized cache, which requires FA)
+    bool dsv4_cache_cpu    = false; // if true, keep DeepSeek-V4 compressed-attention K caches in host memory
     bool split_mode_graph_scheduling = false; // if true, force split mode graph scheduling
     //bool split_mode_f16    = true;  // if true, intermediate results will be cast to f16 before copying to other GPUs to perform reduce ops
     bool scheduler_async   = false; // if true, in split mode graph the scheduler will use multiple threads to evaluate the graph

--- a/common/common.h
+++ b/common/common.h
@@ -450,7 +450,8 @@ struct gpt_params {
     int  prefetch_experts_threads = 0; // number of expert prefetch workers (<=0 = auto)
     bool k_cache_hadamard  = false; // if true, use Hadamard transform for the K-cache (only makes sense with quantized cache)
     bool v_cache_hadamard  = false; // if true, use Hadamard transform for the V-cache (only makes sense with quantized cache, which requires FA)
-    bool dsv4_cache_cpu    = false; // if true, keep DeepSeek-V4 compressed-attention K caches in host memory
+    bool dsv4_cache_cpu    = false; // if true, keep DeepSeek-V4 compressed-attention K caches (CSA/HCA) in host memory
+    bool dsv4_lid_cache_cpu= false; // if true, also keep the DeepSeek-V4 indexer (LID) K cache in host memory
     bool split_mode_graph_scheduling = false; // if true, force split mode graph scheduling
     //bool split_mode_f16    = true;  // if true, intermediate results will be cast to f16 before copying to other GPUs to perform reduce ops
     bool scheduler_async   = false; // if true, in split mode graph the scheduler will use multiple threads to evaluate the graph

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3487,7 +3487,10 @@ void server_context::context_shift() {
 }
 
 void server_context::add_sampled_tokens() {
-    const bool uniform_seq_batch = llama_model_requires_uniform_seq_batch(model);
+    // DeepSeek-V4 processes each batch as a rectangular [n_seqs, n_tokens_per_seq]
+    // grid (stream-structured KV/side-state caches), so every sequence in a batch
+    // must contribute the same number of tokens.
+    const bool uniform_seq_batch = llama_model_is_deepseek4(model);
     for (auto& slot : slots) {
         slot.released = false;
         if (slot.state == SLOT_STATE_IDLE) {
@@ -3806,7 +3809,8 @@ bool server_context::create_checkpoint(server_slot & slot) {
 
 void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t n_batch,  int32_t & batch_type) {
     if (params_base.cont_batching || batch.n_tokens == 0) {
-        const bool uniform_seq_batch = llama_model_requires_uniform_seq_batch(model);
+        // DeepSeek-V4 requires uniform batches (see add_sampled_tokens).
+        const bool uniform_seq_batch = llama_model_is_deepseek4(model);
         for (auto& slot : slots) {
             slot.prompt_batch_i0 = -1;
             slot.prompt_batch_i1 = -1;

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3487,10 +3487,28 @@ void server_context::context_shift() {
 }
 
 void server_context::add_sampled_tokens() {
+    const bool uniform_seq_batch = llama_model_requires_uniform_seq_batch(model);
     for (auto& slot : slots) {
         slot.released = false;
         if (slot.state == SLOT_STATE_IDLE) {
             continue;
+        }
+        if (uniform_seq_batch) {
+            // Models requiring uniform batches (e.g. DeepSeek-V4) cannot mix
+            // decode tokens (1 per slot) with prompt chunks from other slots
+            // in the same batch. Defer decode tokens while any slot still has
+            // a pending prompt; batch_pending_prompt will process it (one
+            // slot per batch) and decode resumes once prompts are done.
+            bool prompt_pending = false;
+            for (auto& other : slots) {
+                if (other.state == SLOT_STATE_IDLE && other.command == SLOT_COMMAND_LOAD_PROMPT) {
+                    prompt_pending = true;
+                    break;
+                }
+            }
+            if (prompt_pending) {
+                return;
+            }
         }
         slot.spec_target_only = false;
 
@@ -3788,9 +3806,18 @@ bool server_context::create_checkpoint(server_slot & slot) {
 
 void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t n_batch,  int32_t & batch_type) {
     if (params_base.cont_batching || batch.n_tokens == 0) {
+        const bool uniform_seq_batch = llama_model_requires_uniform_seq_batch(model);
         for (auto& slot : slots) {
             slot.prompt_batch_i0 = -1;
             slot.prompt_batch_i1 = -1;
+
+            if (uniform_seq_batch && batch.n_tokens > 0) {
+                // Models requiring uniform batches (e.g. DeepSeek-V4): process
+                // at most one slot's prompt chunk per batch, keeping every
+                // batch uniform across sequences. Remaining pending prompts
+                // are handled on the next iterations.
+                continue;
+            }
 
             // this slot still has a prompt to be processed
             if (slot.state == SLOT_STATE_IDLE && slot.command == SLOT_COMMAND_LOAD_PROMPT) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -494,6 +494,7 @@ extern "C" {
         bool graph_reuse;       // whether to reuse graphs when possible [EXPERIMENTAL]
         bool dsa;               // enable GLM DSA sparse attention (off by default) [EXPERIMENTAL]
         bool fused_idx_topk;    // enable the fused indexer topk op (off by default) [EXPERIMENTAL]
+        bool dsv4_cache_cpu;    // keep the DeepSeek-V4 compressed-attention K caches (CSA/HCA/LID) in host memory [EXPERIMENTAL]
         int  dsa_top_k;         // DSA top-k override (<0 => model's configured indexer_top_k) [EXPERIMENTAL]
         int  min_experts;
         float thresh_experts;

--- a/include/llama.h
+++ b/include/llama.h
@@ -722,13 +722,6 @@ extern "C" {
     // (e.g. openPangu keeps only the current recurrent conv state).
     LLAMA_API bool llama_model_supports_partial_kv_reuse(const struct llama_model * model);
 
-    // Returns true for models that process each decode batch as a rectangular
-    // [n_seqs, n_tokens_per_seq] grid, i.e. every sequence in a batch must
-    // contribute the same number of tokens (e.g. DeepSeek-V4 with its
-    // stream-structured KV/side-state caches). Callers building batches for
-    // such models should keep batches uniform across sequences.
-    LLAMA_API bool llama_model_requires_uniform_seq_batch(const struct llama_model * model);
-
     LLAMA_API const char * llama_model_arch_string(const struct llama_model * model);
 
     // Returns 0 on success

--- a/include/llama.h
+++ b/include/llama.h
@@ -494,7 +494,8 @@ extern "C" {
         bool graph_reuse;       // whether to reuse graphs when possible [EXPERIMENTAL]
         bool dsa;               // enable GLM DSA sparse attention (off by default) [EXPERIMENTAL]
         bool fused_idx_topk;    // enable the fused indexer topk op (off by default) [EXPERIMENTAL]
-        bool dsv4_cache_cpu;    // keep the DeepSeek-V4 compressed-attention K caches (CSA/HCA/LID) in host memory [EXPERIMENTAL]
+        bool dsv4_cache_cpu;    // keep the DeepSeek-V4 compressed-attention K caches (CSA/HCA) in host memory [EXPERIMENTAL]
+        bool dsv4_lid_cache_cpu; // also keep the DeepSeek-V4 indexer (LID) K cache in host memory [EXPERIMENTAL]
         int  dsa_top_k;         // DSA top-k override (<0 => model's configured indexer_top_k) [EXPERIMENTAL]
         int  min_experts;
         float thresh_experts;

--- a/include/llama.h
+++ b/include/llama.h
@@ -722,6 +722,13 @@ extern "C" {
     // (e.g. openPangu keeps only the current recurrent conv state).
     LLAMA_API bool llama_model_supports_partial_kv_reuse(const struct llama_model * model);
 
+    // Returns true for models that process each decode batch as a rectangular
+    // [n_seqs, n_tokens_per_seq] grid, i.e. every sequence in a batch must
+    // contribute the same number of tokens (e.g. DeepSeek-V4 with its
+    // stream-structured KV/side-state caches). Callers building batches for
+    // such models should keep batches uniform across sequences.
+    LLAMA_API bool llama_model_requires_uniform_seq_batch(const struct llama_model * model);
+
     LLAMA_API const char * llama_model_arch_string(const struct llama_model * model);
 
     // Returns 0 on success

--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -44,6 +44,29 @@ static ggml_tensor * dsv4_concat_named(
     return r;
 }
 
+// Concat along dim 2 (the KV dimension), multi-stream aware: with ne[3] > 1
+// the CUDA backend's type-generic concat fast paths require ne[3] == 1 and the
+// general path is F32-only, so concat per stream (dim 2) and re-assemble (dim 3).
+static ggml_tensor * dsv4_concat_kv(
+        ggml_context * ctx,
+        ggml_tensor  * a,
+        ggml_tensor  * b) {
+    if (a->ne[3] <= 1) {
+        return ggml_concat(ctx, a, b, 2);
+    }
+    GGML_ASSERT(a->ne[3] == b->ne[3]);
+    ggml_tensor * result = nullptr;
+    for (int64_t s = 0; s < a->ne[3]; ++s) {
+        ggml_tensor * a_s = ggml_view_4d(ctx, a, a->ne[0], a->ne[1], a->ne[2], 1,
+                a->nb[1], a->nb[2], a->nb[3], s*a->nb[3]);
+        ggml_tensor * b_s = ggml_view_4d(ctx, b, b->ne[0], b->ne[1], b->ne[2], 1,
+                b->nb[1], b->nb[2], b->nb[3], s*b->nb[3]);
+        ggml_tensor * c_s = dsv4_concat_named(ctx, a_s, b_s, 2, "dsv4_concat_kv_s");
+        result = result == nullptr ? c_s : dsv4_concat_named(ctx, result, c_s, 3, "dsv4_concat_kv");
+    }
+    return result;
+}
+
 static ggml_tensor * dsv4_hc_affine(
         ggml_context * ctx,
         ggml_tensor  * x,
@@ -1170,7 +1193,7 @@ static ggml_tensor * ds4_attention(ggml_cgraph * gf, ggml_context * ctx0, llm_bu
         if (raw_k->type != extra_k->type) {
             extra_k = ggml_cast(ctx0, extra_k, raw_k->type);
         }
-        ggml_tensor * k_all = ggml_concat(ctx0, raw_k, extra_k, 2);
+        ggml_tensor * k_all = dsv4_concat_kv(ctx0, raw_k, extra_k);
         ggml_tensor * kq_mask = ggml_concat(ctx0, raw_mask, extra_mask, 0);
         cb(extra_k, (tag + "_k").c_str(), il);
         cb(k_all, (tag + "_k_all").c_str(), il);

--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -241,6 +241,24 @@ static ggml_tensor * dsv4_pad_mask_tokens(
         return mask;
     }
 
+    if (n_stream > 1) {
+        // Pad each stream separately and re-assemble along dim 3. This keeps
+        // every concat on the contiguous fast paths supported by the CUDA
+        // backend for any tensor type (dim 1 with ne[2]*ne[3] == 1, and dim 3),
+        // whereas a single multi-stream concat along dim 1 falls back to the
+        // F32-only general path and fails for f16 flash-attention masks.
+        ggml_tensor * result = nullptr;
+        for (int64_t s = 0; s < n_stream; ++s) {
+            ggml_tensor * mask_s = ggml_view_4d(ctx, mask, mask->ne[0], mask->ne[1], 1, 1,
+                    mask->nb[1], mask->nb[2], mask->nb[3], s*mask->nb[3]);
+            ggml_tensor * pad_s = ggml_new_tensor_4d(ctx, mask->type, mask->ne[0], n_tokens_pad - mask->ne[1], 1, 1);
+            pad_s = ggml_fill(ctx, pad_s, -INFINITY);
+            ggml_tensor * padded_s = dsv4_concat_named(ctx, mask_s, pad_s, 1, "dsv4_mask_tokens_pad_s");
+            result = result == nullptr ? padded_s : dsv4_concat_named(ctx, result, padded_s, 3, "dsv4_mask_tokens_pad");
+        }
+        return result;
+    }
+
     ggml_tensor * pad = ggml_new_tensor_4d(ctx, mask->type, mask->ne[0], n_tokens_pad - mask->ne[1], mask->ne[2], mask->ne[3]);
     pad = ggml_fill(ctx, pad, -INFINITY);
     auto new_mask = dsv4_concat_named(ctx, mask, pad, 1, "dsv4_mask_tokens_pad");
@@ -502,7 +520,12 @@ static ggml_tensor * dsv4_build_attn(
     const bool v_trans = v->nb[1] > v->nb[2];
     const int64_t n_stream = k->ne[3];
 
-    if (!cparams.flash_attn && n_stream > 1) {
+    // Multi-stream (parallel sequences) is handled by slicing per stream and
+    // processing each stream independently. This applies to the flash attention
+    // path as well: the DSV4 cache/controller is non-unified, so a multi-stream
+    // mask (ne[3] == n_stream) cannot be routed through ggml_flash_attn_ext,
+    // which requires mask->ne[3] == 1.
+    if (n_stream > 1) {
         GGML_ASSERT(q->ne[2] % n_stream == 0);
         const int64_t n_tokens_stream = q->ne[2]/n_stream;
         ggml_tensor * result = nullptr;
@@ -1121,6 +1144,13 @@ static ggml_tensor * ds4_attention(ggml_cgraph * gf, ggml_context * ctx0, llm_bu
         auto extra_k = cache;
         if (extra_k->ne[1] > 1) {
             extra_k = dsv4_comp_get_k(ctx0, cache, extra_ctx, n_embd_head, cache->ne[1]/n_stream);
+        }
+        if (extra_k->ne[3] > 1 && extra_mask != nullptr && extra_mask->ne[3] == 1) {
+            // The K side is multi-stream, but the mask was built as a flat
+            // [n_kv, n_tokens] plan mask (e.g. CSA/HCA plans where the indexer
+            // top-k path is skipped). Bring it into the same per-stream layout
+            // as the raw mask ([n_kv, n_tokens/n_stream, 1, n_stream]).
+            extra_mask = dsv4_build_mask_stream_view(ctx0, extra_mask, extra_k->ne[3], n_tokens);
         }
         if (cparams.flash_attn) {
             extra_mask = dsv4_pad_mask_tokens(ctx0, extra_mask, n_tokens);

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -45,6 +45,7 @@ struct llama_cparams {
     bool dsa_indexer_hadamard = true; // apply Walsh-Hadamard rotation to DSA indexer q/k (precision)
     bool dsa = false;                 // enable GLM DSA sparse attention (off by default; opt-in via --dsa)
     bool fused_idx_topk = false;      // enable the fused indexer topk op (off by default; opt-in via -fidx or --fused-indexer-topk)
+    bool dsv4_cache_cpu = false;      // keep DeepSeek-V4 compressed-attention K caches (CSA/HCA/LID) in host memory
     int  dsa_top_k = -1;              // DSA top-k override (<0 => use the model's configured indexer_top_k)
     bool split_mode_graph_scheduling;
     //bool split_mode_f16;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -45,7 +45,8 @@ struct llama_cparams {
     bool dsa_indexer_hadamard = true; // apply Walsh-Hadamard rotation to DSA indexer q/k (precision)
     bool dsa = false;                 // enable GLM DSA sparse attention (off by default; opt-in via --dsa)
     bool fused_idx_topk = false;      // enable the fused indexer topk op (off by default; opt-in via -fidx or --fused-indexer-topk)
-    bool dsv4_cache_cpu = false;      // keep DeepSeek-V4 compressed-attention K caches (CSA/HCA/LID) in host memory
+    bool dsv4_cache_cpu = false;      // keep DeepSeek-V4 compressed-attention K caches (CSA/HCA) in host memory
+    bool dsv4_lid_cache_cpu = false;  // also keep the DeepSeek-V4 indexer (LID) K cache in host memory
     int  dsa_top_k = -1;              // DSA top-k override (<0 => use the model's configured indexer_top_k)
     bool split_mode_graph_scheduling;
     //bool split_mode_f16;

--- a/src/llama-dsv4.cpp
+++ b/src/llama-dsv4.cpp
@@ -920,12 +920,18 @@ bool llama_context::ensure_dsv4_cache_tensors() {
     // context-sized K caches (CSA/HCA/LID K) are moved; the small per-layer
     // compression state tensors stay next to the layer so ggml_ds4_comp can
     // keep running on the layer's backend.
-    const ggml_backend_buffer_type_t cpu_buft = cparams.dsv4_cache_cpu ? llama_default_buffer_type_cpu(true) : nullptr;
+    const ggml_backend_buffer_type_t cpu_buft = (cparams.dsv4_cache_cpu || cparams.dsv4_lid_cache_cpu)
+        ? llama_default_buffer_type_cpu(true) : nullptr;
 
     for (int32_t il = 0; il < n_layer; ++il) {
         const uint32_t ratio = model.hparams.dsv4_compress_ratios[(size_t) il];
         ggml_backend_buffer_type_t buft = llama_dsv4_layer_buft(*this, il);
         ggml_backend_buffer_type_t k_buft = cpu_buft != nullptr ? cpu_buft : buft;
+        // The LID/indexer K cache is small and is scanned by the indexer top-k
+        // on every step - keep it on the layer's device unless explicitly
+        // requested otherwise. The CSA/HCA K caches are the large ones and are
+        // only read via sparse gathers, so they tolerate host memory well.
+        ggml_backend_buffer_type_t lid_buft = cparams.dsv4_lid_cache_cpu && cpu_buft != nullptr ? cpu_buft : buft;
 
         if (ratio == dsv4_runtime::CSA_RATIO) {
             cache.csa_k[(size_t) il] = ggml_new_tensor_3d(cache.cache_ctx, kv_self.type_k, n_embd_head, csa_kv*n_stream, 1);
@@ -936,7 +942,7 @@ bool llama_context::ensure_dsv4_cache_tensors() {
             cache.lid_state_score[(size_t) il] = ggml_new_tensor_2d(cache.cache_ctx, GGML_TYPE_F32, 2*n_indexer_head, 2*dsv4_runtime::CSA_RATIO*n_stream);
 
             if (!alloc_tensor(cache.csa_k[(size_t) il], k_buft) ||
-                !alloc_tensor(cache.lid_k[(size_t) il], k_buft) ||
+                !alloc_tensor(cache.lid_k[(size_t) il], lid_buft) ||
                 !alloc_tensor(cache.csa_state_kv[(size_t) il], buft) ||
                 !alloc_tensor(cache.csa_state_score[(size_t) il], buft) ||
                 !alloc_tensor(cache.lid_state_kv[(size_t) il], buft) ||

--- a/src/llama-dsv4.cpp
+++ b/src/llama-dsv4.cpp
@@ -916,9 +916,16 @@ bool llama_context::ensure_dsv4_cache_tensors() {
         return true;
     };
 
+    // When the compressed-attention K caches live in host memory, only the
+    // context-sized K caches (CSA/HCA/LID K) are moved; the small per-layer
+    // compression state tensors stay next to the layer so ggml_ds4_comp can
+    // keep running on the layer's backend.
+    const ggml_backend_buffer_type_t cpu_buft = cparams.dsv4_cache_cpu ? llama_default_buffer_type_cpu(true) : nullptr;
+
     for (int32_t il = 0; il < n_layer; ++il) {
         const uint32_t ratio = model.hparams.dsv4_compress_ratios[(size_t) il];
         ggml_backend_buffer_type_t buft = llama_dsv4_layer_buft(*this, il);
+        ggml_backend_buffer_type_t k_buft = cpu_buft != nullptr ? cpu_buft : buft;
 
         if (ratio == dsv4_runtime::CSA_RATIO) {
             cache.csa_k[(size_t) il] = ggml_new_tensor_3d(cache.cache_ctx, kv_self.type_k, n_embd_head, csa_kv*n_stream, 1);
@@ -928,8 +935,8 @@ bool llama_context::ensure_dsv4_cache_tensors() {
             cache.lid_state_kv[(size_t) il] = ggml_new_tensor_2d(cache.cache_ctx, GGML_TYPE_F32, 2*n_indexer_head, 2*dsv4_runtime::CSA_RATIO*n_stream);
             cache.lid_state_score[(size_t) il] = ggml_new_tensor_2d(cache.cache_ctx, GGML_TYPE_F32, 2*n_indexer_head, 2*dsv4_runtime::CSA_RATIO*n_stream);
 
-            if (!alloc_tensor(cache.csa_k[(size_t) il], buft) ||
-                !alloc_tensor(cache.lid_k[(size_t) il], buft) ||
+            if (!alloc_tensor(cache.csa_k[(size_t) il], k_buft) ||
+                !alloc_tensor(cache.lid_k[(size_t) il], k_buft) ||
                 !alloc_tensor(cache.csa_state_kv[(size_t) il], buft) ||
                 !alloc_tensor(cache.csa_state_score[(size_t) il], buft) ||
                 !alloc_tensor(cache.lid_state_kv[(size_t) il], buft) ||
@@ -943,7 +950,7 @@ bool llama_context::ensure_dsv4_cache_tensors() {
             cache.hca_state_kv[(size_t) il] = ggml_new_tensor_2d(cache.cache_ctx, GGML_TYPE_F32, n_embd_head, dsv4_runtime::HCA_RATIO*n_stream);
             cache.hca_state_score[(size_t) il] = ggml_new_tensor_2d(cache.cache_ctx, GGML_TYPE_F32, n_embd_head, dsv4_runtime::HCA_RATIO*n_stream);
 
-            if (!alloc_tensor(cache.hca_k[(size_t) il], buft) ||
+            if (!alloc_tensor(cache.hca_k[(size_t) il], k_buft) ||
                 !alloc_tensor(cache.hca_state_kv[(size_t) il], buft) ||
                 !alloc_tensor(cache.hca_state_score[(size_t) il], buft)) {
                 LLAMA_LOG_ERROR("%s: failed to allocate DSV4 HCA buffers for layer %d\n", __func__, il);
@@ -978,6 +985,9 @@ bool llama_context::ensure_dsv4_cache_tensors() {
             (float) (csa_state_bytes + hca_state_bytes + lid_state_bytes) / (1024.0f * 1024.0f),
             (float) (csa_k_bytes + hca_k_bytes + lid_k_bytes + csa_state_bytes + hca_state_bytes + lid_state_bytes) / (1024.0f * 1024.0f),
             n_stream);
+    if (cparams.dsv4_cache_cpu) {
+        LLAMA_LOG_INFO("%s: DSV4 compressed-attention K caches (CSA/HCA/LID) are in host memory\n", __func__);
+    }
 
     return true;
 }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2224,6 +2224,12 @@ bool llama_model_supports_partial_kv_reuse(const struct llama_model * model) {
     return model && model->arch != LLM_ARCH_OPENPANGU;
 }
 
+bool llama_model_requires_uniform_seq_batch(const struct llama_model * model) {
+    // DeepSeek-V4 keeps per-stream KV/side-state in a rectangular layout, so all
+    // sequences in a batch must contribute the same number of tokens.
+    return model && model->arch == LLM_ARCH_DEEPSEEK4;
+}
+
 llm_tensor llm_tensor_type(llm_arch arch, const std::string & tensor_name, int il) {
     auto it = LLM_TENSOR_NAMES.find(arch);
     if (it == LLM_TENSOR_NAMES.end()) {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2224,12 +2224,6 @@ bool llama_model_supports_partial_kv_reuse(const struct llama_model * model) {
     return model && model->arch != LLM_ARCH_OPENPANGU;
 }
 
-bool llama_model_requires_uniform_seq_batch(const struct llama_model * model) {
-    // DeepSeek-V4 keeps per-stream KV/side-state in a rectangular layout, so all
-    // sequences in a batch must contribute the same number of tokens.
-    return model && model->arch == LLM_ARCH_DEEPSEEK4;
-}
-
 llm_tensor llm_tensor_type(llm_arch arch, const std::string & tensor_name, int il) {
     auto it = LLM_TENSOR_NAMES.find(arch);
     if (it == LLM_TENSOR_NAMES.end()) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7309,6 +7309,7 @@ struct llama_context_params llama_context_default_params() {
         /*.dsa                         =*/ false,
         /*.fused_idx_topk              =*/ true,
         /*.dsv4_cache_cpu              =*/ false,
+        /*.dsv4_lid_cache_cpu          =*/ false,
         /*.dsa_top_k                   =*/ -1,
         /*.min_experts                 =*/ -1,
         /*.thtesh_experts              =*/ 0.0f,
@@ -7799,6 +7800,7 @@ struct llama_context * llama_init_from_model(
     cparams.dsa              = params.dsa;
     cparams.fused_idx_topk   = params.fused_idx_topk;
     cparams.dsv4_cache_cpu   = params.dsv4_cache_cpu;
+    cparams.dsv4_lid_cache_cpu = params.dsv4_lid_cache_cpu;
     cparams.dsa_top_k        = params.dsa_top_k;
     // The DSA lightning indexer is built only in the layer-mode (non-TP) attention path. Under
     // -sm graph / -sm attn the model runs the tensor-parallel attention path, which has no indexer,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -7308,6 +7308,7 @@ struct llama_context_params llama_context_default_params() {
         /*.graph_reuse                 =*/ true,
         /*.dsa                         =*/ false,
         /*.fused_idx_topk              =*/ true,
+        /*.dsv4_cache_cpu              =*/ false,
         /*.dsa_top_k                   =*/ -1,
         /*.min_experts                 =*/ -1,
         /*.thtesh_experts              =*/ 0.0f,
@@ -7797,6 +7798,7 @@ struct llama_context * llama_init_from_model(
     cparams.graph_reuse      = params.graph_reuse;
     cparams.dsa              = params.dsa;
     cparams.fused_idx_topk   = params.fused_idx_topk;
+    cparams.dsv4_cache_cpu   = params.dsv4_cache_cpu;
     cparams.dsa_top_k        = params.dsa_top_k;
     // The DSA lightning indexer is built only in the layer-mode (non-TP) attention path. Under
     // -sm graph / -sm attn the model runs the tensor-parallel attention path, which has no indexer,


### PR DESCRIPTION
## Motivation

DeepSeek-V4 allocates per-layer compressed-attention caches (CSA/HCA/LID K) sized by *total context × streams* on the layer's device. These scale ~33 MiB per 1k tokens of total context — comparable to the KV cache proper — which on a single 24 GB GPU caps total context well below what the model supports:

| target | VRAM needed | fits 24 GB? |
|---|---|---|
| 4 slots × 100k | ~32 GB | ❌ |
| 3 slots × 133k | ~25 GB | ❌ |
| 3 slots × 133k, caches on host | ~20 GB | ✅ |

Users running big-RAM CPU-expert setups (the natural way to run DSV4 Flash quants) have plenty of host memory but scarce VRAM, so context is currently VRAM-capped for no fundamental reason.

## Change

New  () flag: allocates only the context-sized K caches (CSA/HCA/LID K) in host memory; the small per-layer compression *state* tensors stay on the layer's device so  keeps running there.

No new CPU kernels were needed — every op touching these caches (, , views, , ) already has a CPU implementation. Default behavior (caches on the layer's device) is unchanged.

## Measured (single RTX 3090 Ti + 16-core CPU, DeepSeek-V4-Flash-0731-MXFP4, experts on CPU)

 (~133k ctx/slot) — does not fit in VRAM without this flag:
- single-slot decode: **11.1 t/s — identical to GPU-resident caches**
- 3 concurrent slots: ~3.2 t/s per slot (~10% below GPU-resident at the same load)
- VRAM: 20.2 GB vs ~25 GB (OOM) with GPU-resident caches

## Notes

- Stacked on top of #2229 (multi-stream fix); the interesting part of this PR is the last commit only.
- While testing I also confirmed DSV4's latent K cache accepts only F16/BF16/Q8_0 ( is rejected with a clear message) — so Q8_0 is currently the best available KV compression for this arch. A follow-up could plumb the indexer K cache type (?) and/or q4_0 support for the latent cache for even more context.