### PR TITLE
Qwen-3.8-Next op fusions

### DIFF
--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4045,7 +4045,14 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
             ggml_cuda_up_gate_unary(ctx, dst);
             break;
         case GGML_OP_SCALE:
-            ggml_cuda_op_scale(ctx, dst);
+            if (fusion && i + 1 < cgraph->n_nodes &&
+                cgraph->nodes[i+1]->op == GGML_OP_UNARY &&
+                cgraph->nodes[i+1]->src[0] == dst &&
+                ggml_cuda_op_scale_unary(ctx, cgraph->nodes[i+1])) {
+                i += 1;
+            } else {
+                ggml_cuda_op_scale(ctx, dst);
+            }
             break;
         case GGML_OP_SOFTCAP:
             ggml_cuda_op_softcap(ctx, dst);

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -92,6 +92,15 @@ static __global__ void fused_mul_sigmoid_f32(int ne0, const float * x, const flo
     dst[i] = y[i] / (1.0f + expf(-x[row]));
 }
 
+static __global__ void fused_mul_sigmoid_f32(const float * x, const float * y, float * dst, const int k) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    dst[i] = y[i] / (1.0f + expf(-x[i]));
+}
+
 static __global__ void fused_mul_silu_f32(int ne0, const float * x, const float * y, float * dst, const int k, float limit) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 
@@ -310,6 +319,11 @@ static void fused_mul_relu_f32_cuda(const float * x, const float * y, float * ds
     fused_mul_relu_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, y, dst, k);
 }
 
+static void fused_mul_sigmoid_f32_cuda(const float * x, const float * y, float * dst, const int k, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_RELU_BLOCK_SIZE - 1) / CUDA_RELU_BLOCK_SIZE;
+    fused_mul_sigmoid_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, y, dst, k);
+}
+
 static void fused_mul_gelu_f32_cuda(const float * x, const float * y, float * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_GELU_BLOCK_SIZE - 1) / CUDA_GELU_BLOCK_SIZE;
     fused_mul_gelu_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, y, dst, k);
@@ -433,6 +447,7 @@ void ggml_fused_mul_unary(ggml_backend_cuda_context & ctx, ggml_unary_op op,
         case GGML_UNARY_OP_SILU: fused_mul_silu_f32_cuda(src0_d, src1_d, dst_d, nelements, limit, stream); break;
         case GGML_UNARY_OP_RELU: fused_mul_relu_f32_cuda(src0_d, src1_d, dst_d, nelements, stream); break;
         case GGML_UNARY_OP_GELU: fused_mul_gelu_f32_cuda(src0_d, src1_d, dst_d, nelements, stream); break;
+        case GGML_UNARY_OP_SIGMOID: fused_mul_sigmoid_f32_cuda(src0_d, src1_d, dst_d, nelements, stream); break;
         default: GGML_ASSERT(false);
     }
 }

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -38,6 +38,16 @@ static __global__ void silu_f32(const float * x, float * dst, const int k) {
     dst[i] = x[i] / (1.0f + expf(-x[i]));
 }
 
+static __global__ void scaled_silu_f32(const float * x, float * dst, const int k, float scale) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    float sx = scale*x[i];
+    dst[i] = sx / (1.0f + expf(-sx));
+}
+
 #if 0
 static __global__ void swiglu_f32(const float * x, float * dst, const int k, const int ne0, const int64_t nb1) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
@@ -215,6 +225,15 @@ static __global__ void sigmoid_f32(const float * x, float * dst, const int k) {
     dst[i] = 1.0f / (1.0f + expf(-x[i]));
 }
 
+static __global__ void scaled_sigmoid_f32(const float * x, float * dst, const int k, float scale) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    dst[i] = 1.0f / (1.0f + expf(-scale*x[i]));
+}
+
 static __global__ void biased_sigmoid_f32(const float * x, const float * bias, float * dst, float * dst_biased, const int k, const int ncols) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 
@@ -361,6 +380,16 @@ static void relu_f32_cuda(const float * x, float * dst, const int k, cudaStream_
 static void sigmoid_f32_cuda(const float * x, float * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_SIGMOID_BLOCK_SIZE - 1) / CUDA_SIGMOID_BLOCK_SIZE;
     sigmoid_f32<<<num_blocks, CUDA_SIGMOID_BLOCK_SIZE, 0, stream>>>(x, dst, k);
+}
+
+static void scaled_sigmoid_f32_cuda(const float * x, float * dst, const int k, float scale, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_SIGMOID_BLOCK_SIZE - 1) / CUDA_SIGMOID_BLOCK_SIZE;
+    scaled_sigmoid_f32<<<num_blocks, CUDA_SIGMOID_BLOCK_SIZE, 0, stream>>>(x, dst, k, scale);
+}
+
+static void scaled_silu_f32_cuda(const float * x, float * dst, const int k, float scale, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_SIGMOID_BLOCK_SIZE - 1) / CUDA_SIGMOID_BLOCK_SIZE;
+    scaled_silu_f32<<<num_blocks, CUDA_SIGMOID_BLOCK_SIZE, 0, stream>>>(x, dst, k, scale);
 }
 
 static void biased_sigmoid_f32_cuda(const float * x, const float * bias, float * dst, float * dst_biased, const int k, const int ncols, cudaStream_t stream) {
@@ -550,6 +579,23 @@ void ggml_cuda_op_sigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT( dst->type == GGML_TYPE_F32);
 
     sigmoid_f32_cuda(src0_d, dst_d, ggml_nelements(src0), stream);
+}
+
+bool ggml_cuda_op_scale_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    auto src = dst->src[0];
+    if (src->op != GGML_OP_SCALE) return false;
+    auto src0 = src->src[0];
+    if (src0->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32) return false;
+    auto op = (ggml_unary_op)dst->op_params[0];
+    if (op != GGML_UNARY_OP_SILU && op != GGML_UNARY_OP_SIGMOID) return false;
+    float scale;
+    memcpy(&scale, src->op_params, sizeof(scale));
+    if (op == GGML_UNARY_OP_SILU) {
+        scaled_silu_f32_cuda((const float *)src0->data, (float *)dst->data, ggml_nelements(src0), scale, ctx.stream());
+    } else {
+        scaled_sigmoid_f32_cuda((const float *)src0->data, (float *)dst->data, ggml_nelements(src0), scale, ctx.stream());
+    }
+    return true;
 }
 
 void ggml_cuda_op_biased_sigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/unary.cuh
+++ b/ggml/src/ggml-cuda/unary.cuh
@@ -101,3 +101,5 @@ void ggml_cuda_op_multi_add(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 void ggml_cuda_fused_softplus(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_fused_mul_exp_mul(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+bool ggml_cuda_op_scale_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6700,8 +6700,7 @@ static struct ggml_tensor * ggml_fused_mul_unary_impl(
         result->src[1] = b;
         return result;
     }
-    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU);
-    //GGML_ASSERT(ggml_are_same_shape(b, a));
+    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU || op == GGML_UNARY_OP_SIGMOID);
 
     bool is_node = false;
 
@@ -17061,7 +17060,7 @@ static void ggml_compute_forward_fused_mul_unary_f32(
     GGML_ASSERT(ggml_is_contiguous_1(src0));
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_are_same_shape(src0, src1));
-    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU);
+    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU || op == GGML_UNARY_OP_SIGMOID);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
         float * z = (float *) ((char *) dst->data  + i1*( dst->nb[1]));
@@ -17070,6 +17069,7 @@ static void ggml_compute_forward_fused_mul_unary_f32(
         switch (op) {
             case GGML_UNARY_OP_GELU: ggml_vec_gelu_f32(nc, z, x); ggml_vec_mul_f32(nc, z, z, y); break;
             case GGML_UNARY_OP_RELU: ggml_vec_relu_f32(nc, z, x); ggml_vec_mul_f32(nc, z, z, y); break;
+            case GGML_UNARY_OP_SIGMOID: ggml_vec_sigmoid_f32(nc, z, x); ggml_vec_mul_f32(nc, z, z, y); break;
             case GGML_UNARY_OP_SILU: {
                 if (limit < 1e-6f) {
                     ggml_vec_mul_silu_f32(nc, z, x, y);

--- a/src/graphs/build_qwen4exp.cpp
+++ b/src/graphs/build_qwen4exp.cpp
@@ -40,11 +40,20 @@ static ggml_tensor * qwen4exp_hc_mix(
     cb(xn, "hc_norm", il);
 
     ggml_tensor * lo = llm_build_context::llm_build_lora_mm(lctx, ctx0, w_down, xn);
-    lo = ggml_silu(ctx0, ggml_scale(ctx0, lo, 1.0f / (float) hc));
-    ggml_tensor * gate = ggml_sigmoid(ctx0, llm_build_context::llm_build_lora_mm(lctx, ctx0, w_up, lo));
-    cb(gate, "hc_gate", il);
+    cb(lo, "mix_down", il);
+    lo = ggml_scale(ctx0, lo, 1.0f / (float) hc);
+    cb(lo, "mix_down_scaled", il);
+    lo = ggml_silu(ctx0, lo);
+    cb(lo, "mix_down_silu", il);
+    auto up = llm_build_context::llm_build_lora_mm(lctx, ctx0, w_up, lo);
+    cb(up, "mix_up", il);
+    auto gated = ggml_fused_mul_unary(ctx0, up, xn, GGML_UNARY_OP_SIGMOID);
+    cb(gated, "mix_gated", il);
+    //auto gate = ggml_sigmoid(ctx0, up);
+    ////ggml_tensor * gate = ggml_sigmoid(ctx0, llm_build_context::llm_build_lora_mm(lctx, ctx0, w_up, lo));
+    //cb(gate, "hc_gate", il);
 
-    ggml_tensor * gated = ggml_mul(ctx0, xn, gate);
+    //ggml_tensor * gated = ggml_mul(ctx0, xn, gate);
     gated = ggml_reshape_3d(ctx0, gated, n_embd, hc, nt);
 
     ggml_tensor * mixed = ggml_multi_add(ctx0,


### PR DESCRIPTION

The PR adds a few op fusions relevant for Qwen-3.8-Flash-Next.

In my setup (2x3090+Ryzen-3995WX, UD-IQ4_XS model, `-ncmoe 20`) I observe 3-4% better TG and 1-2% better PP.

Here is the sweep-bench with the above system and model after merging #2372 and #2373 and rebasing on main:

|    PP |     TG |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |
|-------|--------|--------|----------|----------|----------|----------|
|  2048 |     64 |      0 |    1.653 |  1239.08 |    1.236 |    51.80 |
|  2048 |     64 |   2048 |    1.628 |  1258.31 |    1.331 |    48.08 |
|  2048 |     64 |   4096 |    1.659 |  1234.31 |    1.281 |    49.94 |
|  2048 |     64 |   6144 |    1.716 |  1193.78 |    1.313 |    48.74 |
|  2048 |     64 |   8192 |    1.761 |  1163.06 |    1.384 |    46.23 |
|  2048 |     64 |  10240 |    1.782 |  1149.42 |    1.359 |    47.11 |
|  2048 |     64 |  12288 |    1.813 |  1129.86 |    1.375 |    46.53 |
|  2048 |     64 |  14336 |    1.859 |  1101.83 |    1.391 |    46.01 |
|  2048 |     64 |  16384 |    1.891 |  1083.27 |    1.426 |    44.89 |
|  2048 |     64 |  18432 |    1.934 |  1059.11 |    1.434 |    44.63 |
|  2048 |     64 |  20480 |    1.951 |  1049.67 |    1.519 |    42.12 |
|  2048 |     64 |  22528 |    1.992 |  1027.87 |    1.475 |    43.38 |
|  2048 |     64 |  24576 |    2.024 |  1012.01 |    1.452 |    44.06 |
|  2048 |     64 |  26624 |    2.061 |   993.59 |    1.502 |    42.62 |
|  2048 |     64 |  28672 |    2.088 |   980.90 |    1.487 |    43.03 |
|  2048 |     64 |  30720 |    2.128 |   962.37 |    1.503 |    42.60 |
|  2048 |     64 |  32768 |    2.165 |   946.08 |    1.505 |    42.53 |
|  2048 |     64 |  34816 |    2.182 |   938.65 |    1.527 |    41.92 |
|  2048 |     64 |  36864 |    2.237 |   915.48 |    1.559 |    41.06 |
|  2048 |     64 |  38912 |    2.265 |   904.18 |    1.592 |    40.21 |
|  2048 |     64 |  40960 |    2.299 |   890.79 |    1.553 |    41.20 |
|  2048 |     64 |  43008 |    2.330 |   879.13 |    1.584 |    40.41 |
|  2048 |     64 |  45056 |    2.370 |   864.23 |    1.582 |    40.46 |
|  2048 |     64 |  47104 |    2.429 |   843.05 |    1.593 |    40.19 |
|  2048 |     64 |  49152 |    2.432 |   842.09 |    1.606 |    39.86 |
|  2048 |     64 |  51200 |    2.465 |   830.87 |    1.638 |    39.07 |
|  2048 |     64 |  53248 |    2.500 |   819.09 |    1.648 |    38.83 |
|  2048 |     64 |  55296 |    2.528 |   810.23 |    1.705 |    37.53 |
|  2048 |     64 |  57344 |    2.570 |   796.85 |    1.693 |    37.80 |
|  2048 |     64 |  59392 |    2.616 |   782.88 |    1.686 |    37.96 |
|  2048 |     64 |  61440 |    2.662 |   769.25 |    1.850 |    34.59 |
|  2048 |     64 |  63488 |    2.827 |   724.32 |    1.796 |    35.64 |
