### PR TITLE
Synch DFlash Tokens ID

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6560,8 +6560,6 @@ static int llama_decode_internal(
                     lctx.dflash.draft_tokens_tensor,
                     lctx.dflash.draft_tokens.data(), 0,
                     (size_t) n_tokens_argmax * sizeof(int32_t));
-                // Synchronize argmax results before consuming them.
-                ggml_backend_synchronize(backend_argmax);
             }
         }
 
@@ -11661,6 +11659,8 @@ float * llama_get_logits_ith(struct llama_context * ctx, int32_t i) {
 }
 
 llama_token llama_get_dflash_draft_token_ith(struct llama_context * ctx, int32_t i) {
+    llama_synchronize(ctx);
+
     if ((size_t) i >= ctx->dflash.draft_tokens.size()) {
         return LLAMA_TOKEN_NULL;
     }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6560,6 +6560,8 @@ static int llama_decode_internal(
                     lctx.dflash.draft_tokens_tensor,
                     lctx.dflash.draft_tokens.data(), 0,
                     (size_t) n_tokens_argmax * sizeof(int32_t));
+                // Synchronize argmax results before consuming them.
+                ggml_backend_synchronize(backend_argmax);
             }
         }
 


### PR DESCRIPTION
Since Dflash in particular computes ID tokens on the GPU, one concern is ensuring that the results are stored correctly. We call `ggml_backend_tensor_get_async` to copy the data into the `draft_tokens` vector and immediately call `llama_get_dflash_draft_token_ith`, which reads the vector without any guarantees about its contents. One consequence is that we might consume an old or unavailable token. For DSpark, there is an additional complication: each predicted token conditions the next Markov position, so an error here can alter the proposed block.

When I tested `DeepSeek-V4-Flash-0731 MXFP4` with `DeepSeek-V4-Flash DSpark Q8_0`, n_max=1, Seed: 42, Temp: 0, --predict 512, Using only Cuda1, --cpu-moe, -b 256, -ub 256, and for the prompt `Write a quick sort python algorithm, answer only the code.`

I had 267 draft calls/tokens, of these, the first variation I found was at logical target position 478. When I ran the test again and scaled it up to a more robust benchmark using `--max-tokens 2000` and `--repeat 10` the problem no longer occurred.