### PR TITLE
Add work buffer size calculation for the ds4_comp op

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -28972,8 +28972,15 @@ struct ggml_cplan ggml_graph_plan(const struct ggml_cgraph * cgraph, int n_threa
                 } break;
             case GGML_OP_INDEXER_TOPK:
                 {
-                    size_t size = iqk_idx_topk_work_buffer_size(node, n_tasks);
-                    cur = MAX(cur, size);
+                    cur = iqk_idx_topk_work_buffer_size(node, n_tasks);
+                } break;
+            case GGML_OP_DS4_COMP:
+                {
+                    if (node->op_params[0] == 0) {
+                        struct ggml_tensor * idx = node->src[2];
+                        int ratio = idx->ne[0] / (2*node->ne[1]);
+                        cur = 32*(4*ratio + 3)*sizeof(float)*n_tasks;
+                    }
                 } break;
             case GGML_OP_CROSS_ENTROPY_LOSS:
                 {


### PR DESCRIPTION

When running on the CPU this op requires a small work buffer to store intermediate results, but wasn't calculating the required work buffer size during compute plan creation. Normally this is not an issue as other ops will have larger work buffers. Hence, as work buffer is allocated only once for the entire compute graph but used sequentially by each op,  the `ds4_comp` does not end up in a situation without enough space in the work buffer. However, if someone is running a CUDA build with `-ngl 0` thinking that this is CPU-only inference (for instance, see #2300), the `ds4_comp` can end up in a graph split with no other ops in it (or just other ops that do not require work buffer or require a smaller work buffer), so the work buffer size is not large enough, and in that case the computation fails with an assert.

Closes #2300   