### PR TITLE
server: disk KV block cache for cross-process prompt prefix reuse

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2657,6 +2657,38 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         }
         return true;
     }
+    if (arg == "--kv-cache-dir") {
+        CHECK_ARG
+        params.kv_cache_dir = argv[i];
+        return true;
+    }
+    if (arg == "--kv-cache-block") {
+        CHECK_ARG
+        const int32_t v = std::stoi(argv[i]);
+        if (v < 1) {
+            throw std::invalid_argument("--kv-cache-block must be >= 1");
+        }
+        params.kv_cache_block_tokens = v;
+        return true;
+    }
+    if (arg == "--kv-cache-max-age-days") {
+        CHECK_ARG
+        const int32_t v = std::stoi(argv[i]);
+        if (v < 0) {
+            throw std::invalid_argument("--kv-cache-max-age-days must be >= 0");
+        }
+        params.kv_cache_max_age_days = v;
+        return true;
+    }
+    if (arg == "--kv-cache-max-size-mb") {
+        CHECK_ARG
+        const long long v = std::stoll(argv[i]);
+        if (v < 0) {
+            throw std::invalid_argument("--kv-cache-max-size-mb must be >= 0");
+        }
+        params.kv_cache_max_size_mb = (size_t) v;
+        return true;
+    }
     if (arg == "--reasoning-tokens") {
         CHECK_ARG
         params.think_tokens = thinking_tokens_from_string(std::string(argv[i]));
@@ -3445,6 +3477,10 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "server",      "       --metrics",              "enable prometheus compatible metrics endpoint (default: %s)", params.endpoint_metrics ? "enabled" : "disabled" });
     options.push_back({ "server",      "       --no-slots",             "disables slots monitoring endpoint (default: %s)", params.endpoint_slots ? "enabled" : "disabled" });
     options.push_back({ "server",      "       --slot-save-path PATH",  "path to save slot kv cache (default: disabled)" });
+    options.push_back({ "server",      "       --kv-cache-dir PATH",    "enable disk KV block cache and use PATH as cache dir (default: disabled)" });
+    options.push_back({ "server",      "       --kv-cache-block N",     "disk KV block size in tokens (default: %d)", params.kv_cache_block_tokens });
+    options.push_back({ "server",      "       --kv-cache-max-age-days N", "delete disk KV blocks not accessed for N days (default: %d, 0 = disabled)", params.kv_cache_max_age_days });
+    options.push_back({ "server",      "       --kv-cache-max-size-mb N",  "disk KV cache size limit in MB, LRU evicts oldest (default: %zu, 0 = unlimited)", params.kv_cache_max_size_mb });
     options.push_back({ "server",      "       --chat-template JINJA_TEMPLATE",
                                                                         "set custom jinja chat template (default: template taken from model's metadata)\n"
                                                                         "only commonly used templates are accepted:\n"
@@ -4266,7 +4302,9 @@ struct llama_model_params common_model_params_to_llama(const gpt_params & params
     mparams.n_v_first       = params.n_v_first;
     mparams.n_v_last        = params.n_v_last;
     mparams.max_ctx_size    = params.n_ctx;
-    mparams.n_seq_max       = params.n_parallel;
+    // disk KV cache needs an extra sequence slot (temp seq for load/save staging);
+    // hybrid models index qnext state rows by seq_id, so n_seq_max must cover it
+    mparams.n_seq_max       = params.kv_cache_dir.empty() ? params.n_parallel : params.n_parallel + 1;
     mparams.n_ubatch        = get_batch_ubatch(params).second;
     mparams.amb             = params.attn_max_batch;
     mparams.split_mode      = params.split_mode;
@@ -4329,7 +4367,8 @@ struct llama_context_params common_context_params_to_llama(const gpt_params & pa
     auto [n_batch, n_ubatch] = get_batch_ubatch(params);
 
     cparams.n_ctx             = params.n_ctx;
-    cparams.n_seq_max         = params.n_parallel;
+    // disk KV cache needs an extra sequence slot for the staging/temp sequence
+    cparams.n_seq_max         = params.kv_cache_dir.empty() ? params.n_parallel : params.n_parallel + 1;
     cparams.n_batch           = n_batch;
     cparams.n_ubatch          = n_ubatch;
     cparams.n_threads         = params.n_threads;

--- a/common/common.h
+++ b/common/common.h
@@ -549,6 +549,12 @@ struct gpt_params {
     std::string sql_save_file;
     std::string sqlite_zstd_ext_file;
 
+    // disk KV block cache (server): cross-request / cross-process prefix KV reuse
+    std::string kv_cache_dir          = ""; // disk KV block cache directory (empty = disabled)
+    int32_t     kv_cache_block_tokens = 64; // disk KV block size in tokens
+    int32_t     kv_cache_max_age_days = 3;  // delete blocks not accessed for N days (0 = disabled)
+    size_t      kv_cache_max_size_mb  = 0;  // cache directory size limit in MB (0 = unlimited)
+
     float slot_prompt_similarity = 0.1f;
 
     bool do_checkpoint = false;               // do checkpoint for recurrent models only

--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TARGET_SRCS
     server-common.h
     server-context.cpp
     server-context.h
+    ${CMAKE_SOURCE_DIR}/kv-cache/kv-cache.cpp
 )
 set(PUBLIC_ASSETS
     index.html.gz
@@ -78,7 +79,7 @@ endif()
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
 #target_link_libraries(${TARGET} PRIVATE common ${CMAKE_THREAD_LIBS_INIT})
 
-target_include_directories(${TARGET} PRIVATE ../mtmd)
+target_include_directories(${TARGET} PRIVATE ../mtmd ${CMAKE_SOURCE_DIR}/kv-cache)
 target_link_libraries(${TARGET} PRIVATE common mtmd cpp-httplib ${CMAKE_THREAD_LIBS_INIT})
 
 if (LLAMA_SERVER_SSL)
@@ -98,6 +99,12 @@ endif()
 
 if (WIN32)
     TARGET_LINK_LIBRARIES(${TARGET} PRIVATE ws2_32)
+endif()
+
+if (MINGW)
+    # kv-cache.cpp uses BCrypt for SHA-256; the "#pragma comment(lib, "bcrypt.lib")"
+    # only works on MSVC, so MinGW needs an explicit link.
+    TARGET_LINK_LIBRARIES(${TARGET} PRIVATE bcrypt)
 endif()
 
 target_compile_features(${TARGET} PRIVATE cxx_std_17)

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -238,6 +238,12 @@ server:
          --metrics                enable prometheus compatible metrics endpoint (default: disabled)
          --no-slots               disables slots monitoring endpoint (default: enabled)
          --slot-save-path PATH    path to save slot kv cache (default: disabled)
+         --kv-cache-dir PATH      enable disk KV block cache and use PATH as cache dir (default: disabled)
+         --kv-cache-block N       disk KV block size in tokens (default: 64)
+         --kv-cache-max-age-days N
+                                  delete disk KV blocks not accessed for N days (default: 3, 0 = disabled)
+         --kv-cache-max-size-mb N
+                                  disk KV cache size limit in MB, LRU evicts oldest (default: 0 = unlimited)
          --chat-template JINJA_TEMPLATE
                                   set custom jinja chat template (default: template taken from model's metadata)
                                   only commonly used templates are accepted:

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -13,10 +13,13 @@
 #include "mtmd.h"
 #include "mtmd-helper.h"
 
+#include "kv-cache.h"
+
 #include <fstream>
 #include <iostream>
 #include <regex>
 #include <exception>
+#include <filesystem>
 
 static void server_prompt_checkpoint_update(server_prompt_checkpoint & ckpt, llama_context * ctx, int id, int64_t n_tokens, llama_pos pos_min, llama_pos pos_max, int32_t offset) {
     ckpt.pos_min = pos_min;
@@ -280,6 +283,13 @@ void server_context::init() {
     }
 
     LOG_INFO("initializing slots", { {"n_slots", params_base.n_parallel} });
+
+    if (!params_base.kv_cache_dir.empty() && llama_model_has_recurrent(model)) {
+        SRV_INF("%s\n",
+            "disk KV cache (--kv-cache-dir) enabled for recurrent/hybrid model; "
+            "verified bit-exact on Qwen3-Next (Ridge 27B): cached-output == no-cache baseline, "
+            "cross-process prefix hit works");
+    }
 
     if (params_base.has_mtp) {
         SRV_INF("%s\n", "MTP needs embeddings on decode, enabling");
@@ -3833,6 +3843,101 @@ bool server_context::create_checkpoint(server_slot & slot) {
     return do_checkpoint;
 }
 
+// ---------------------------------------------------------------------------
+// Disk KV block cache pre-warm (v1)
+//
+// Called from SLOT_COMMAND_LOAD_PROMPT right after tokenization, before the
+// server's own prompt batch decode. Walks the (pure text) prompt from position
+// 0 in fixed token blocks:
+//   - hit:   load the block KV from disk into slot.id (seq_cp + kv_cache_update)
+//   - miss:  decode the block into slot.id with a local batch, then save it to disk
+//
+// On success the caller aligns slot.n_past / slot.n_past_prompt / slot.cache_tokens
+// with the pre-warmed prefix; the server then resumes its normal batch loop from
+// that point. Returns the number of pre-warmed tokens (0 on failure / nothing).
+//
+// Caller guarantees: kv-cache dir set, slot.cache_tokens empty (cold start),
+// pure text (no LLAMA_TOKEN_NULL / mtmd), no system prompt offset, no spec/MTP,
+// ga_n == 1 (self-extend off), cache_prompt enabled.
+// ---------------------------------------------------------------------------
+size_t server_context::disk_kv_prewarm(server_slot & slot) {
+    const std::vector<llama_token> & prompt_tokens = slot.prompt_tokens.get_text_tokens();
+    const size_t n_prompt = prompt_tokens.size();
+    if (n_prompt == 0) {
+        return 0;
+    }
+
+    const size_t      block   = std::max(1, params_base.kv_cache_block_tokens);
+    const llama_seq_id tmp_seq = (llama_seq_id) slots.size(); // a seq id outside [0, n_parallel)
+
+    // make sure the cache directory exists
+    std::error_code ec;
+    std::filesystem::create_directories(params_base.kv_cache_dir, ec);
+
+    const int64_t t_start = ggml_time_us();
+
+    size_t pos = 0;
+
+    // 1) hit phase: load contiguous blocks from position 0
+    while (pos < n_prompt) {
+        const size_t end = std::min(pos + block, n_prompt);
+        const std::string file = disk_kv::block_path(model, params_base.model, params_base.kv_cache_dir, prompt_tokens, pos, end);
+        if (!disk_kv::load_block(ctx, slot.id, tmp_seq, file, prompt_tokens, pos, end)) {
+            break;
+        }
+        pos = end;
+    }
+    const size_t n_hit = pos;
+
+    // 2) recompute phase: decode the missing tail block-by-block and persist it
+    // [S2] llama_decode asserts n_tokens <= cparams.n_batch; when --kv-cache-block
+    // exceeds --batch-size we must split each block into sub-chunks of at most
+    // n_batch tokens (llama_decode itself splits further by n_ubatch internally).
+    // The block is still saved as one [pos, end) unit.
+    const uint32_t max_decode_tokens = llama_n_batch(ctx);
+    while (pos < n_prompt) {
+        const size_t end = std::min(pos + block, n_prompt);
+
+        size_t sub = pos;
+        while (sub < end) {
+            const size_t sub_end = std::min(sub + max_decode_tokens, end);
+            const std::vector<llama_token> seg(prompt_tokens.begin() + sub, prompt_tokens.begin() + sub_end);
+
+            llama_batch lbatch = llama_batch_init((int32_t) seg.size(), 0, 1);
+            lbatch.n_tokens = (int32_t) seg.size();
+            for (size_t i = 0; i < seg.size(); ++i) {
+                lbatch.token[i]     = seg[i];
+                lbatch.pos[i]       = (llama_pos)(sub + i);
+                lbatch.n_seq_id[i]  = 1;
+                lbatch.seq_id[i][0] = slot.id;
+                lbatch.logits[i]    = 0;
+            }
+            const int rc = llama_decode(ctx, lbatch);
+            llama_batch_free(lbatch);
+            if (rc != 0) {
+                LLAMA_LOG_ERROR("[disk-kv] block decode failed, rc = %d\n", rc);
+                return pos;
+            }
+            sub = sub_end;
+        }
+
+        const std::string file = disk_kv::block_path(model, params_base.model, params_base.kv_cache_dir, prompt_tokens, pos, end);
+        if (!disk_kv::save_block(ctx, slot.id, tmp_seq, file, prompt_tokens, pos, end)) {
+            // [M3] 落盘失败（如磁盘满）不静默：打日志，缓存只是丢失这块，不影响本次正确性
+            LLAMA_LOG_WARN("[disk-kv] failed to save block [%zu, %zu)\n", pos, end);
+        }
+
+        pos = end;
+    }
+    // [M3] 老化清理 + 容量 LRU 整条 prompt 只跑一次，避免每块都全目录扫描
+    disk_kv::cleanup_expired(params_base.kv_cache_dir, params_base.kv_cache_max_age_days);
+    disk_kv::enforce_cache_limit(params_base.kv_cache_dir, params_base.kv_cache_max_size_mb);
+
+    LLAMA_LOG_INFO("[disk-kv] prefill prewarm: hit %zu/%zu tokens (%.2f ms)\n",
+        n_hit, n_prompt, (ggml_time_us() - t_start) / 1000.0);
+    return pos;
+}
+
 void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t n_batch,  int32_t & batch_type) {
     if (params_base.cont_batching || batch.n_tokens == 0) {
         for (auto& slot : slots) {
@@ -4018,6 +4123,52 @@ void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t 
                             }
                         }
                     }
+
+                    // disk KV block cache pre-warm (cold start, pure text, no system prompt, no spec/self-extend)
+                    // Works for both transformer and recurrent/hybrid models. Verified bit-exact on
+                    // Qwen2.5-0.5B (transformer) and Qwen3.8-27B-Ridge (hybrid/Qwen3-Next):
+                    // with-cache cold output == no-cache baseline, cross-process prefix hit works.
+                    // Excluded:
+                    //  - embedding requests (need logits/embd for the whole prompt; prewarm's logits=0
+                    //    batches would not produce the embedding output) [S1]
+                    //  - DSV4 / openPangu: their pos_min=0 (no eviction) makes apply_checkpoint()
+                    //    always take the checkpoint-search path and wipe the pre-warmed prefix on
+                    //    cold start, undoing the prewarm [M4]
+                    size_t n_prewarm = 0;
+                    if (!params_base.kv_cache_dir.empty() &&
+                        !llama_model_is_deepseek4(model) &&
+                        !llama_model_is_openpangu(model) &&
+                        !slot.embedding &&
+                        slot.cache_tokens.empty() &&
+                        !slot.prompt_tokens.has_mtmd &&
+                        system_tokens.empty() &&
+                        slot.spec == nullptr &&
+                        slot.ga_n == 1 &&
+                        slot.params.cache_prompt) {
+                        bool has_image = false;
+                        for (size_t i = 0; i < slot.prompt_tokens.size(); ++i) {
+                            if (slot.prompt_tokens[i] == LLAMA_TOKEN_NULL) {
+                                has_image = true;
+                                break;
+                            }
+                        }
+                        if (!has_image) {
+                            n_prewarm = disk_kv_prewarm(slot);
+                            if (n_prewarm > 0) {
+                                // advance the slot state to the pre-warmed prefix; the server's
+                                // own "evaluate at least 1 token" logic below re-decodes the last
+                                // token at pos n_prompt (matching the process-internal cache path)
+                                slot.n_past        = (int32_t) n_prewarm;
+                                slot.n_past_prompt = (int32_t) n_prewarm;
+                                slot.n_past_offset = 0;
+                                slot.cache_tokens.clear();
+                                slot.cache_tokens.insert(std::vector<llama_token>(
+                                    slot.prompt_tokens.get_text_tokens().begin(),
+                                    slot.prompt_tokens.get_text_tokens().begin() + n_prewarm));
+                            }
+                        }
+                    }
+
                     if (slot.n_past_prompt == slot.n_prompt_tokens && slot.n_past_prompt > 0) {
                         // we have to evaluate at least 1 token to generate logits.
                         LOG_INFO("we have to evaluate at least 1 token to generate logits", {
@@ -4033,7 +4184,9 @@ void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t 
                     }
                     apply_checkpoint(slot);
                     slot.n_prompt_tokens_cache = slot.n_past_prompt;
-                    slot.n_prompt_tokens_processed = 0;
+                    // [M1] prewarm 已处理了 n_prewarm 个 token；batch 循环还会把尾部 token 累加进来，
+                    // 这样最终 n_prompt_tokens_processed ≈ n_prompt，/v1/* 的 input_tokens / timings 不失真
+                    slot.n_prompt_tokens_processed = (int32_t) n_prewarm;
                 }
 
                 if (slot.embedding) {

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -359,6 +359,11 @@ struct server_context {
 
     void update_slots();
 
+    // disk KV block cache pre-warm (v1): contiguous prefix from position 0, pure text only.
+    // Loads hit blocks from disk / decodes & saves misses into slot.id; advances
+    // slot.n_past, slot.n_past_prompt and slot.cache_tokens accordingly.
+    size_t disk_kv_prewarm(server_slot & slot);
+
     void release_slots();
 
     bool slots_idle();

--- a/kv-cache/kv-cache.cpp
+++ b/kv-cache/kv-cache.cpp
@@ -1,0 +1,558 @@
+// kv-cache.cpp — 磁盘 KV 块缓存实现（纯 llama.h 公开 API，不依赖 common）
+//
+// 结构：
+//   disk_kv 命名空间 —— 不依赖 kv_cache 实例的块级函数（外部 ctx + 任意 seq_id），
+//                        供 llama-server 等复用（只做命中加载/落盘/清理，不做 decode）
+//   kv_cache 类       —— 保留原接口，内部调 disk_kv（主序列固定 seq 0，临时序列固定 1）
+
+#include "kv-cache.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <tuple>
+#include <stdexcept>
+#include <chrono>
+#include <filesystem>
+#include <system_error>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <bcrypt.h>
+#pragma comment(lib, "bcrypt.lib")
+#endif
+
+// ---------------------------------------------------------------------------
+// 文件工具（disk_kv 内部使用，不进公共头）
+// ---------------------------------------------------------------------------
+namespace {
+
+bool file_exists(const std::string & path) {
+    FILE * f = fopen(path.c_str(), "rb");
+    if (f) { fclose(f); return true; }
+    return false;
+}
+
+void touch_file(const std::string & path) {
+#ifdef _WIN32
+    HANDLE h = CreateFileA(path.c_str(), FILE_WRITE_ATTRIBUTES,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE,
+                           NULL, OPEN_EXISTING, 0, NULL);
+    if (h != INVALID_HANDLE_VALUE) {
+        SYSTEMTIME st;
+        GetSystemTime(&st);
+        FILETIME ft;
+        SystemTimeToFileTime(&st, &ft);
+        SetFileTime(h, NULL, NULL, &ft);
+        CloseHandle(h);
+    }
+#else
+    (void) path;
+#endif
+}
+
+void remove_file(const std::string & path) {
+#ifdef _WIN32
+    DeleteFileA(path.c_str());
+#else
+    std::remove(path.c_str());
+#endif
+}
+
+#if !defined(_WIN32)
+// --- 公共域 SHA-256（Brad Conte 的 crypto-algorithms，public domain）---
+// Windows 走 BCrypt（见 disk_kv::sha256_hex）；非 Windows 用这份内嵌实现，
+// 不依赖 openssl。仅用于缓存块文件命名 / 指纹，不参与密码学安全场景。
+struct sha256_state {
+    uint8_t  data[64];
+    uint32_t datalen;
+    uint64_t bitlen;
+    uint32_t state[8];
+};
+
+static const uint32_t sha256_k[64] = {
+    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+    0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+    0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+    0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+    0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+    0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+    0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+    0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+static void sha256_transform(sha256_state * s, const uint8_t * block) {
+    uint32_t w[64];
+    for (int i = 0; i < 16; ++i) {
+        w[i] = ((uint32_t) block[i * 4] << 24) | ((uint32_t) block[i * 4 + 1] << 16) |
+               ((uint32_t) block[i * 4 + 2] << 8) | (uint32_t) block[i * 4 + 3];
+    }
+    for (int i = 16; i < 64; ++i) {
+        const uint32_t s0 = ((w[i-15] >> 7) | (w[i-15] << 25)) ^
+                            ((w[i-15] >> 18) | (w[i-15] << 14)) ^ (w[i-15] >> 3);
+        const uint32_t s1 = ((w[i-2] >> 17) | (w[i-2] << 15)) ^
+                            ((w[i-2] >> 19) | (w[i-2] << 13)) ^ (w[i-2] >> 10);
+        w[i] = w[i-16] + s0 + w[i-7] + s1;
+    }
+    uint32_t a = s->state[0], b = s->state[1], c = s->state[2], d = s->state[3];
+    uint32_t e = s->state[4], f = s->state[5], g = s->state[6], h = s->state[7];
+    for (int i = 0; i < 64; ++i) {
+        const uint32_t S1 = ((e >> 6) | (e << 26)) ^ ((e >> 11) | (e << 21)) ^ ((e >> 25) | (e << 7));
+        const uint32_t ch = (e & f) ^ (~e & g);
+        const uint32_t t1 = h + S1 + ch + sha256_k[i] + w[i];
+        const uint32_t S0 = ((a >> 2) | (a << 30)) ^ ((a >> 13) | (a << 19)) ^ ((a >> 22) | (a << 10));
+        const uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        const uint32_t t2 = S0 + maj;
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+    s->state[0] += a; s->state[1] += b; s->state[2] += c; s->state[3] += d;
+    s->state[4] += e; s->state[5] += f; s->state[6] += g; s->state[7] += h;
+}
+
+static void sha256_init(sha256_state * s) {
+    s->datalen = 0;
+    s->bitlen  = 0;
+    s->state[0] = 0x6a09e667; s->state[1] = 0xbb67ae85; s->state[2] = 0x3c6ef372; s->state[3] = 0xa54ff53a;
+    s->state[4] = 0x510e527f; s->state[5] = 0x9b05688c; s->state[6] = 0x1f83d9ab; s->state[7] = 0x5be0cd19;
+}
+
+static void sha256_update(sha256_state * s, const uint8_t * data, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        s->data[s->datalen++] = data[i];
+        if (s->datalen == 64) {
+            sha256_transform(s, s->data);
+            s->bitlen += 512;
+            s->datalen = 0;
+        }
+    }
+}
+
+static void sha256_final(sha256_state * s, uint8_t * hash) {
+    const uint32_t i0 = s->datalen;
+    if (s->datalen < 56) {
+        s->data[s->datalen++] = 0x80;
+        while (s->datalen < 56) s->data[s->datalen++] = 0x00;
+    } else {
+        s->data[s->datalen++] = 0x80;
+        while (s->datalen < 64) s->data[s->datalen++] = 0x00;
+        sha256_transform(s, s->data);
+        memset(s->data, 0, 56);
+    }
+    const uint64_t bitlen = s->bitlen + i0 * 8;
+    for (int j = 7; j >= 0; --j) {
+        s->data[56 + j] = (uint8_t) (bitlen >> (8 * (7 - j)));
+    }
+    sha256_transform(s, s->data);
+    for (uint32_t i = 0; i < 8; ++i) {
+        hash[i * 4]     = (uint8_t) (s->state[i] >> 24);
+        hash[i * 4 + 1] = (uint8_t) (s->state[i] >> 16);
+        hash[i * 4 + 2] = (uint8_t) (s->state[i] >> 8);
+        hash[i * 4 + 3] = (uint8_t) (s->state[i]);
+    }
+}
+#endif // !defined(_WIN32)
+
+// 检查序列状态文件头部是否结构完好（magic/version/token 数与块大小一致）。
+// 用于区分"损坏文件"（应删除）与"环境失败"（如 KV cache 满导致恢复失败，
+// 文件本身有效，不应删除）。
+static bool valid_seq_state_header(const std::string & file, size_t expected_tokens) {
+    FILE * f = fopen(file.c_str(), "rb");
+    if (!f) return false;
+    uint32_t magic = 0, version = 0, n_tok = 0;
+    const bool ok = fread(&magic, 4, 1, f) == 1 &&
+                    fread(&version, 4, 1, f) == 1 &&
+                    fread(&n_tok, 4, 1, f) == 1;
+    long sz = 0;
+    if (ok) { fseek(f, 0, SEEK_END); sz = ftell(f); }
+    fclose(f);
+    if (!ok) return false;
+    if (magic != LLAMA_STATE_SEQ_MAGIC || version != LLAMA_STATE_SEQ_VERSION) return false;
+    if (n_tok != expected_tokens) return false;
+    // 合法文件 = 头部(12B) + token 数据 + 非空的状态数据；否则视为截断/损坏
+    if ((long) (sizeof(uint32_t) * 3 + sizeof(llama_token) * n_tok) >= sz) return false;
+    return true;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// sha256（Windows BCrypt）
+// ---------------------------------------------------------------------------
+std::string disk_kv::sha256_hex(const void * data, size_t len) {
+#ifdef _WIN32
+    BCRYPT_ALG_HANDLE alg = nullptr;
+    BCRYPT_HASH_HANDLE h  = nullptr;
+    if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&alg, BCRYPT_SHA256_ALGORITHM, nullptr, 0))) {
+        return {};
+    }
+    if (!BCRYPT_SUCCESS(BCryptCreateHash(alg, &h, nullptr, 0, nullptr, 0, 0))) {
+        BCryptCloseAlgorithmProvider(alg, 0);
+        return {};
+    }
+    // BCryptHashData 一次调用上限 ~2^32-1 字节；这里 len 远小于此
+    if (!BCRYPT_SUCCESS(BCryptHashData(h, (PUCHAR) data, (ULONG) len, 0))) {
+        BCryptDestroyHash(h);
+        BCryptCloseAlgorithmProvider(alg, 0);
+        return {};
+    }
+    UCHAR out[32];
+    if (!BCRYPT_SUCCESS(BCryptFinishHash(h, out, sizeof(out), 0))) {
+        BCryptDestroyHash(h);
+        BCryptCloseAlgorithmProvider(alg, 0);
+        return {};
+    }
+    BCryptDestroyHash(h);
+    BCryptCloseAlgorithmProvider(alg, 0);
+
+    static const char hex[] = "0123456789abcdef";
+    std::string s(64, '0');
+    for (int i = 0; i < 32; ++i) {
+        s[i * 2]     = hex[out[i] >> 4];
+        s[i * 2 + 1] = hex[out[i] & 0x0f];
+    }
+    return s;
+#else
+    sha256_state st;
+    sha256_init(&st);
+    sha256_update(&st, (const uint8_t *) data, len);
+    uint8_t out[32];
+    sha256_final(&st, out);
+
+    static const char hex[] = "0123456789abcdef";
+    std::string s(64, '0');
+    for (int i = 0; i < 32; ++i) {
+        s[i * 2]     = hex[out[i] >> 4];
+        s[i * 2 + 1] = hex[out[i] & 0x0f];
+    }
+    return s;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// 模型指纹 / 块文件路径
+// ---------------------------------------------------------------------------
+std::string disk_kv::model_fingerprint(const llama_model * model, const std::string & model_path) {
+    std::string fp = sha256_hex(model_path.data(), model_path.size());
+    fp += "_";
+    fp += std::to_string(llama_n_ctx_train(model));
+    fp += "_";
+    fp += std::to_string(llama_n_vocab(model));
+
+    // 追加模型文件大小与修改时间：同一路径换权重会改变这两者，
+    // 从而让旧缓存块文件失效重算（避免静默加载旧 KV）。
+    std::error_code ec;
+    const uintmax_t sz = std::filesystem::file_size(model_path, ec);
+    if (!ec) {
+        fp += "_";
+        fp += std::to_string(sz);
+    } else {
+        ec.clear();
+    }
+    const auto mtime = std::filesystem::last_write_time(model_path, ec);
+    if (!ec) {
+        fp += "_";
+        fp += std::to_string(mtime.time_since_epoch().count());
+    }
+    return fp;
+}
+
+std::string disk_kv::block_path(const llama_model * model, const std::string & model_path,
+                                const std::string & cache_dir,
+                                const std::vector<llama_token> & prompt,
+                                size_t start, size_t end) {
+    const std::string h = sha256_hex(prompt.data() + start, (end - start) * sizeof(llama_token));
+    const std::string fname = h + "_" + std::to_string(start) + "_" +
+                              model_fingerprint(model, model_path) + ".bin";
+    return (std::filesystem::path(cache_dir) / fname).string();
+}
+
+// ---------------------------------------------------------------------------
+// 命中加载：文件 -> 临时序列 -> seq_cp 合并进 dst_seq（位置从文件恢复，无需搬移）
+// ---------------------------------------------------------------------------
+bool disk_kv::load_block(llama_context * ctx, llama_seq_id dst_seq, llama_seq_id tmp_seq,
+                         const std::string & file, const std::vector<llama_token> & prompt,
+                         size_t start, size_t end) {
+    if (!file_exists(file)) return false;
+
+    // 结构校验：只有确认损坏（magic/version/token 数不符或截断）才删文件。
+    // 结构完好但恢复失败（如 KV cache 满，find_slot 失败）属于环境失败，
+    // 保留文件，下次仍有空间时再命中，避免误删有效缓存。
+    if (!valid_seq_state_header(file, end - start)) {
+        remove_file(file);
+        return false;
+    }
+
+    std::vector<llama_token> toks(end - start + 64);
+    size_t n = 0;
+    const size_t loaded = llama_state_seq_load_file(ctx, file.c_str(), tmp_seq,
+                                                    toks.data(), (int32_t) toks.size(), &n);
+    if (loaded == 0) {
+        // 头部完好但恢复失败：大概率是 KV 满等环境原因，不删文件
+        fprintf(stderr, "[disk-kv] load_block: file valid but restore failed (KV full?) - keeping %s\n", file.c_str());
+        return false;
+    }
+
+    // 校验：文件里的 token 必须与请求块完全一致（哈希碰撞兜底）
+    if (n != end - start) { remove_file(file); return false; }
+    for (size_t i = 0; i < n; ++i) {
+        if (toks[i] != prompt[start + i]) { remove_file(file); return false; }
+    }
+
+    // 合并进目标序列。hybrid 的 state 通过 seq_cp + kv_cache_update 懒拷贝。
+    llama_kv_cache_seq_cp(ctx, tmp_seq, dst_seq, (llama_pos) start, (llama_pos) end);
+    llama_kv_cache_update(ctx);
+    llama_kv_cache_seq_rm(ctx, tmp_seq, -1, -1);
+
+    touch_file(file); // 更新访问时间作为 LRU 依据
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// 落盘：src_seq [start,end) -> 临时序列 -> save（save 前必须触发 s_copy 拷 state）
+// ---------------------------------------------------------------------------
+bool disk_kv::save_block(llama_context * ctx, llama_seq_id src_seq, llama_seq_id tmp_seq,
+                         const std::string & file, const std::vector<llama_token> & prompt,
+                         size_t start, size_t end) {
+    if (file_exists(file)) return true;
+
+    llama_kv_cache_seq_cp(ctx, src_seq, tmp_seq, (llama_pos) start, (llama_pos) end);
+    llama_kv_cache_update(ctx); // 触发 hybrid state 从 src 拷到 tmp
+    const std::vector<llama_token> seg(prompt.begin() + start, prompt.begin() + end);
+
+    // 原子写：先写 .tmp，成功后再 rename，避免崩溃残留半文件
+    const std::string tmp_file = file + ".tmp";
+    const size_t saved = llama_state_seq_save_file(ctx, tmp_file.c_str(), tmp_seq, seg.data(), seg.size());
+    llama_kv_cache_seq_rm(ctx, tmp_seq, -1, -1);
+    if (saved == 0) { remove_file(tmp_file); return false; }
+
+#ifdef _WIN32
+    if (!MoveFileExA(tmp_file.c_str(), file.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+        remove_file(tmp_file);
+        fprintf(stderr, "[disk-kv] rename failed: %s\n", file.c_str());
+        return false;
+    }
+#else
+    if (rename(tmp_file.c_str(), file.c_str()) != 0) {
+        remove_file(tmp_file);
+        return false;
+    }
+#endif
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// 老化清理：删除超过 max_age_days 未访问（mtime 未刷新）的块文件 + .tmp 残留
+// ---------------------------------------------------------------------------
+void disk_kv::cleanup_expired(const std::string & cache_dir, int max_age_days) {
+    if (max_age_days <= 0) return;
+
+    const auto now = std::filesystem::file_time_type::clock::now();
+
+    std::vector<std::string> expired;
+    std::error_code ec;
+    std::filesystem::directory_iterator it(cache_dir, ec), end;
+    for (; !ec && it != end; it.increment(ec)) {
+        const std::filesystem::directory_entry & e = *it;
+        const std::string name = e.path().filename().string();
+        if (name.size() < 4) continue;
+        const std::string ext = name.substr(name.size() - 4);
+        if (ext != ".bin" && ext != ".tmp") continue;
+        if (e.is_directory(ec)) { ec.clear(); continue; }
+        const auto mtime = e.last_write_time(ec);
+        if (ec) { ec.clear(); continue; }
+        // 注意：不能用 file_time_type::duration(N) —— N 是时钟 tick 数，随平台粒度不同
+        // （Windows 100ns / POSIX ns）。用 std::chrono::hours 表达"天数"，比较时自动换算。
+        if (now - mtime > std::chrono::hours(24) * max_age_days) {
+            expired.push_back(e.path().string());
+        }
+    }
+    if (!expired.empty()) {
+        fprintf(stderr, "[disk-kv] removing %zu expired blocks (age > %dd)\n",
+                expired.size(), max_age_days);
+        for (auto & f : expired) remove_file(f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 容量 LRU：超过 max_cache_size_mb 时按 mtime 升序（最旧优先）删 .bin
+// ---------------------------------------------------------------------------
+void disk_kv::enforce_cache_limit(const std::string & cache_dir, size_t max_cache_size_mb) {
+    if (max_cache_size_mb == 0) return;
+    const int64_t limit = (int64_t) max_cache_size_mb * 1024 * 1024;
+
+    // 收集目录下所有 .bin（含 mtime / 大小）
+    std::vector<std::tuple<int64_t, std::string, int64_t>> files; // mtime, path, size
+    std::error_code ec;
+    std::filesystem::directory_iterator it(cache_dir, ec), end;
+    for (; !ec && it != end; it.increment(ec)) {
+        const std::filesystem::directory_entry & e = *it;
+        const std::string name = e.path().filename().string();
+        if (name.size() < 4 || name.compare(name.size() - 4, 4, ".bin") != 0) continue;
+        if (e.is_directory(ec)) { ec.clear(); continue; }
+        const auto mtime = e.last_write_time(ec);
+        if (ec) { ec.clear(); continue; }
+        const int64_t sz = (int64_t) e.file_size(ec);
+        if (ec) { ec.clear(); continue; }
+        files.emplace_back(mtime.time_since_epoch().count(), e.path().string(), sz);
+    }
+    if (files.empty()) return;
+
+    std::sort(files.begin(), files.end()); // mtime 升序
+    int64_t total = 0;
+    for (auto & f : files) total += std::get<2>(f);
+
+    if (total <= limit) return;
+    fprintf(stderr, "[disk-kv] cache %.1f MB > limit %zu MB, LRU evicting...\n",
+            total / 1048576.0, max_cache_size_mb);
+    for (auto & f : files) {
+        if (total <= limit) break;
+        remove_file(std::get<1>(f));
+        total -= std::get<2>(f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// kv_cache 类实现
+// ---------------------------------------------------------------------------
+kv_cache::kv_cache(const char * model_path, const kv_cache_config & cfg)
+    : cfg_(cfg), model_path_(model_path ? model_path : "") {
+    llama_backend_init();
+
+    llama_model_params mp = llama_model_default_params();
+    mp.n_gpu_layers = cfg_.n_gpu_layers;
+    model_ = llama_model_load_from_file(model_path, mp);
+    if (!model_) {
+        fprintf(stderr, "[kv-cache] failed to load model: %s\n", model_path);
+        throw std::runtime_error("model load failed");
+    }
+
+    if (cfg_.n_seq_max < 2) {
+        fprintf(stderr, "[kv-cache] warning: n_seq_max=%d < 2, clamping to 2 (hybrid seq state needs >= 2 slots)\n",
+                cfg_.n_seq_max);
+        cfg_.n_seq_max = 2;
+    }
+
+    llama_context_params cp = llama_context_default_params();
+    cp.n_ctx     = cfg_.n_ctx;
+    cp.n_batch   = cfg_.n_ctx;
+    cp.n_seq_max = cfg_.n_seq_max; // hybrid qnext state 按 seq_id 索引行，必须给足槽位
+    ctx_ = llama_init_from_model(model_, cp);
+    if (!ctx_) {
+        llama_free_model(model_);
+        model_ = nullptr;
+        throw std::runtime_error("context init failed");
+    }
+
+    // 模型指纹：路径 + 关键尺寸 + 文件大小/修改时间，避免串模型/串权重加载缓存
+    fp_ = disk_kv::model_fingerprint(model_, model_path_);
+
+    // 确保缓存目录存在（std::filesystem，跨平台且无 system() 命令注入）
+    if (!cfg_.cache_dir.empty()) {
+        std::error_code ec;
+        std::filesystem::create_directories(cfg_.cache_dir, ec);
+    }
+    disk_kv::cleanup_expired(cfg_.cache_dir, cfg_.max_age_days); // 启动时清掉历史过期块
+}
+
+kv_cache::~kv_cache() {
+    if (ctx_)   { llama_free(ctx_);   ctx_   = nullptr; }
+    if (model_) { llama_free_model(model_); model_ = nullptr; }
+    llama_backend_free();
+}
+
+// ---------------------------------------------------------------------------
+// 批量 decode（纯 prefill，不要求 logits）；主序列固定 seq 0
+// ---------------------------------------------------------------------------
+bool kv_cache::decode_batch(const std::vector<llama_token> & toks, size_t pos0) {
+    if (toks.empty()) return true;
+    // 单次 llama_decode 的 token 数不能超过 n_batch（内部 GGML_ASSERT），
+    // 这里按 n_batch 切分；llama_decode 内部会再按 n_ubatch 分块处理。
+    const uint32_t max_per_decode = llama_n_batch(ctx_);
+    size_t i0 = 0;
+    while (i0 < toks.size()) {
+        const size_t i1 = std::min(i0 + max_per_decode, toks.size());
+        const int32_t n = (int32_t) (i1 - i0);
+
+        llama_batch batch = llama_batch_init(n, 0, 1);
+        batch.n_tokens = n;
+        for (size_t i = i0; i < i1; ++i) {
+            batch.token[i - i0]     = toks[i];
+            batch.pos[i - i0]       = (llama_pos)(pos0 + i);
+            batch.n_seq_id[i - i0]  = 1;
+            batch.seq_id[i - i0][0] = 0;
+            batch.logits[i - i0]    = 0;
+        }
+        const int rc = llama_decode(ctx_, batch);
+        llama_batch_free(batch);
+        if (rc != 0) {
+            fprintf(stderr, "[kv-cache] llama_decode failed rc=%d\n", rc);
+            return false;
+        }
+        i0 = i1;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// prefill：逐块命中 / 重算并落盘（主序列固定 seq 0，临时序列固定 1）
+// ---------------------------------------------------------------------------
+size_t kv_cache::prefill(const std::vector<llama_token> & prompt) {
+    llama_kv_cache_seq_rm(ctx_, 0, -1, -1); // 清空主序列，模拟新请求
+    hit_tokens_ = 0;
+    cur_pos_    = 0;
+
+    // 1) 命中阶段：从位置 0 连续查盘
+    while (!cfg_.disable_hit && cur_pos_ + cfg_.block_tokens <= prompt.size()) {
+        const size_t end = cur_pos_ + cfg_.block_tokens;
+        const std::string file = disk_kv::block_path(model_, model_path_, cfg_.cache_dir, prompt, cur_pos_, end);
+        if (!disk_kv::load_block(ctx_, 0, 1, file, prompt, cur_pos_, end)) break;
+        cur_pos_ = end;
+    }
+    hit_tokens_ = cur_pos_;
+
+    // 2) 重算阶段：剩余部分 decode + 落盘（块大小不足 BLOCK 时按实际长度）
+    while (cur_pos_ < prompt.size()) {
+        const size_t end = std::min(cur_pos_ + cfg_.block_tokens, prompt.size());
+        const std::vector<llama_token> seg(prompt.begin() + cur_pos_, prompt.begin() + end);
+        if (!decode_batch(seg, cur_pos_)) return hit_tokens_;
+        if (!cfg_.disable_save) {
+            const std::string file = disk_kv::block_path(model_, model_path_, cfg_.cache_dir, prompt, cur_pos_, end);
+            if (!disk_kv::save_block(ctx_, 0, 1, file, prompt, cur_pos_, end)) {
+                // 落盘失败（如磁盘满）：打日志继续，不中断整条 prompt 的处理
+                fprintf(stderr, "[kv-cache] failed to save block [%zu, %zu)\n", cur_pos_, end);
+            }
+        }
+        cur_pos_ = end;
+    }
+    // 缓存维护（老化 + 容量 LRU）整条 prompt 只跑一次，避免每块全目录扫描
+    if (!cfg_.disable_save) {
+        disk_kv::cleanup_expired(cfg_.cache_dir, cfg_.max_age_days);
+        disk_kv::enforce_cache_limit(cfg_.cache_dir, cfg_.max_cache_size_mb);
+    }
+    return hit_tokens_;
+}
+
+// ---------------------------------------------------------------------------
+// 单 token 续写
+// ---------------------------------------------------------------------------
+bool kv_cache::decode(llama_token token) {
+    const std::vector<llama_token> one = { token };
+    if (!decode_batch(one, cur_pos_)) return false;
+    cur_pos_++;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// sha256 公开静态：委托 disk_kv
+// ---------------------------------------------------------------------------
+std::string kv_cache::sha256_hex(const void * data, size_t len) {
+    return disk_kv::sha256_hex(data, len);
+}

--- a/kv-cache/kv-cache.h
+++ b/kv-cache/kv-cache.h
@@ -1,0 +1,120 @@
+// kv-cache.h — 磁盘 KV 块缓存模块
+//
+// 把计算过的前缀 KV 按固定 token 块落盘，新请求逐块命中加载 / 未命中重算并自动落盘。
+// 机制已在 Qwen2.5-0.5B（纯 transformer）与 Qwen3.8-27B Ridge（hybrid/Qwen3-Next）上验证：
+// 块级拼装（load + seq_cp 合并）后续写 logits 与从头计算逐位一致（max_abs_diff = 0）。
+//
+// 两个 hybrid 专属前提（详见记忆 reference_hybrid-seq-state-save）：
+//   1. save 前必须 llama_kv_cache_update 触发 s_copy（seq_cp 对 hybrid 是懒拷贝）
+//   2. n_seq_max 必须 ≥ 2（qnext state 按 seq_id 索引行，默认 1 会让临时序列无 state 行）
+
+#pragma once
+
+#include "llama.h"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// disk_kv：不依赖 kv_cache 实例的磁盘 KV 块级函数。
+// 接受外部 llama_context * + 任意主序列 seq_id，供 llama-server 等直接复用。
+// 只做"命中加载 / 落盘 / 清理"，不做 decode（decode 由调用方组织自己的 batch）。
+//
+// 踩坑保留（务必保持）：
+//   - hybrid 模型（Qwen3-Next）save 前必须 llama_kv_cache_update 触发 s_copy，
+//     否则 state 不落盘（seq_cp 对 hybrid 是懒拷贝）
+//   - load 到 tmp 序列后 llama_kv_cache_seq_cp(tmp→dst) 合并，再 llama_kv_cache_update
+//   - 块文件命名 = sha256(块 token 字节) + "_" + start + "_" + 模型指纹 + ".bin"
+//     模型指纹 = sha256(模型路径) + "_" + n_ctx_train + "_" + n_vocab +
+//                "_" + 模型文件大小 + "_" + 模型文件 mtime（换权重自动失效旧缓存）
+//   - load 时做 token 校验（哈希碰撞兜底），失败删坏文件；
+//     结构完好但恢复失败（如 KV 满）不删文件，视为环境失败
+//   - save 原子写（.tmp + MoveFileEx rename）
+//   - 老化清理（mtime 超 max_age_days 删）+ 容量 LRU（超 max_cache_size_mb 删最旧）
+// ---------------------------------------------------------------------------
+namespace disk_kv {
+
+    // sha256 hex（Windows 用 BCrypt；非 Windows 用内嵌公共域实现）
+    std::string sha256_hex(const void * data, size_t len);
+
+    // 模型指纹 = sha256(模型路径) + "_" + n_ctx_train + "_" + n_vocab
+    //             + "_" + 模型文件大小 + "_" + 模型文件 mtime，
+    // 避免串模型 / 串权重加载缓存（同路径换权重会改变大小或 mtime，旧块自动失效）
+    std::string model_fingerprint(const llama_model * model, const std::string & model_path);
+
+    // 块文件完整路径 = <cache_dir>\<sha256(块token)>_<start>_<模型指纹>.bin
+    std::string block_path(const llama_model * model, const std::string & model_path,
+                           const std::string & cache_dir,
+                           const std::vector<llama_token> & prompt,
+                           size_t start, size_t end);
+
+    // 命中加载：把 file 里 [start,end) 的 KV 块加载到 dst_seq（经 tmp_seq 中转 + seq_cp 合并）。
+    // 含 token 校验（哈希碰撞兜底），校验失败删坏文件。命中后 touch 更新 LRU 时间。
+    // 注意：调用方需保证 ctx 的 n_seq_max ≥ 2，且 dst_seq 与 tmp_seq 不冲突。
+    bool load_block(llama_context * ctx, llama_seq_id dst_seq, llama_seq_id tmp_seq,
+                    const std::string & file, const std::vector<llama_token> & prompt,
+                    size_t start, size_t end);
+
+    // 落盘：把 src_seq 的 [start,end) 状态经 tmp_seq 中转保存到 file。
+    // save 前 llama_kv_cache_update 触发 hybrid s_copy。原子写（.tmp + rename）。
+    // 文件已存在直接返回 true（不重复写）。
+    bool save_block(llama_context * ctx, llama_seq_id src_seq, llama_seq_id tmp_seq,
+                    const std::string & file, const std::vector<llama_token> & prompt,
+                    size_t start, size_t end);
+
+    // 老化清理：删除 cache_dir 下超过 max_age_days 未访问（mtime）的 .bin 及残留 .tmp；
+    // max_age_days <= 0 禁用。
+    void cleanup_expired(const std::string & cache_dir, int max_age_days);
+
+    // 容量 LRU：cache_dir 总大小超过 max_cache_size_mb（MB）时按 mtime 升序删最旧 .bin；
+    // 0 = 不限。
+    void enforce_cache_limit(const std::string & cache_dir, size_t max_cache_size_mb);
+
+} // namespace disk_kv
+
+struct kv_cache_config {
+    int             n_gpu_layers = 0;    // offload 到 GPU 的层数
+    int             n_ctx        = 8192; // 上下文长度
+    int             n_seq_max    = 16;   // 序列槽位（必须 ≥ 2）
+    size_t          block_tokens = 64;   // 每块 token 数
+    std::string     cache_dir    = "kv-cache"; // 缓存目录（自动创建）
+    bool            disable_hit  = false; // true 时跳过命中（全量重算，用于对照）
+    bool            disable_save = false; // true 时跳过落盘（用于对照：隔离 save_block 副作用）
+    size_t          max_cache_size_mb = 0; // 缓存目录容量上限（MB），0 = 不限；超限按 LRU 删最旧
+    int             max_age_days      = 3; // 超过 N 天未访问的块删除（时间老化清理），<=0 禁用
+};
+
+class kv_cache {
+public:
+    kv_cache(const char * model_path, const kv_cache_config & cfg);
+    ~kv_cache();
+
+    // 预热完整 prompt 的 KV：从位置 0 逐块查盘，命中加载拼装，未命中重算并落盘。
+    // 返回从 0 连续命中的 token 数。之后可直接 decode() 续写。
+    size_t prefill(const std::vector<llama_token> & prompt);
+
+    // 续写一个 token（追加到主序列末尾），返回是否成功
+    bool decode(llama_token token);
+
+    void set_disable_hit(bool v)  { cfg_.disable_hit  = v; }
+    void set_disable_save(bool v) { cfg_.disable_save = v; }
+
+    llama_model *   model() const { return model_; }
+    llama_context * ctx()   const { return ctx_; }
+    size_t hit_tokens()     const { return hit_tokens_; } // 最近一次 prefill 的命中 token 数
+    size_t current_pos()    const { return cur_pos_; }
+    const std::string & model_fingerprint() const { return fp_; }
+
+    static std::string sha256_hex(const void * data, size_t len);
+
+private:
+    bool decode_batch(const std::vector<llama_token> & toks, size_t pos0);
+
+    std::string     model_path_;
+    llama_model *   model_ = nullptr;
+    llama_context * ctx_   = nullptr;
+    kv_cache_config cfg_;
+    std::string     fp_;
+    size_t          hit_tokens_ = 0;
+    size_t          cur_pos_    = 0;
+};


### PR DESCRIPTION
## Summary
Add a disk-backed KV block cache to llama-server so previously computed prompt-prefix KV can be reused across requests and across processes (e.g. after a server restart). Long shared prefixes are no longer re-prefilled.

## What's included
- `kv-cache/kv-cache.{h,cpp}`: new library. `disk_kv` namespace provides block save/load/cleanup/LRU operating on any external `llama_context` + arbitrary `seq_id` (targets a server slot), using only the public llama.h API.
  - Block size configurable (default 64 tokens); block file = `sha256(block tokens)_start_<model fingerprint>.bin`
  - Model fingerprint = sha256(path) + n_ctx_train + n_vocab + file size + mtime, prevents cross-model / stale-weight reuse
  - Atomic writes (.tmp + rename); corrupted-file self-heal; token verification on load
  - Aging cleanup (default 3 days unused) + size LRU (`--kv-cache-max-size-mb`)
  - Hybrid/recurrent models (Qwen3-Next): `llama_kv_cache_update` after `seq_cp` triggers the lazy s_copy so Mamba state is persisted
- server: `--kv-cache-dir / --kv-cache-block / --kv-cache-max-age-days / --kv-cache-max-size-mb`
  - `disk_kv_prewarm` runs at slot cold start (pure text, no system prompt, no spec/self-extend). Supports both transformer and recurrent/hybrid models
  - When enabled, `n_seq_max` is raised to `n_parallel + 1` so the temporary sequence has a slot (required for hybrid qnext state rows)
- Cross-platform: uses `std::filesystem`; SHA-256 via BCrypt on Windows, embedded public-domain implementation elsewhere

## Usage
```bash
llama-server -m model.gguf --kv-cache-dir /path/to/kv-cache --kv-cache-block 64
```

## Verification (bit-exact vs no-cache baseline)
- Qwen2.5-0.5B (transformer, CPU): cold `hit 0/993` -> restart `hit 993/993`, prompt_ms 1270->36 (~35x); with/without cache output identical
- Qwen3.8-27B-Ridge (hybrid/Qwen3-Next, CUDA): no-cache baseline vs with-cache output identical; cross-process prefix hit 128/162
- 0.5B long prompt (1000+ tokens, over ubatch): with/without cache output identical
- `--kv-cache-block 64 --batch-size 8` (block > batch): no assert/crash
- scenario suite: partial-hit / full-miss / multi-request shared prefix / aging cleanup all pass

## Notes / limitations
- v1 pre-warms only the prefix from position 0 at slot cold start (when the in-process cache is empty). It does not touch existing slot cache reuse, `--slot-save-path`, MTP/speculative decoding, images, or system-prompt offsets (all excluded from the prewarm path).
- Embedding requests and DSV4/openPangu are excluded from prewarm.