### PR TITLE
openpangu: per-sequence state save/restore with --swa-compress

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -391,12 +391,6 @@ void server_context::init() {
         reuse_forced_off = true;
     }
 
-    if (params_base.cache_ram_mib != 0 && !llama_supports_full_state_io(ctx)) {
-        LLAMA_LOG_WARN("prompt cache is disabled: this context cannot save full sequence state (--swa-compress)\n");
-        params_base.cache_ram_mib = 0;
-        reuse_forced_off = true;
-    }
-
     if (params_base.cache_ram_mib != 0 && llama_model_supports_partial_kv_reuse(model)) {
         if (params_base.cache_ram_mib < 0) {
             LLAMA_LOG_INFO("prompt cache is enabled, size limit: %s\n", "no limit");

--- a/include/llama.h
+++ b/include/llama.h
@@ -722,8 +722,7 @@ extern "C" {
     // Currently true for every model; no architecture is excluded from partial KV reuse.
     LLAMA_API bool llama_model_supports_partial_kv_reuse(const struct llama_model * model);
 
-    // False when full-state seq save/restore cannot work for this context (--swa-compress).
-    // PARTIAL_ONLY is unaffected. Context property, not a model one.
+    // true for every non-null context; none is excluded from full-state seq save/restore
     LLAMA_API bool llama_supports_full_state_io(const struct llama_context * ctx);
 
     LLAMA_API const char * llama_model_arch_string(const struct llama_model * model);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1070,6 +1070,7 @@ static llama_pos llama_kv_openpangu_state_pos(const llama_kv_cache & cache, llam
 
 static constexpr uint32_t LLAMA_OPENPANGU_PARTIAL_LAYOUT_MAGIC = 0x50414732u; // "PAG2"
 static constexpr uint32_t LLAMA_OPENPANGU_PARTIAL_STATE_MAGIC  = 0x50414731u; // "PAG1"
+static constexpr uint32_t LLAMA_SWA_COMPACT_LAYOUT_MAGIC       = 0x53574143u; // "SWAC"
 
 static inline bool llama_kv_qnext_seq_id_in_range(const llama_kv_cache & cache, llama_seq_id seq_id) {
     const uint32_t n_slots = llama_kv_qnext_state_slots(cache);
@@ -1512,6 +1513,7 @@ static bool llama_kv_cache_init(
         LLAMA_LOG_ERROR("%s: bailing out\n", __func__);
         GGML_ABORT("fatal error");
     }
+
 
     // allocate tensors and initialize the buffers to avoid NaNs in the padding
     for (auto it : ctx_map) {
@@ -8595,7 +8597,7 @@ void llama_free(struct llama_context * ctx) {
 }
 
 bool llama_supports_full_state_io(const struct llama_context * ctx) {
-    return ctx != nullptr && !ctx->kv_self.any_compacted();
+    return ctx != nullptr;
 }
 
 const struct llama_vocab* llama_model_get_vocab(const struct llama_model* model) {
@@ -9716,6 +9718,15 @@ struct llama_data_write {
                 continue;
             }
 
+            // only k_l is compacted; it holds the window at [sink_rows, sink_rows + live_swa())
+            if (kv_self.is_compacted((int) il)) {
+                const size_t live = kv_self.live_swa();
+                if (live) {
+                    write_tensor_data(kv_self.k_l[il], kv_self.sink_rows * k_size_row, live * k_size_row, il);
+                }
+                continue;
+            }
+
             // Read each range of cells of k_size length each into tmp_buf and write out
             for (const auto & range : cell_ranges) {
                 const size_t range_size = range.second - range.first;
@@ -9950,6 +9961,15 @@ struct llama_data_write {
         }
         GGML_ASSERT(cell_count == cell_count_check);
 
+        if (kv_self.any_compacted()) {
+            const uint32_t live_rows = kv_self.live_swa();
+            write(&LLAMA_SWA_COMPACT_LAYOUT_MAGIC, sizeof(LLAMA_SWA_COMPACT_LAYOUT_MAGIC));
+            write(&kv_self.size_swa, sizeof(kv_self.size_swa));
+            write(&live_rows, sizeof(live_rows));
+            write(&kv_self.pos_base_swa, sizeof(kv_self.pos_base_swa));
+            write(&kv_self.head_swa, sizeof(kv_self.head_swa));
+        }
+
         write(&cell_count, sizeof(cell_count));
 
         write_kv_cache_meta(kv_self, cell_ranges, seq_id);
@@ -10060,6 +10080,11 @@ struct llama_data_read {
 
             if (cell_count == 0 && ctx->model.arch == LLM_ARCH_OPENPANGU) {
                 LLAMA_LOG_ERROR("%s: openPangu sequence state carries no kv cells\n", __func__);
+                return false;
+            }
+
+            if (cell_count > kv_self.size) {
+                LLAMA_LOG_ERROR("%s: not enough cells in kv cache\n", __func__);
                 return false;
             }
 
@@ -10353,12 +10378,16 @@ struct llama_data_read {
                 return false;
             }
 
-            if (cell_count) {
+            const bool     k_compact = kv_self.is_compacted((int) il);
+            const uint32_t k_rows    = k_compact ? kv_self.live_swa() : cell_count;
+            const uint32_t k_dst     = k_compact ? kv_self.sink_rows  : kv_self.head;
+
+            if (k_rows) {
                 // Read and set the keys for the whole cell range
                 if (kv_self.k_l[il]->extra) {
-                    read_kv_cache_data_split(ctx, kv_self.k_l[il], read(cell_count * k_size_row), kv_self.head, k_size_row, cell_count, il);
+                    read_kv_cache_data_split(ctx, kv_self.k_l[il], read(k_rows * k_size_row), k_dst, k_size_row, k_rows, il);
                 } else {
-                    ggml_backend_tensor_set(kv_self.k_l[il], read(cell_count * k_size_row), kv_self.head * k_size_row, cell_count * k_size_row);
+                    ggml_backend_tensor_set(kv_self.k_l[il], read(k_rows * k_size_row), k_dst * k_size_row, k_rows * k_size_row);
                 }
             }
         }
@@ -10697,7 +10726,44 @@ struct llama_data_read {
             return;
         }
 
-        bool res = read_kv_cache_meta(ctx, cell_count, seq_id) && read_kv_cache_data(ctx, cell_count, seq_id, flags);
+        struct llama_kv_cache & kv_self = ctx->kv_self;
+
+        const bool compacted    = kv_self.any_compacted();
+        const bool compact_blob = cell_count == LLAMA_SWA_COMPACT_LAYOUT_MAGIC;
+        if (compacted != compact_blob) {
+            throw std::runtime_error("failed to restore kv cache: incompatible compacted sliding-window layout");
+        }
+
+        uint32_t  restore_size_swa = 0;
+        uint32_t  restore_live     = 0;
+        llama_pos restore_pos_base = 0;
+        uint32_t  restore_head_swa = 0;
+        if (compact_blob) {
+            read_to(&restore_size_swa, sizeof(restore_size_swa));
+            read_to(&restore_live,     sizeof(restore_live));
+            read_to(&restore_pos_base, sizeof(restore_pos_base));
+            read_to(&restore_head_swa, sizeof(restore_head_swa));
+            if (restore_size_swa != kv_self.size_swa) {
+                throw std::runtime_error("failed to restore kv cache: compacted row count differs from this context");
+            }
+            if (restore_head_swa < kv_self.sink_rows || restore_head_swa > kv_self.size_swa ||
+                restore_head_swa - kv_self.sink_rows != restore_live) {
+                throw std::runtime_error("failed to restore kv cache: inconsistent compacted window state");
+            }
+            read_to(&cell_count, sizeof(cell_count));
+            if (restore_pos_base < 0 ||
+                (uint64_t) restore_pos_base + restore_live != (uint64_t) cell_count) {
+                throw std::runtime_error("failed to restore kv cache: compacted window base inconsistent with cell count");
+            }
+        }
+
+        // scalars before rows: they set the placement offset, and seq_rm inside meta resets head_swa
+        bool res = read_kv_cache_meta(ctx, cell_count, seq_id);
+        if (res && compact_blob) {
+            kv_self.pos_base_swa = restore_pos_base;
+            kv_self.head_swa     = restore_head_swa;
+        }
+        res = res && read_kv_cache_data(ctx, cell_count, seq_id, flags);
 
         if (!res) {
             if (seq_id == -1) {
@@ -10967,13 +11033,6 @@ static bool llama_state_io_supported(
                         const char * func,
              llama_state_seq_flags flags = 0,
                       llama_seq_id seq_id = -1) {
-    if (ctx->kv_self.any_compacted() && flags == 0) {
-        LLAMA_LOG_ERROR("%s: full state save/restore is not supported with --swa-compress "
-                        "(state I/O addresses cache rows by cell index; compacted layers hold a "
-                        "translated subset)\n", func);
-        return false;
-    }
-
     if (ctx->model.arch == LLM_ARCH_OPENPANGU) {
         if (seq_id >= 0 &&
             llama_kv_qnext_seq_id_in_range(ctx->kv_self, seq_id) &&


### PR DESCRIPTION
Deferred in #2253, this PR enables per-sequence state save and restore for compacted SWA contexts, the path the server prompt cache uses. As with `--swa-compress` itself, the changes here are opt-in, off by default, and when opted in currently reachable only by `openPangu`, with one necessary exception described below.

`--swa-compress` allocates each sliding-window layer as a compacted `[sinks | window]` block instead of one row per context cell. With current main, per-sequence state save and restore is refused for any context holding a compacted layer, because the serializer writes and places key rows by cell index and a compacted layer has no row for most cells. The server prompt cache is built on that path, so `--swa-compress` costs a server its prompt-cache reuse. Context checkpoints are a separate path and unaffected, but they can't substitute: they carry no per-layer keys, so they rewind within the conversation currently holding the slot and cannot restore one whose keys another conversation has already overwritten.

This adds a compacted layout to the per-sequence state format and removes the refusal.

**Format.** When any layer is compacted, the writer places a layout marker in the leading `cell_count` slot, following the `PAG1`/`PAG2` markers the reader already recognizes in that position, then the compacted row count, the live window length, the window base position, and the window head. The reader validates all four against the receiving context and throws rather than restoring into a different geometry. Compacted keys are written as one contiguous block at the window offset in place of per-cell-range copies. Values and the indexer cache are unchanged, since a compacted layer allocates neither of them per cell. The path branches on whether a layer is compacted rather than on architecture, and the header carries no architecture-specific field.

**Compatibility.** A build predating this change reads the layout marker as a cell count. No in-tree path carries a compacted blob to such a build: the producer and consumer are the same process through the buffer API, and the sequence file wrappers preflight with `seq_id = -1`, which openPangu refuses independently of compaction. **The exception to the openPangu gating above** is a `cell_count` bound added to the single-sequence reader, matching the one the whole-context branch already had. It is conditioned on neither the flag nor the architecture, so any architecture restoring a sequence now refuses an out-of-range count instead of sizing a batch from it. It can only fire where the previous path was already headed for failure. DeepSeek4 context-checkpoint restore does reach this; I tested it, and checkpoint counts and generated text match the pre-change build.

**Scope.** Per-sequence state, `seq_id >= 0` and `flags == 0`. Whole-context state (`seq_id == -1`) stays refused for openPangu, as do both sequence file wrappers.

**Cost.** A resend that diverges before `pos_base_swa + n_swa` still reprocesses from scratch: `llama_kv_cache_seq_rm` refuses that rewind because the positions it would need were overwritten when the window was compacted. This is unchanged from #2253 and is reachable there through context checkpoints.

**`llama_supports_full_state_io`** returned false for any context holding a compacted layer, and the server used it to force the prompt cache off. That branch is now unreachable and is removed, warning included. The predicate is kept, with a corrected header comment, as a public `LLAMA_API` symbol; it has no in-tree caller.

### Validation

openPangu-2.0-Flash IQ4_NL, `-c 32768 -ot exps=CPU -ctk q8_0 -ictk q8_0 -np 1 -ngl 999 --cache-ram 4096`, RTX 4070 with routed experts on CPU. Compacted geometry is 1152 rows per compacted layer, 128 sink plus a 1024-row window.

One slot, three requests: conversation A, then conversation B which evicts A, then a continuation of A. Returning to A can only succeed through `llama_state_seq_set_data`.

| build | `--swa-compress` | A2 cached tokens | state blob | prompt-cache entry |
| --- | --- | ---: | ---: | ---: |
| patched | on | **3578** | 67.9 MiB | 78.7 MiB |
| main | on | 0, refused | n/a | n/a |
| patched | off | 3578 | 112.8 MiB | 123.5 MiB |
| main | off | 3578 | 112.8 MiB | 123.5 MiB |

Without the restore, the whole conversation is reprocessed: main spends 18,493 ms of prefill on 3596 tokens at 190 to 195 tokens per second with the routed experts on the CPU. With it, the restore takes 18 ms and only the 18 genuinely new tokens are prefilled, 496 ms in total. The A2 answer names words from conversation A's list and none from B's.

With the flag off, the patched build and main agree on every column and their A2 completions are character-identical, so the change is inert for contexts that do not compact. With it on, the same conversation serializes to 67.9 MiB against the dense 112.8 MiB, 39.8% smaller; the prompt-cache entry holding it is 78.7 MiB against 123.5 MiB, 36.3% smaller. The difference between the two pairs is four context checkpoints, 10.8 MiB in both arms. The entry figure is the one that decides how many prompts fit under a given `--cache-ram`.

A 32K-context needle retrieved at 10, 50 and 90 percent depth, and again after the conversation is evicted and restored, matching the dense arm in every case. Malformed compacted headers are refused by the specific check that owns each field, none of them reaching row placement. Context checkpoints are unaffected: across a five-turn conversation grown past the compacted capacity and then forced to rewind, the compacted arm refused the rewind at the boundary described above and reprocessed cleanly, the dense arm restored a checkpoint, no state was corrupted in either arm, and forward prefix reuse matches dense.

`bulgaria`, `quicksort`, `sayap`, `double-link-list` generate as expected, same build and flags, greedy decoding at a fixed seed with thinking disabled.  The first three generate inside the window and never compact. `double-link-list` exercises compaction: 2764 generated tokens against a 1024-row window, so it compacts many times inside one generation, and it repeats less than the reference run.

*Adversarial code review, and assessment of blast radius and accuracy of this description, by Opus 5.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High