### PR TITLE
server: accept max_completion_tokens as alias for max_tokens

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -1125,7 +1125,7 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
     auto stream_opt = json_value(data, "stream_options", json::object());
     slot.params.include_usage = json_value(stream_opt, "include_usage", false);
     slot.params.cache_prompt = json_value(data, "cache_prompt", true);
-    slot.params.n_predict = json_value(data, "n_predict", json_value(data, "max_tokens", defaults.n_predict));
+    slot.params.n_predict = json_value(data, "n_predict", json_value(data, "max_tokens", json_value(data, "max_completion_tokens", defaults.n_predict)));
     slot.saturate_predict = json_value(data, "saturate_predict", false);
     slot.sparams.top_k = json_value(data, "top_k", default_sparams.top_k);
     slot.sparams.top_p = json_value(data, "top_p", default_sparams.top_p);


### PR DESCRIPTION
OpenAI-compatible clients send `max_completion_tokens` (the OpenAI Responses
API field name) for the output token cap when talking to custom
openai-completions providers. Notably, the pi coding agent sends
`max_completion_tokens` for any provider whose baseUrl is not in its
hardcoded `max_tokens` list, and ik_llama is not.

The server only read `n_predict` and `max_tokens`, so the cap was silently
dropped and `n_predict` fell back to `-1` (unlimited). Observed consequence:
a pi auto-compaction on a ~120k-token MiniMax-M3 session generated a 40k+
token summary before the harness
classified the attempt as failed and cleared the context.

This PR adds `max_completion_tokens` to the `n_predict` fallback chain in
`launch_slot_with_task()`, matching upstream llama.cpp behavior where
`max_completion_tokens` is a schema alias of `n_predict`
(`tools/server/server-schema.cpp`).

### Known Quirk (out of scope)

When the cap is hit, this fork reports `finish_reason: "stop"` instead of
`"length"`. Pre-existing; not changed by this PR.