### PR TITLE
llama: pass rope freq factors to build_std_attention

### DIFF
--- a/src/graphs/build_llama.cpp
+++ b/src/graphs/build_llama.cpp
@@ -46,17 +46,15 @@ ggml_cgraph * llm_build_context::build_llama() {
         int this_n_swa = this_KQ_mask == KQ_mask_swa ? hparams.n_swa : 0;
 
         // rope freq factors for llama3; may return nullptr for llama2 and other models
-        //auto rope_factors = build_rope_factors(il);
+        auto rope_factors = build_rope_factors(il);
 
         // self-attention
         if (use_rope) {
             cur = build_std_attention(gf, model.layers[il].attn_norm, inpL,
-                    inp_pos, il == n_layer - 1 && n_tokens > 1 ? inp_out_ids : nullptr, nullptr,
+                    inp_pos, il == n_layer - 1 && n_tokens > 1 ? inp_out_ids : nullptr, rope_factors,
                     this_KQ_mask, nullptr, nullptr, kq_scale, hparams.f_attention_scale, this_n_swa, il, true, false, true);
         }
         else {
-
-            auto rope_factors = build_rope_factors(il);
 
             // norm
             cur = llm_build_norm(ctx0, inpL, hparams, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, cb, il);


### PR DESCRIPTION
# llama: pass rope freq factors to build_std_attention

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

`build_llama` passes `nullptr` for `build_std_attention`'s `rope_factors_in`
argument, so `rope_freqs.weight` never reaches `ggml_rope_ext` and llama3 rope
frequency scaling is not applied. The tensor is loaded, then unused.

The split-graph branch inside `build_std_attention` has its own fallback to
`model.layers[il].rope_freqs`, so only the standard path is affected.

Degradation begins at the llama3 rope-scaling knee
(`original_max_position_embeddings` 8192).

The commented-out `build_rope_factors(il)` call and the `nullptr` both date
from `#1022`, which added `build_std_attention`: the split path got a
fallback, the standard path did not.

## Measurements

Perplexity, CPU-only (`CUDA_VISIBLE_DEVICES=""` and `-ngl 0`), 48 threads, a
private held-out Python corpus, span fixed at 65536 tokens on every row.

| model | ctx | chunks | before (main) | after (this PR) |
|---|---|---|---|---|
| Llama-3.2-1B-Instruct-Q4_K_M | 32768 | 2 | 2916.4075 +/- 60.40646 | 5.4968 +/- 0.08206 |
| Meta-Llama-3.1-8B-Instruct-Q4_K_M | 32768 | 2 | 5.2242 +/- 0.07569 | 3.1992 +/- 0.03784 |

Ladder before the change, Llama-3.2-1B, 2 chunks per rung: 8k 5.8852, 16k
50.5958, 24k 1002.5000, 32k 2916.4075.

At `-c 8192` the model sits on the knee rather than past it, and Llama-3.2-1B
moves 5.6446 -> 5.3034 (8 chunks). There is no upstream reference for that row,
so it is reported without a correctness claim.

A local build of upstream llama.cpp from a clean tree (`0278d8362`) gives
5.5123 and 3.1988 for the two 32k rows, CPU-only, same method. Upstream
binaries do not embed their commit, so attribution rests on the tree being
clean at build time and the commit being recorded. The fixed values match
upstream to 0.3% / 0.01%, which looks like the fix restores correct behavior.

### Negative control

SmolLM2-1.7B-Instruct-Q4_K_M is arch `llama` and carries no rope factor tensor,
so `build_rope_factors` returns `nullptr` and the graph is unchanged.

| model | ctx | chunks | before (main) | after (this PR) |
|---|---|---|---|---|
| SmolLM2-1.7B-Instruct-Q4_K_M | 8192 | 8 | 3.3987 +/- 0.04171 | 3.3987 +/- 0.04171 |

### Also run

`llama-cli` CPU-only and full GPU offload, and `llama-server` startup plus a
chat completion, on the after build. The `-sm graph` run across 2 GPUs
matters: it exercises the split path, where the restored argument changes
which branch is taken. It runs cleanly with no assert.

Prepared with AI assistance; I ran the measurements and reviewed the change.
