### PR TITLE
DSpark: fix draft-block seed position off-by-one (depth-dependent acceptance collapse)

### DIFF
--- a/common/speculative-dflash-impl.h
+++ b/common/speculative-dflash-impl.h
@@ -299,11 +299,13 @@ struct common_speculative_state_dflash : public common_speculative_state {
         llama_kv_cache_clear(ctx_dft);
         batch.n_tokens = 0;
         const int32_t batch_len = is_dspark ? n_keep : n_keep + 1;
+        // id_last's true position is one past the newest committed feature row
+        // (last_target_pos): seed there, masks follow. Mirrors mainline's
+        // [id_last @ n_past, mask @ n_past+1, ...] block geometry.
         const llama_pos draft_pos_base = last_target_pos >= 0 ? last_target_pos + 1 : (llama_pos) target_window_rows;
-        const llama_pos seed_pos = last_target_pos >= 0 ? last_target_pos : draft_pos_base - 1;
-        common_batch_add(batch, id_last, seed_pos, { 0 }, is_dspark);
+        common_batch_add(batch, id_last, draft_pos_base, { 0 }, is_dspark);
         for (int32_t i = 1; i < batch_len; ++i) {
-            common_batch_add(batch, mask_token_id, draft_pos_base + (i - 1), { 0 }, true);
+            common_batch_add(batch, mask_token_id, draft_pos_base + i, { 0 }, true);
         }
 
         if (llama_decode(ctx_dft, batch) != 0) {

--- a/src/llama-dflash.cpp
+++ b/src/llama-dflash.cpp
@@ -671,7 +671,9 @@ bool llama_prepare_dflash_graph_inputs(
 
     if (kq_mask_swa != nullptr) {
         const int32_t swa_window = (int32_t) lctx.model.hparams.n_swa;
-        const int32_t draft_pos_base = (int32_t) last_target_pos;
+        // keep in sync with the draft batch geometry: block starts one past
+        // the newest committed feature row
+        const int32_t draft_pos_base = (int32_t) last_target_pos + 1;
 
         if (kq_mask_swa->type == GGML_TYPE_F16) {
             const ggml_fp16_t h_inf = ggml_fp32_to_fp16(-INFINITY);


### PR DESCRIPTION
## Problem

DSpark draft acceptance collapses with context depth: on DeepSeek-V4-Flash Q8 + the Q8_0 DSpark draft (RTX 3090, `-b 4096 -ub 2048 -ngld 99 --spec-type dspark:n_max=2,p_min=0.1`), acceptance falls from ~0.8 at 1K-token prompts to **0.22 at 12K**, at which point speculation is net-harmful (9.7 tok/s vs 13.25 vanilla). Mainline llama.cpp's DSpark with the same GGUFs and settings holds 0.57–0.87 across all depths — and base (non-spec) decode is identical between the engines at every depth, isolating the defect to the speculative layer. This is also the acceptance side of what #2288's reporter saw once the crashes were out of the way.

## Cause

The draft block is seeded one position early. In `common_speculative_state_dflash::draft()`, `seed_pos = last_target_pos` — but `last_target_pos` is the position of the newest *committed feature row*, i.e. `id_last`'s **predecessor**. The whole block `[id_last, mask, mask]` is therefore roped one position behind its true location and the seed collides positionally with the newest cross-KV row. (Mainline seeds at `n_past`, `id_last`'s true position — `common/speculative.cpp:1153`.) The graph-side SWA mask base in `llama_prepare_dflash_graph_inputs` uses the same shifted origin, so the geometry was internally consistent but globally off by one — with the draft's hard `sliding_window = 128`, every relative distance the model sees is perturbed vs training.

## Fix

Shift the draft batch positions and the SWA mask base by +1, coherently (2 hunks, 8 lines).

## Measured effect (identical prompts, `ignore_eos`, 200 tokens, seed 42)

| depth | acceptance before | after | tg before | after |
|---|---|---|---|---|
| 2K | 0.454 | ~0.8 (tg-implied) | 12.34 | 16.63 |
| 12K | **0.223** | **0.621** | 9.72 | **14.82** |

At 12K the fix takes DSpark from net-harmful (9.72 vs 13.25 vanilla) to a +12% win, and acceptance lands inside mainline's observed band (its 8K point measured exactly 0.621). A residual gap to mainline's 12K (0.845) remains — possibly the unimplemented `p_min` confidence head (`dspark_conf_proj` is loaded but no graph computes it; note `params.p_min` is currently silently ignored in the dspark stage), though we verified the gate is not the depth mechanism (mainline with `--spec-draft-p-min 0` still holds 0.845 at 12K).

Happy to iterate; the 2K/12K A/B repro takes ~10 minutes on our hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
