### PR TITLE
server: fix finish_reason for token-limit stops

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -2396,7 +2396,6 @@ void server_context::send_error(const int id_task, const int id_multi, const std
     auto res = std::make_unique<server_task_result_error>();
     res->id = id_task;
     res->id_multi = id_multi;
-    res->stop = false;
     res->error = true;
     res->err_type = type;
     res->err_msg = error;
@@ -2423,7 +2422,6 @@ void server_context::send_partial_response(server_slot& slot, completion_token_o
     res->id_multi = slot.id_multi;
     res->index = slot.task->index;
     res->error = false;
-    res->stop = false;
     res->stream = slot.params.stream;
     res->content = tkn.text_to_send;
     res->post_sampling_probs = slot.params.post_sampling_probs;
@@ -2497,7 +2495,10 @@ void server_context::send_final_response(server_slot& slot) {
     res->id_multi = slot.id_multi;
     res->index = slot.task->index;
     res->error = false;
-    res->stop = true; // to do: set value
+    res->stop = slot.stopped_word  ? STOP_TYPE_WORD
+              : slot.stopped_eos   ? STOP_TYPE_EOS
+              : slot.stopped_limit ? STOP_TYPE_LIMIT
+                                   : STOP_TYPE_EOS;
     res->stream = slot.params.stream;
     res->include_usage = slot.params.include_usage;
     res->content = slot.generated_text;
@@ -2911,7 +2912,6 @@ void server_context::process_single_task(server_task&& task) {
         server_task_result res;
         res.id = task.id;
         res.id_multi = task.id_multi;
-        res.stop = true;
         res.error = false;
         res.data = {
             { "idle",                            n_idle_slots       },
@@ -2975,7 +2975,6 @@ void server_context::process_single_task(server_task&& task) {
 
         server_task_result result;
         result.id = task.id;
-        result.stop = true;
         result.error = false;
         result.data = json{
             { "id_slot",   id_slot },
@@ -3023,7 +3022,6 @@ void server_context::process_single_task(server_task&& task) {
 
         server_task_result result;
         result.id = task.id;
-        result.stop = true;
         result.error = false;
         result.data = json{
             { "id_slot",    id_slot },
@@ -3059,7 +3057,6 @@ void server_context::process_single_task(server_task&& task) {
         slot->server_cached_prompt.data.clear();
         server_task_result result;
         result.id = task.id;
-        result.stop = true;
         result.error = false;
         result.data = json{
             { "id_slot",  id_slot },
@@ -3072,7 +3069,6 @@ void server_context::process_single_task(server_task&& task) {
         llama_lora_adapters_apply(ctx, lora_adapters);
         server_task_result result;
         result.id = task.id;
-        result.stop = true;
         result.error = false;
         result.data = json{ { "success", true } };
         queue_results.send(result);
@@ -3280,7 +3276,6 @@ void server_context::on_finish_multitask(const server_task_multi& multitask) {
     // all subtasks done == multitask is done
     server_task_result result;
     result.id = multitask.id;
-    result.stop = true;
     result.error = false;
 
     // collect json results into one json result

--- a/examples/server/server-task.cpp
+++ b/examples/server/server-task.cpp
@@ -370,7 +370,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat_final() {
         msg.role = "assistant";
         msg.content = content;
     }
-    if (stop) {
+    if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
         finish_reason = msg.tool_calls.empty() ? "stop" : "tool_calls";
     }
 
@@ -412,8 +412,7 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat_final() {
 json server_task_result_cmpl_final::to_json_oaicompat_chat_stream() {
     std::time_t t = std::time(0);
     std::string finish_reason = "length";
-    if (stop) {
-        //if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
+    if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
         finish_reason = oaicompat_msg.tool_calls.empty() ? "stop" : "tool_calls";
     }
 

--- a/examples/server/server-task.h
+++ b/examples/server/server-task.h
@@ -144,7 +144,7 @@ struct server_task_result {
 
     json data;
 
-    bool stop;
+    stop_type stop = STOP_TYPE_NONE;
     bool error;
     bool final_result = false;
     result_timings timings;


### PR DESCRIPTION
`main` server reports the wrong stop reason when generation reaches the token limit. A client can't distinguish a completion that finished from one that was cut off mid-sentence, which can break continuation loops, retry logic, and anything branching on the limit case.  On one server, the same one-token budget produces two contradictory answers:

```shell
# native endpoint
curl -s localhost:8080/completion \
  -d '{"prompt":"Hello","n_predict":1,"seed":666,"temperature":0,"stream":false}' \
  | jq -c '{stopped_eos, stopped_word, stopped_limit}'
{"stopped_eos":false,"stopped_word":false,"stopped_limit":true}

# OpenAI-compatible endpoint, same server, same budget
curl -s localhost:8080/v1/chat/completions \
  -d '{"model":"test","messages":[{"role":"user","content":"Hello"}],"max_tokens":1,"seed":666,"temperature":0,"stream":false}' \
  | jq -r '.choices[0].finish_reason'
stop
```

The native endpoint reports the limit stop. `/v1/completions` and `/v1/chat/completions` report `finish_reason: "stop"`, and `/v1/messages` reports `stop_reason: "end_turn"`.  One consumer is affected: `examples/server/bench/script.js` records `llamacpp_completions_truncated_rate.add(finish_reason === 'length')`, and that metric can never fire.

The cause is a type mismatch. `server_task_result::stop` is a `bool`, while the serializers compare it against the `stop_type` enum, and `send_final_response` sets it unconditionally:

```cpp
res->stop = true; // to do: set value
```

`true` promotes to `1`, which is `STOP_TYPE_EOS`, so every final response takes the natural-stop branch. The chat serializer still carries the intended comparison in a comment beside the reachable one:

```cpp
std::string finish_reason = "length";
if (stop) {
    //if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
    finish_reason = oaicompat_msg.tool_calls.empty() ? "stop" : "tool_calls";
```

This PR changes the field to `stop_type` and maps it in `send_final_response` from the `stopped_word`, `stopped_eos`, and `stopped_limit` slot flags that the native response already serializes. Word and EOS stops take precedence over a simultaneous limit stop, which the exact-budget boundary produces. A final response carrying no stop flag at all keeps reporting `finish_reason: "stop"` as it does now. The two chat serializers adopt the enum comparison that the text-completion and Anthropic serializers already contained. Those three needed no edit, because their comparisons were written for the enum all along and failed only because of the field's type.

Eight further assignments to the field become `STOP_TYPE_NONE`. Six of them previously assigned `true`, which the old `bool` field compared equal to `STOP_TYPE_EOS`; they now hold `STOP_TYPE_NONE`. None of the eight is read: they belong to error, partial-completion, metrics, slot-operation, LoRA-operation, and multitask results, and no serializer reads `stop` for those types. Terminal-result handling is governed by `is_stop()`, which returns a fixed value per result type and does not consult the field.

The A/B produced these final stop reasons, identically on all five models tested:

| Endpoint | Token limit `main` | Token limit PR | Natural stop before and after |
| --- | --- | --- | --- |
| `/v1/completions` | `stop` | `length` | `stop` |
| `/v1/chat/completions` | `stop` | `length` | `stop` |
| `/v1/chat/completions` stream | `stop` | `length` | `stop` |
| `/v1/messages` | `end_turn` | `max_tokens` | `end_turn` |
| `/v1/messages` stream | `end_turn` | `max_tokens` | `end_turn` |

Two boundary cases checked: a generation that hits EOS on the exact token budget sets both `stopped_eos` and `stopped_limit`, and reports `finish_reason: "stop"` in both builds. An empty prompt follows whichever path the model takes: on a model that fills the token budget it is an ordinary limit stop, so this PR reports `length` where before it reported `stop`, and on a model whose final response carries no stop flag both builds report `stop`, which is the preserved fallback.

The native `/completion` response is unchanged. Responses API is unchanged, and has no reader of the field. The change is limited to `server-task.h`, `server-task.cpp`, and `server-context.cpp`.

- `main` vs. this PR endpoint A/B on five models. Every run passed 45 of 45 assertions, and the table above is identical on all five.

| Model | Serving shape |
| --- | --- |
| DeepSeek-V4-Flash-0731 IQ1_S | 256K context, `--swa-compress` over 43 of 43 layers, `-ncmoe 43`, 44 of 44 layers offloaded |
| Qwen3.8-27B IQ3_KT | 40960 context, fully resident at 66 of 66 layers, MTP speculative decoding at `n_max=1` |
| Meta-Llama-3.1-8B-Instruct IQ4_NL | CPU only, 512 context |
| Mistral-7B-Instruct-v0.3 Q6_K | CPU only, 512 context |
| Qwen3-Next 2.8M random weights | CPU only, 512 context, fast control |

- The Qwen3.8-27B arm also runs speculative decoding, so the limit stop is reported correctly through the MTP path as well.
- Tested token-limit and natural stops for the five serializers in the table. The limit stop was repeated five times per arm on `/v1/chat/completions`: `main` reported `stop` on all five, the PR reported `length` on all five.
- Tested an empty prompt on all five models. Meta-Llama-3.1 and Mistral fill the token budget, so that request is an ordinary limit stop and with this PR correctly reports `length` where `main` reports `stop`. DeepSeek-V4-Flash, Qwen3.8-27B, and the random-weight control end with no stop flag set, which exercises the fallback, and both builds report `stop`.
- Tested EOS on the exact token budget, biasing each model's own end-of-sequence token, which differs per family and is read from each server's load log. Both builds reported `stopped_eos: true`, `stopped_limit: true`, and `finish_reason: "stop"`.
- Confirmed identical `main` vs. PR content for the native, text-completion, chat-completion, empty-prompt, and exact-budget controls.

*Adversarial code review and assessment of blast radius and accuracy of this description by GPT-5.6.*

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)

- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High