### PR TITLE
Fix wrong output for hybrid/recurrent models at -np > 1 (graph reuse key)

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -564,8 +564,38 @@ struct llama_context::Prev {
     int32_t mtp_n_heads;
     int64_t swa_w_view;
     int64_t swa_win_off;
+    // Which sequences the cached graph was built for. Hybrid and recurrent graphs
+    // bake the recurrent state row in as a view offset, and update_cache_copies()
+    // re-points ATTENTION layers only, so such a graph is only reusable for the
+    // same sequence composition.
+    uint64_t seq_fingerprint;
     ggml_cgraph * graph;
 };
+
+// Identifies the sequence composition of a ubatch: which sequences, in which
+// order, and which of them start at position 0 (a state reset is baked into the
+// graph as a node, so it is part of the graph's identity too).
+static uint64_t llama_ubatch_seq_fingerprint(const llama_batch & b) {
+    uint64_t h = 1469598103934665603ull;                    // FNV-1a
+    auto mix = [&h](uint64_t v) { h ^= v; h *= 1099511628211ull; };
+    mix((uint64_t) (uint32_t) b.n_tokens);
+    for (int32_t i = 0; i < b.n_tokens; ++i) {
+        const int32_t ns = b.n_seq_id ? b.n_seq_id[i] : 0;
+        mix((uint64_t) (uint32_t) ns);
+        if (b.seq_id && b.seq_id[i]) {
+            for (int32_t j = 0; j < ns; ++j) {
+                mix((uint64_t) (uint32_t) b.seq_id[i][j]);
+            }
+        }
+        mix(b.pos && b.pos[i] == 0 ? 1ull : 0ull);
+    }
+    return h;
+}
+
+// Only these architectures bake a recurrent state row into the graph.
+static inline bool llama_graph_bakes_seq_state(const llm_arch & arch) {
+    return llm_arch_is_hybrid(arch) || llm_arch_is_recurrent(arch);
+}
 
 void llama_context::reset_scheduler() {
     ggml_backend_sched_reset(sched);
@@ -597,6 +627,15 @@ bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
     auto the_prev = cparams.mtp_op_type == MTP_OP_NONE ? prev.get() : prev_mtp.get();
     if (!the_prev || !the_prev->graph) return false;
     if (u_batch.embd) return false;
+    // A graph built for sequence A must not be reused to decode sequence B: the
+    // recurrent state row is baked in as a view offset and nothing re-points it,
+    // so every sequence would read and write sequence A's state. Set
+    // IK_LEGACY_GRAPH_REUSE to restore the previous behaviour for A/B testing.
+    static const bool legacy_graph_reuse = getenv("IK_LEGACY_GRAPH_REUSE") != nullptr;
+    if (!legacy_graph_reuse && llama_graph_bakes_seq_state(model.arch) &&
+            llama_ubatch_seq_fingerprint(u_batch) != the_prev->seq_fingerprint) {
+        return false;
+    }
     auto & kv_self_used = (model.arch == LLM_ARCH_GEMMA4_MTP || model.arch == LLM_ARCH_GEMMA4_ASSISTANT) &&
                           mtp_target_ctx != nullptr ? mtp_target_ctx->kv_self : kv_self;
     if (the_prev->save_per_step_ssm != kv_self_used.save_per_step_ssm ||
@@ -6321,7 +6360,11 @@ static int llama_decode_internal(
                         kv_self_used.save_per_step_ssm, kv_self_used.ckpt.per_step_max_allocated,
                         cparams.mtp_op_type, lctx.mtp_step_idx, lctx.mtp_n_heads,
                         lctx.swa_window_view.w_view,
-                        lctx.swa_window_view.win_off, gf});
+                        lctx.swa_window_view.win_off,
+                        // Only hybrid/recurrent graphs compare this; don't make
+                        // every other architecture pay to compute it.
+                        llama_graph_bakes_seq_state(model.arch)
+                            ? llama_ubatch_seq_fingerprint(u_batch) : 0, gf});
             }
         } else {
             //printf("Reusing graph with type = %d, n_kv = %d, n_tokens = %d\n", cparams.mtp_op_type, (int)prev->n_kv, (int)prev->n_tokens);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -564,19 +564,20 @@ struct llama_context::Prev {
     int32_t mtp_n_heads;
     int64_t swa_w_view;
     int64_t swa_win_off;
-    // Which sequences the cached graph was built for. Hybrid and recurrent graphs
-    // bake the recurrent state row in as a view offset, and update_cache_copies()
-    // re-points ATTENTION layers only, so such a graph is only reusable for the
-    // same sequence composition.
     uint64_t seq_fingerprint;
     ggml_cgraph * graph;
 };
 
-// Identifies the sequence composition of a ubatch: which sequences, in which
-// order, and which of them start at position 0 (a state reset is baked into the
-// graph as a node, so it is part of the graph's identity too).
-static uint64_t llama_ubatch_seq_fingerprint(const llama_batch & b) {
-    uint64_t h = 1469598103934665603ull;                    // FNV-1a
+static inline bool llama_graph_bakes_seq_state(const llm_arch & arch) {
+    return llm_arch_is_hybrid(arch) || llm_arch_is_recurrent(arch);
+}
+
+static uint64_t llama_ubatch_seq_fingerprint(const llama_batch & b, const llm_arch & arch) {
+    static const bool legacy_graph_reuse = getenv("IK_LEGACY_GRAPH_REUSE") != nullptr;
+    if (!llama_graph_bakes_seq_state(arch) || legacy_graph_reuse) {
+        return 0ull;
+    }
+    uint64_t h = 1469598103934665603ull;
     auto mix = [&h](uint64_t v) { h ^= v; h *= 1099511628211ull; };
     mix((uint64_t) (uint32_t) b.n_tokens);
     for (int32_t i = 0; i < b.n_tokens; ++i) {
@@ -590,11 +591,6 @@ static uint64_t llama_ubatch_seq_fingerprint(const llama_batch & b) {
         mix(b.pos && b.pos[i] == 0 ? 1ull : 0ull);
     }
     return h;
-}
-
-// Only these architectures bake a recurrent state row into the graph.
-static inline bool llama_graph_bakes_seq_state(const llm_arch & arch) {
-    return llm_arch_is_hybrid(arch) || llm_arch_is_recurrent(arch);
 }
 
 void llama_context::reset_scheduler() {
@@ -627,13 +623,7 @@ bool llama_context::can_reuse_graph(const llama_batch & u_batch) {
     auto the_prev = cparams.mtp_op_type == MTP_OP_NONE ? prev.get() : prev_mtp.get();
     if (!the_prev || !the_prev->graph) return false;
     if (u_batch.embd) return false;
-    // A graph built for sequence A must not be reused to decode sequence B: the
-    // recurrent state row is baked in as a view offset and nothing re-points it,
-    // so every sequence would read and write sequence A's state. Set
-    // IK_LEGACY_GRAPH_REUSE to restore the previous behaviour for A/B testing.
-    static const bool legacy_graph_reuse = getenv("IK_LEGACY_GRAPH_REUSE") != nullptr;
-    if (!legacy_graph_reuse && llama_graph_bakes_seq_state(model.arch) &&
-            llama_ubatch_seq_fingerprint(u_batch) != the_prev->seq_fingerprint) {
+    if (llama_ubatch_seq_fingerprint(u_batch, model.arch) != the_prev->seq_fingerprint) {
         return false;
     }
     auto & kv_self_used = (model.arch == LLM_ARCH_GEMMA4_MTP || model.arch == LLM_ARCH_GEMMA4_ASSISTANT) &&
@@ -6361,10 +6351,7 @@ static int llama_decode_internal(
                         cparams.mtp_op_type, lctx.mtp_step_idx, lctx.mtp_n_heads,
                         lctx.swa_window_view.w_view,
                         lctx.swa_window_view.win_off,
-                        // Only hybrid/recurrent graphs compare this; don't make
-                        // every other architecture pay to compute it.
-                        llama_graph_bakes_seq_state(model.arch)
-                            ? llama_ubatch_seq_fingerprint(u_batch) : 0, gf});
+                        llama_ubatch_seq_fingerprint(u_batch, model.arch), gf});
             }
         } else {
             //printf("Reusing graph with type = %d, n_kv = %d, n_tokens = %d\n", cparams.mtp_op_type, (int)prev->n_kv, (int)prev->n_tokens);


### PR DESCRIPTION
Fixes the silent wrong-output bug reported in #1932.

Credit where it's due: @poisonxa16 found and documented this first, and #1933 was
their fix. This PR is narrower, and takes an approach they explicitly considered
insufficient — I've put the measurement on that disagreement below rather than
gloss over it.

## The bug

Hybrid and recurrent architectures return silently wrong output whenever more
than one sequence is resident. There's no crash and no warning. Every slot keeps
emitting fluent text; it just stops being conditioned on that slot's prompt, and
slots degenerate into repetition loops.

It's easy to ship without noticing, because single-stream is unaffected and
quality suites run one request at a time. Downstream, `club-3090` ships an
ik_llama compose for Qwen3.6-35B-A3B that exposes `-np ${NP:-1}` as a
user-tunable knob (noonghunna/club-3090#896).

## Root cause

Three things line up:

1. `can_reuse_graph()` keys reuse on the ubatch **shape**. Two consecutive decode
   steps for different sequences match on every field it checks.
2. `update_cache_copies()` re-points the baked `view_offs` for K/V — but only for
   attention layers. It skips recurrent ones:
   `is_attn_layer = !hparams.is_recurrent(il)`.
3. The delta-net bakes the recurrent state row into the graph as a compile-time
   view offset (`state_seq_id_local * state_row_size`), not as an input tensor.

So a graph built for sequence A gets reused to decode sequence B and nothing
re-points the recurrent state — every sequence reads and writes sequence A's
state. On Qwen3.6-35B-A3B only 10 of 40 layers carry a KV cache, so the layers
that silently share state are three quarters of the network.

This also explains the symptom set: it needs concurrent residency, it's clean
when sequential, it's worst under `-ub 1 -b 1` (identical shapes, so reuse hits
every step), it's backend-independent, and the output is coherent-but-unconditioned
rather than noise.

## The fix

Extend the reuse key with a fingerprint of the ubatch's sequence composition:
which sequences, in what order, and which start at position 0 (a state reset is
baked in as a graph node, so it's part of the graph's identity). Gated on
`llm_arch_is_hybrid() || llm_arch_is_recurrent()` on both the compare and the
compute side, so architectures that never consult the fingerprint don't pay to
build it either. One file.

Two details a reviewer will probably want up front:

- `prev` and `prev_mtp` are populated through the same reference binding
  (`auto & prev = ... ? lctx.prev : lctx.prev_mtp`), so the MTP cache carries the
  fingerprint too — there's no second construction site to miss.
- The `pos == 0` term isn't a heuristic for "is this a reset": it's the same
  condition `build_layer_attn_linear` itself uses to decide whether to bake the
  reset node in.

## Evidence

RTX 3090 / sm_86, `Qwen3.6-35B-A3B-UD-IQ4_XS`, q4_0 KV, no offload.

**Correctness** — 6 concurrent requests, each carrying a unique codeword, 600-token
generations, 2 rounds. A reply must contain its own codeword and no other:

| build | degenerate / lost own codeword |
|---|---|
| `IK_LEGACY_GRAPH_REUSE=1` (previous behaviour) | **7/12** |
| this PR | **0/12** |

**np=1 throughput** — 132.9 tok/s vs 132.4 before. Unchanged.

**MTP** — I don't have an MTP GGUF, so I measured the mechanism instead of one
prompt. The fingerprint is a pure *additional* invalidation: it can only ever add
reuse misses, never remove them. So counting the misses it causes **on its own**
bounds its cost exactly. Over 13,000 `can_reuse_graph()` calls at np=1:

```
calls=13000  hit=12949  miss_other=51  miss_fingerprint_only=0
```

Zero. np=1 graph reuse is bit-identical to before this patch, which covers MTP,
since MTP runs at `n_parallel == 1`. Its draft/verify ubatch alternation was
already keyed by the existing `n_tokens` / `mtp_op_type` / `mtp_step_idx` /
`mtp_n_heads` checks; all the fingerprint adds beyond those is per-token
`seq_id`s and the `pos == 0` flags, both constant at np=1 during decode.

**Update — now measured on a real MTP GGUF**, details in [this comment](https://github.com/ikawrakow/ik_llama.cpp/pull/2260#issuecomment-5198273794):
acceptance is `279/476` = 0.5861 on all 20 runs across both arms, sd 0.0000 —
bit-identical draft counts rather than merely close means. TG is −0.18% pooled,
once run order is controlled for (a sequential A/B on this model has a ~1%
second-arm-is-faster bias that flips the sign if you don't swap the order).

## Reproducing

`IK_LEGACY_GRAPH_REUSE` restores the previous behaviour, so before/after comes
from one build:

```bash
llama-server -m Qwen3.6-35B-A3B-*.gguf -c 32768 -np 6 -fa -ctk q4_0 -ctv q4_0
# 6 concurrent requests, each told a distinct codeword, each asked to echo it back.
# unset  -> every reply carries its own codeword
# IK_LEGACY_GRAPH_REUSE=1 -> roughly half degenerate into repetition
```

I kept that env var in the patch precisely so this is reproducible on your
machine from a single build; happy to drop it if you'd rather not carry it.

## Scope, and where this disagrees with #1932

#1932 attributes the corruption to the ggml graph allocator reusing freed offsets
across the N interleaved per-token subgraphs the delta-net builds, and states that
fixes changing only the read/write mechanism — *"graph-reuse guard, runtime gather,
deferred scatter"* — change the failure mode without eliminating it. This PR is
exactly such a guard, so I tested that claim directly: the codeword test above is
clean at np=6 with 600-token generations, with a positive control proving the test
detects the broken build.

I'm not claiming their diagnosis is wrong. Their testing is Tesla P100 / sm_60 on
Qwen3.5-35B and Coder-Next-80B; mine is sm_86 on Qwen3.6-35B-A3B at np=6. Those
are different enough that both results can hold, and if there's a configuration
where the guard is insufficient I'd like to know which one. What I can say is that
this change fixes the failure I can reproduce, at a cost of zero on np=1.

Deliberately **not** in this PR: no batched multi-sequence delta-net, no
performance work, no change to the per-token loop structure. Only the reuse key.

One deliberate choice worth surfacing: the key is a 64-bit FNV-1a hash rather
than an exact comparison of the sequence list, so it is theoretically possible
for two different compositions to collide and reuse the wrong graph. At 2^-64
per comparison I judged that far below the noise floor of everything else here,
and it keeps an O(n_tokens) allocation off the hot path — but if you would
rather have an exact comparison, say so and I will store the list.

Untested by me: CPU-only, non-CUDA backends, other hybrid/recurrent architectures
(the gate covers them, but I only have Qwen3.6-35B-A3B), and MTP end-to-end.

