### PR TITLE
CUDA: Fix non-F16 indexer top-k

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -5085,11 +5085,12 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                    op->src[1]->ne[0] == op->src[0]->ne[1] &&
                    op->src[3]->ne[0] == op->src[0]->ne[2];
         case GGML_OP_DELTA_NET:
-        case GGML_OP_INDEXER_TOPK:
         case GGML_OP_MASK_TOPK:
         case GGML_OP_MASK_TO_IDX:
         case GGML_OP_DS4_COMP:
             return true;
+        case GGML_OP_INDEXER_TOPK:
+            return ggml_is_quantized(op->src[0]->type) || ggml_is_contiguous(op->src[0]);
         case GGML_OP_HC_PRE:
         case GGML_OP_HC_POST:
             return true;

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -5085,12 +5085,11 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                    op->src[1]->ne[0] == op->src[0]->ne[1] &&
                    op->src[3]->ne[0] == op->src[0]->ne[2];
         case GGML_OP_DELTA_NET:
+        case GGML_OP_INDEXER_TOPK:
         case GGML_OP_MASK_TOPK:
         case GGML_OP_MASK_TO_IDX:
         case GGML_OP_DS4_COMP:
             return true;
-        case GGML_OP_INDEXER_TOPK:
-            return ggml_is_quantized(op->src[0]->type) || ggml_is_contiguous(op->src[0]);
         case GGML_OP_HC_PRE:
         case GGML_OP_HC_POST:
             return true;

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -72,7 +72,6 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     //if (k->type != GGML_TYPE_F16 && !ggml_is_quantized(k->type)) printf("%s: K is %s?\n", __func__, ggml_type_name(k->type));
     GGML_ASSERT(k->type == GGML_TYPE_F16 || k->type == GGML_TYPE_BF16 ||
                 k->type == GGML_TYPE_F32 || ggml_is_quantized(k->type));
-    GGML_ASSERT(ggml_is_quantized(k->type) || ggml_is_contiguous(k));
     GGML_ASSERT(k->ne[2] == 1 || k->ne[3] == 1);
     GGML_ASSERT(k->ne[1] > n_top_k);
     GGML_ASSERT(k->ne[1] == m->ne[0]);
@@ -162,6 +161,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     ggml_cuda_pool_alloc<float> k_f32(ctx.pool());
     ggml_cuda_pool_alloc<char>  q_converted(ctx.pool());
     const float * k_data = nullptr;
+    int k_ld = k->ne[0];
     auto q_padded = GGML_PAD(q->ne[0], MATRIX_ROW_PADDING);
     if (ggml_is_quantized(k->type)) {
         auto nbytes_q = (size_t)(q_padded/QK8_1) * ((size_t) q->ne[1] * max_rows) * sizeof(block_q8_1);
@@ -169,6 +169,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         q_converted.alloc(nbytes_q);
     } else if (k->type == GGML_TYPE_F32) {
         k_data = (const float *) k->data;
+        k_ld   = k->nb[1]/sizeof(float);
     } else {
         k_f32.alloc(k->ne[0]*k->ne[1]);
         ggml_get_to_fp32_cuda(k->type)(k->data, k_f32.get(), k->ne[1]*k->ne[0], 1, ctx.stream());
@@ -199,7 +200,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
             CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
             CUBLAS_CHECK(cublasSgemm(ctx.cublas_handle(ctx.device), CUBLAS_OP_T, CUBLAS_OP_N,
                     k->ne[1], q->ne[1]*nrows, q->ne[0],
-                    &alpha,     k_data,                k->ne[0],
+                    &alpha,     k_data,                k_ld,
                        (const float *)q_data, q->ne[0],
                     &beta,      kq.get(),     k->ne[1]));
         }

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -70,7 +70,9 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     int n_kv    = k->ne[1];
     int n_head  = q->ne[1];
     //if (k->type != GGML_TYPE_F16 && !ggml_is_quantized(k->type)) printf("%s: K is %s?\n", __func__, ggml_type_name(k->type));
-    GGML_ASSERT(k->type == GGML_TYPE_F16 || k->type == GGML_TYPE_F32 || ggml_is_quantized(k->type));
+    GGML_ASSERT(k->type == GGML_TYPE_F16 || k->type == GGML_TYPE_BF16 ||
+                k->type == GGML_TYPE_F32 || ggml_is_quantized(k->type));
+    GGML_ASSERT(ggml_is_quantized(k->type) || ggml_is_contiguous(k));
     GGML_ASSERT(k->ne[2] == 1 || k->ne[3] == 1);
     GGML_ASSERT(k->ne[1] > n_top_k);
     GGML_ASSERT(k->ne[1] == m->ne[0]);
@@ -159,16 +161,19 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     ggml_cuda_pool_alloc<int>   sorted(ctx.pool(), int64_t(n_kv)*max_rows);
     ggml_cuda_pool_alloc<float> k_f32(ctx.pool());
     ggml_cuda_pool_alloc<char>  q_converted(ctx.pool());
+    const float * k_data = nullptr;
     auto q_padded = GGML_PAD(q->ne[0], MATRIX_ROW_PADDING);
     if (ggml_is_quantized(k->type)) {
         auto nbytes_q = (size_t)(q_padded/QK8_1) * ((size_t) q->ne[1] * max_rows) * sizeof(block_q8_1);
         nbytes_q += get_mmq_x_max_host(ggml_cuda_info().devices[ctx.device].cc)*sizeof(block_q8_1_mmq);
         q_converted.alloc(nbytes_q);
+    } else if (k->type == GGML_TYPE_F32) {
+        k_data = (const float *) k->data;
     } else {
         k_f32.alloc(k->ne[0]*k->ne[1]);
-        auto to_fp32_cuda = ggml_get_to_fp32_cuda(k->type);
-        to_fp32_cuda(k->data, k_f32.get(), k->ne[1]*k->ne[0], 1, ctx.stream());
+        ggml_get_to_fp32_cuda(k->type)(k->data, k_f32.get(), k->ne[1]*k->ne[0], 1, ctx.stream());
         CUDA_CHECK(cudaGetLastError());
+        k_data = k_f32.get();
     }
 
     for (int istep = 0; istep < nstep; ++istep) {
@@ -177,6 +182,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         int nrows = last - first;
         auto q_data = (const char *)q->data + istep*max_rows*q->nb[2];
         auto m_data = (const char *)m->data + istep*max_rows*m->nb[1];
+        auto w_data = (const float *)w->data + first*q->ne[1];
         if (ggml_is_quantized(k->type)) {
             quantize_mmq_q8_1_cuda((const float *)q_data, q_converted.get(), q->ne[0], q->ne[1]*nrows, 1, q_padded, k->type, ctx.stream());
             CUDA_CHECK(cudaGetLastError());
@@ -193,15 +199,15 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
             CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
             CUBLAS_CHECK(cublasSgemm(ctx.cublas_handle(ctx.device), CUBLAS_OP_T, CUBLAS_OP_N,
                     k->ne[1], q->ne[1]*nrows, q->ne[0],
-                    &alpha,     k_f32.get(),  k->ne[0],
+                    &alpha,     k_data,                k->ne[0],
                        (const float *)q_data, q->ne[0],
                     &beta,      kq.get(),     k->ne[1]));
         }
         if (m->type == GGML_TYPE_F32) {
-            k_fused_relu_mul_sum_rows<<<nrows, k_block_size, 0, ctx.stream()>>>(kq.get(), (const float *)w->data, (const float *)m_data,
+            k_fused_relu_mul_sum_rows<<<nrows, k_block_size, 0, ctx.stream()>>>(kq.get(), w_data, (const float *)m_data,
                     score.get(), k->ne[1], q->ne[1], m->nb[1]);
         } else {
-            k_fused_relu_mul_sum_rows<<<nrows, k_block_size, 0, ctx.stream()>>>(kq.get(), (const float *)w->data, (const half  *)m_data,
+            k_fused_relu_mul_sum_rows<<<nrows, k_block_size, 0, ctx.stream()>>>(kq.get(), w_data, (const half  *)m_data,
                     score.get(), k->ne[1], q->ne[1], m->nb[1]);
         }
         CUDA_CHECK(cudaGetLastError());


### PR DESCRIPTION
Main's `CUDA INDEXER_TOPK` kernel splits large query batches into chunks, and in the non-F16 path on main it was handing every chunk the first chunk's weights. Later query rows got scored against the wrong head weighting and silently picked the wrong cache rows. Two smaller problems: F32 keys go through a conversion dispatch that has no F32 entry, so it calls a null converter, and BF16 passes the openPangu and DeepSeek-V4 cache-type checks but the CUDA operator asserts on it.

The fix here advances the weight pointer with each chunk, as the F16 path already does. F32 keys now go straight to cuBLAS instead of through the missing converter, and BF16 is converted once before the chunk loop. I also made CUDA report the operator unsupported for strided nonquantized keys, since the pointer math there always assumed tight rows; the quantized path already honored k->nb[1] and keeps it.

`-ictk` **stays disabled** from #2236, so as far as I can tell nothing in a default build exercises the corrected code: indexer keys stay f16 and take the unchanged path. These changes do not touch model graphs, cache allocation, quantization formats, or the separate direct-quantized-key work. The new support condition is checked on every call, but it returns true for all three in-tree callers, since they pass contiguous keys.

The results below come from a small standalone program that runs a single `ggml_indexer_topk` node on CUDA, no model involved. Keys and weights are rigged so every query row should pick key row 0 except the last, which should pick row 1. The last row is alone in the final chunk, so reusing the first chunk's weights misses exactly that row.

| Case | Compared rows | Main `61b37f5f4` | PR `6425cc8d9` |
| --- | ---: | --- | --- |
| Q8_0, one chunk | 2 | 0 mismatches | 0 mismatches |
| F16, multiple chunks | 17 | 0 mismatches | 0 mismatches |
| Q8_0, multiple chunks | 65 | 1 mismatch, first at row 64 | 0 mismatches |
| F32, multiple chunks | 65 | Exit 139 after type admission | 0 mismatches |
| BF16, multiple chunks | 65 | Exit 134 at the CUDA type assertion | 0 mismatches |
| F32, strided K support query | 1 | Incorrectly reports supported | Correctly reports unsupported |
| Q8_0, strided K support query | 1 | Reports supported | Reports supported |

*Adversarial code review and assessment of blast radius and accuracy of this description by GPT-5.6.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High