### PR TITLE
state: include compacted sliding-window rows in partial sequence state

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -9793,13 +9793,18 @@ struct llama_data_write {
         write(&v_state, sizeof(v_state));
         write(&n_layer, sizeof(n_layer));
 
+        const bool openpangu_partial = llama_kv_has_openpangu_partial_state(kv_self, ctx->model.arch, flags);
+
         // Iterate and write all the keys first, each row is a cell
         // Get whole range at a time
         for (uint32_t il = 0; il < n_layer; ++il) {
             const uint32_t n_embd_k_gqa = llama_kv_k_row_embd(ctx->model, hparams, il);
             const uint32_t n_embd_head_qk_rope = hparams.n_rot;
             const uint32_t kv_lora_rank = hparams.n_lora_kv;
-            const bool has_k_cache = kv_self.k_l[il] != nullptr && need_kv;
+            // a compacted layer holds the only copy of its window, so partial state has to carry it.
+            // the openPangu layout is excluded: it records no live_swa(), and seq_rm can move head_swa
+            // between save and restore, so writer and reader would disagree on the row count.
+            const bool has_k_cache = kv_self.k_l[il] != nullptr && (need_kv || (!openpangu_partial && kv_self.is_compacted((int) il)));
 
             // Write key type
             const int32_t k_type_i = has_k_cache ? (int32_t) kv_self.k_l[il]->type : -1;
@@ -9895,7 +9900,6 @@ struct llama_data_write {
             }
         }
 
-        const bool openpangu_partial = llama_kv_has_openpangu_partial_state(kv_self, ctx->model.arch, flags);
         const uint32_t qnext_state = (llama_kv_has_qnext_state_storage(kv_self) || openpangu_partial) ? 1 : 0;
         write(&qnext_state, sizeof(qnext_state));
 
@@ -10437,12 +10441,14 @@ struct llama_data_read {
             return false;
         }
 
+        const bool openpangu_partial = llama_kv_has_openpangu_partial_state(kv_self, ctx->model.arch, flags);
+
         // For each layer, read the keys for each cell, one row is one cell, read as one contiguous block
         for (uint32_t il = 0; il < n_layer; ++il) {
             const uint32_t n_embd_k_gqa = llama_kv_k_row_embd(ctx->model, hparams, il);
             const uint32_t n_embd_head_qk_rope = hparams.n_rot;
             const uint32_t kv_lora_rank = hparams.n_lora_kv;
-            const bool has_k_cache = kv_self.k_l[il] != nullptr && need_kv;
+            const bool has_k_cache = kv_self.k_l[il] != nullptr && (need_kv || (!openpangu_partial && kv_self.is_compacted((int) il)));
 
 
             // Read type of key
@@ -10608,7 +10614,6 @@ struct llama_data_read {
         uint32_t qnext_state_ref = 0;
         read_to(&qnext_state_ref, sizeof(qnext_state_ref));
 
-        const bool openpangu_partial = llama_kv_has_openpangu_partial_state(kv_self, ctx->model.arch, flags);
         const bool has_qnext_state = llama_kv_has_qnext_state_storage(kv_self) || openpangu_partial;
         if ((qnext_state_ref != 0) != has_qnext_state) {
             LLAMA_LOG_ERROR("%s: incompatible qwen3next state cache presence\n", __func__);


### PR DESCRIPTION
Intended to fix #2275. On main, context checkpoints ask for `LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY`, which sets `need_kv = false`, so `write_kv_cache_data` and `read_kv_cache_data` skip the K rows entirely. Normally that's fine, since re-processing the tokens rebuilds them. Under `--swa-compress` it isn't: a compacted layer's rows are the only copy of its window, and `llama_kv_cache_compact_swa` has already thrown away everything below `pos_base_swa`. The compacted layout scalars get saved and restored anyway, so restoring a checkpoint from before a compaction points `pos_base_swa` and `head_swa` at rows that no longer hold what they claim, and the sliding-window layers read whatever the window last left there.

The patch lets a compacted layer through that same gate, and the machinery underneath already handles it: the write side puts `live_swa()` rows at `sink_rows`, the read side recomputes from the scalars it restores first, and the size accounting behind `llama_state_seq_get_size` follows the same path.

On DeepSeek-V4-Flash at `-c 8192 -ngl 999 --cpu-moe --swa-compress -fa on --jinja --chat-template-kwargs '{"reasoning_effort":"max"}'`, sending the same chat request three times in a row reproduces the report. The first response is generated from scratch; the second and third enter the checkpoint-restore path.

| request | restores a checkpoint | before | after |
| --- | --- | --- | --- |
| 1 | no | coherent, 9967 chars of reasoning | coherent, 9967 chars of reasoning |
| 2 | yes, pos 132 | **degenerate**, 9217 chars | identical to request 1 |
| 3 | yes, pos 132 | **degenerate**, 8190 chars | identical to request 1 |

Sampling is greedy (`temperature 0`, `top_k 1`, fixed seed), so all three requests must produce the same tokens and any difference is restored state rather than sampling. At `max_tokens` 2048 the whole budget goes to reasoning, so the excerpts below and the sizes above are the reasoning trace and `content` is empty in every run. The quants in #2275 are beyond local hardware capacity, but the defect and the fix are in state serialization and are independent of quantization, so the same fix should apply there.

Request:
>System: You are a helpful, knowledgeable and precise assistant. Answer the user's question thoroughly and at length. When a question touches on science, explain the underlying physical mechanism in depth rather than only stating the result [...]
User:   why is the sky blue

`main`, responding to request 1 (generated from scratch, no restore):
>We need to answer "why is the sky blue" thoroughly. This is a classic physics/optics question. We should explain Rayleigh scattering, the wavelength dependence, the role of molecules, the color of the sky, why not violet, why not

`main`, responding to request 2 (restored from the checkpoint at pos 132):
>about the sky's blue appearance. The sky is blue because of the sky's blue appearance. The sky is blue because of the sky's blue appearance. The sky is blue because of the sky's blue appearance. The sky is blue because of the sky

`main`, responding to request 3 (restored from the checkpoint at pos 132):
>1) blue sky blue sky blue sky sky blue sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky sky

This PR, requests 2 and 3 (same restores, same checkpoint):
>We need to answer "why is the sky blue" thoroughly. This is a classic physics/optics question. We should explain Rayleigh scattering, the wavelength dependence, the role of molecules, the color of the sky, why not violet, why not

Fixing my own oversight here from `--swa-compress` unfortunately adds a bit of overhead. The added state is `live_swa()` rows per compacted layer, measured at 43.0 KiB per live row across six checkpoints spanning three compactions. Over the 133 to 768 live rows here, that adds 5.6 to 32.2 MiB to each checkpoint, taking a checkpoint from 69.1 MiB to between 74.7 and 101.4 MiB, the upper figure being the full 768-row compacted allocation, and the worst case at this u-batch.

*Adversarial code review and arrangement of description evidence by Opus 5.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High