### PR TITLE
Fix rope type for 39 architectures

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8782,6 +8782,7 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
         case LLM_ARCH_MISTRAL3:
         case LLM_ARCH_GLM_DSA:
         case LLM_ARCH_MISTRAL4:
+        case LLM_ARCH_DFLASH:
             return LLAMA_ROPE_TYPE_NORM;
 
         // the pairs of head values are offset by n_rot/2
@@ -8824,8 +8825,6 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
         case LLM_ARCH_LAGUNA:
         case LLM_ARCH_GEMMA4:
         case LLM_ARCH_GEMMA4_MTP:
-        case LLM_ARCH_DFLASH:
-            return LLAMA_ROPE_TYPE_NORM;
         case LLM_ARCH_DFLASH_DRAFT:
         case LLM_ARCH_GEMMA4_ASSISTANT:
             return LLAMA_ROPE_TYPE_NEOX;


### PR DESCRIPTION
# Fix rope type for 39 architectures

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

`#2280` inserted `case LLM_ARCH_DFLASH: return LLAMA_ROPE_TYPE_NORM;` into the NEOX fall-through
group in `llama_rope_type()`. The 39 cases above it now return NORM instead of NEOX, among them
QWEN2, QWEN3, GEMMA2, GEMMA3, PHI3, GPTNEOX, FALCON, MELLUM and OPENAI_MOE.

`llm_load_print_meta: rope type`, loading one GGUF per arch:

| arch | main | this PR |
|---|---|---|
| `qwen2` | 0 | 2 |
| `qwen3moe` | 0 | 2 |
| `gemma4` | 0 | 2 |
| `mellum` | 0 | 2 |
| `llama` (not in the group) | 0 | 0 |

Perplexity, Mellum2-12B-A2.5B-Instruct-Q4_K_M, `-c 2048`, 8 chunks:

| build | rope type | PPL |
|---|---|---|
| main | 0 | 252.8348 +/- 11.75610 |
| main, CPU-only | 0 | 241.9627 +/- 11.15477 |
| this PR | 2 | 4.2637 +/- 0.17274 |
| before `#2280` | 2 | 4.2637 +/- 0.17274 |

It reproduces CPU-only too, so as far as we can tell this is not a CUDA issue.

A Qwen3.5 GGUF shows no change either way: `QWEN35` is IMROPE and outside the affected group.

Prepared with AI assistance; I ran the measurements and reviewed the change.
