### PR TITLE
CUDA: handle GQA = 12 for head size = 256 via new MMA

### DIFF
--- a/ggml/src/ggml-cuda/fattn-new-mma.cu
+++ b/ggml/src/ggml-cuda/fattn-new-mma.cu
@@ -2277,8 +2277,12 @@ void ggml_cuda_flash_attn_ext_mma_new(ggml_backend_cuda_context & ctx, ggml_tens
     }
     if (K->ne[0] == 256) {
         GGML_ASSERT(Q->ne[0] == 256 && V->ne[0] == 256);
-        if (gqa_ratio == 6) {
+        if (gqa_ratio % 6 == 0) {
             ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
+        //if (gqa_ratio == 12) {
+        //    ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 16>(ctx, dst);
+        //} else if (gqa_ratio == 6) {
+        //    ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
         } else {
             GGML_ABORT("Not implemented");
         }

--- a/ggml/src/ggml-cuda/fattn-new-mma.cu
+++ b/ggml/src/ggml-cuda/fattn-new-mma.cu
@@ -2279,10 +2279,6 @@ void ggml_cuda_flash_attn_ext_mma_new(ggml_backend_cuda_context & ctx, ggml_tens
         GGML_ASSERT(Q->ne[0] == 256 && V->ne[0] == 256);
         if (gqa_ratio % 6 == 0) {
             ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
-        //if (gqa_ratio == 12) {
-        //    ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 16>(ctx, dst);
-        //} else if (gqa_ratio == 6) {
-        //    ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
         } else {
             GGML_ABORT("Not implemented");
         }

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -117,13 +117,15 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
         return;
     }
 
+    int gqa_ratio = Q->ne[2] / K->ne[2];
+
     if (new_mma_available(cc) && K->ne[0] == 128 && V->ne[0] == 128 && Q->ne[0] == 128 && Q->ne[1] == 1 &&
-            (Q->ne[2] / K->ne[2] == 12 || Q->ne[2] / K->ne[2] == 6 || Q->ne[2] / K->ne[2] == 10)) {
+            (gqa_ratio == 12 || gqa_ratio == 6 || gqa_ratio == 10)) {
         ggml_cuda_flash_attn_ext_mma_new(ctx, dst);
         return;
     }
 
-    if (new_mma_available(cc) && K->ne[0] == 256 && V->ne[0] == 256 && Q->ne[0] == 256 && Q->ne[1] == 1 && Q->ne[2] / K->ne[2] == 6) {
+    if (new_mma_available(cc) && K->ne[0] == 256 && V->ne[0] == 256 && Q->ne[0] == 256 && Q->ne[1] == 1 && (gqa_ratio == 6 || gqa_ratio == 12)) {
         ggml_cuda_flash_attn_ext_mma_new(ctx, dst);
         return;
     }


### PR DESCRIPTION

This is for the Qwen-3.8-Flash-Next situation. FA is not very expensive due to the indexer use. Nevertheless, I get ~3% better TG performance for context > 8k tokens in my setup (2x3090, hybrid with `-ncmoe 20`). 