### PR TITLE
Better placement of MoE tensors with -ncmoe and 1 GPU

### DIFF
--- a/src/llama-load-tensors.cpp
+++ b/src/llama-load-tensors.cpp
@@ -264,10 +264,17 @@ create_tensors_helper::create_tensors_helper(llama_model_loader & _ml, llama_mod
     if (ml.ncmoe > 0) {
         auto buft = llama_default_buffer_type_cpu(true);
         if (model.split_mode == LLAMA_SPLIT_MODE_ATTN || model.split_mode == LLAMA_SPLIT_MODE_GRAPH || ml.ncmoe >= n_layer || model.devices.size() < 2) {
-            int nmax = std::min(ml.ncmoe, n_layer);
-            for (int i = 0; i < nmax; ++i) {
-                std::string pattern = "blk\\." + std::to_string(i) + "\\.ffn_(up|down|gate|gate_up)_exps\\.(weight|scale)";
-                this->overrides.emplace_back(std::make_pair(std::regex(pattern), buft));
+            const auto tn = LLM_TN(model.arch);
+            int last_layer = n_layer - model.hparams.nextn_predict_layers;
+            int ndone = 0;
+            for (int i = last_layer-1; i >= 0; --i) {
+                auto d_name = tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i);
+                auto d_meta = ml.get_tensor_meta(d_name.c_str());
+                if (d_meta) {
+                    std::string pattern = "blk\\." + std::to_string(i) + "\\.ffn_(up|down|gate|gate_up)_exps\\.(weight|scale)";
+                    this->overrides.emplace_back(std::make_pair(std::regex(pattern), buft));
+                    if (++ndone == ml.ncmoe) break;
+                }
             }
         }
         else if (model.split_mode == LLAMA_SPLIT_MODE_LAYER) {


### PR DESCRIPTION

We have PR #2259, which claims better performance for hybrid CUDA/CPU inference by using the "ATSInfer solver" (whatever that is, the PR doesn't tell us). The PR is far from ready (it doesn't even compile), but I did play with it some after fixing the compilation failures. The PR disintegrates into nothingness with more than 1 GPU. But for one GPU I was somewhat surprised to find that it does get about 10% better PP performance compared to `-ncmoe` when using the exact same VRAM budget (TG is more or less the same, perhaps 1-2% better). Looking at the difference of generated tensor overrides, I observe that the "ATSInfer solver" places the last `N` MoE layers on the CPU, while `-ncmoe N` places the first `N` on the CPU (when running on a single GPU, behavior is different on a multi-GPU setup).

Well, we can change `-ncmoe` to do the same. This PR does it with 11 lines added, 4 deleted. No 4000 LoC PR and a magic "solver" required.

Tested with `Q8_0` quantized Qwen3.6-35B-A3B on a single RTX-3090 GPU. Here is what we get for `-ncmoe 22`

### This PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.917 |  2233.82 |    1.446 |    88.54 |
|  2048 |    128 |   2048 |    0.912 |  2244.65 |    1.447 |    88.45 |
|  2048 |    128 |   4096 |    0.905 |  2262.95 |    1.456 |    87.93 |
|  2048 |    128 |   6144 |    0.932 |  2198.05 |    1.464 |    87.42 |
|  2048 |    128 |   8192 |    0.941 |  2177.30 |    1.477 |    86.69 |
|  2048 |    128 |  10240 |    0.932 |  2196.58 |    1.488 |    86.05 |
|  2048 |    128 |  12288 |    0.955 |  2144.90 |    1.502 |    85.23 |
|  2048 |    128 |  14336 |    0.954 |  2146.76 |    1.506 |    85.02 |
|  2048 |    128 |  16384 |    0.976 |  2098.62 |    1.511 |    84.70 |
|  2048 |    128 |  18432 |    0.983 |  2082.75 |    1.527 |    83.81 |
|  2048 |    128 |  20480 |    0.990 |  2068.34 |    1.525 |    83.94 |
|  2048 |    128 |  22528 |    0.994 |  2060.93 |    1.545 |    82.82 |
|  2048 |    128 |  24576 |    0.992 |  2063.95 |    1.550 |    82.61 |
|  2048 |    128 |  26624 |    1.011 |  2025.38 |    1.556 |    82.28 |
|  2048 |    128 |  28672 |    1.024 |  1999.65 |    1.563 |    81.87 |
|  2048 |    128 |  30720 |    1.028 |  1992.66 |    1.574 |    81.30 |

### Main branch

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.022 |  2003.82 |    1.437 |    89.07 |
|  2048 |    128 |   2048 |    1.006 |  2036.39 |    1.451 |    88.23 |
|  2048 |    128 |   4096 |    1.017 |  2014.57 |    1.457 |    87.88 |
|  2048 |    128 |   6144 |    1.035 |  1978.86 |    1.466 |    87.29 |
|  2048 |    128 |   8192 |    1.047 |  1956.11 |    1.474 |    86.83 |
|  2048 |    128 |  10240 |    1.050 |  1951.20 |    1.488 |    86.02 |
|  2048 |    128 |  12288 |    1.057 |  1938.05 |    1.507 |    84.95 |
|  2048 |    128 |  14336 |    1.065 |  1923.65 |    1.522 |    84.10 |
|  2048 |    128 |  16384 |    1.079 |  1897.84 |    1.513 |    84.62 |
|  2048 |    128 |  18432 |    1.088 |  1882.14 |    1.520 |    84.20 |
|  2048 |    128 |  20480 |    1.103 |  1856.20 |    1.543 |    82.94 |
|  2048 |    128 |  22528 |    1.105 |  1853.92 |    1.543 |    82.94 |
|  2048 |    128 |  24576 |    1.115 |  1837.54 |    1.548 |    82.69 |
|  2048 |    128 |  26624 |    1.128 |  1814.89 |    1.559 |    82.08 |
|  2048 |    128 |  28672 |    1.140 |  1797.08 |    1.564 |    81.85 |
|  2048 |    128 |  30720 |    1.152 |  1777.51 |    1.569 |    81.58 |

I.e, about 10% better PP, TG within the noise.

Worth noting that for 2+ GPUs, `-ncmoe` already does the MoE placement in that way: MoE tensors are overridden to CPU starting from the last layer of each GPU and counting down until the requested `ncmoe` has been reached. Here is what we get on 2x3090 with the same `-ncmoe 22` (both, on the main branch and with this PR as the PR does not touch the 2+ GPU logic):

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    0.923 |  2219.90 |    1.463 |    87.51 |
|  2048 |    128 |   2048 |    0.918 |  2232.07 |    1.438 |    89.01 |
|  2048 |    128 |   4096 |    0.904 |  2264.92 |    1.445 |    88.61 |
|  2048 |    128 |   6144 |    0.932 |  2197.59 |    1.451 |    88.21 |
|  2048 |    128 |   8192 |    0.942 |  2174.18 |    1.464 |    87.41 |
|  2048 |    128 |  10240 |    0.936 |  2188.83 |    1.474 |    86.82 |
|  2048 |    128 |  12288 |    0.957 |  2139.97 |    1.493 |    85.71 |
|  2048 |    128 |  14336 |    0.958 |  2138.51 |    1.515 |    84.46 |
|  2048 |    128 |  16384 |    0.977 |  2095.69 |    1.506 |    84.98 |
|  2048 |    128 |  18432 |    0.984 |  2081.00 |    1.510 |    84.76 |
|  2048 |    128 |  20480 |    0.997 |  2054.96 |    1.518 |    84.32 |
|  2048 |    128 |  22528 |    0.992 |  2065.54 |    1.543 |    82.94 |
|  2048 |    128 |  24576 |    0.998 |  2052.46 |    1.541 |    83.06 |
|  2048 |    128 |  26624 |    1.017 |  2014.34 |    1.552 |    82.50 |
|  2048 |    128 |  28672 |    1.028 |  1992.05 |    1.553 |    82.42 |
|  2048 |    128 |  30720 |    1.032 |  1983.77 |    1.563 |    81.91 |
