### PR TITLE
GLM-5.2 vision hack

### DIFF
--- a/examples/mtmd/mtmd.cpp
+++ b/examples/mtmd/mtmd.cpp
@@ -313,9 +313,17 @@ struct mtmd_context {
             //image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
         }
         else if (proj == PROJECTOR_TYPE_KIMIK25) {
-            // template renders: <|media_begin|>image<|media_content|> <pad/embeddings> <|media_end|>
-            img_beg = "<|media_begin|>image<|media_content|>";
-            img_end = "<|media_end|>";
+            // GLM-5.2-V reuses the Kimi-K2.5 vision encoder and projector, but marks
+            // images with its own tokens, so decide based on the text model vocab
+            if (lookup_token("<|begin_of_image|>") != LLAMA_TOKEN_NULL) {
+                // <|begin_of_image|> ... (image embeddings) ... <|end_of_image|>
+                img_beg = "<|begin_of_image|>";
+                img_end = "<|end_of_image|>";
+            } else {
+                // template renders: <|media_begin|>image<|media_content|> <pad/embeddings> <|media_end|>
+                img_beg = "<|media_begin|>image<|media_content|>";
+                img_end = "<|media_end|>";
+            }
         }
     }
 

--- a/models/templates/GLM-5.2.jinja
+++ b/models/templates/GLM-5.2.jinja
@@ -1,0 +1,121 @@
+[gMASK]<sop>
+{%- set effective_reasoning_effort = 'high' if reasoning_effort is defined and reasoning_effort == 'high' else 'max' -%}
+{%- if (enable_thinking is not defined or enable_thinking) and effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{%- if tools -%}
+{%- macro tool_to_json(tool) -%}
+    {%- set ns_tool = namespace(first=true) -%}
+    {{ '{' -}}
+    {%- for k, v in tool.items() -%}
+        {%- if k != 'defer_loading' and k != 'strict' -%}
+            {%- if not ns_tool.first -%}{{- ', ' -}}{%- endif -%}
+            {%- set ns_tool.first = false -%}
+            "{{ k }}": {{ v | tojson(ensure_ascii=False) }}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- '}' -}}
+{%- endmacro -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools %}
+{%- if 'function' in tool -%}
+    {%- set tool = tool['function'] -%}
+{%- endif -%}
+{% if tool.defer_loading is not defined or not tool.defer_loading %}
+{{ tool_to_json(tool) }}
+{% endif %}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text }}
+            {%- elif item is string -%}
+                {{- item }}
+            {%- elif item is mapping and item.type in ['image', 'image_url'] -%}
+                {{- '<|begin_of_image|><|image|><|end_of_image|>' }}
+            {%- elif item is mapping and item.type in ['video', 'video_url', 'audio', 'audio_url', 'input_audio'] -%}
+                {%- set media_type = item.type | replace('_url', '') | replace('input_', '') -%}
+                {{- "<reminder>You are unable to process this " ~ media_type ~ " because you don't have multi-modal input ability. Try different methods.</reminder>" }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{%- set ns = namespace(last_user_index=-1) -%}
+{%- for m in messages %}
+    {%- if m.role == 'user' %}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif %}
+{%- endfor %}
+{%- for m in messages -%}
+{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+{%- set content = visible_text(m.content) %}
+{%- if m.reasoning_content is string %}
+    {%- set reasoning_content = m.reasoning_content %}
+{%- elif '</think>' in content %}
+    {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}
+    {%- set content = content.split('</think>')[-1] %}
+{%- endif %}
+{%- if ((clear_thinking is defined and not clear_thinking) or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}
+{{ '<think>' + reasoning_content +  '</think>'}}
+{%- else -%}
+{{ '<think></think>' }}
+{%- endif -%}
+{%- if content.strip() -%}
+{{ content.strip() }}
+{%- endif -%}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc = tc.function %}
+{%- endif %}
+{{- '<tool_call>' + tc.name -}}
+{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
+{% endif %}
+{%- elif m.role == 'tool' -%}
+{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+    {{- '<|observation|>' -}}
+{%- endif %}
+{%- if m.content is string -%}
+    {{- '<tool_response>' + m.content + '</tool_response>' -}}
+{%- elif m.content is iterable and m.content is not mapping and m.content and m.content.0.type == "tool_reference" -%}
+    {{- '<tool_response><tools>\n' -}}
+    {% for tr in m.content %}
+        {%- for tool in tools -%}
+            {%- if 'function' in tool -%}
+                {%- set tool = tool['function'] -%}
+            {%- endif -%}
+            {%- if tool.name == tr.name -%}
+                {{- tool_to_json(tool) + '\n' -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {{- '</tools></tool_response>' -}}
+{%- elif m.content is iterable and m.content is not mapping and m.content and m.content.0 is mapping and m.content.0.output is defined -%}
+    {%- for tr in m.content -%}
+        {{- '<tool_response>' + tr.output + '</tool_response>' -}}
+    {%- endfor -%}
+{%- else -%}
+    {{- '<tool_response>' + visible_text(m.content) + '</tool_response>' -}}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>{{ visible_text(m.content) }}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    <|assistant|>{{- '<think></think>' if (enable_thinking is defined and not enable_thinking) else '<think>' -}}
+{%- endif -%}


### PR DESCRIPTION
This PR only adds a small vocab check to mtmd.cpp, enabling GLM 5.2 to use a vision chat template (also included). The real work that gives "eyes" to the model is a modified MoonViT3d vision encoder (originally from Kimi k2.5) adapted to work with GLM-5.2. No conversion code included in this PR.

This is copied from [llama.cpp#26126](https://github.com/ggml-org/llama.cpp/pull/26126). The modified mmproj GGUF tested comes from [QuixiAI/GLM-5.2-Vision-GGUF](https://huggingface.co/QuixiAI/GLM-5.2-Vision-GGUF) (and also the chat template). The original vision support was first shared (as far as I can gather) by [baseten/GLM-5.2-Vision-NVFP4](https://huggingface.co/baseten/GLM-5.2-Vision-NVFP4). They have done the heavy lifting.

I have used it for over a week. It is OK in the vision department, but it is a very large improvement for GLM when I need to share visual feedback with it. It isn't perfect, but decreases some of GLM 5.2 limitations.

How I use it:
```
~/ik_llama.cpp/build/bin/llama-server \
      --model ~/models/GLM-5.2-GGUF/GLM-5.2-GGUF-2.788bpw-muzzy-imatrix.gguf \
      --mmproj ~/models/GLM-5.2-GGUF/mmproj-GLM-5.2-Vision-f16.gguf \
      --no-mmproj-offload \
      --image-min-tokens 1024 --image-max-tokens 4096 \
      -c 120000 \
      --jinja --parallel-tool-calls \
      --chat-template-file ~/ik_llama.cpp/models/templates/GLM-5.2.jinja \
      -fa 1 -ngl 99 -ub 4096 -b 8192 \
      -cuda fusion=1,offload-batch-size=4,mmq-id-size=128,graphs=1 \
      -gr -ger -mla 1 -dsa -fidx \
      -mea 256 -wgt 1
```

(some flags are missing, as they are `-ot` flags dependant on the GPUs the user has at their disposal).

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
