### PR TITLE
Fix KQ mask padding for the Vulkan back-end

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2483,7 +2483,11 @@ extern "C" {
             int                   nk,
             int                   topk_experts);
 
+#if GGML_USE_VULKAN
+#define GGML_KQ_MASK_PAD 64
+#else
 #define GGML_KQ_MASK_PAD 16
+#endif
 
     // q:    [n_embd, n_batch,     n_head,    1]
     // k:    [n_embd, n_kv,        n_head_kv, 1]


### PR DESCRIPTION

KQ mask padding must be 64 for the Vulkan back-end, but at some point I changed that to 16. 