### PR TITLE
rpc: fix crash running GLM-5.2 (glm-dsa) split over RPC

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -7,9 +7,9 @@
 extern "C" {
 #endif
 
-#define RPC_PROTO_MAJOR_VERSION    3
-#define RPC_PROTO_MINOR_VERSION    5
-#define RPC_PROTO_PATCH_VERSION    2
+#define RPC_PROTO_MAJOR_VERSION    4
+#define RPC_PROTO_MINOR_VERSION    0
+#define RPC_PROTO_PATCH_VERSION    0
 #define GGML_RPC_MAX_SERVERS       16
 
 // backend API

--- a/ggml/src/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc.cpp
@@ -237,15 +237,15 @@ struct ggml_backend_rpc_buffer_type_context {
 struct graph_cache {
 
     bool is_cached(const ggml_cgraph * cgraph) {
-        if ((int)last_graph.size() != cgraph->n_nodes) {
-            return false;
-        }
-        for (int i = 0; i < cgraph->n_nodes; i++) {
-            if (memcmp(&last_graph[i], cgraph->nodes[i], sizeof(ggml_tensor)) != 0) {
-                return false;
-            }
-        }
-        return true;
+        // Disabled: comparing graphs by memcmp of the tensor structs treats successive
+        // same-shape prefill micro-batches as identical, so they take the
+        // GRAPH_RECOMPUTE path and re-run a stored graph against a grown KV context.
+        // Stale KV/mask views then make context-dependent ops (e.g. the GLM-5.2 DSA
+        // indexer) read past their buffers -> server crash. Always send the full graph
+        // instead (metadata only; tensor data stays in RPC buffers). Upstream
+        // llama.cpp retired this cache design in ggml-org/llama.cpp#22701.
+        (void)cgraph;
+        return false;
     }
 
     void add(const ggml_cgraph * cgraph) {

--- a/ggml/src/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc.cpp
@@ -73,8 +73,12 @@ struct rpc_tensor {
     uint64_t id;
     uint32_t type;
     uint64_t buffer;
-    uint32_t ne[GGML_MAX_DIMS];
-    uint32_t nb[GGML_MAX_DIMS];
+    // 64-bit to match ggml_tensor (int64_t ne, size_t nb). A 32-bit nb silently
+    // truncated any stride >= 4 GiB on the wire; the GLM-5.2 DSA indexer query's
+    // per-token stride crosses that at ~26k tokens, corrupting the stride on the
+    // remote server.
+    uint64_t ne[GGML_MAX_DIMS];
+    uint64_t nb[GGML_MAX_DIMS];
     uint32_t op;
     int32_t  op_params[GGML_MAX_OP_PARAMS / sizeof(int32_t)];
     int32_t  flags;

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -8846,8 +8846,9 @@ struct ggml_tensor * ggml_permute(
     //ggml_format_name(result, "%s (permuted)", a->name);
     ggml_format_name_fast(a->name, " (permuted)", 11, result->name);
 
-    int ne[GGML_MAX_DIMS];
-    int nb[GGML_MAX_DIMS];
+    // 64-bit: nb is size_t in ggml_tensor; a 32-bit int truncated any stride > 2 GiB.
+    int64_t ne[GGML_MAX_DIMS];
+    size_t  nb[GGML_MAX_DIMS];
 
     ne[axis0] = a->ne[0];
     ne[axis1] = a->ne[1];


### PR DESCRIPTION
Fixes #2355.

Running GLM-5.2 (`glm-dsa`) split across two machines over the RPC backend crashed deterministically in `iqk_indexer_topk` once the prompt passed ~26k tokens. Full diagnosis is in #2355; this is the fix I validated. Three commits, each independent:

**1. `rpc: disable unsafe memcmp graph cache`**
The client-side `graph_cache::is_cached` compares graphs by `memcmp` of each node's `ggml_tensor`. Successive same-shape prefill micro-batches (e.g. three 8192-token batches in a row) compare equal, so the client sends `GRAPH_RECOMPUTE` and the server re-runs the *stored* graph against a grown KV context. The DSA indexer's tensors no longer match the current context and `iqk_indexer_topk` reads past its buffers. I've disabled reuse so every batch sends a full graph (metadata only; tensor data stays in RPC buffers) — the simplest safe fix. Note you retired this exact `memcmp` cache upstream in favour of a graph-uid comparison (ggml-org/llama.cpp#22701); if you'd prefer to keep the reuse optimization, porting that scheme is the more complete fix and I'm happy to do it instead — I went minimal here.

**2. `rpc: use 64-bit ne/nb in rpc_tensor wire struct`**
`ggml_tensor` holds `int64_t ne` / `size_t nb`, but the wire struct stored them as `uint32_t`, truncating any stride ≥ 4 GiB. The DSA indexer query's per-token stride crosses that at ~26k tokens, so the stride arrived corrupted on the server. Widened to `uint64_t` and bumped `RPC_PROTO_MAJOR` (wire-format change; both ends must match). This matches the current upstream `rpc_tensor` layout.

**3. `ggml: use 64-bit locals in ggml_permute`**
`ggml_permute` built its permuted strides in `int` locals, truncating any stride > 2 GiB before it reached `result->nb`. Affects any permuted tensor over ~2 GiB. This one also exists in mainline `ggml.c`; I'll raise it there separately.

**Validation:** a 30,846-token prompt on GLM-5.2 2-bit (`unsloth UD-IQ2_M`) split across two 64 GB machines with `--rpc <peer> -ngl 13 -dsa -fidx --spec-type mtp -b 8192 -ub 8192` now runs to completion and produces correct output. Before the fix it crashed in `iqk_indexer_topk` every time at ~26k tokens.

Thanks again for the batch-size and `--prefetch-experts` tips — they cut prefill dramatically.
