### PR TITLE
Allow Q8_0 cache in the CUDA DSA implementation

### DIFF
--- a/ggml/src/ggml-cuda/dsa_attn.cu
+++ b/ggml/src/ggml-cuda/dsa_attn.cu
@@ -25,12 +25,26 @@ static __global__ void k_prepare_one_batch_kv(int nk, int ncol, const int * idx,
     int i = idx[row*stride_idx + col];
     if (i < 0) {
         i = 0;
-        //return;
     }
     auto k_row = (const half *)(k_in + stride_k * i);
     k_out += (row*ncol + col)*nk;
     for (int j = threadIdx.x; j < nk; j += blockDim.x) {
         k_out[j] = k_row[j];
+    }
+}
+
+static __global__ void k_prepare_one_batch_kv_q8_0(int nk, int ncol, const int * idx, const char * k_in,
+        half * k_out, size_t stride_k, size_t stride_idx) {
+    int row = blockIdx.y;
+    int col = blockIdx.x;
+    int i = idx[row*stride_idx + col];
+    if (i < 0) {
+        i = 0;
+    }
+    auto k_row = (const block_q8_0 *)(k_in + stride_k * i);
+    k_out += (row*ncol + col)*nk;
+    for (int j = threadIdx.x; j < nk; j += blockDim.x) {
+        k_out[j] = k_row[j/32].d * (half)k_row[j/32].qs[j%32];
     }
 }
 
@@ -228,7 +242,8 @@ bool ggml_cuda_dsa_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
         if (K->ne[1] < 4*indexer->ne[0]) return false; // for efficiency
     }
     if (K->ne[2] > 1 || K->ne[3] > 1 || mask->ne[2] > 1 || mask->ne[3] > 1 || Q->ne[3] > 1) return false;
-    if (K->type != GGML_TYPE_F16 || V->type != GGML_TYPE_F16 || mask->type != GGML_TYPE_F16 || Q->type != GGML_TYPE_F32) return false;
+    if ((K->type != GGML_TYPE_F16 && K->type != GGML_TYPE_Q8_0) ||
+        (V->type != GGML_TYPE_F16 && V->type != GGML_TYPE_Q8_0) || mask->type != GGML_TYPE_F16 || Q->type != GGML_TYPE_F32) return false;
     if (K->ne[0] != Q->ne[0]) return false;
 
     //printf("%s(%s)\n", __func__, dst->name);
@@ -274,13 +289,25 @@ bool ggml_cuda_dsa_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
         int nrows = last - first;
         {
             dim3 grid(indexer->ne[0], nrows, 1);
-            k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(K->ne[0], indexer->ne[0],
-                    (const int *)indexer->data + stride_idx*first,
-                    (const char *)K->data, k16.get(), K->nb[1], stride_idx);
-            if (!is_k_view) {
-                k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(V->ne[0], indexer->ne[0],
+            if (K->type == GGML_TYPE_F16) {
+                k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(K->ne[0], indexer->ne[0],
                         (const int *)indexer->data + stride_idx*first,
-                        (const char *)V->data, v16.get(), V->nb[1], stride_idx);
+                        (const char *)K->data, k16.get(), K->nb[1], stride_idx);
+            } else {
+                k_prepare_one_batch_kv_q8_0<<<grid, 256, 0, ctx.stream()>>>(K->ne[0], indexer->ne[0],
+                        (const int *)indexer->data + stride_idx*first,
+                        (const char *)K->data, k16.get(), K->nb[1], stride_idx);
+            }
+            if (!is_k_view) {
+                if (V->type == GGML_TYPE_F16) {
+                    k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(V->ne[0], indexer->ne[0],
+                            (const int *)indexer->data + stride_idx*first,
+                            (const char *)V->data, v16.get(), V->nb[1], stride_idx);
+                } else {
+                    k_prepare_one_batch_kv_q8_0<<<grid, 256, 0, ctx.stream()>>>(V->ne[0], indexer->ne[0],
+                            (const int *)indexer->data + stride_idx*first,
+                            (const char *)V->data, v16.get(), V->nb[1], stride_idx);
+                }
             }
         }
         {

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -92,15 +92,6 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         size_t per_row = size_t(n_kv)*(q->ne[1]*sizeof(half) + sizeof(int) + sizeof(float)) + q->ne[0]*q->ne[1]*sizeof(half);
         int max_rows = (k_max_buf_size + per_row - 1)/per_row;
         max_rows = std::min<int>(max_rows, q->ne[2]);
-        //int max_rows = 1;
-        //while (true) {
-        //    if (max_rows >= int(q->ne[2])) break;
-        //    if (per_row*max_rows*2 > k_max_buf_size) break;
-        //    max_rows *= 2;
-        //}
-        //max_rows = std::min<int>(max_rows, q->ne[2]);
-        ////constexpr int k_max_rows = 16;
-        //int max_rows = std::min<int>(k_max_rows, q->ne[2]);
         int nstep = (q->ne[2] + max_rows - 1)/max_rows;
 
         ggml_cuda_pool_alloc<half>  kq(ctx.pool(), int64_t(n_kv)*q->ne[1]*max_rows);
@@ -113,9 +104,6 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
 
         const half alpha = 1.0f;
         const half beta = 0.0f;
-
-        //printf("========================================= %s: n_kv = %d, q->ne[2] = %ld, max_rows = %d, nstep = %d -> %g MiB\n", __func__,
-        //        n_kv, q->ne[2], max_rows, nstep, 1.*max_rows*per_row/1024./1024.);
 
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
 
@@ -151,10 +139,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
             }
             CUDA_CHECK(cudaGetLastError());
 
-            //auto tim1 = ggml_time_us();
             argsort_f32_i32_cuda_cub(ctx.pool(), score.get(), sorted.get(), k->ne[1], nrows, GGML_SORT_ORDER_DESC, ctx.stream());
-            //auto tim2 = ggml_time_us();
-            //printf("argsort_f32_i32(%s,%d,%d): %d us\n", dst->name, first_row, last_row, int(tim2-tim1));
             CUDA_CHECK(cudaGetLastError());
 
             k_copy_topk<<<nrows, k_block_size, 0, ctx.stream()>>>(sorted.get(),

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -88,8 +88,19 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     constexpr int k_block_size = 256;
 
     if (k->type == GGML_TYPE_F16 && q->type == GGML_TYPE_F32) {
-        constexpr int k_max_rows = 16;
-        int max_rows = std::min<int>(k_max_rows, q->ne[2]);
+        constexpr size_t k_max_buf_size = 1 << 28;
+        size_t per_row = size_t(n_kv)*(q->ne[1]*sizeof(half) + sizeof(int) + sizeof(float)) + q->ne[0]*q->ne[1]*sizeof(half);
+        int max_rows = (k_max_buf_size + per_row - 1)/per_row;
+        max_rows = std::min<int>(max_rows, q->ne[2]);
+        //int max_rows = 1;
+        //while (true) {
+        //    if (max_rows >= int(q->ne[2])) break;
+        //    if (per_row*max_rows*2 > k_max_buf_size) break;
+        //    max_rows *= 2;
+        //}
+        //max_rows = std::min<int>(max_rows, q->ne[2]);
+        ////constexpr int k_max_rows = 16;
+        //int max_rows = std::min<int>(k_max_rows, q->ne[2]);
         int nstep = (q->ne[2] + max_rows - 1)/max_rows;
 
         ggml_cuda_pool_alloc<half>  kq(ctx.pool(), int64_t(n_kv)*q->ne[1]*max_rows);
@@ -103,15 +114,19 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         const half alpha = 1.0f;
         const half beta = 0.0f;
 
+        //printf("========================================= %s: n_kv = %d, q->ne[2] = %ld, max_rows = %d, nstep = %d -> %g MiB\n", __func__,
+        //        n_kv, q->ne[2], max_rows, nstep, 1.*max_rows*per_row/1024./1024.);
+
+        CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
+
         for (int istep = 0; istep < nstep; ++istep) {
             int first_row = max_rows*istep;
-            int last_row  = std::min(first_row + k_max_rows, int(q->ne[2]));
+            int last_row  = std::min(first_row + max_rows, int(q->ne[2]));
             int nrows     = last_row - first_row;
 
             to_fp16_cuda((const float *)q->data + q->ne[0]*q->ne[1]*first_row, q_f16.get(), q->ne[0]*q->ne[1]*nrows, 1, ctx.stream());
             CUDA_CHECK(cudaGetLastError());
 
-            CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
             CUBLAS_CHECK(cublasGemmEx(ctx.cublas_handle(ctx.device), CUBLAS_OP_T, CUBLAS_OP_N,
                     k->ne[1], q->ne[1]*nrows, q->ne[0],
                     &alpha, (const half *)k->data,       CUDA_R_16F, k->ne[0],
@@ -135,7 +150,10 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
             }
             CUDA_CHECK(cudaGetLastError());
 
+            //auto tim1 = ggml_time_us();
             argsort_f32_i32_cuda_cub(ctx.pool(), score.get(), sorted.get(), k->ne[1], nrows, GGML_SORT_ORDER_DESC, ctx.stream());
+            //auto tim2 = ggml_time_us();
+            //printf("argsort_f32_i32(%s,%d,%d): %d us\n", dst->name, first_row, last_row, int(tim2-tim1));
             CUDA_CHECK(cudaGetLastError());
 
             k_copy_topk<<<nrows, k_block_size, 0, ctx.stream()>>>(sorted.get(),

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -121,6 +121,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
 
         for (int istep = 0; istep < nstep; ++istep) {
             int first_row = max_rows*istep;
+            if (first_row >= int(q->ne[2])) break;
             int last_row  = std::min(first_row + max_rows, int(q->ne[2]));
             int nrows     = last_row - first_row;
 


### PR DESCRIPTION

The CUDA DSA implementation currently only allows `f16` cache and falls back to standard FA for other cache types. This PR adds `Q8_0` as a possible quantization type to the DSA implementation.

We get massive PP performance gains. For DS4-IQ3_XXS running on 2x3090 with `-ncmoe 32` we get 1.4X for zero context  and 2.3X at a context of 128k tokens (see tables below).

There are some modest performance gains for TG as well, but for TG there are other inefficiencies when using quantized cache for DS4, so TG performance is noticeably lower than `f16` cache.

### Main branch with --swa-compress

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |    7.855 |   521.47 |    2.244 |    28.53 |
|  4096 |     64 |   4096 |    8.230 |   497.71 |    2.374 |    26.96 |
|  4096 |     64 |   8192 |    8.607 |   475.90 |    2.359 |    27.14 |
|  4096 |     64 |  12288 |    8.934 |   458.48 |    2.370 |    27.00 |
|  4096 |     64 |  16384 |    9.280 |   441.37 |    2.391 |    26.76 |
|  4096 |     64 |  20480 |    9.705 |   422.03 |    2.429 |    26.35 |
|  4096 |     64 |  24576 |   10.078 |   406.43 |    2.417 |    26.48 |
|  4096 |     64 |  28672 |   10.443 |   392.23 |    2.414 |    26.51 |
|  4096 |     64 |  32768 |   10.864 |   377.04 |    2.422 |    26.42 |
|  4096 |     64 |  36864 |   11.282 |   363.06 |    2.543 |    25.17 |
|  4096 |     64 |  40960 |   11.693 |   350.29 |    2.551 |    25.09 |
|  4096 |     64 |  45056 |   12.100 |   338.52 |    2.577 |    24.84 |
|  4096 |     64 |  49152 |   12.525 |   327.03 |    2.561 |    24.99 |
|  4096 |     64 |  53248 |   12.815 |   319.62 |    2.566 |    24.95 |
|  4096 |     64 |  57344 |   13.360 |   306.58 |    2.640 |    24.24 |
|  4096 |     64 |  61440 |   13.613 |   300.88 |    2.614 |    24.48 |
|  4096 |     64 |  65536 |   14.091 |   290.69 |    2.579 |    24.82 |
|  4096 |     64 |  69632 |   14.536 |   281.79 |    2.716 |    23.56 |
|  4096 |     64 |  73728 |   14.877 |   275.33 |    2.733 |    23.42 |
|  4096 |     64 |  77824 |   15.369 |   266.51 |    2.748 |    23.29 |
|  4096 |     64 |  81920 |   15.662 |   261.52 |    2.747 |    23.30 |
|  4096 |     64 |  86016 |   16.096 |   254.48 |    2.724 |    23.50 |
|  4096 |     64 |  90112 |   16.584 |   246.99 |    2.732 |    23.43 |
|  4096 |     64 |  94208 |   16.724 |   244.91 |    2.815 |    22.74 |
|  4096 |     64 |  98304 |   17.133 |   239.07 |    2.802 |    22.84 |
|  4096 |     64 | 102400 |   17.525 |   233.72 |    2.934 |    21.81 |
|  4096 |     64 | 106496 |   17.969 |   227.94 |    2.908 |    22.01 |
|  4096 |     64 | 110592 |   18.424 |   222.32 |    2.901 |    22.06 |
|  4096 |     64 | 114688 |   18.825 |   217.58 |    2.937 |    21.79 |
|  4096 |     64 | 118784 |   19.223 |   213.08 |    2.910 |    22.00 |
|  4096 |     64 | 122880 |   19.672 |   208.21 |    2.949 |    21.70 |
|  4096 |     64 | 126976 |   19.780 |   207.08 |    2.909 |    22.00 |

### This PR with --swa-compress

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |    6.038 |   678.41 |    2.251 |    28.43 |
|  4096 |     64 |   4096 |    5.915 |   692.50 |    2.249 |    28.46 |
|  4096 |     64 |   8192 |    6.002 |   682.43 |    2.264 |    28.26 |
|  4096 |     64 |  12288 |    6.042 |   677.89 |    2.254 |    28.40 |
|  4096 |     64 |  16384 |    6.231 |   657.35 |    2.255 |    28.38 |
|  4096 |     64 |  20480 |    6.372 |   642.85 |    2.311 |    27.70 |
|  4096 |     64 |  24576 |    6.442 |   635.81 |    2.314 |    27.65 |
|  4096 |     64 |  28672 |    6.498 |   630.37 |    2.316 |    27.64 |
|  4096 |     64 |  32768 |    6.561 |   624.29 |    2.329 |    27.48 |
|  4096 |     64 |  36864 |    6.665 |   614.53 |    2.463 |    25.98 |
|  4096 |     64 |  40960 |    6.769 |   605.15 |    2.448 |    26.15 |
|  4096 |     64 |  45056 |    6.863 |   596.78 |    2.449 |    26.13 |
|  4096 |     64 |  49152 |    7.181 |   570.42 |    2.459 |    26.03 |
|  4096 |     64 |  53248 |    7.170 |   571.26 |    2.462 |    26.00 |   
|  4096 |     64 |  57344 |    7.356 |   556.84 |    2.475 |    25.86 |    
|  4096 |     64 |  61440 |    7.336 |   558.33 |    2.497 |    25.64 |  
|  4096 |     64 |  65536 |    7.415 |   552.39 |    2.487 |    25.73 |
|  4096 |     64 |  69632 |    7.547 |   542.74 |    2.644 |    24.21 |
|  4096 |     64 |  73728 |    7.574 |   540.80 |    2.614 |    24.48 |
|  4096 |     64 |  77824 |    7.675 |   533.66 |    2.651 |    24.14 |
|  4096 |     64 |  81920 |    7.817 |   524.00 |    2.699 |    23.71 |
|  4096 |     64 |  86016 |    7.929 |   516.61 |    2.749 |    23.28 |
|  4096 |     64 |  90112 |    7.961 |   514.51 |    2.691 |    23.78 |
|  4096 |     64 |  94208 |    7.968 |   514.05 |    2.737 |    23.38 |
|  4096 |     64 |  98304 |    7.997 |   512.18 |    2.731 |    23.43 |
|  4096 |     64 | 102400 |    8.072 |   507.43 |    2.768 |    23.12 |
|  4096 |     64 | 106496 |    8.145 |   502.87 |    2.797 |    22.88 |
|  4096 |     64 | 110592 |    8.358 |   490.08 |    2.794 |    22.90 |
|  4096 |     64 | 114688 |    8.585 |   477.09 |    2.861 |    22.37 |
|  4096 |     64 | 118784 |    8.650 |   473.50 |    2.826 |    22.65 |
|  4096 |     64 | 122880 |    8.772 |   466.93 |    2.948 |    21.71 |
|  4096 |     64 | 126976 |    8.659 |   473.02 |    2.906 |    22.03 |
