### PR TITLE
laguna: compacted sliding-window KV cache (--swa-compress)

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -316,8 +316,15 @@ void server_context::init() {
             {"n_ctx_slot", slot.n_ctx}
             });
 
-        const int ga_n = params_base.grp_attn_n;
-        const int ga_w = params_base.grp_attn_w;
+        int ga_n = params_base.grp_attn_n;
+        int ga_w = params_base.grp_attn_w;
+
+        if (ga_n != 1 && !llama_supports_ctx_shift(slot.ctx)) {
+            // self-extend re-positions cached rows, which a compacted layer cannot represent
+            LOG_WARNING("%s\n", "self-extend is not supported with --swa-compress, it will be disabled");
+            ga_n = 1;
+            ga_w = 512;
+        }
 
         if (ga_n != 1) {
             GGML_ASSERT(ga_n > 0 && "ga_n must be positive");                       // NOLINT
@@ -1824,6 +1831,12 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
             LOG_WARNING("%s\n", "ctx_shift is not supported by this model's KV cache, it will be disabled");
         }
     }
+    if (!llama_supports_ctx_shift(slot.ctx)) {
+        if (params_base.ctx_shift) {
+            params_base.ctx_shift = false;
+            LOG_WARNING("%s\n", "ctx_shift is not supported with --swa-compress, it will be disabled");
+        }
+    }
     {
         const auto& stop = data.find("stop");
         if (stop != data.end() && stop->is_array()) {
@@ -2951,10 +2964,6 @@ void server_context::process_single_task(server_task&& task) {
             send_error(task, "slot save is unsupported for openPangu because per-sequence file state is not implemented", ERROR_TYPE_NOT_SUPPORTED);
             break;
         }
-        if (!llama_supports_full_state_io(ctx)) {
-            send_error(task, "slot save is unsupported with --swa-compress because file-session state is not implemented for compacted contexts", ERROR_TYPE_NOT_SUPPORTED);
-            break;
-        }
 
         const size_t token_count = slot->cache_tokens.size();
         const int64_t t_start = ggml_time_us();
@@ -2996,10 +3005,6 @@ void server_context::process_single_task(server_task&& task) {
             // if requested slot is unavailable, we defer this task for processing later
             LOG_VERBOSE("requested slot is unavailable", { {"id_task", task.id} });
             queue_tasks.defer(std::move(task));
-            break;
-        }
-        if (!llama_supports_full_state_io(ctx)) {
-            send_error(task, "slot restore is unsupported with --swa-compress because file-session state is not implemented for compacted contexts", ERROR_TYPE_NOT_SUPPORTED);
             break;
         }
         const int64_t t_start = ggml_time_us();

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -321,7 +321,7 @@ void server_context::init() {
 
         if (ga_n != 1 && !llama_supports_ctx_shift(slot.ctx)) {
             // self-extend re-positions cached rows, which a compacted layer cannot represent
-            LOG_WARNING("%s\n", "self-extend is not supported with --swa-compress, it will be disabled");
+            LOG_WARNING("%s\n", "self-extend is not supported by this context's KV cache, it will be disabled");
             ga_n = 1;
             ga_w = 512;
         }
@@ -1825,16 +1825,10 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
             LOG_WARNING("%s\n", "ctx_shift is not implemented for split mode graph, it will be disabled");
         }
     }
-    if (!llama_model_supports_ctx_shift(llama_get_model(slot.ctx))) {
-        if (params_base.ctx_shift) {
-            params_base.ctx_shift = false;
-            LOG_WARNING("%s\n", "ctx_shift is not supported by this model's KV cache, it will be disabled");
-        }
-    }
     if (!llama_supports_ctx_shift(slot.ctx)) {
         if (params_base.ctx_shift) {
             params_base.ctx_shift = false;
-            LOG_WARNING("%s\n", "ctx_shift is not supported with --swa-compress, it will be disabled");
+            LOG_WARNING("%s\n", "ctx_shift is not supported by this context's KV cache, it will be disabled");
         }
     }
     {

--- a/include/llama.h
+++ b/include/llama.h
@@ -724,8 +724,8 @@ extern "C" {
     // Currently true for every model; no architecture is excluded from partial KV reuse.
     LLAMA_API bool llama_model_supports_partial_kv_reuse(const struct llama_model * model);
 
-    // false when the context's KV cache cannot be re-positioned after the fact (--swa-compress).
-    // The model-level query above cannot answer this, because compaction is a context option.
+    // The complete answer for a context: the model-level query above, plus the context options it
+    // cannot see (--swa-compress). Matches the gate the engine applies before a K-shift.
     LLAMA_API bool llama_supports_ctx_shift(const struct llama_context * ctx);
 
     LLAMA_API const char * llama_model_arch_string(const struct llama_model * model);

--- a/include/llama.h
+++ b/include/llama.h
@@ -724,8 +724,9 @@ extern "C" {
     // Currently true for every model; no architecture is excluded from partial KV reuse.
     LLAMA_API bool llama_model_supports_partial_kv_reuse(const struct llama_model * model);
 
-    // false when the context cannot serialize whole-context or file-session state (--swa-compress); per-sequence buffer state is unaffected
-    LLAMA_API bool llama_supports_full_state_io(const struct llama_context * ctx);
+    // false when the context's KV cache cannot be re-positioned after the fact (--swa-compress).
+    // The model-level query above cannot answer this, because compaction is a context option.
+    LLAMA_API bool llama_supports_ctx_shift(const struct llama_context * ctx);
 
     LLAMA_API const char * llama_model_arch_string(const struct llama_model * model);
 

--- a/src/graphs/build_laguna.cpp
+++ b/src/graphs/build_laguna.cpp
@@ -12,7 +12,11 @@ ggml_cgraph * llm_build_context::build_laguna() {
     ggml_tensor * KQ_mask     = build_inp_KQ_mask();
     // Laguna M.1 has only global-attention layers and leaves n_swa at zero; building
     // the SWA mask in that case trips the generic SWA precondition.
-    ggml_tensor * KQ_mask_swa = hparams.n_swa > 0 ? build_inp_KQ_mask_swa() : nullptr;
+    ggml_tensor * KQ_mask_swa = hparams.n_swa > 0
+        ? kv_self.any_compacted()
+            ? build_swa_mask_for_graph(hparams.n_swa, true)
+            : build_inp_KQ_mask_swa()
+        : nullptr;
 
     for (int il = 0; il < n_layer; ++il) {
         const bool is_swa = hparams.swa_layers[il];

--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -597,7 +597,7 @@ ggml_tensor * llm_build_context::build_inp_KQ_mask_swa_win(int64_t n_kv_win, boo
 }
 
 ggml_tensor * llm_build_context::build_swa_mask_for_graph(uint32_t window, bool compacted, bool * windowed) {
-    *windowed = false;
+    if (windowed) *windowed = false;
     lctx.swa_window_view = {};
 
     if (window == 0) {
@@ -625,7 +625,7 @@ ggml_tensor * llm_build_context::build_swa_mask_for_graph(uint32_t window, bool 
         view.w_view,
         view.win_off,
     };
-    *windowed = true;
+    if (windowed) *windowed = true;
     return build_inp_KQ_mask_swa_win(view.w_view);
 }
 
@@ -917,6 +917,7 @@ void llm_build_context::llm_build_kv_store(
          const llm_build_cb & cb,
                     int64_t   il) {
     const int64_t n_ctx = cparams.n_ctx;
+    const int32_t n_cache_rows = kv.rows(il);
 
     //const int64_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
     const int64_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
@@ -952,7 +953,7 @@ void llm_build_context::llm_build_kv_store(
         } else {
             // note: the V cache is transposed for legacy non-FA layouts
             v_cache_view = ggml_view_2d(ctx, kv.v_l[il], n_tokens, n_embd_v_gqa,
-                    (  n_ctx)*ggml_element_size(kv.v_l[il]),
+                    (n_cache_rows)*ggml_element_size(kv.v_l[il]),
                     (kv_head)*ggml_element_size(kv.v_l[il]));
             lctx.cache_copies[2*il+1].step = ggml_element_size(kv.v_l[il]);
 
@@ -1992,19 +1993,21 @@ static ggml_tensor * llm_build_kqv(
          const llm_build_cb & cb,
                     int       il,
                 ggml_tensor * sinks = nullptr, int n_swa = 0, int kv_il = -1,
-                ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr) {
+                ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr,
+                    int32_t kv_view_offset = 0) {
     const llama_model   & model   = lctx.model;
     const llama_hparams & hparams = lctx.model.hparams;
     const llama_cparams & cparams = lctx.cparams;
 
+    const int     kv_layer      = kv_il >= 0 ? kv_il : il;
     const int64_t n_ctx         = kv.size;
+    const int32_t n_cache_rows  = kv.rows(kv_layer);
     const int64_t n_head        = hparams.n_head(il);
     const int64_t n_head_kv     = hparams.n_head_kv(il);
     const int64_t n_embd_head_k = hparams.n_embd_head_k(il);
     //const int64_t n_embd_k_gqa  = hparams.n_embd_k_gqa(il);
     const int64_t n_embd_head_v = hparams.n_embd_head_v(il);
     const int64_t n_embd_v_gqa  = hparams.n_embd_v_gqa(il);
-    const int     kv_layer      = kv_il >= 0 ? kv_il : il;
 
     struct ggml_tensor * q = ggml_permute(ctx, q_cur, 0, 2, 1, 3);
     cb(q, "q", il);
@@ -2025,7 +2028,7 @@ static ggml_tensor * llm_build_kqv(
                     n_embd_head_k, n_kv, n_head_kv,
                     ggml_row_size(k_cache->type, n_embd_head_k)*n_head_kv, //n_embd_k_gqa),
                     ggml_row_size(k_cache->type, n_embd_head_k),
-                    0);
+                    (size_t) kv_view_offset*ggml_row_size(k_cache->type, n_embd_head_k)*n_head_kv);
         if (k_cache_view) {
             *k_cache_view = k;
         }
@@ -2065,7 +2068,7 @@ static ggml_tensor * llm_build_kqv(
                         n_embd_head_v, n_kv, n_head_kv,
                         ggml_row_size(v_cache->type, n_embd_v_gqa),
                         ggml_row_size(v_cache->type, n_embd_head_v),
-                        0);
+                        (size_t) kv_view_offset*ggml_row_size(v_cache->type, n_embd_v_gqa));
             if (v_cache_view) {
                 *v_cache_view = v;
             }
@@ -2103,15 +2106,15 @@ static ggml_tensor * llm_build_kqv(
             if (kv.v_trans) {
                 v = ggml_view_3d(ctx, v_cache,
                         n_kv, n_embd_head_v, n_head_kv,
-                        ggml_element_size(v_cache)*n_ctx,
-                        ggml_element_size(v_cache)*n_ctx*n_embd_head_v,
-                        0);
+                        ggml_element_size(v_cache)*n_cache_rows,
+                        ggml_element_size(v_cache)*n_cache_rows*n_embd_head_v,
+                        (size_t) kv_view_offset*ggml_element_size(v_cache));
             } else {
                 v = ggml_view_3d(ctx, v_cache,
                         n_embd_head_v, n_kv, n_head_kv,
                         ggml_row_size(v_cache->type, n_embd_v_gqa),
                         ggml_row_size(v_cache->type, n_embd_head_v),
-                        0);
+                        (size_t) kv_view_offset*ggml_row_size(v_cache->type, n_embd_v_gqa));
                 v = ggml_cont(ctx, ggml_transpose(ctx, v));
             }
             if (v_cache_view) {
@@ -2253,7 +2256,8 @@ ggml_tensor * llm_build_context::llm_build_kv(
                     int32_t   n_kv,
                     float     kq_scale,
          const llm_build_cb & cb, int il, ggml_tensor * sinks, int n_swa, int kv_il,
-         ggml_tensor ** k_cache_view, ggml_tensor ** v_cache_view) {
+         ggml_tensor ** k_cache_view, ggml_tensor ** v_cache_view,
+                    int32_t   swa_head) {
     const llama_hparams & hparams = lctx.model.hparams;
     const llama_cparams & cparams = lctx.cparams;
 
@@ -2283,12 +2287,18 @@ ggml_tensor * llm_build_context::llm_build_kv(
         ggml_build_forward_expand(graph, v_cur);
     }
 
+    const bool compacted = kv.is_compacted(il);
+    const bool use_swa_window = compacted && lctx.swa_window_view.active;
+    const int32_t store_head = compacted ? swa_head : kv_head;
+    const int32_t n_kv_view = use_swa_window ? (int32_t) lctx.swa_window_view.w_view : n_kv;
+    const int32_t kv_view_offset = use_swa_window ? (int32_t) lctx.swa_window_view.win_off : 0;
+
     if (k_cur || v_cur) {
-        llm_build_kv_store(lctx, ctx, hparams, cparams, kv, graph, k_cur, v_cur, n_tokens, kv_head, cb, il);
+        llm_build_kv_store(lctx, ctx, hparams, cparams, kv, graph, k_cur, v_cur, n_tokens, store_head, cb, il);
     }
 
-    auto cur = llm_build_kqv(ctx, lctx, kv, graph, wo, wo_b, q_cur, kq_mask, n_tokens, n_kv, kq_scale, cb, il, sinks, n_swa, kv_il,
-            k_cache_view, v_cache_view);
+    auto cur = llm_build_kqv(ctx, lctx, kv, graph, wo, wo_b, q_cur, kq_mask, n_tokens, n_kv_view, kq_scale, cb, il, sinks, n_swa, kv_il,
+            k_cache_view, v_cache_view, kv_view_offset);
     cb(cur, "kqv_out", il);
 
     return cur;
@@ -3442,7 +3452,8 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
     if (auto wqkv_gate = model.layers[il].wqkv_gate; wqkv_gate != nullptr) {
         cur = llm_build_kv(ctx0, lctx, kv_self, gf,
                 nullptr, nullptr,
-                Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa, kv_il);
+                Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa, kv_il,
+                nullptr, nullptr, swa_head);
         cb(cur, "wqkv", il);
         auto gate = llm_build_lora_mm(lctx, ctx0, wqkv_gate, input_normed);
         if (model.arch == LLM_ARCH_LAGUNA) {
@@ -3483,7 +3494,8 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
     } else {
         if (gate) {
             cur = llm_build_kv(ctx0, lctx, kv_self, gf, nullptr, nullptr,
-                    Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa, kv_il);
+                    Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa, kv_il,
+                    nullptr, nullptr, swa_head);
             if (false && cur->ne[1] == 1) { // we need to add GGML_UNARY_OP_SIGMOID to the ops supported by ggml_fused_mul_unary
                 cur = ggml_fused_mul_unary(ctx0, cur, gate, GGML_UNARY_OP_SIGMOID);
             } else {
@@ -3500,7 +3512,8 @@ ggml_tensor * llm_build_context::build_std_attention(ggml_cgraph * gf, ggml_tens
         } else {
             cur = llm_build_kv(ctx0, lctx, kv_self, gf,
                     model.layers[il].wo, model.layers[il].bo,
-                    Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa, kv_il);
+                    Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, KQ_scale, cb, il, sinks, n_swa, kv_il,
+                    nullptr, nullptr, swa_head);
         }
     }
 

--- a/src/llama-build-context.h
+++ b/src/llama-build-context.h
@@ -159,7 +159,7 @@ struct llm_build_context {
 
     ggml_tensor * build_inp_KQ_mask_swa_win(int64_t n_kv_win, bool causal = true);
 
-    ggml_tensor * build_swa_mask_for_graph(uint32_t window, bool compacted, bool * windowed);
+    ggml_tensor * build_swa_mask_for_graph(uint32_t window, bool compacted, bool * windowed = nullptr);
 
     ggml_tensor * build_inp_mean();
 
@@ -501,7 +501,8 @@ struct llm_build_context {
                     int32_t   n_kv,
                     float     kq_scale,
          const llm_build_cb & cb, int il, ggml_tensor * sinks = nullptr, int n_swa = 0, int kv_il = -1,
-         ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr);
+         ggml_tensor ** k_cache_view = nullptr, ggml_tensor ** v_cache_view = nullptr,
+                    int32_t   swa_head = -1);
 
     static ggml_tensor * llm_build_ffn(ggml_context * ctx, llama_context & lctx, ggml_tensor * ffn_norm,
          ggml_tensor * cur,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2524,7 +2524,9 @@ size_t llama_model::cache_size(int il, ggml_type type_k, ggml_type type_v, ggml_
     }
 
     auto n_head_kv = hparams.n_head_kv(il);
-    auto k_size = ggml_row_size(type_k, hparams.n_embd_head_k(il)) * n_head_kv*kv_size;
-    auto v_size = ggml_row_size(type_v, hparams.n_embd_v_gqa(il)) * kv_size;
+    const uint32_t rows = llama_kv_layer_rows(hparams, il, kv_size, swa_compress && supports_swa_compress(), n_ubatch,
+                                              llama_kv_cache::get_padding(flash_attn));
+    auto k_size = ggml_row_size(type_k, hparams.n_embd_head_k(il)) * n_head_kv*rows;
+    auto v_size = ggml_row_size(type_v, hparams.n_embd_v_gqa(il)) * rows;
     return k_size + v_size;
 }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -602,10 +602,9 @@ struct llama_model {
     }
 
     // a compacted sliding-window cache needs the graph to build its KQ mask over the compacted
-    // layout, and the compacted mask keys on position alone, so it also requires K-only cache
-    // rows and a single sequence
+    // layout, and the compacted mask keys on position alone, so it requires a single sequence
     bool supports_swa_compress() const {
-        return arch == LLM_ARCH_OPENPANGU || arch == LLM_ARCH_DEEPSEEK4;
+        return arch == LLM_ARCH_OPENPANGU || arch == LLM_ARCH_DEEPSEEK4 || arch == LLM_ARCH_LAGUNA;
     }
 
     static inline int hadamard_size(int head_size) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -2490,7 +2490,7 @@ static void llama_kv_cache_seq_add(
     // by absolute position. Fail loudly instead of corrupting.
     GGML_ASSERT(!cache.s_l_position_strict && "K-shift/context shift is not supported for this model's position-indexed KV cache");
     // a compacted layer holds window rows rather than one row per context cell, so the cells this
-    // would re-position do not describe it and build_k_shift would read past the layer
+    // would re-position do not describe it
     GGML_ASSERT(!cache.any_compacted() && "K-shift/context shift is not supported for a compacted KV cache (--swa-compress)");
 
     uint32_t new_head = cache.size;
@@ -7184,9 +7184,9 @@ static void llama_kv_cache_defrag_internal(struct llama_context & lctx) {
     //LLAMA_LOG_INFO("(tmp log) KV defrag time: %.3f ms\n", (t_end - t_start)/1000.0);
 }
 
-static bool get_can_shift(struct llama_context & lctx) {
-    bool no_shift = lctx.model.is_mla_model();
-    no_shift = no_shift || lctx.model.arch == LLM_ARCH_DEEPSEEK4;
+static bool get_can_shift(const struct llama_context & lctx) {
+    bool no_shift = !llama_model_supports_ctx_shift(&lctx.model);
+    no_shift = no_shift || lctx.model.is_mla_model();
     no_shift = no_shift || lctx.model.hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE;
     // build_k_shift views n_ctx rows per layer, but a compacted layer holds only its window rows
     no_shift = no_shift || lctx.kv_self.any_compacted();
@@ -8742,7 +8742,7 @@ void llama_free(struct llama_context * ctx) {
 }
 
 bool llama_supports_ctx_shift(const struct llama_context * ctx) {
-    return ctx != nullptr && !ctx->kv_self.any_compacted();
+    return ctx != nullptr && get_can_shift(*ctx);
 }
 
 const struct llama_vocab* llama_model_get_vocab(const struct llama_model* model) {

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -760,6 +760,7 @@ bool llama_context::update_cache_copies() {
         if (!layer_has_attention_kv(il) || kv_self.k_l[il] == nullptr) {
             continue;
         }
+        const int32_t cache_head = kv_self.is_compacted(il) ? (int32_t) kv_self.head_swa : (int32_t) kv_self.head;
         auto kl = (ggml_split_tensor_t *)kv_self.k_l[il]->extra;
         if (kl) {
             GGML_ASSERT(model.split_mode == LLAMA_SPLIT_MODE_GRAPH || model.split_mode == LLAMA_SPLIT_MODE_ATTN);
@@ -776,7 +777,7 @@ bool llama_context::update_cache_copies() {
                 if (!c.cpy || c.cpy->op != GGML_OP_CPY || c.cpy->view_src != kl->splits[id]) {
                     return false;
                 }
-                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->view_offs = cache_head*c.step;
                 c.cpy->src[1]->data = (char *)kl->splits[id]->data + c.cpy->view_offs;
                 c.cpy->data = c.cpy->src[1]->data;
             }
@@ -787,7 +788,7 @@ bool llama_context::update_cache_copies() {
                 if (!c.cpy || c.cpy->op != GGML_OP_CPY || c.cpy->view_src != vl->splits[id]) {
                     return false;
                 }
-                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->view_offs = cache_head*c.step;
                 c.cpy->src[1]->data = (char *)vl->splits[id]->data + c.cpy->view_offs;
                 c.cpy->data = c.cpy->src[1]->data;
             }
@@ -797,7 +798,7 @@ bool llama_context::update_cache_copies() {
                 printf("%s: K has no copy or is not a copy in layer %d\n", __func__, il);
                 return false;
             }
-            c.cpy->view_offs = kv_self.head*c.step;
+            c.cpy->view_offs = cache_head*c.step;
             c.cpy->src[1]->data = (char *)kv_self.k_l[il]->data + c.cpy->view_offs;
             c.cpy->data = c.cpy->src[1]->data;
             if (!kv_self.v_l.empty() && kv_self.v_l[il]) {
@@ -806,7 +807,7 @@ bool llama_context::update_cache_copies() {
                     printf("%s: V has no copy or is not a copy in layer %d\n", __func__, il);
                     return false;
                 }
-                c.cpy->view_offs = kv_self.head*c.step;
+                c.cpy->view_offs = cache_head*c.step;
                 c.cpy->src[1]->data = (char *)kv_self.v_l[il]->data + c.cpy->view_offs;
                 c.cpy->data = c.cpy->src[1]->data;
             }
@@ -1492,7 +1493,7 @@ static bool llama_kv_cache_init(
             if (this_type_k != type_k) {
                 LLAMA_LOG_INFO("================= Setting K-cache type in layer %2d to %s\n", i, ggml_type_name(this_type_k));
             }
-            int64_t v_ne = int64_t(n_embd_v_row)*kv_size;
+            int64_t v_ne = int64_t(n_embd_v_row)*cache.rows(i);
             auto this_type_v = type_v;
             if (model.arch != LLM_ARCH_OPENPANGU && type_v_first != type_v && n_v_first > 0 && i < n_v_first) {
                 this_type_v = type_v_first;
@@ -1512,7 +1513,7 @@ static bool llama_kv_cache_init(
             } else if (is_dsv4_k_only) {
                 k = ggml_new_tensor_2d(ctx, this_type_k, n_embd_head_k, n_head_kv*cache.rows(i));
             } else {
-                k = ggml_new_tensor_2d(ctx, this_type_k, n_embd_head_k, n_head_kv*kv_size);
+                k = ggml_new_tensor_2d(ctx, this_type_k, n_embd_head_k, n_head_kv*cache.rows(i));
                 v = ggml_new_tensor_1d(ctx, this_type_v, v_ne);
             }
 
@@ -1774,6 +1775,14 @@ static void llama_kv_cache_compact_swa(struct llama_context & lctx, uint32_t n_t
     const uint32_t src_row = cache.sink_rows + live - W;
     const uint32_t dst_row = cache.sink_rows;
 
+    auto copy_bytes = [&](ggml_tensor * tensor, size_t src_offset, size_t dst_offset, size_t nbytes) {
+        if (scratch.size() < nbytes) {
+            scratch.resize(nbytes);
+        }
+        ggml_backend_tensor_get(tensor, scratch.data(), src_offset, nbytes);
+        ggml_backend_tensor_set(tensor, scratch.data(), dst_offset, nbytes);
+    };
+
     for (size_t il = 0; il < cache.k_l.size(); ++il) {
         if (!cache.is_compacted((int) il) || cache.k_l[il] == nullptr) {
             continue;
@@ -1782,12 +1791,33 @@ static void llama_kv_cache_compact_swa(struct llama_context & lctx, uint32_t n_t
         // kl rows are position-major: kl->ne[1]/rows(il) rows per position (n_head_kv)
         const size_t rows_per_pos = (size_t) kl->ne[1] / cache.rows((int) il);
         const size_t stride = kl->nb[1] * rows_per_pos;
-        const size_t nbytes = (size_t) W * stride;
-        if (scratch.size() < nbytes) {
-            scratch.resize(nbytes);
+        copy_bytes(kl, (size_t) src_row*stride, (size_t) dst_row*stride, (size_t) W*stride);
+
+        // K-only layouts push nothing to v_l, so it is empty rather than null-filled
+        ggml_tensor * vl = il < cache.v_l.size() ? cache.v_l[il] : nullptr;
+        if (vl == nullptr) {
+            continue;
         }
-        ggml_backend_tensor_get(kl, scratch.data(), (size_t) src_row*stride, nbytes);
-        ggml_backend_tensor_set(kl, scratch.data(), (size_t) dst_row*stride, nbytes);
+
+        const int32_t n_embd_v_row = llama_kv_v_row_embd(lctx.model, lctx.model.hparams, il);
+        if (!cache.v_trans) {
+            const size_t v_stride = ggml_row_size(vl->type, n_embd_v_row);
+            copy_bytes(vl, (size_t) src_row*v_stride, (size_t) dst_row*v_stride, (size_t) W*v_stride);
+        } else {
+            // transposed V is position-minor, so one position is a column, not a row
+            const size_t v_size_el = ggml_type_size(vl->type);
+            const size_t v_rows    = cache.rows((int) il);
+            const size_t nbytes    = ggml_nbytes(vl);
+            if (scratch.size() < nbytes) {
+                scratch.resize(nbytes);
+            }
+            ggml_backend_tensor_get(vl, scratch.data(), 0, nbytes);
+            for (int32_t j = 0; j < n_embd_v_row; ++j) {
+                uint8_t * row = scratch.data() + (size_t) j*v_rows*v_size_el;
+                memmove(row + (size_t) dst_row*v_size_el, row + (size_t) src_row*v_size_el, (size_t) W*v_size_el);
+            }
+            ggml_backend_tensor_set(vl, scratch.data(), 0, nbytes);
+        }
     }
 
     cache.pos_base_swa += (llama_pos) (live - W);
@@ -2459,6 +2489,9 @@ static void llama_kv_cache_seq_add(
     // re-positioned: rope is baked into the cached k_pe rows and the side state is keyed
     // by absolute position. Fail loudly instead of corrupting.
     GGML_ASSERT(!cache.s_l_position_strict && "K-shift/context shift is not supported for this model's position-indexed KV cache");
+    // a compacted layer holds window rows rather than one row per context cell, so the cells this
+    // would re-position do not describe it and build_k_shift would read past the layer
+    GGML_ASSERT(!cache.any_compacted() && "K-shift/context shift is not supported for a compacted KV cache (--swa-compress)");
 
     uint32_t new_head = cache.size;
 
@@ -2510,6 +2543,7 @@ static void llama_kv_cache_seq_div(
                           int   d) {
     // see llama_kv_cache_seq_add: position-strict caches cannot be re-positioned
     GGML_ASSERT(!cache.s_l_position_strict && "self-extend/position division is not supported for this model's position-indexed KV cache");
+    GGML_ASSERT(!cache.any_compacted() && "self-extend/position division is not supported for a compacted KV cache (--swa-compress)");
 
     if (p0 < 0) p0 = 0;
     if (p1 < 0) p1 = std::numeric_limits<llama_pos>::max();
@@ -7154,6 +7188,8 @@ static bool get_can_shift(struct llama_context & lctx) {
     bool no_shift = lctx.model.is_mla_model();
     no_shift = no_shift || lctx.model.arch == LLM_ARCH_DEEPSEEK4;
     no_shift = no_shift || lctx.model.hparams.rope_type == LLAMA_ROPE_TYPE_IMROPE;
+    // build_k_shift views n_ctx rows per layer, but a compacted layer holds only its window rows
+    no_shift = no_shift || lctx.kv_self.any_compacted();
     return !no_shift;
 }
 
@@ -7957,13 +7993,6 @@ struct llama_context * llama_init_from_model(
         return nullptr;
     }
 
-    if (params.n_seq_max > 1 && params.swa_compress && model->arch == LLM_ARCH_DEEPSEEK4) {
-        // the compacted window is one position stream (head_swa/pos_base_swa are per-cache, not per-sequence)
-        LLAMA_LOG_ERROR("%s: --swa-compress supports a single sequence only (requested n_seq_max = %u); run with -np 1\n",
-                __func__, params.n_seq_max);
-        return nullptr;
-    }
-
     if (model->arch == LLM_ARCH_OPENPANGU) {
         std::string error_msg;
         if (!llama_openpangu_validate_latent_cache_types(params.type_k, params.type_v, &error_msg)) {
@@ -8455,6 +8484,13 @@ struct llama_context * llama_init_from_model(
             return nullptr;
         }
 
+        if (params.n_seq_max > 1 && ctx->kv_self.any_compacted()) {
+            LLAMA_LOG_ERROR("%s: --swa-compress supports a single sequence only (requested n_seq_max = %u); run with -np 1\n",
+                    __func__, params.n_seq_max);
+            llama_free(ctx);
+            return nullptr;
+        }
+
         {
             size_t memory_size_k = 0;
             size_t memory_size_v = 0;
@@ -8705,7 +8741,7 @@ void llama_free(struct llama_context * ctx) {
     delete ctx;
 }
 
-bool llama_supports_full_state_io(const struct llama_context * ctx) {
+bool llama_supports_ctx_shift(const struct llama_context * ctx) {
     return ctx != nullptr && !ctx->kv_self.any_compacted();
 }
 
@@ -9835,7 +9871,7 @@ struct llama_data_write {
                 continue;
             }
 
-            // only k_l is compacted; it holds the window at [sink_rows, sink_rows + live_swa())
+            // compacted K and V hold the window at [sink_rows, sink_rows + live_swa())
             if (kv_self.is_compacted((int) il)) {
                 const size_t live = kv_self.live_swa();
                 if (live) {
@@ -9855,7 +9891,7 @@ struct llama_data_write {
         if (v_state == 0) {
             for (uint32_t il = 0; il < n_layer; ++il) {
                 const uint32_t n_embd_v_gqa = llama_kv_v_row_embd(ctx->model, hparams, il);
-                const bool has_v_cache = kv_self.v_l[il] != nullptr && need_kv;
+                const bool has_v_cache = kv_self.v_l[il] != nullptr && (need_kv || kv_self.is_compacted((int) il));
 
                 // Write value type
                 const int32_t v_type_i = has_v_cache ? (int32_t) kv_self.v_l[il]->type : -1;
@@ -9869,6 +9905,14 @@ struct llama_data_write {
                     continue;
                 }
 
+                if (kv_self.is_compacted((int) il)) {
+                    const size_t live = kv_self.live_swa();
+                    if (live) {
+                        write_tensor_data(kv_self.v_l[il], kv_self.sink_rows * v_size_row, live * v_size_row, il);
+                    }
+                    continue;
+                }
+
                 // Read each range of cells of v_size length each into tmp_buf and write out
                 for (const auto & range : cell_ranges) {
                     const size_t range_size = range.second - range.first;
@@ -9879,10 +9923,9 @@ struct llama_data_write {
         }
         else if (v_state == 1) {
             // When v is transposed, we also need the element size and get the element ranges from each row
-            const uint32_t kv_size = kv_self.size;
             for (uint32_t il = 0; il < n_layer; ++il) {
                 const uint32_t n_embd_v_gqa = llama_kv_v_row_embd(ctx->model, hparams, il);
-                const bool has_v_cache = kv_self.v_l[il] != nullptr && need_kv;
+                const bool has_v_cache = kv_self.v_l[il] != nullptr && (need_kv || kv_self.is_compacted((int) il));
 
                 // Write value type
                 const int32_t v_type_i = has_v_cache ? (int32_t) kv_self.v_l[il]->type : -1;
@@ -9897,6 +9940,18 @@ struct llama_data_write {
                 write(&n_embd_v_gqa_write, sizeof(n_embd_v_gqa_write));
 
                 if (!has_v_cache) {
+                    continue;
+                }
+
+                const uint32_t kv_size = kv_self.rows((int) il);
+                if (kv_self.is_compacted((int) il)) {
+                    const size_t live = kv_self.live_swa();
+                    if (live) {
+                        for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
+                            const size_t src_offset = (kv_self.sink_rows + (size_t) j * kv_size) * v_size_el;
+                            write_tensor_data(kv_self.v_l[il], src_offset, live * v_size_el, il);
+                        }
+                    }
                     continue;
                 }
 
@@ -10513,7 +10568,7 @@ struct llama_data_read {
         if (v_state == 0) {
             for (uint32_t il = 0; il < n_layer; ++il) {
                 const uint32_t n_embd_v_gqa = llama_kv_v_row_embd(ctx->model, hparams, il);
-                const bool has_v_cache = kv_self.v_l[il] != nullptr && need_kv;
+                const bool has_v_cache = kv_self.v_l[il] != nullptr && (need_kv || kv_self.is_compacted((int) il));
 
                 // Read type of value
                 int32_t v_type_i_ref;
@@ -10547,12 +10602,16 @@ struct llama_data_read {
                     return false;
                 }
 
-                if (cell_count) {
+                const bool     v_compact = kv_self.is_compacted((int) il);
+                const uint32_t v_rows    = v_compact ? kv_self.live_swa() : cell_count;
+                const uint32_t v_dst     = v_compact ? kv_self.sink_rows  : kv_self.head;
+
+                if (v_rows) {
                     // Read and set the values for the whole cell range
                     if (kv_self.v_l[il]->extra) {
-                        read_kv_cache_data_split(ctx, kv_self.v_l[il], read(cell_count * v_size_row), kv_self.head, v_size_row, cell_count, il);
+                        read_kv_cache_data_split(ctx, kv_self.v_l[il], read(v_rows * v_size_row), v_dst, v_size_row, v_rows, il);
                     } else {
-                        ggml_backend_tensor_set(kv_self.v_l[il], read(cell_count * v_size_row), kv_self.head * v_size_row, cell_count * v_size_row);
+                        ggml_backend_tensor_set(kv_self.v_l[il], read(v_rows * v_size_row), v_dst * v_size_row, v_rows * v_size_row);
                     }
                 }
             }
@@ -10561,7 +10620,7 @@ struct llama_data_read {
             // For each layer, read the values for each cell (transposed)
             for (uint32_t il = 0; il < n_layer; ++il) {
                 const uint32_t n_embd_v_gqa = llama_kv_v_row_embd(ctx->model, hparams, il);
-                const bool has_v_cache = kv_self.v_l[il] != nullptr && need_kv;
+                const bool has_v_cache = kv_self.v_l[il] != nullptr && (need_kv || kv_self.is_compacted((int) il));
 
                 // Read type of value
                 int32_t v_type_i_ref;
@@ -10610,15 +10669,20 @@ struct llama_data_read {
                     return false;
                 }
 
-                if (cell_count) {
+                const bool     v_compact = kv_self.is_compacted((int) il);
+                const uint32_t v_rows    = v_compact ? kv_self.live_swa() : cell_count;
+                const uint32_t v_dst     = v_compact ? kv_self.sink_rows  : kv_self.head;
+
+                if (v_rows) {
                     const size_t v_size_el = ggml_type_size(kv_self.v_l[il]->type);
                     if (kv_self.v_l[il]->extra) {
                         throw std::runtime_error("Transposed V cache is not sypported with split mode 'graph'");
                     }
                     // For each row in the transposed matrix, read the values for the whole cell range
+                    const uint32_t kv_size = kv_self.rows((int) il);
                     for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
-                        const size_t dst_offset = (kv_self.head + j * kv_self.size) * v_size_el;
-                        ggml_backend_tensor_set(kv_self.v_l[il], read(cell_count * v_size_el), dst_offset, cell_count * v_size_el);
+                        const size_t dst_offset = (v_dst + (size_t) j * kv_size) * v_size_el;
+                        ggml_backend_tensor_set(kv_self.v_l[il], read(v_rows * v_size_el), dst_offset, v_rows * v_size_el);
                     }
                 }
             }
@@ -11392,7 +11456,7 @@ size_t llama_state_seq_set_data(struct llama_context * ctx, const uint8_t * src,
 }
 
 static size_t llama_state_seq_save_file_internal(struct llama_context * ctx, const char * filepath, llama_seq_id seq_id, const llama_token * tokens, size_t n_token_count) {
-    if (!llama_state_io_supported(ctx, __func__)) {
+    if (!llama_state_io_supported(ctx, __func__, 0, seq_id)) {
         return 0;
     }
     llama_file file(filepath, "wb");
@@ -11416,7 +11480,7 @@ static size_t llama_state_seq_save_file_internal(struct llama_context * ctx, con
 }
 
 static size_t llama_state_seq_load_file_internal(struct llama_context * ctx, const char * filepath, llama_seq_id dest_seq_id, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
-    if (!llama_state_io_supported(ctx, __func__)) {
+    if (!llama_state_io_supported(ctx, __func__, 0, dest_seq_id)) {
         return 0;
     }
     llama_file file(filepath, "rb");


### PR DESCRIPTION
This PR admits Laguna to `--swa-compress`, as requested in comments to #2171, opt-in and off by default. #2253 and #2266 admitted openPangu and DeepSeek4, and both of those store K and no V, so the flag has never rolled a V cache. A Laguna XS-2.1 Q4_K_M fails to load above 96K ctx on a 12GB 4070 with routed experts on CPU, but with this PR it serves **the model's full trained 256K ctx**, with about 5.6 GB of VRAM to spare.

Laguna is a mixed case: 30 of its 40 layers are sliding-window at width 512, the other 10 are full attention, and every layer allocates K and V at one row per context cell. Compacted, the 30 sliding-window layers stop scaling with `-c` while the 10 full-attention layers keep scaling, so the saving converges on 40/10 rather than on the four-figure factors DeepSeek4 reaches.

Allocation A/B on Laguna-XS-2.1-Q4_K_M at `-ngl 0 -fa on -ctk q8_0 -ctv q8_0 -b 2048 -ub 512` (host-side buffer lines, machine-independent):

| `-c` | dense KV | compacted KV | factor |
| --- | ---: | ---: | ---: |
| 32K | 2720.00 MiB | 743.75 MiB | 3.66x |
| 64K | 5440.00 MiB | 1423.75 MiB | 3.82x |
| 128K | 10880.00 MiB | 2783.75 MiB | 3.91x |
| 256K | 21760.00 MiB | 5503.75 MiB | **3.95x** |

A compacted layer holds `sink + window + max(n_ubatch, 256)` rows, pad-aligned, so the saving depends on the u-batch: at `-c 65536` the same model measures 3.82x at `-ub 512` and 3.30x at `-ub 4096`. An eightfold u-batch change moves the factor that little because the residual is owned by the 10 full-attention layers, not by the u-batch term.

Served context ceiling, same model and GPU (`-ngl 99 -ot exps=CPU -fa on -ctk q8_0 -ctv q8_0`), total CUDA0 as measured:

| `-c` | dense | `--swa-compress` |
| --- | --- | --- |
| 32K | loads, 3839 MiB | loads, 1863 MiB |
| 48K | loads, 5199 MiB | loads, 2203 MiB |
| 64K | loads, 6559 MiB | loads, 2543 MiB |
| 96K | loads, 9279 MiB | loads, 3223 MiB |
| 128K | fails: cudaMalloc OOM on the 10880 MiB KV buffer | loads, 3903 MiB |
| 192K | fails: cudaMalloc OOM on the 16320 MiB KV buffer | loads, 5263 MiB |
| 256K | fails: cudaMalloc OOM on the 21760 MiB KV buffer | **loads, 6623 MiB** |

The compacted arm at 256K costs about as much VRAM as the dense arm at 64K.

Beyond admission: cache fit and allocation take per-layer row counts from `llama_kv_layer_rows`, for K and for V, so no new architecture branch appears. `llama_kv_cache_compact_swa` now rolls V as well as K, position-major with flash attention and one strided move per V row without it. The compacted store row and window view move into `llm_build_kv`. State save and restore carry compacted V without a format bump. The `n_seq_max > 1` refusal keys on the layout, not on an architecture. openPangu geometry is unchanged.

Context shift and self-extend are refused on a compacted cache. `build_k_shift` views `n_ctx` rows per layer, but a compacted layer holds only its window rows. Laguna is the first compacted architecture repositioning does not already exclude, so the gate is new: `get_can_shift` returns false, `llama_kv_cache_seq_add` and `llama_kv_cache_seq_div` assert, and the server disables both at slot setup with a warning. A compacted server then stops when the context fills, as openPangu and DeepSeek4 do. `llama_supports_ctx_shift(ctx)` is new. `llama_supports_full_state_io(ctx)` loses its last caller here and is removed.

Measured throughput unchanged on this hardware. `--sweep-memory` from #2273 shows the savings holding under load rather than only at allocation. A-B-A on an idle machine at `-c 65536 -ngl 99 -ot exps=CPU -t 6 -fa on -ctk q8_0 -ctv q8_0 -b 4096 -ub 4096 -n 256 --sweep-memory`, compacted then dense then compacted, with the two compacted arms agreeing to 0.8% on median TG.

`--swa-compress`:

```
|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |    RSS HWM | VRAM delta |
|-------|--------|--------|----------|----------|----------|----------|------------|------------|
|  4096 |    256 |      0 |    3.353 |  1221.44 |    5.361 |    47.75 |    19486.3 |     4650.0 |
|  4096 |    256 |   4096 |    3.431 |  1193.71 |    5.607 |    45.66 |    19487.0 |     4650.0 |
|  4096 |    256 |   8192 |    3.516 |  1164.93 |    5.795 |    44.17 |    19487.3 |     4650.0 |
|  4096 |    256 |  12288 |    3.607 |  1135.49 |    6.079 |    42.11 |    19487.4 |     4650.0 |
|  4096 |    256 |  16384 |    3.698 |  1107.50 |    6.370 |    40.19 |    19487.6 |     4650.0 |
|  4096 |    256 |  20480 |    3.814 |  1073.86 |    6.645 |    38.52 |    19487.7 |     4650.0 |
|  4096 |    256 |  24576 |    3.907 |  1048.42 |    6.904 |    37.08 |    19487.9 |     4650.0 |
|  4096 |    256 |  28672 |    4.003 |  1023.22 |    7.156 |    35.77 |    19488.1 |     4650.0 |
|  4096 |    256 |  32768 |    4.124 |   993.14 |    7.412 |    34.54 |    19488.3 |     4650.0 |
|  4096 |    256 |  36864 |    4.319 |   948.47 |    7.667 |    33.39 |    19488.4 |     4650.0 |
|  4096 |    256 |  40960 |    4.500 |   910.31 |    7.923 |    32.31 |    19488.6 |     4650.0 |
|  4096 |    256 |  45056 |    4.635 |   883.78 |    8.183 |    31.28 |    19489.0 |     4662.0 |
|  4096 |    256 |  49152 |    4.798 |   853.75 |    8.425 |    30.38 |    19489.1 |     4678.0 |
|  4096 |    256 |  53248 |    4.989 |   821.07 |    8.682 |    29.49 |    19489.3 |     4694.0 |
|  4096 |    256 |  57344 |    5.197 |   788.21 |    8.931 |    28.66 |    19489.5 |     4710.0 |
|  4096 |    256 |  61440 |    5.376 |   761.87 |    9.179 |    27.89 |    19489.6 |     4726.0 |
```

Dense:

```
|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |    RSS HWM | VRAM delta |
|-------|--------|--------|----------|----------|----------|----------|------------|------------|
|  4096 |    256 |      0 |    3.304 |  1239.80 |    5.394 |    47.46 |    19965.2 |     8556.0 |
|  4096 |    256 |   4096 |    3.376 |  1213.20 |    5.665 |    45.19 |    19965.4 |     8556.0 |
|  4096 |    256 |   8192 |    3.488 |  1174.24 |    5.841 |    43.83 |    19965.8 |     8556.0 |
|  4096 |    256 |  12288 |    3.578 |  1144.65 |    6.130 |    41.76 |    19965.9 |     8556.0 |
|  4096 |    256 |  16384 |    3.687 |  1110.92 |    6.413 |    39.92 |    19966.0 |     8556.0 |
|  4096 |    256 |  20480 |    3.815 |  1073.72 |    6.700 |    38.21 |    19966.1 |     8556.0 |
|  4096 |    256 |  24576 |    3.902 |  1049.71 |    6.966 |    36.75 |    19966.3 |     8556.0 |
|  4096 |    256 |  28672 |    4.012 |  1020.91 |    7.242 |    35.35 |    19966.5 |     8556.0 |
|  4096 |    256 |  32768 |    4.132 |   991.34 |    7.479 |    34.23 |    19966.8 |     8556.0 |
|  4096 |    256 |  36864 |    4.332 |   945.54 |    7.743 |    33.06 |    19967.0 |     8556.0 |
|  4096 |    256 |  40960 |    4.506 |   909.03 |    7.989 |    32.04 |    19967.1 |     8556.0 |
|  4096 |    256 |  45056 |    4.671 |   876.82 |    8.236 |    31.08 |    19967.3 |     8568.0 |
|  4096 |    256 |  49152 |    4.842 |   845.96 |    8.478 |    30.19 |    19967.5 |     8584.0 |
|  4096 |    256 |  53248 |    5.014 |   816.94 |    8.792 |    29.12 |    19967.6 |     8600.0 |
|  4096 |    256 |  57344 |    5.201 |   787.49 |    9.052 |    28.28 |    19967.8 |     8616.0 |
|  4096 |    256 |  61440 |    5.398 |   758.86 |    9.311 |    27.49 |    19968.0 |     8632.0 |
```

Medians are 1008.18 PP and 35.155 TG compacted against 1006.12 PP and 34.790 TG dense: 0.2% and 1.0% against 0.8% drift, so no change rather than a gain. That is expected with flash attention on. `ggml_cuda_flash_attn_ext` re-points K, V and the mask to the last `nton` rows when `n_swa > 0`, so both arms give the kernel the same 768 rows at decode. The flag moves rows and does not remove reads. The window rolled about fifteen times per arm, and the `VRAM delta` held at 3906 MiB on every row.

Correctness: generation is identical with and without the flag on both V layouts, across a compaction roll. Perplexity over 6 chunks of `wiki.test` is unchanged on both layouts, including at `-ub 384`, where the u-batch does not divide the compacted row count. State saves and restores through the server slot endpoints on both layouts, and a corrupted payload diverges into garbage, so the test discriminates. Of four generation fixtures, three are byte-identical. The fourth differs by 2% in length, and its Python passes 29 of 29 of its own tests.

Limitations, beyond those inherited from #2253 and #2266:

- Single sequence only (`-np 1`), matching the openPangu restriction. The refusal is now keyed on the compacted layout rather than on the architecture, so it applies to Laguna automatically.
- The server slot file endpoints (`/slots/{id}?action=save|restore`) are no longer refused for compacted contexts, since per-sequence file state is what the state work here implements. openPangu remains refused for its own pre-existing reason, unchanged by this PR.
- Defrag still warns and skips for compacted caches, inherited from #2266; rows are window-addressed rather than cell-addressed. Laguna needs no separate guard.
- Context shift and self-extend are unavailable with `--swa-compress`, as described above. The server disables both with a warning and stops generation when the context fills.

*Adversarial code review and assessment of accuracy of this description by GPT-5.6.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High