### PR TITLE
Fix Gemma4 MTP

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -104,12 +104,11 @@ static bool common_speculative_are_compatible(
         return false;
     }
 
-    if (
-        llama_vocab_get_add_bos(vocab_tgt) != llama_vocab_get_add_bos(vocab_dft) ||
+    if (!llama_model_is_gemma4_mtp_assistant(model_dft) &&
+       (llama_vocab_get_add_bos(vocab_tgt) != llama_vocab_get_add_bos(vocab_dft) ||
         llama_vocab_get_add_eos(vocab_tgt) != llama_vocab_get_add_eos(vocab_dft) ||
         llama_vocab_bos(vocab_tgt) != llama_vocab_bos(vocab_dft) ||
-        llama_vocab_eos(vocab_tgt) != llama_vocab_eos(vocab_dft)
-    ) {
+        llama_vocab_eos(vocab_tgt) != llama_vocab_eos(vocab_dft))) {
         LOG_WRN("%s: draft model special tokens must match target model to use speculation\n", __func__);
         return false;
     }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -104,15 +104,15 @@ static bool common_speculative_are_compatible(
         return false;
     }
 
-    //if (
-    //    llama_vocab_get_add_bos(vocab_tgt) != llama_vocab_get_add_bos(vocab_dft) ||
-    //    llama_vocab_get_add_eos(vocab_tgt) != llama_vocab_get_add_eos(vocab_dft) ||
-    //    llama_vocab_bos(vocab_tgt) != llama_vocab_bos(vocab_dft) ||
-    //    llama_vocab_eos(vocab_tgt) != llama_vocab_eos(vocab_dft)
-    //) {
-    //    LOG_WRN("%s: draft model special tokens must match target model to use speculation\n", __func__);
-    //    return false;
-    //}
+    if (
+        llama_vocab_get_add_bos(vocab_tgt) != llama_vocab_get_add_bos(vocab_dft) ||
+        llama_vocab_get_add_eos(vocab_tgt) != llama_vocab_get_add_eos(vocab_dft) ||
+        llama_vocab_bos(vocab_tgt) != llama_vocab_bos(vocab_dft) ||
+        llama_vocab_eos(vocab_tgt) != llama_vocab_eos(vocab_dft)
+    ) {
+        LOG_WRN("%s: draft model special tokens must match target model to use speculation\n", __func__);
+        return false;
+    }
 
     {
         const int n_vocab_tgt = llama_vocab_n_tokens(vocab_tgt);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -99,20 +99,20 @@ static bool common_speculative_are_compatible(
     LOG_DBG("%s: vocab_type dft: %d\n", __func__, vocab_type_dft);
 
     if (vocab_type_tgt != vocab_type_dft) {
-        LOG_DBG("%s: draft model vocab type must match target model to use speculation but ", __func__);
-        LOG_DBG("vocab_type_dft = %d while vocab_type_tgt = %d\n", vocab_type_dft, vocab_type_tgt);
+        LOG_WRN("%s: draft model vocab type must match target model to use speculation but ", __func__);
+        LOG_WRN("vocab_type_dft = %d while vocab_type_tgt = %d\n", vocab_type_dft, vocab_type_tgt);
         return false;
     }
 
-    if (
-        llama_vocab_get_add_bos(vocab_tgt) != llama_vocab_get_add_bos(vocab_dft) ||
-        llama_vocab_get_add_eos(vocab_tgt) != llama_vocab_get_add_eos(vocab_dft) ||
-        llama_vocab_bos(vocab_tgt) != llama_vocab_bos(vocab_dft) ||
-        llama_vocab_eos(vocab_tgt) != llama_vocab_eos(vocab_dft)
-    ) {
-        LOG_DBG("%s: draft model special tokens must match target model to use speculation\n", __func__);
-        return false;
-    }
+    //if (
+    //    llama_vocab_get_add_bos(vocab_tgt) != llama_vocab_get_add_bos(vocab_dft) ||
+    //    llama_vocab_get_add_eos(vocab_tgt) != llama_vocab_get_add_eos(vocab_dft) ||
+    //    llama_vocab_bos(vocab_tgt) != llama_vocab_bos(vocab_dft) ||
+    //    llama_vocab_eos(vocab_tgt) != llama_vocab_eos(vocab_dft)
+    //) {
+    //    LOG_WRN("%s: draft model special tokens must match target model to use speculation\n", __func__);
+    //    return false;
+    //}
 
     {
         const int n_vocab_tgt = llama_vocab_n_tokens(vocab_tgt);
@@ -122,8 +122,8 @@ static bool common_speculative_are_compatible(
             : n_vocab_dft - n_vocab_tgt;
 
         if (vocab_diff > SPEC_VOCAB_MAX_SIZE_DIFFERENCE) {
-            LOG_DBG("%s: draft model vocab must closely match target model to use speculation but ", __func__);
-            LOG_DBG("target vocab size %d does not match draft vocab size %d - difference %d, max allowed %d\n",
+            LOG_WRN("%s: draft model vocab must closely match target model to use speculation but ", __func__);
+            LOG_WRN("target vocab size %d does not match draft vocab size %d - difference %d, max allowed %d\n",
                     n_vocab_tgt, llama_vocab_n_tokens(vocab_dft), vocab_diff, SPEC_VOCAB_MAX_SIZE_DIFFERENCE);
             return false;
         }
@@ -133,8 +133,8 @@ static bool common_speculative_are_compatible(
             const char * token_text_dft = llama_vocab_get_text(vocab_dft, i);
 
             if (std::strcmp(token_text_tgt, token_text_dft) != 0) {
-                LOG_DBG("%s: draft model vocab must match target model to use speculation but ", __func__);
-                LOG_DBG("token %d content differs - target '%s', draft '%s'\n", i,
+                LOG_WRN("%s: draft model vocab must match target model to use speculation but ", __func__);
+                LOG_WRN("token %d content differs - target '%s', draft '%s'\n", i,
                         common_token_to_piece(vocab_tgt, i).c_str(),
                         common_token_to_piece(vocab_dft, i).c_str());
                 return false;

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -672,7 +672,7 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
                 GGML_ASSERT(model.layers[il].attn_q_norm && model.layers[il].attn_q_norm->extra);
                 Qcur = do_split_norm(ctx0, Qcur, model.layers[il].attn_q_norm, hparams, cb, id, il_cb, false);
                 cb(Qcur, "Qcur_normed", il_cb);
-                auto freq_factors = is_sliding ? nullptr : ((const ggml_split_tensor_t *)model.layers[il].rope_freqs->extra)->splits[id];
+                auto freq_factors = is_sliding || !model.layers[il].rope_freqs ? nullptr : ((const ggml_split_tensor_t *)model.layers[il].rope_freqs->extra)->splits[id];
                 Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, freq_factors, n_rot_l, rope_type, n_ctx_orig, freq_base_l, freq_scale_l,
                         ext_factor, attn_factor, beta_fast, beta_slow);
                 cb(Qcur, "Qcur_rope", il_cb);

--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -548,10 +548,6 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
                 ggml_row_size(hidden_state->type, n_backbone), 0);
         cb(cur, "mtp_init_hidden_view", -1);
 
-        ggml_tensor * mtp_embd = ggml_dup(ctx0, hidden_state);
-        cb(mtp_embd, "result_mtp_embd", -1);
-        ggml_build_forward_expand(gf, mtp_embd);
-
         ggml_tensor * logits = build_output(lctx, ctx0, cur, model.output, model.output_norm, cb);
         cb(logits, "result_output", -1);
         ggml_build_forward_expand(gf, logits);
@@ -1122,12 +1118,6 @@ ggml_cgraph * llm_build_context::build_gemma4() {
     }
 
     cur = inpL;
-
-    if (cparams.mtp) {
-        ggml_tensor * mtp_embd = ggml_dup(ctx0, cur);
-        cb(mtp_embd, "result_mtp_embd", -1);
-        ggml_build_forward_expand(gf, mtp_embd);
-    }
 
     cur = llm_build_norm(ctx0, cur, hparams, model.output_norm, NULL, LLM_NORM_RMS, cb, -1);
     cb(cur, "result_norm", -1);


### PR DESCRIPTION

#2250 also broke Gemma4 MTP - embeddings are gather pre-normalization rather than post-normalization. This PR changes back to post-normalization.

There are still two more things broken with Gemma4 MTP it seems
* The main and draft models I have that used to work in the past now no longer do due to a vocabulary compatibility check - now fixed by disabling this check when the draft model is the Gemma4 assistant
* Split mode `graph` is broken with MTP (we get a hard crash). That used to work. Ha, it looks like I broke it in #2022, which is very strange as I have surely tested split `graph` in a PR adding split mode `graph` to the Gemma4 assistant. - now fixed (`rope_freqs` were missing for a non-SWA layers but we were assuming they are there, so crashing on nullptr dereference). 

It is interesting to see the performance progression as I was going through the commits to find the one breaking split mode `graph` with MTP. For the case I was using for testing with Gemma4-31b we went up from ~100 t/s to 115 t/s to 128 t/s. In this PR we are at 136 t/s after fixing all issues. 