### PR TITLE
Do not include ggml-impl.h in ggml-cuda.cu

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1305,6 +1305,8 @@ add_library(ggml
             ggml-moe-prefetch.h
             ggml-quants.c
             ggml-quants.h
+            ggml-utils.h
+            ggml-impl.h
             ${GGML_SOURCES_CUDA}      ${GGML_HEADERS_CUDA}
             ${GGML_SOURCES_METAL}     ${GGML_HEADERS_METAL}
             ${GGML_SOURCES_RPC}       ${GGML_HEADERS_RPC}

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -8,7 +8,8 @@
 #include "ggml-cuda.h"
 #include "ggml.h"
 #include "ggml-backend-impl.h"
-#include "ggml-impl.h"
+//#include "ggml-impl.h"
+#include "ggml-utils.h"
 
 #include "ggml-cuda/common.cuh"
 #include "ggml-cuda/acc.cuh"

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -766,10 +766,6 @@ static size_t ggml_hash_find_or_insert(struct ggml_hash_set * hash_set, struct g
     GGML_ABORT("fatal error");
 }
 
-// Finds the copy the delta-net fusion can skip: the CPY that writes this node's new recurrent
-// state back into the slot it was read from. Its index in cgraph, or -1 if there is none.
-int ggml_delta_net_find_state_cpy(const struct ggml_cgraph * cgraph, int i);
-
 static int32_t ggml_get_op_params_i32(const struct ggml_tensor * tensor, uint32_t i) {
     assert(i < GGML_MAX_OP_PARAMS / sizeof(int32_t));
     return ((const int32_t *)(tensor->op_params))[i];

--- a/ggml/src/ggml-utils.h
+++ b/ggml/src/ggml-utils.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ggml_cgraph;
+
+// Finds the copy the delta-net fusion can skip: the CPY that writes this node's new recurrent
+// state back into the slot it was read from. Its index in cgraph, or -1 if there is none.
+int ggml_delta_net_find_state_cpy(const struct ggml_cgraph * cgraph, int i);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -8,6 +8,7 @@
 #define _USE_MATH_DEFINES // For M_PI on MSVC
 
 #include "ggml-impl.h"
+#include "ggml-utils.h"
 #include "ggml-quants.h"
 #include "ggml.h"
 #include "ggml-aarch64.h"


### PR DESCRIPTION

Closes #2263 

Not a good idea to include `ggml-impl.h` in compilation units that are not compiled by the host compiler. I didn't like the idea of doing this in PR #2251, but it was building and working fine on my system, so I let it go in. But it came to bite us with an older GCC version when compiling `ggml-cuda.cu` where `ggml-impl.h` got added as an include.