### PR TITLE
Fix MMQ check when quant does not support MMQ

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2577,7 +2577,8 @@ static int ggml_cuda_mul_mat_q(ggml_backend_cuda_context & ctx, const ggml_tenso
                                || dst->op == GGML_OP_PERMUTE || dst->op == GGML_OP_NONE) {
             ++node_n; continue;
         }
-        if (dst->op != GGML_OP_MUL_MAT || dst->src[1] != src1 || !ggml_is_quantized(dst->src[0]->type)) break;
+        if (dst->op != GGML_OP_MUL_MAT || dst->src[1] != src1 || !ggml_is_quantized(dst->src[0]->type) ||
+                !ggml_cuda_should_use_mmq(dst->src[0]->type, ggml_cuda_info().devices[ctx.device].cc, src1->ne[1])) break;
         if (!is_gemv && mmq_get_q8_1_ds_layout(src0->type) != mmq_get_q8_1_ds_layout(dst->src[0]->type)) break;
         if (is_gemv) {
             if (fusion && node_n + 2 < cgraph->n_nodes &&


### PR DESCRIPTION

Closes #2333 

The issue was that `ffn_up` and `ffn_gate` are quantized with different types, and one of the types is `IQ1_M`. Because of the different types, the fused `ffn_up/ffn_gate` op is rejected and the matrix multiplications are performed sequentially. But that goes into `ggml_cuda_mul_mat_q`, where we notice that there are two consecutive matrix multiplications with the same activations (`src1`), so we check if we can reuse the quantization of `src1`. But because `IQ1_M` does not support MMQ, the check for the quantization layout leads to the observed assert. The fix is to first check if MMQ is supported before  checking for the quantization layout.

@Thireus

Because of #2333 I had to download 2 Qwen-3.8 models from Unsloth and see what kind of quantization types are being used. It seems these have been done with the latest and greatest "Dynamic 3.0", where the tensors appear to be a bit of a random salad of quantization types. For instance, here is what I see for the `IQ2_S` model:
```
llama_model_loader: - type  f32:  353 tensors
llama_model_loader: - type q8_0:   96 tensors
llama_model_loader: - type q2_K:    8 tensors
llama_model_loader: - type q4_K:   16 tensors
llama_model_loader: - type iq2_xxs:   95 tensors
llama_model_loader: - type iq2_xs:   51 tensors
llama_model_loader: - type iq3_xxs:   60 tensors
llama_model_loader: - type iq1_s:   46 tensors
llama_model_loader: - type iq3_s:   37 tensors
llama_model_loader: - type iq2_s:   71 tensors
llama_model_loader: - type iq4_xs:    6 tensors
llama_model_loader: - type iq1_m:   12 tensors
```

This reminds me quite a bit of your GGUF suite, including the usage of different quantization types for `ffn_up` and `ffn_gate` in early versions. Is it possible Unsloth are using all or parts of your GGUF suite?    