### PR TITLE
Qwen3.8-Flash-Next: faster TG on CUDA

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2647,8 +2647,39 @@ static void mul_mat_1row(const ggml_tensor * src0, const ggml_tensor * src1, ggm
     }
 }
 
+static __global__ void k_simple_gemm_f32(int n, int nx, const float * x, const float * y, float * z, size_t nb01, size_t nb11) {
+    int ix = blockIdx.x;
+    int iy = blockIdx.y;
+    x += nb01 * ix;
+    y += nb11 * iy;
+    float sum = 0;
+    for (int j = threadIdx.x; j < n; j += blockDim.x) {
+        sum += x[j]*y[j];
+    }
+    sum = warp_reduce_sum(sum);
+    __shared__ float tmp[32];
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    if (lane_id == 0) tmp[warp_id] = sum;
+    __syncthreads();
+    sum = tmp[lane_id];
+    sum = warp_reduce_sum(sum);
+    z[iy*nx + ix] = sum;
+}
+
 static int ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst,
         const ggml_cgraph * cgraph, int node_n) {
+
+    if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32 &&
+        src0->ne[0] >= 1024 && src0->ne[2]*src0->ne[3] == 1 && src1->ne[2]*src1->ne[3] == 1 && src1->ne[1] <= 8) {
+        auto nsm = ggml_cuda_info().devices[ctx.device].nsm;
+        if (src0->ne[1] * src1->ne[1] <= nsm) {
+            dim3 grid(src0->ne[1], src1->ne[1], 1);
+            k_simple_gemm_f32<<<grid, 1024, 0, ctx.stream()>>>(src0->ne[0], src0->ne[1], (const float *)src0->data, (const float *)src1->data, (float *)dst->data,
+                    src0->nb[1]/sizeof(float), src1->nb[1]/sizeof(float));
+            return node_n;
+        }
+    }
 
     // If src0 is a temporary compute buffer it may have some padding that needs to be cleared for mul_mat_vec_q or mul_mat_q.
     // But if src0 is also a view of another tensor then this cannot be done safely because it may overwrite valid tensor data.

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -2664,7 +2664,9 @@ static __global__ void k_simple_gemm_f32(int n, int nx, const float * x, const f
     __syncthreads();
     sum = tmp[lane_id];
     sum = warp_reduce_sum(sum);
-    z[iy*nx + ix] = sum;
+    if (threadIdx.x == 0) {
+        z[iy*nx + ix] = sum;
+    }
 }
 
 static int ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst,


### PR DESCRIPTION

There are several matrix multiplications involved in the Qwen-3.8-Flash-Next compute graph that seem to be not handled very well on the current main branch. The most prominent once are those with the `hc_attn_inject` and `hc_ffn_inject` tensors (present in every layer). In the Unsloth model that I have downloaded for playing with Q38-Next these are left as `f32`, so in `ik_llama.cpp` GEMM/GEMV goes via cuBLAS. From TG profiling it seems an unexpectedly large fraction of inference time goes into these matrix multiplications, so it seems cuBLAS is not handling the shapes involved very well.

The `hc_attn_inject` and `hc_ffn_inject` have `[10240 x 4]` elements, so we are dealing with a large dot product but very few rows, hence tensor cores are unlikely to be very useful in this case (especially for the GEMV case). So, I decided to see if I can improve things with a simple GEMM implementation without developing a whole new framework for floating point  GEMM/GEMV as they have done in `llama.cpp`. This PR is the result.

In my setup (2x3090 + Ryzen-3995WX) using the UD-IQ4_XS model with `-ncmoe 20`, I observe ~15% (!!!) TG performance gain at short context, slowly decreasing to about 10% at a context of 64k tokens. I personally find this quite astounding, given the simplicity of the kernel and the 31 LoC added by the PR.

Curious to see when this optimizations will be fully independently discovered in llama.cpp land.

Here the sweep-bench result
```
./bin/llama-sweep-bench -m /mnt/data/iwan/q38next/UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf \
    -t 64 -c 65536 -ngl 100 -ncmoe 20 -wgt 1 -ub 2048 -n 128
```

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |    128 |      0 |    1.671 |  1225.47 |    2.795 |    45.80 |
|  2048 |    128 |   2048 |    1.643 |  1246.28 |    2.719 |    47.07 |
|  2048 |    128 |   4096 |    1.677 |  1220.97 |    2.758 |    46.41 |
|  2048 |    128 |   6144 |    1.742 |  1175.61 |    2.811 |    45.54 |
|  2048 |    128 |   8192 |    1.776 |  1153.43 |    2.800 |    45.71 |
|  2048 |    128 |  10240 |    1.791 |  1143.63 |    2.867 |    44.65 |
|  2048 |    128 |  12288 |    1.834 |  1116.51 |    2.928 |    43.71 |
|  2048 |    128 |  14336 |    1.874 |  1092.93 |    3.010 |    42.53 |
|  2048 |    128 |  16384 |    1.905 |  1074.94 |    2.995 |    42.73 |
|  2048 |    128 |  18432 |    1.952 |  1049.27 |    3.122 |    41.00 |
|  2048 |    128 |  20480 |    1.987 |  1030.86 |    3.217 |    39.79 |
|  2048 |    128 |  22528 |    2.009 |  1019.21 |    3.185 |    40.19 |
|  2048 |    128 |  24576 |    2.039 |  1004.58 |    3.375 |    37.92 |
|  2048 |    128 |  26624 |    2.064 |   992.21 |    3.494 |    36.64 |
|  2048 |    128 |  28672 |    2.104 |   973.55 |    3.350 |    38.21 |
|  2048 |    128 |  30720 |    2.159 |   948.74 |    3.334 |    38.39 |
|  2048 |    128 |  32768 |    2.174 |   942.09 |    3.313 |    38.64 |
|  2048 |    128 |  34816 |    2.211 |   926.22 |    3.330 |    38.43 |
|  2048 |    128 |  36864 |    2.269 |   902.43 |    3.431 |    37.30 |
|  2048 |    128 |  38912 |    2.283 |   897.21 |    3.638 |    35.19 |
|  2048 |    128 |  40960 |    2.327 |   880.05 |    3.579 |    35.76 |
|  2048 |    128 |  43008 |    2.354 |   869.93 |    3.577 |    35.79 |
|  2048 |    128 |  45056 |    2.392 |   856.22 |    3.599 |    35.56 |
|  2048 |    128 |  47104 |    2.448 |   836.47 |    3.558 |    35.97 |
|  2048 |    128 |  49152 |    2.445 |   837.67 |    3.812 |    33.58 |
|  2048 |    128 |  51200 |    2.484 |   824.37 |    3.733 |    34.29 |
|  2048 |    128 |  53248 |    2.516 |   814.04 |    3.794 |    33.73 |
|  2048 |    128 |  55296 |    2.566 |   798.26 |    3.901 |    32.81 |
|  2048 |    128 |  57344 |    2.596 |   788.81 |    3.960 |    32.32 |
|  2048 |    128 |  59392 |    2.638 |   776.33 |    3.772 |    33.94 |
|  2048 |    128 |  61440 |    2.683 |   763.39 |    3.954 |    32.37 |
|  2048 |    128 |  63488 |    2.844 |   720.05 |    3.970 |    32.24 |
 