### PR TITLE
Reduce the indexer temporary buffer size on CUDA

### DIFF
--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -146,7 +146,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
 
     }
 
-    constexpr int64_t k_max_work_buffer_elements = 1 << 28;
+    constexpr int64_t k_max_work_buffer_elements = 1 << 26;
 
     int max_rows = k_max_work_buffer_elements / n_kv / n_head;
     if (max_rows < 1) max_rows = 1;


### PR DESCRIPTION

I intended to set it to 256 MiB, but instead ended up with 1 GiB because of forgetting to multiply with `sizeof(float)`.

Not noticing a measurable performance impact even at a context of 128k tokens.
