### PR TITLE
DSA: do not copy V rows when V == K (CPU)

### DIFF
--- a/ggml/src/iqk/iqk_flash_attn.cpp
+++ b/ggml/src/iqk/iqk_flash_attn.cpp
@@ -216,13 +216,17 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
                         work_m[j] = M[idx[j]];
                         if (j % nth == ith) {
                             std::memcpy(work_k + row_size_k*j, ((const char *)k + idx[j]*stride_k), row_size_k);
-                            std::memcpy(work_v + row_size_v*j, ((const char *)v + idx[j]*stride_v), row_size_v);
+                            if (k != v) {
+                                std::memcpy(work_v + row_size_v*j, ((const char *)v + idx[j]*stride_v), row_size_v);
+                            }
                         }
                     } else {
                         work_m[j] = h_inf;
                         if (j % nth == ith) {
                             std::memset(work_k + row_size_k*j, 0, row_size_k);
-                            std::memset(work_v + row_size_v*j, 0, row_size_v);
+                            if (k != v) {
+                                std::memset(work_v + row_size_v*j, 0, row_size_v);
+                            }
                         }
                     }
                 }
@@ -234,7 +238,7 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
                 auto this_qkv = qkv + first*nb1/sizeof(float);
                 if (!iqk_flash_attn_impl(int_type_k_in, int_type_v,
                          Dk, Dv, neq2_this_thread, this_nkv, nbq2, row_size_k, row_size_v, 0, Dv,
-                         (const float *)this_q, work_k, work_v, work_m, (const float *)sinks, 1,
+                         (const float *)this_q, work_k, k == v ? work_k : work_v, work_m, (const float *)sinks, 1,
                          scale, softcap,
                          this_qkv, nullptr, nullptr)) return false;
                 return true;
@@ -261,12 +265,16 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
                 for (int j = 0; j < nkv; ++j) {
                     if (idx[j] >= 0) {
                         std::memcpy(work_k + row_size_k*j, ((const char *)k + idx[j]*stride_k), row_size_k);
-                        std::memcpy(work_v + row_size_v*j, ((const char *)v + idx[j]*stride_v), row_size_v);
+                        if (k != v) {
+                            std::memcpy(work_v + row_size_v*j, ((const char *)v + idx[j]*stride_v), row_size_v);
+                        }
                         work_m[j] = M[idx[j]];
                         last_found = j;
                     } else {
                         std::memset(work_k + row_size_k*j, 0, row_size_k);
-                        std::memset(work_v + row_size_v*j, 0, row_size_v);
+                        if (k != v) {
+                            std::memset(work_v + row_size_v*j, 0, row_size_v);
+                        }
                         work_m[j] = h_inf;
                     }
                 }
@@ -277,7 +285,7 @@ extern "C" IQK_API bool iqk_flash_attn_noalibi(int type_q, int type_mask, float 
                 auto this_qkv = qkv + iq*ne1*nb1/sizeof(float);
                 if (!iqk_flash_attn_impl(int_type_k_in, int_type_v,
                          Dk, Dv, neq2, this_nkv, nbq2, row_size_k, row_size_v, 0, Dv,
-                         (const float *)this_q, work_k, work_v, work_m, (const float *)sinks, 1,
+                         (const float *)this_q, work_k, k == v ? work_k : work_v, work_m, (const float *)sinks, 1,
                          scale, softcap,
                          this_qkv, nullptr, nullptr)) return false;
             }


### PR DESCRIPTION

For DS4-0731-MXFP4 this results in ~2% better CPU-only TG performance (running on a Ryzen-3995WX). 

This optimization is already used on CUDA, not sure why I didn't do it when adding the CPU DSA implementation. 

The impact for PP is negligible. Here is the CPU-only sweep-bench table with the latest performance optimizations, including this PR. 

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  4096 |     64 |      0 |   33.284 |   123.06 |    5.941 |    10.77 |
|  4096 |     64 |   4096 |   34.442 |   118.92 |    6.445 |     9.93 |
|  4096 |     64 |   8192 |   34.971 |   117.13 |    6.509 |     9.83 |
|  4096 |     64 |  12288 |   35.603 |   115.05 |    6.528 |     9.80 |
|  4096 |     64 |  16384 |   36.053 |   113.61 |    6.553 |     9.77 |
|  4096 |     64 |  20480 |   36.516 |   112.17 |    6.598 |     9.70 |
|  4096 |     64 |  24576 |   37.226 |   110.03 |    6.637 |     9.64 |
|  4096 |     64 |  28672 |   37.629 |   108.85 |    6.645 |     9.63 |
|  4096 |     64 |  32768 |   38.010 |   107.76 |    6.716 |     9.53 |
|  4096 |     64 |  36864 |   38.319 |   106.89 |    6.720 |     9.52 |
|  4096 |     64 |  40960 |   38.875 |   105.36 |    6.783 |     9.44 |
|  4096 |     64 |  45056 |   39.401 |   103.96 |    6.782 |     9.44 |
|  4096 |     64 |  49152 |   39.618 |   103.39 |    6.810 |     9.40 |
|  4096 |     64 |  53248 |   40.366 |   101.47 |    6.833 |     9.37 |
|  4096 |     64 |  57344 |   40.452 |   101.26 |    6.883 |     9.30 |
|  4096 |     64 |  61440 |   40.972 |    99.97 |    6.863 |     9.33 |
|  4096 |     64 |  65536 |   41.361 |    99.03 |    6.893 |     9.28 |
|  4096 |     64 |  69632 |   41.883 |    97.80 |    6.909 |     9.26 |
|  4096 |     64 |  73728 |   42.449 |    96.49 |    6.964 |     9.19 |
|  4096 |     64 |  77824 |   42.997 |    95.26 |    6.959 |     9.20 |
|  4096 |     64 |  81920 |   43.213 |    94.79 |    7.001 |     9.14 |
|  4096 |     64 |  86016 |   43.723 |    93.68 |    7.084 |     9.03 |
|  4096 |     64 |  90112 |   44.174 |    92.72 |    7.076 |     9.04 |
|  4096 |     64 |  94208 |   45.895 |    89.25 |    7.081 |     9.04 |
|  4096 |     64 |  98304 |   45.237 |    90.55 |    7.130 |     8.98 |
|  4096 |     64 | 102400 |   45.597 |    89.83 |    7.150 |     8.95 |
|  4096 |     64 | 106496 |   46.082 |    88.89 |    7.194 |     8.90 |
|  4096 |     64 | 110592 |   46.625 |    87.85 |    7.186 |     8.91 |
|  4096 |     64 | 114688 |   46.976 |    87.19 |    7.235 |     8.85 |
|  4096 |     64 | 118784 |   47.454 |    86.32 |    7.245 |     8.83 |
|  4096 |     64 | 122880 |   47.856 |    85.59 |    7.315 |     8.75 |
|  4096 |     64 | 126976 |   48.879 |    83.80 |    7.311 |     8.75 |
```
llama_print_timings:        load time =    1195.31 ms
llama_print_timings:      sample time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings: prompt eval time = 1322109.12 ms / 131072 tokens (   10.09 ms per token,    99.14 tokens per second)
llama_print_timings:        eval time =  219948.85 ms /  2048 runs   (  107.40 ms per token,     9.31 tokens per second)
llama_print_timings:       total time = 1544650.64 ms / 133120 tokens
```