### PR TITLE
ggml-cuda: bind cublas handle to the backend stream in DSA attention

### DIFF
--- a/ggml/src/ggml-cuda/dsa_attn.cu
+++ b/ggml/src/ggml-cuda/dsa_attn.cu
@@ -344,6 +344,7 @@ bool ggml_cuda_dsa_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
                     (const float *)((const char *)Q->data + first*Q->nb[1]), q16.get());
         }
 
+        CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(), ctx.stream()));
         CUBLAS_CHECK(cublasHgemmStridedBatched(ctx.cublas_handle(), CUBLAS_OP_T, CUBLAS_OP_N,
                     indexer->ne[0], Q->ne[2], Q->ne[0],
                     &alpha, k16.get(), K->ne[0], K->ne[0]*indexer->ne[0],


### PR DESCRIPTION
~~DeepSeek-V4 Q.K logits overflow fp16 (65504), saturating the KQ GEMM output to inf/NaN and collapsing the stream to all-NaN logits past the SWA window. Compute KQ in f32.~~

~~Bind the shared cublas handle to the backend's stream before the GEMMs; the handle defaults to the legacy stream and other ops rebind it, so the GEMMs can otherwise race with the kernels on ctx.stream().~~

The GEMMs raced with the gather/softmax on ctx.stream(), producing NaN scores.


- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
