### PR TITLE
CUDA: clear MMQ row padding on partially offloaded quantized weights

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2042,7 +2042,7 @@ static void ggml_cuda_op_mul_mat(
 
         // If src0 is on a temporary compute buffer (partial offloading) there may be some padding that needs to be cleared:
         if (ne00 % MATRIX_ROW_PADDING != 0 && ggml_is_quantized(src0->type) && ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE && src0->view_src == nullptr) {
-            const int64_t nbytes_data    = ggml_row_size(src0->type, (dev[id].row_high - dev[id].row_low)*ne00);
+            const int64_t nbytes_data    = ggml_nbytes(src0);
             const int64_t nbytes_padding = ggml_row_size(src0->type, MATRIX_ROW_PADDING - ne00 % MATRIX_ROW_PADDING);
             CUDA_CHECK(cudaMemsetAsync(dev[id].src0_dd + nbytes_data , 0, nbytes_padding, stream));
         }
@@ -2647,8 +2647,11 @@ static int ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor 
     // If src0 is a temporary compute buffer it may have some padding that needs to be cleared for mul_mat_vec_q or mul_mat_q.
     // But if src0 is also a view of another tensor then this cannot be done safely because it may overwrite valid tensor data.
     // Therefore, in such cases use cuBLAS.
-    const bool bad_padding_clear = ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE
-        && ggml_nbytes(src0) != ggml_backend_buffer_get_alloc_size(src0->buffer, src0) && src0->view_src;
+    const size_t src0_nbytes = ggml_nbytes(src0);
+    const size_t src0_alloc  = ggml_backend_buffer_get_alloc_size(src0->buffer, src0);
+    const bool   src0_padded = ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE
+        && src0_nbytes != src0_alloc;
+    const bool bad_padding_clear = src0_padded && src0->view_src;
 
     bool use_dequantize_mul_mat_vec = ggml_cuda_dmmv_type_supported(src0->type)
         && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32
@@ -2672,6 +2675,10 @@ static int ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor 
     any_gpus_with_slow_fp16 = any_gpus_with_slow_fp16 || !fast_fp16_available(cc);
 
     if ((use_mul_mat_vec_q || use_mul_mat_q) && src1->ne[2]*src1->ne[3] == 1) {
+        // This return does not go through ggml_cuda_op_mul_mat, which is where the padding is otherwise cleared.
+        if (src0_padded) {
+            CUDA_CHECK(cudaMemsetAsync((char *) src0->data + src0_nbytes, 0, src0_alloc - src0_nbytes, ctx.stream()));
+        }
         return ggml_cuda_mul_mat_q(ctx, src0, src1, dst, cgraph, node_n, use_mul_mat_vec_q);
     }
 


### PR DESCRIPTION
MMQ requires the row padding after a quantized tensor to be zero. `ggml_backend_cuda_buffer_init_tensor` writes those zeros, but not for a buffer with the usage `GGML_BACKEND_BUFFER_USAGE_COMPUTE`. Partial offload uploads a CPU-resident weight and copies `ggml_nbytes` bytes, so the padding keeps whatever the device pool held. MMQ reads it while it computes the last row, which is then wrong.

`ggml_cuda_op_mul_mat` already clears this padding, with partial offloading as the reason. This patch extends that in two places:

- Fast return: `ggml_cuda_mul_mat` returns through `ggml_cuda_mul_mat_q`, the one exit for a quantized source that doesn't reach the existing clear. This patch clears there. `bad_padding_clear` keeps its meaning, rewritten in terms of the two values the clear needs.

- Clear size: the current expression is `ggml_row_size(type, (row_high - row_low)*ne00)`. It counts one matrix's rows, so it is short when `ne02 > 1`. It also adds `row_meta_size` once for the whole block instead of once per row, so it is short by `(nrows - 1)*row_meta_size` for a layout with per-row metadata. The clear then starts before the end of the data, and the tail keeps its previous contents. `ggml_nbytes(src0)` is the byte extent, and the CUDA allocator starts from it before adding the padding extent. At `ne00 = 2816` and 2048 rows the current expression matches for 62 of the 83 valid quantized layouts. The 21 others carry per-row metadata, among them `iq4_ks`, `iq2_kl` and the `_r4` repacks.

A weight is exposed only if its row length is not a multiple of `MATRIX_ROW_PADDING`. Most models have no such tensor. DeepSeek-V2-Lite-Chat Q4_K_M has 53 in the file, including `ffn_down_shexp` at `ne0=2816`, and the loader derives one more, `attn_k_b`, as a padded `q8_0` `[128, 512, 16]`. At `-ngl 0`, 26 two-dimensional sources reach `ggml_cuda_mul_mat` by the fast return, and 27 `attn_k_b` sources reach it by the generic path.

The runs below use DSV2 Lite at `-ngl 0 -t 8 -c 2048 -n 128 --temp 0 --seed 1234` with a 41 token prompt, alternating between builds. Each build reports `CUDA0 compute buffer size = 368.07 MiB`, so the offload path is active.

| build | result |
| --- | --- |
| `main` at `5763a901d` | degenerate, 3 of 3 fresh processes |
| this PR | coherent, 3 of 3 fresh processes |
| Meta-Llama-3.1-8B IQ4_NL, `main` against this PR | identical token stream |

Sampling is greedy with a fixed seed. Llama-3.1 is the control: nothing in it is padded, so the clear never runs.

Prompt:
>Write a detailed technical explanation of how a B-tree index works in a relational database, covering node splits, fill factor, and range scans. Be precise and thorough in your explanation of each mechanism.

`main`:
>emanooloate(二四月龙食四月龙四龙龙龙龙龙龙龙
>十年之后，我们再来看今天的互联网，会发现，互联网就像历史上的每一场革命一样，它使所有的行业重新洗牌，它使所有的行业重新洗牌。

This PR:
>A B-tree index in a relational database is a type of data structure that allows for efficient search, insertion, and deletion of data. It is commonly used in databases to optimize the performance of queries that involve range scans, such

The corruption doesn't occur in every run, because it depends on the bytes the pool held. Perplexity is 10.4344 +/- 0.48907 in both builds, and a longer prompt gives the same tokens either way. The corrupt characters come from pool contents and can differ elsewhere.

I measured no cost to PP or TG. Short prompts on this model can't be compared for speed, because `main` computes on a corrupted weight and the builds don't do the same work.

`ggml_cuda_mul_mat_id` clears this padding inside `ggml_cuda_mul_mat_q_id`, so the fused MMQ path is covered. The direct `ggml_cuda_op_mul_mat_vec_q_id` calls are not; this PR doesn't change that.

*Adversarial code review, and assessment of blast radius and accuracy of this description, by Opus 5.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High