### PR TITLE
DSpark: gather BF16 Markov rows

### DIFF
--- a/src/graphs/build_dflash.cpp
+++ b/src/graphs/build_dflash.cpp
@@ -26,13 +26,8 @@ ggml_tensor * llm_build_context::build_dspark_logits(
     ggml_tensor * draft_tokens = nullptr;
 
     for (int64_t i = 0; i < n_tokens; ++i) {
-        ggml_tensor * markov_w1;
-        if (model.dspark_markov_w1->type == GGML_TYPE_BF16) {
-            markov_w1 = ggml_get_rows_ext(ctx0, model.dspark_markov_w1, previous, true, false);
-            markov_w1 = ggml_cast(ctx0, markov_w1, GGML_TYPE_F32);
-        } else {
-            markov_w1 = ggml_get_rows(ctx0, model.dspark_markov_w1, previous);
-        }
+        ggml_tensor * markov_w1 = ggml_get_rows_ext(
+                ctx0, model.dspark_markov_w1, previous, true, false);
         ggml_tensor * markov_bias = ggml_mul_mat(ctx0, model.dspark_markov_w2, markov_w1);
         ggml_tensor * base_row = ggml_view_2d(
                 ctx0,

--- a/src/graphs/build_dflash.cpp
+++ b/src/graphs/build_dflash.cpp
@@ -26,7 +26,13 @@ ggml_tensor * llm_build_context::build_dspark_logits(
     ggml_tensor * draft_tokens = nullptr;
 
     for (int64_t i = 0; i < n_tokens; ++i) {
-        ggml_tensor * markov_w1 = ggml_get_rows(ctx0, model.dspark_markov_w1, previous);
+        ggml_tensor * markov_w1;
+        if (model.dspark_markov_w1->type == GGML_TYPE_BF16) {
+            markov_w1 = ggml_get_rows_ext(ctx0, model.dspark_markov_w1, previous, true, false);
+            markov_w1 = ggml_cast(ctx0, markov_w1, GGML_TYPE_F32);
+        } else {
+            markov_w1 = ggml_get_rows(ctx0, model.dspark_markov_w1, previous);
+        }
         ggml_tensor * markov_bias = ggml_mul_mat(ctx0, model.dspark_markov_w2, markov_w1);
         ggml_tensor * base_row = ggml_view_2d(
                 ctx0,


### PR DESCRIPTION
For every drafted position, DSpark adjusts the draft model’s base logits using the previously selected token, Conceptually is:
```
markov_state[i] = W1[token[i - 1]]
markov_bias[i]  = W2(markov_state[i])
logits[i]       = base_logits[i] + markov_bias[i]
token[i]        = argmax(logits[i])
```
The problem is, in the models I tested, `markov_w1.weight` is BF16, which amounts to 74.19 MiB for Qwen 3 8B or 63.13 MiB for DSV4, and since `GET_ROWS` doesn’t support BF16, our W1 row lookup falls back to the CPU. This makes things worse because a copy occurs for every draft cycle:

- 99 draft cycles.
- 99 full W1 D2H copies.
- 74.19 MiB each.
- 6.117 ms average per cycle.
- 605.54 ms total.
- 43.15% of the measured draft time.

Fortunately, since `ggml_get_rows_ext` was recently implemented, it’s possible to avoid the entire copy. For cases where the weight isn’t BF16 I kept the original logic since `ggml_get_rows` works for them and would also avoid a cast to F32.

For Qwen 3 8B on Spec-bench using `n_max=5`, 1,500 tokens, and 10 repetitions per task I have:

| Measurement | Main | Branch | Change |
|---|---:|---:|---:|
| Code | 89.619 ± 2.051 | 112.130 ± 4.956 | +25.12% |
| Extract | 87.320 ± 1.409 | 107.194 ± 0.997 | +22.76% |
| Story | 68.361 ± 0.899 | 84.033 ± 0.738 | +22.93% |
| Aggregate decode | 80.466 | 99.371 | +23.49% |
| Aggregate overall | 80.092 | 98.771 | +23.32% |
| Draft time | 225.76 s | 120.99 s | −46.41% |

For DSV4, however, I ran a more modest test, reducing it to `--repeat 3`:

| Measurement | Main | Branch | Change |
|---|---:|---:|---:|
| Code | 21.093 | 21.092 | effectively 0% |
| Extract | 17.786 | 18.900 | +6.26% |
| Story | 11.881 | 13.361 | +12.46% |
| Aggregate decode | 15.432 | 16.656 | +7.93% |
| Aggregate overall | 15.037 | 16.215 | +7.83% |
| Draft time | 72.56 s | 44.38 s | −38.83% |