### PR TITLE
server: fix prompt re-use with `--reasoning-tokens none`

### DIFF
--- a/examples/server/server-task.cpp
+++ b/examples/server/server-task.cpp
@@ -1094,7 +1094,7 @@ bool server_prompt_cache::load(server_prompt& prompt, const server_tokens& token
         tokens_new_ex = tokens_new.get_tokens_exclude_think(ctx, think_tokens);
     }
     else {
-        prompt_tokens = std::move(prompt.tokens); 
+        prompt_tokens = prompt.tokens.clone();
         tokens_new_ex = tokens_new.clone();
     }
     const auto lcp_best = prompt_tokens.get_common_prefix(ctx, tokens_new_ex);
@@ -1111,7 +1111,7 @@ bool server_prompt_cache::load(server_prompt& prompt, const server_tokens& token
             tokens = it->tokens.get_tokens_exclude_think(ctx, think_tokens);
         }
         else {
-            tokens = std::move(it->tokens);
+            tokens = it->tokens.clone();
         }
         const auto lcp_cur = tokens.get_common_prefix(ctx, tokens_new_ex);
         const float f_keep_cur = float(lcp_cur.first) / tokens.size();


### PR DESCRIPTION
While testing Qwen3.8-27B with `--reasoning-tokens none` on agent tasks, I found a big increase in wall clock over `--reasoning-tokens auto`. On `main`, the scoring branch used when exclusion is off moves each token ledger instead of copying it. `server_tokens` is move-only, so the move empties the ledger it reads. The slot passes its own ledger to the scoring function by reference, so the move empties that ledger in place. The slot then holds a ledger that reports zero tokens. A later request that continues the conversation in that slot replays the whole prompt.

Four requests, the last two continue the conversation the slot already holds:

| `--reasoning-tokens` | prompt tokens processed per request | total prompt time |
| --- | --- | --- |
| `auto` | 3366, 3250, 61, 61 | 8594.9 ms |
| `none` | 3366, 3250, 3306, 3362 | 16434.4 ms |

Both runs save once, attempt three loads, and select nothing from the cache. The slot loses a prefix that its own KV cache still holds.

This PR replaces the two moves with a copy. The exclusion-on branch builds a new ledger and leaves its source intact, so it never had the defect. Entries stay in the cache, and the cache grows toward the `--cache-ram` limit, default 8192 MiB.

Qwen3.8-27B IQ3_KT. `GGML_CUDA_NO_PINNED=1` `-c 8192 -fa on -ngl 99 -ctk q4_0 -ctv q4_0 -np 1 -b 128 -ub 128 -amb 256 --spec-type mtp:n_max=1,p_min=0.0 --reasoning on --reasoning-budget -1 --jinja --metrics --cache-ram 8192`, six requests alternate between two conversations of about 3400 tokens in one slot:

| configuration | build | selections / attempts | total prompt time |
| --- | --- | --- | --- |
| `--reasoning-tokens none` | current | 0 / 5 | 24796.1 ms |
| `--reasoning-tokens none` | patched | 4 / 5 | 9110.7 ms |
| `--reasoning-tokens auto` | current | 4 / 5 | 9102.9 ms |
| `--reasoning-tokens auto` | patched | 4 / 5 | 9127.3 ms |

The patched exclusion-off configuration gives the same result as the default configuration. The per-request prompt token, selection, and accepted-draft counts are the same.

Default path is untouched, and behavior is independent of architecture and speculative decoding.

*Adversarial code review, and assessment of blast radius and accuracy of this description, by Fable 5.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High