### PR TITLE
Make antirez GGUFs run at least

### DIFF
--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -1295,7 +1295,8 @@ ggml_cgraph * llm_build_context::build_deepseek4() {
     }
 
     const int n_layer_begin = is_mtp ? n_layer - hparams.nextn_predict_layers : 0;
-    for (int il = n_layer_begin; il < n_layer; ++il) {
+    const int n_layer_end   = is_mtp ? n_layer : n_layer - hparams.nextn_predict_layers;
+    for (int il = n_layer_begin; il < n_layer_end; ++il) {
 
         auto cur = ds4_attention(gf, ctx0, *this, inpL,
                              &append_csa_state, &append_csa_score,


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High


I still get gibberish and extra 3 layers have to go to CPU but at least segfault is gone.