### PR TITLE
ggml: fix HC_POST single-token CPU chunk count

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -24471,7 +24471,8 @@ static void ggml_compute_forward_hc_post_f32(
         const float * post_r = (const float *)((const char *)post->data);
         const float * comb_r = (const float *)((const char *)comb->data);
 
-        int nchunk = (ne0 + nth - 1)/nth;
+        // chunks are 64 elements wide (see `first` below); threads stride over chunks
+        int nchunk = (ne0 + 63)/64;
 
         for (int ic = ith; ic < nchunk; ic += nth) {
             int first = 64*ic;


### PR DESCRIPTION
The HC_POST single-token CPU kernel sizes its chunk count from the thread count, but the chunks are a fixed 64 elements wide. At a high enough thread count it runs out of chunks before it runs out of tensor and leaves the tail of the output unwritten. This PR's patch derives the count from `ne0` and the 64-element stride the loop already uses.

The op receives the full configured thread count and `-t` is not clamped. Any thread count above the crossover reaches the defect irrespective of the machine's core count. Since the default thread count is the machine's core count, a machine with 66 or more cores reaches it with no flags at all. DeepSeek4 at `n_embd` 4096 and openPangu at `n_embd` 2560 both cross over at 66 threads. The CUDA path is unaffected.

A standalone test sets every element of `dst` to a known value before each compute, so an element the kernel never writes cannot pass by still holding a correct value from the previous run. It compares each build against its own `nth=1` result at `nth=2, 8, 16, 63, 64, 65, 96, 128, 192`:

| `n_embd` | Current main | This PR |
| ---: | ---: | ---: |
| 4096 | 3/9 thread counts wrong | 0/9 |
| 2560 | 3/9 thread counts wrong | 0/9 |
| 128 | 2/9 thread counts wrong | 0/9 |
| 100 | 2/9 thread counts wrong | 0/9 |

Three fixed-prompt CPU-only generation checks follow, all greedy, all with every layer on CPU.

1. openPangu-2.0-Flash at Q2_K, `n_embd` 2560, over 64 generated tokens. This check and the next compare the two builds at one fixed thread count. At `-t 65`, one step below the crossover, the two builds produce identical output. At `-t 66` they diverge from generated token 6, and current main degenerates into repetition:

-t 66, `main`:
> The history of Bulgaria is as follows: The Thraci were first of all the first known to have a significant presence of the Roman Empire. The Roman Empire of the 1st century BC is the Roman Empire of the 1st century BC.

> The history of Bulgaria is as follows: The Thraci were first of

-t 66, this PR:
> The history of Bulgaria is a complex and fascinating story that spans thousands of years, from the arrival of the Thracians in the region to the modern era. The Thracians were the first to settle in the region, and

Both excerpts stop where the token budget ends. openPangu at Q2_K is not thread-invariant on CPU in general, which is the reason this comparison varies only the build.

2. DeepSeek-V4-Flash at IQ1_S, `n_embd` 4096, the width DeepSeek4 ships at, over 128 generated tokens on the same prompt. At `-t 65` the two builds produce identical output, and this PR produces that same output at `-t 66`. Current main at `-t 66` emits one token and then repeats token id 0 for the remaining 127:

-t 66, `main`:
>  Your

-t 66, this PR:
>  Your summary must include evidence and conclusions from 2-3 reputable sources. \n" + "History of Bulgaria\n" + "Bulgaria's history spans from the 5th-1st century BC (modern-day Bulgaria) to the present day. The land known as Bulgaria is diverse and has a rich history. The territory of Bulgaria (Bulgaria) is located on the Balkan Peninsula.

That current-main trace contains two distinct token ids across its 128 tokens. Output collapses at generated token 2.

3. RalphSeekv4 at `n_embd` 128, over 32 generated tokens on a different fixed prompt. A narrower tensor needs fewer chunks, so it crosses over at 128 threads rather than 66. This PR produced identical token IDs at `-t 1`, `64`, `127` and `128`, so thread count does not change greedy output on this model, and `main` matched it at `-t 127`. At `-t 128` `main` diverged at generated token 3:

-t 128, `main`:
> My left rainI thinkMy right cold sandwich by a sleepy feel! The sidewalk.I think feel! ...

-t 128, this PR:
> My left knee says clouds carry rain in their pockets by a paper cup. A sleepy kite made me ...

*Adversarial code review and assessment of accuracy of this description by Opus 5.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High