### PR TITLE
Fix Qwen35+ MTP

### DIFF
--- a/src/graphs/build_qwen35.cpp
+++ b/src/graphs/build_qwen35.cpp
@@ -64,12 +64,6 @@ ggml_cgraph * llm_build_context::build_qwen35moe() {
             inpL = cur;
         }
 
-        if (lctx.cparams.mtp) {
-            ggml_tensor * mtp_embd = inpL->type == GGML_TYPE_F32 ? inpL : ggml_cast(ctx0, inpL, GGML_TYPE_F32);
-            cb(mtp_embd, "result_mtp_embd", -1);
-            ggml_set_output(mtp_embd);
-        }
-
         cur = build_output(lctx, ctx0, inpL, model.output, model.output_norm, cb);
         cb(cur, "result_output", -1);
     }
@@ -134,12 +128,6 @@ ggml_cgraph * llm_build_context::build_qwen35() {
             cb(cur, "l_out", il);
 
             inpL = cur;
-        }
-
-        if (lctx.cparams.mtp) {
-            ggml_tensor * mtp_embd = inpL->type == GGML_TYPE_F32 ? inpL : ggml_cast(ctx0, inpL, GGML_TYPE_F32);
-            cb(mtp_embd, "result_mtp_embd", -1);
-            ggml_set_output(mtp_embd);
         }
 
         cur = build_output(lctx, ctx0, inpL, model.output, model.output_norm, cb);


### PR DESCRIPTION

Qwen-3.5+ MTP requires the embeddings after applying the head `rms_norm`. Due to changes made in PR #2250 to add Step-3.7 MTP support, we ended up using the embeddings before `rms_norm` since this PR.

This PR fixes the issue by simply deleting the code blocks that add embeddings before `rms_norm` as a possible graph output (so that we don't end up reintroducing the same bug again and again).

The effect is surprisingly small - just 2-5% difference in acceptance rate in the tests I ran. 