### PR TITLE
DS4: do not cast caches to f32

### DIFF
--- a/ggml/src/ggml-cuda/dsa_attn.cu
+++ b/ggml/src/ggml-cuda/dsa_attn.cu
@@ -25,12 +25,26 @@ static __global__ void k_prepare_one_batch_kv(int nk, int ncol, const int * idx,
     int i = idx[row*stride_idx + col];
     if (i < 0) {
         i = 0;
-        //return;
     }
     auto k_row = (const half *)(k_in + stride_k * i);
     k_out += (row*ncol + col)*nk;
     for (int j = threadIdx.x; j < nk; j += blockDim.x) {
         k_out[j] = k_row[j];
+    }
+}
+
+static __global__ void k_prepare_one_batch_kv_q8_0(int nk, int ncol, const int * idx, const char * k_in,
+        half * k_out, size_t stride_k, size_t stride_idx) {
+    int row = blockIdx.y;
+    int col = blockIdx.x;
+    int i = idx[row*stride_idx + col];
+    if (i < 0) {
+        i = 0;
+    }
+    auto k_row = (const block_q8_0 *)(k_in + stride_k * i);
+    k_out += (row*ncol + col)*nk;
+    for (int j = threadIdx.x; j < nk; j += blockDim.x) {
+        k_out[j] = k_row[j/32].d * (half)k_row[j/32].qs[j%32];
     }
 }
 
@@ -228,7 +242,8 @@ bool ggml_cuda_dsa_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
         if (K->ne[1] < 4*indexer->ne[0]) return false; // for efficiency
     }
     if (K->ne[2] > 1 || K->ne[3] > 1 || mask->ne[2] > 1 || mask->ne[3] > 1 || Q->ne[3] > 1) return false;
-    if (K->type != GGML_TYPE_F16 || V->type != GGML_TYPE_F16 || mask->type != GGML_TYPE_F16 || Q->type != GGML_TYPE_F32) return false;
+    if ((K->type != GGML_TYPE_F16 && K->type != GGML_TYPE_Q8_0) ||
+        (V->type != GGML_TYPE_F16 && V->type != GGML_TYPE_Q8_0) || mask->type != GGML_TYPE_F16 || Q->type != GGML_TYPE_F32) return false;
     if (K->ne[0] != Q->ne[0]) return false;
 
     //printf("%s(%s)\n", __func__, dst->name);
@@ -274,13 +289,25 @@ bool ggml_cuda_dsa_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
         int nrows = last - first;
         {
             dim3 grid(indexer->ne[0], nrows, 1);
-            k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(K->ne[0], indexer->ne[0],
-                    (const int *)indexer->data + stride_idx*first,
-                    (const char *)K->data, k16.get(), K->nb[1], stride_idx);
-            if (!is_k_view) {
-                k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(V->ne[0], indexer->ne[0],
+            if (K->type == GGML_TYPE_F16) {
+                k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(K->ne[0], indexer->ne[0],
                         (const int *)indexer->data + stride_idx*first,
-                        (const char *)V->data, v16.get(), V->nb[1], stride_idx);
+                        (const char *)K->data, k16.get(), K->nb[1], stride_idx);
+            } else {
+                k_prepare_one_batch_kv_q8_0<<<grid, 256, 0, ctx.stream()>>>(K->ne[0], indexer->ne[0],
+                        (const int *)indexer->data + stride_idx*first,
+                        (const char *)K->data, k16.get(), K->nb[1], stride_idx);
+            }
+            if (!is_k_view) {
+                if (V->type == GGML_TYPE_F16) {
+                    k_prepare_one_batch_kv<<<grid, 256, 0, ctx.stream()>>>(V->ne[0], indexer->ne[0],
+                            (const int *)indexer->data + stride_idx*first,
+                            (const char *)V->data, v16.get(), V->nb[1], stride_idx);
+                } else {
+                    k_prepare_one_batch_kv_q8_0<<<grid, 256, 0, ctx.stream()>>>(V->ne[0], indexer->ne[0],
+                            (const int *)indexer->data + stride_idx*first,
+                            (const char *)V->data, v16.get(), V->nb[1], stride_idx);
+                }
             }
         }
         {

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -92,15 +92,6 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         size_t per_row = size_t(n_kv)*(q->ne[1]*sizeof(half) + sizeof(int) + sizeof(float)) + q->ne[0]*q->ne[1]*sizeof(half);
         int max_rows = (k_max_buf_size + per_row - 1)/per_row;
         max_rows = std::min<int>(max_rows, q->ne[2]);
-        //int max_rows = 1;
-        //while (true) {
-        //    if (max_rows >= int(q->ne[2])) break;
-        //    if (per_row*max_rows*2 > k_max_buf_size) break;
-        //    max_rows *= 2;
-        //}
-        //max_rows = std::min<int>(max_rows, q->ne[2]);
-        ////constexpr int k_max_rows = 16;
-        //int max_rows = std::min<int>(k_max_rows, q->ne[2]);
         int nstep = (q->ne[2] + max_rows - 1)/max_rows;
 
         ggml_cuda_pool_alloc<half>  kq(ctx.pool(), int64_t(n_kv)*q->ne[1]*max_rows);
@@ -113,9 +104,6 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
 
         const half alpha = 1.0f;
         const half beta = 0.0f;
-
-        //printf("========================================= %s: n_kv = %d, q->ne[2] = %ld, max_rows = %d, nstep = %d -> %g MiB\n", __func__,
-        //        n_kv, q->ne[2], max_rows, nstep, 1.*max_rows*per_row/1024./1024.);
 
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
 
@@ -151,10 +139,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
             }
             CUDA_CHECK(cudaGetLastError());
 
-            //auto tim1 = ggml_time_us();
             argsort_f32_i32_cuda_cub(ctx.pool(), score.get(), sorted.get(), k->ne[1], nrows, GGML_SORT_ORDER_DESC, ctx.stream());
-            //auto tim2 = ggml_time_us();
-            //printf("argsort_f32_i32(%s,%d,%d): %d us\n", dst->name, first_row, last_row, int(tim2-tim1));
             CUDA_CHECK(cudaGetLastError());
 
             k_copy_topk<<<nrows, k_block_size, 0, ctx.stream()>>>(sorted.get(),

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -88,8 +88,19 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     constexpr int k_block_size = 256;
 
     if (k->type == GGML_TYPE_F16 && q->type == GGML_TYPE_F32) {
-        constexpr int k_max_rows = 16;
-        int max_rows = std::min<int>(k_max_rows, q->ne[2]);
+        constexpr size_t k_max_buf_size = 1 << 28;
+        size_t per_row = size_t(n_kv)*(q->ne[1]*sizeof(half) + sizeof(int) + sizeof(float)) + q->ne[0]*q->ne[1]*sizeof(half);
+        int max_rows = (k_max_buf_size + per_row - 1)/per_row;
+        max_rows = std::min<int>(max_rows, q->ne[2]);
+        //int max_rows = 1;
+        //while (true) {
+        //    if (max_rows >= int(q->ne[2])) break;
+        //    if (per_row*max_rows*2 > k_max_buf_size) break;
+        //    max_rows *= 2;
+        //}
+        //max_rows = std::min<int>(max_rows, q->ne[2]);
+        ////constexpr int k_max_rows = 16;
+        //int max_rows = std::min<int>(k_max_rows, q->ne[2]);
         int nstep = (q->ne[2] + max_rows - 1)/max_rows;
 
         ggml_cuda_pool_alloc<half>  kq(ctx.pool(), int64_t(n_kv)*q->ne[1]*max_rows);
@@ -103,15 +114,19 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         const half alpha = 1.0f;
         const half beta = 0.0f;
 
+        //printf("========================================= %s: n_kv = %d, q->ne[2] = %ld, max_rows = %d, nstep = %d -> %g MiB\n", __func__,
+        //        n_kv, q->ne[2], max_rows, nstep, 1.*max_rows*per_row/1024./1024.);
+
+        CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
+
         for (int istep = 0; istep < nstep; ++istep) {
             int first_row = max_rows*istep;
-            int last_row  = std::min(first_row + k_max_rows, int(q->ne[2]));
+            int last_row  = std::min(first_row + max_rows, int(q->ne[2]));
             int nrows     = last_row - first_row;
 
             to_fp16_cuda((const float *)q->data + q->ne[0]*q->ne[1]*first_row, q_f16.get(), q->ne[0]*q->ne[1]*nrows, 1, ctx.stream());
             CUDA_CHECK(cudaGetLastError());
 
-            CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(ctx.device), ctx.stream()));
             CUBLAS_CHECK(cublasGemmEx(ctx.cublas_handle(ctx.device), CUBLAS_OP_T, CUBLAS_OP_N,
                     k->ne[1], q->ne[1]*nrows, q->ne[0],
                     &alpha, (const half *)k->data,       CUDA_R_16F, k->ne[0],
@@ -135,7 +150,10 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
             }
             CUDA_CHECK(cudaGetLastError());
 
+            //auto tim1 = ggml_time_us();
             argsort_f32_i32_cuda_cub(ctx.pool(), score.get(), sorted.get(), k->ne[1], nrows, GGML_SORT_ORDER_DESC, ctx.stream());
+            //auto tim2 = ggml_time_us();
+            //printf("argsort_f32_i32(%s,%d,%d): %d us\n", dst->name, first_row, last_row, int(tim2-tim1));
             CUDA_CHECK(cudaGetLastError());
 
             k_copy_topk<<<nrows, k_block_size, 0, ctx.stream()>>>(sorted.get(),

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -121,6 +121,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
 
         for (int istep = 0; istep < nstep; ++istep) {
             int first_row = max_rows*istep;
+            if (first_row >= int(q->ne[2])) break;
             int last_row  = std::min(first_row + max_rows, int(q->ne[2]));
             int nrows     = last_row - first_row;
 

--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -281,10 +281,6 @@ static ggml_tensor * dsv4_require_f32_rows(
     return ggml_cast(ctx, t, GGML_TYPE_F32);
 }
 
-static ggml_tensor * dsv4_cache_read_f32(ggml_context * ctx, ggml_tensor * t) {
-    return t != nullptr && ggml_is_quantized(t->type) ? ggml_cast(ctx, t, GGML_TYPE_F32) : t;
-}
-
 static ggml_tensor * dsv4_cache_stream_view_3d(
         ggml_context * ctx,
         ggml_tensor  * cache,
@@ -450,10 +446,10 @@ static ggml_tensor * dsv4_comp_get_k(
     }
 
     if (comp.sinfo.n_stream() == 0) {
-        return dsv4_cache_read_f32(ctx, ggml_reshape_4d(ctx, dsv4_cache_view_3d(ctx, cache, n_embd_head, n_kv), n_embd_head, 1, n_kv, 1));
+        return ggml_reshape_4d(ctx, dsv4_cache_view_3d(ctx, cache, n_embd_head, n_kv), n_embd_head, 1, n_kv, 1);
     }
 
-    return dsv4_cache_read_f32(ctx, dsv4_cache_stream_view_4d(ctx, cache, n_embd_head, n_kv, kv_size, comp.sinfo.s0, (int64_t) comp.sinfo.n_stream()));
+    return dsv4_cache_stream_view_4d(ctx, cache, n_embd_head, n_kv, kv_size, comp.sinfo.s0, (int64_t) comp.sinfo.n_stream());
 }
 
 static ggml_tensor * dsv4_comp_cpy_k(
@@ -1136,6 +1132,7 @@ static ggml_tensor * ds4_attention(ggml_cgraph * gf, ggml_context * ctx0, llm_bu
         auto extra_k = cache;
         if (extra_k->ne[1] > 1) {
             extra_k = dsv4_comp_get_k(ctx0, cache, extra_ctx, n_embd_head, cache->ne[1]/n_stream);
+            cb(extra_k, "extra_k", il);
         }
         if (cparams.flash_attn) {
             extra_mask = dsv4_pad_mask_tokens(ctx0, extra_mask, n_tokens);
@@ -1158,6 +1155,7 @@ static ggml_tensor * ds4_attention(ggml_cgraph * gf, ggml_context * ctx0, llm_bu
         }
         if (raw_k->type != extra_k->type) {
             extra_k = ggml_cast(ctx0, extra_k, raw_k->type);
+            cb(extra_k, (tag + "_k_cast").c_str(), il);
         }
         ggml_tensor * k_all = ggml_concat(ctx0, raw_k, extra_k, 2);
         ggml_tensor * kq_mask = ggml_concat(ctx0, raw_mask, extra_mask, 0);
@@ -1190,6 +1188,7 @@ static ggml_tensor * ds4_attention(ggml_cgraph * gf, ggml_context * ctx0, llm_bu
                 // raw_kv and csa_kv concetenation much less expensive for long context.
                 csa_kv = ggml_get_rows_ext(ctx0, csa_kv, top_k, true, false);
                 csa_kv = ggml_reshape_3d(ctx0, csa_kv, csa_kv->ne[0], 1, csa_kv->ne[1]);
+                cb(csa_kv, "csa_kv_getrows", il);
                 csa_mask = ggml_get_rows_ext(ctx0, csa_mask, top_k, true, true);
             } else {
                 csa_mask = build_top_k_mask(ctx0, dsv4_build_raw_mask_view(ctx0, lctx.dsv4.inputs.csa.kq_mask, nullptr,


### PR DESCRIPTION

On the main branch (and on this PR stack as well), CSA and HCA caches are first cast to `f32`, and then cast to the type of the raw cache to concatenate them. The cast to `f32` can obviously be avoided, and this is what this PR does.

I fad actually looked into this specific cast while working on the various DS4 optimizations, but found no real performance impact, so left it in place. But now that I have started looking into allowing and optimizing `Q8_0` cache for DSA models such as DS4, I saw a massive TG performance difference from avoiding the cast to `f32` when using `Q8_0` cache. Which basically tells us that there is something wrong with the `Q8_0 -> f32` copy kernel (and possibly there is the same problem for other quantization types). I'll look into that in a follow up.

Here is what we now get for DS4 `UD-IQ3_XXS` with `Q8_0` cache using `-ncmoe 32` on a 2x3090 system.  +6.7% TG at zero context and +24% TG at a context of 128k tokens. Minor performance gain for PP as well. Using `Q8_0` cache now basically matches `f16` cache performance. It seems to work perfectly fine as well after the bug fixes in #2272.  

### PR #2276 (previous PR in the stack)

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |    6.038 |   678.41 |    2.251 |    28.43 |
|  4096 |     64 |   4096 |    5.915 |   692.50 |    2.249 |    28.46 |
|  4096 |     64 |   8192 |    6.002 |   682.43 |    2.264 |    28.26 |
|  4096 |     64 |  12288 |    6.042 |   677.89 |    2.254 |    28.40 |
|  4096 |     64 |  16384 |    6.231 |   657.35 |    2.255 |    28.38 |
|  4096 |     64 |  20480 |    6.372 |   642.85 |    2.311 |    27.70 |
|  4096 |     64 |  24576 |    6.442 |   635.81 |    2.314 |    27.65 |
|  4096 |     64 |  28672 |    6.498 |   630.37 |    2.316 |    27.64 |
|  4096 |     64 |  32768 |    6.561 |   624.29 |    2.329 |    27.48 |
|  4096 |     64 |  36864 |    6.665 |   614.53 |    2.463 |    25.98 |
|  4096 |     64 |  40960 |    6.769 |   605.15 |    2.448 |    26.15 |
|  4096 |     64 |  45056 |    6.863 |   596.78 |    2.449 |    26.13 |
|  4096 |     64 |  49152 |    7.181 |   570.42 |    2.459 |    26.03 |
|  4096 |     64 |  53248 |    7.170 |   571.26 |    2.462 |    26.00 |   
|  4096 |     64 |  57344 |    7.356 |   556.84 |    2.475 |    25.86 |    
|  4096 |     64 |  61440 |    7.336 |   558.33 |    2.497 |    25.64 |  
|  4096 |     64 |  65536 |    7.415 |   552.39 |    2.487 |    25.73 |
|  4096 |     64 |  69632 |    7.547 |   542.74 |    2.644 |    24.21 |
|  4096 |     64 |  73728 |    7.574 |   540.80 |    2.614 |    24.48 |
|  4096 |     64 |  77824 |    7.675 |   533.66 |    2.651 |    24.14 |
|  4096 |     64 |  81920 |    7.817 |   524.00 |    2.699 |    23.71 |
|  4096 |     64 |  86016 |    7.929 |   516.61 |    2.749 |    23.28 |
|  4096 |     64 |  90112 |    7.961 |   514.51 |    2.691 |    23.78 |
|  4096 |     64 |  94208 |    7.968 |   514.05 |    2.737 |    23.38 |
|  4096 |     64 |  98304 |    7.997 |   512.18 |    2.731 |    23.43 |
|  4096 |     64 | 102400 |    8.072 |   507.43 |    2.768 |    23.12 |
|  4096 |     64 | 106496 |    8.145 |   502.87 |    2.797 |    22.88 |
|  4096 |     64 | 110592 |    8.358 |   490.08 |    2.794 |    22.90 |
|  4096 |     64 | 114688 |    8.585 |   477.09 |    2.861 |    22.37 |
|  4096 |     64 | 118784 |    8.650 |   473.50 |    2.826 |    22.65 |
|  4096 |     64 | 122880 |    8.772 |   466.93 |    2.948 |    21.71 |
|  4096 |     64 | 126976 |    8.659 |   473.02 |    2.906 |    22.03 |

### This PR

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |    6.007 |   681.87 |    2.112 |    30.31 |
|  4096 |     64 |   4096 |    5.946 |   688.90 |    2.134 |    30.00 |
|  4096 |     64 |   8192 |    6.001 |   682.53 |    2.115 |    30.27 |
|  4096 |     64 |  12288 |    6.038 |   678.34 |    2.122 |    30.17 |
|  4096 |     64 |  16384 |    6.219 |   658.61 |    2.136 |    29.96 |
|  4096 |     64 |  20480 |    6.331 |   646.99 |    2.193 |    29.18 |
|  4096 |     64 |  24576 |    6.404 |   639.63 |    2.189 |    29.24 |
|  4096 |     64 |  28672 |    6.444 |   635.66 |    2.199 |    29.11 |
|  4096 |     64 |  32768 |    6.502 |   629.93 |    2.200 |    29.09 |
|  4096 |     64 |  36864 |    6.613 |   619.40 |    2.207 |    29.00 |
|  4096 |     64 |  40960 |    6.696 |   611.69 |    2.211 |    28.94 |
|  4096 |     64 |  45056 |    6.775 |   604.60 |    2.215 |    28.89 |
|  4096 |     64 |  49152 |    7.093 |   577.47 |    2.253 |    28.41 |
|  4096 |     64 |  53248 |    7.082 |   578.40 |    2.221 |    28.81 |
|  4096 |     64 |  57344 |    7.242 |   565.59 |    2.225 |    28.76 |
|  4096 |     64 |  61440 |    7.220 |   567.34 |    2.239 |    28.59 |
|  4096 |     64 |  65536 |    7.292 |   561.70 |    2.235 |    28.64 |
|  4096 |     64 |  69632 |    7.408 |   552.94 |    2.238 |    28.59 |
|  4096 |     64 |  73728 |    7.440 |   550.50 |    2.265 |    28.26 |
|  4096 |     64 |  77824 |    7.517 |   544.92 |    2.248 |    28.47 |
|  4096 |     64 |  81920 |    7.670 |   533.99 |    2.259 |    28.33 |
|  4096 |     64 |  86016 |    7.753 |   528.33 |    2.260 |    28.32 |
|  4096 |     64 |  90112 |    7.788 |   525.91 |    2.268 |    28.22 |
|  4096 |     64 |  94208 |    7.796 |   525.38 |    2.269 |    28.20 |
|  4096 |     64 |  98304 |    7.807 |   524.65 |    2.278 |    28.09 |
|  4096 |     64 | 102400 |    7.895 |   518.79 |    2.278 |    28.09 |
|  4096 |     64 | 106496 |    7.949 |   515.28 |    2.292 |    27.92 |
|  4096 |     64 | 110592 |    8.126 |   504.04 |    2.293 |    27.91 |
|  4096 |     64 | 114688 |    8.351 |   490.46 |    2.297 |    27.86 |
|  4096 |     64 | 118784 |    8.429 |   485.93 |    2.309 |    27.72 |
|  4096 |     64 | 122880 |    8.541 |   479.59 |    2.347 |    27.27 |
|  4096 |     64 | 126976 |    8.415 |   486.78 |    2.343 |    27.31 |


