### PR TITLE
metal: initialize encode_async in ggml_backend_metal_init

### DIFF
--- a/ggml/src/ggml-metal.m
+++ b/ggml/src/ggml-metal.m
@@ -4509,6 +4509,8 @@ ggml_backend_t ggml_backend_metal_init(void) {
         /* .context   = */ ctx,
     };
 
+    ggml_backend_metal_set_n_cb(metal_backend, 1);
+
     return metal_backend;
 }
 


### PR DESCRIPTION
ggml_metal_init leaves ctx->encode_async nil, but
ggml_backend_metal_graph_compute invokes it unconditionally, so a Metal backend created without a set_n_cb call segfaults on its first graph.

This affects rpc-server and ggml_backend_reg_metal_init, while llama.cpp path is fine because llama_graph_compute sets n_cb before every compute.

Upstream added the same call in cad341d88, the commit that introduced encode_async.

Reproduction (Apple Silicon, -DGGML_METAL=ON):
```
#include "ggml.h"
#include "ggml-backend.h"
#include "ggml-metal.h"

int main() {
    struct ggml_init_params p = { ggml_tensor_overhead()*2 + ggml_graph_overhead(), NULL, true };
    ggml_context * ctx = ggml_init(p);
    ggml_tensor * input = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
    ggml_tensor * out = ggml_sqr(ctx, input);
    ggml_cgraph * g = ggml_new_graph(ctx);
    ggml_build_forward_expand(g, out);

    ggml_backend_t metal = ggml_backend_metal_init();
    ggml_backend_alloc_ctx_tensors(ctx, metal);

    const float value = 1.0f;
    ggml_backend_tensor_set(input, &value, 0, sizeof(value));
    ggml_backend_graph_compute(metal, g);  // SIGSEGV before this change
    return 0;
}
```

Parts of this PR description have been written with AI assistance.

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
