### PR TITLE
Fix Antirez DS4 GGUFs

### DIFF
--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -1665,6 +1665,11 @@ void llm_load_hparams(
             {
                 ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.nextn_predict_layers, false);
                 if (model.arch == LLM_ARCH_DEEPSEEK4 && hparams.n_layer == 43 && hparams.nextn_predict_layers > 0) {
+                    LLAMA_LOG_WARN("===============================================================================================\n");
+                    LLAMA_LOG_WARN("Unexpected number of layers (%d) and nextn_predict_layers (%d) for DeepSeek4-Flash\n",
+                            hparams.n_layer, hparams.nextn_predict_layers);
+                    LLAMA_LOG_WARN("   -> setting nextn_predict_layers to zero\n");
+                    LLAMA_LOG_WARN("===============================================================================================\n");
                     hparams.nextn_predict_layers = 0;
                 }
                 // Probe the first appended predictor block, or n_layer - 1 for base GGUFs.

--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -1664,6 +1664,9 @@ void llm_load_hparams(
         case LLM_ARCH_GLM_DSA:
             {
                 ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.nextn_predict_layers, false);
+                if (model.arch == LLM_ARCH_DEEPSEEK4 && hparams.n_layer == 43 && hparams.nextn_predict_layers > 0) {
+                    hparams.nextn_predict_layers = 0;
+                }
                 // Probe the first appended predictor block, or n_layer - 1 for base GGUFs.
                 const uint32_t dsv4_probe_offset = std::max<uint32_t>(1, hparams.nextn_predict_layers);
                 const uint32_t dsv4_probe_layer = hparams.n_layer > dsv4_probe_offset


### PR DESCRIPTION

GGUFs from antirez will have the number of MTP layers set to 1 (the `deepseek4.nextn_predict_layers` GGUF meta entry) even if they do not contain the actual MTP layer. On top of that the number of layers for DS4-Flash will be set to 43 (i.e., the layer count excluding the MTP layer), which breaks a lot of logic related to tensor loading and MTP. In the initial DS4 PR we still somehow made it work, but after #2216, antirez GGUFs stopped working (see #2248).

This PR makes it so that antirez GGUFs work again. I did not see another way other than to simply reset  `nextn_predict_layers` to zero if the arch is `LLM_ARCH_DEEPSEEK4`, the number of layers is 43, and `nextn_predict_layers` is greater than zero.

Closes #2248 