### PR TITLE
server: fix responses truncated below max_tokens with speculative decoding

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -4286,7 +4286,6 @@ void server_context::speculative_decoding_accept() {
         slot.drafted.clear();
 
         slot.n_past += ids.size();
-        slot.n_decoded += ids.size();
         const int64_t t_current = ggml_time_us();
         slot.t_token_generation = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
 
@@ -4336,6 +4335,8 @@ void server_context::speculative_decoding_accept() {
 
         for (size_t i = 0; i < ids.size(); ++i) {
             completion_token_output result;
+
+            slot.n_decoded += 1;
 
             result.tok = ids[i];
             result.text_to_send = common_token_to_piece(ctx, result.tok, accept_special_token(slot, result.tok));


### PR DESCRIPTION
With speculative decoding active, a request for `max_tokens` can return fewer tokens than requested. `speculative_decoding_accept()` charges the whole accepted block to `slot.n_decoded` before the emission loop, and both exit paths of that loop break mid-block, so a block that crosses the `n_predict` boundary stops emission early while `usage.completion_tokens` still reports the full budget. A stop string or EOG inside an accepted block drops the tail correctly but still counts it, and the same counter feeds `/metrics` and the printed generation rate, so both read high when it happens. This PR charges one token at a time inside the emission loop, matching the ordinary decode path. `slot.n_past` is untouched, since it tracks KV cache occupancy and the block is already committed before emission begins.

Repro with two models: Qwen3.8-27B at IQ3_XXS driving its in-model NextN block with `--spec-type mtp:n_max=4,p_min=0.0` and no draft model, and RalphSeek-V4-Flash (DSv4F+MTP surrogate), driving the separate draft model path with an f32 target, an f32 MTP companion, and `n_max=1`. Greedy at `-c 512 -b 128 -ub 128` against the same two builds, counting delivered entries in the OAI logprobs array against `usage.completion_tokens`.

| Case | `main` | this PR |
| --- | --- | --- |
| Qwen3.8, `max_tokens` 8 to 24 | 14/17 count mismatches | 0/17 count mismatches |
| Qwen3.8, stop inside an accepted block | 3 entries delivered, 5 reported | 3 delivered, 3 reported |
| RalphSeek, `max_tokens` 8 to 24 | 8/17 count mismatches | 0/17 count mismatches |
| RalphSeek, stop inside an accepted block | 3 entries delivered, 4 reported | 3 delivered, 3 reported |

Accepted blocks are five tokens at `n_max=4`, so current main only delivers counts of the form 1 + 5k: within this range 11, 16 and 21 land on a block boundary and come out exact, and every other value is short by the remainder.

| Qwen3.8 `max_tokens` | `main` delivers | this PR delivers |
| ---: | ---: | ---: |
| 8 | 6 | 8 |
| 10 | 6 | 10 |
| 15 | 11 | 15 |
| 20 | 16 | 20 |
| 24 | 21 | 24 |

On the same prompt, both builds at `max_tokens=24`, greedy, thinking off, `main` reports 24 tokens but delivers 21:

> The history of Bulgaria is a complex narrative spanning over two millennia, marked by periods of empire, foreign domination

This PR reports and delivers 24, and its first 21 token IDs are identical to `main`:

> The history of Bulgaria is a complex narrative spanning over two millennia, marked by periods of empire, foreign domination, and national

Both responses end where the token budget ends.

Generation time doesn't change here, 117 ms against 118 ms at `max_tokens=10` and 301 against 299 at 24. The block is decoded and committed to the KV cache either way, so `main` discards tokens it has already computed and already charged to the client.

*Adversarial code review, and assessment of blast radius and accuracy of this description, by Fable 5.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High