### PR TITLE
gemma4: compacted sliding-window KV cache (--swa-compress)

### DIFF
--- a/src/graphs/build_gemma4.cpp
+++ b/src/graphs/build_gemma4.cpp
@@ -169,6 +169,9 @@ static ggml_cgraph * build_gemma4_graph_parallel(llm_build_context & llm, llama_
     int n_device = model.splits.size();
     GGML_ASSERT(n_device > 1);
     GGML_ASSERT(cparams.flash_attn);
+    // llama_kv_cache_init() refuses --swa-compress with a split/replicated cache, so this
+    // builder never sees a compacted cache and does not handle the compacted layout.
+    GGML_ASSERT(!kv_self.any_compacted());
     ggml_cgraph * gf = llm.new_graph_custom();
 
     bool is_moe = hparams.n_expert > 0;
@@ -572,6 +575,10 @@ ggml_cgraph * llm_build_context::build_gemma4_mtp() {
     const llama_kv_cache & target_kv     = lctx.mtp_target_ctx->kv_self;
 
     GGML_ASSERT(n_tokens <= target_kv.n);
+    // llama_new_context_with_model() refuses MTP together with --swa-compress for every arch
+    // except deepseek4, so the target cache here is never compacted and this builder addresses
+    // it by absolute cell index (target_kv.head / target_kv.n) throughout.
+    GGML_ASSERT(!target_kv.any_compacted());
 
     ggml_tensor * inp_pos = build_inp_pos();
 
@@ -914,7 +921,11 @@ ggml_cgraph * llm_build_context::build_gemma4() {
     // KQ_mask (mask for 1 head, it will be broadcasted to all heads)
     // gemma3 requires different mask for layers using sliding window (SWA)
     struct ggml_tensor * KQ_mask     = build_inp_KQ_mask(true);
-    struct ggml_tensor * KQ_mask_swa = build_inp_KQ_mask_swa(true);
+    // With --swa-compress the sliding-window layers are allocated at window size, so their mask
+    // has to be built over the compacted layout rather than over n_ctx rows.
+    struct ggml_tensor * KQ_mask_swa = kv_self.any_compacted()
+        ? build_swa_mask_for_graph(hparams.n_swa, true)
+        : build_inp_KQ_mask_swa(true);
 
     auto inp_out_ids = n_tokens > 1 ? build_inp_out_ids() : nullptr;
 
@@ -1011,8 +1022,11 @@ ggml_cgraph * llm_build_context::build_gemma4() {
                         ext_factor, attn_factor, beta_fast, beta_slow);
                 cb(Kcur, "Kcur_rope", il);
             }
+            // swa_head is the store head for a compacted layer; build_std_attention passes it on the
+            // path above, so the shared-KV / no-wv path here has to pass it too.
             cur = llm_build_kv(ctx0, lctx, kv_self, gf, model.layers[il].wo, model.layers[il].bo,
-                Kcur, Vcur, Qcur, KQ_mask_l, n_tokens, kv_head, n_kv, hparams.f_attention_scale, cb, il, nullptr, n_swa);
+                Kcur, Vcur, Qcur, KQ_mask_l, n_tokens, kv_head, n_kv, hparams.f_attention_scale, cb, il, nullptr, n_swa,
+                -1, nullptr, nullptr, swa_head);
 
 
             if (il == n_layer - 1 && inp_out_ids) {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -642,7 +642,8 @@ struct llama_model {
     // a compacted sliding-window cache needs the graph to build its KQ mask over the compacted
     // layout, and the compacted mask keys on position alone, so it requires a single sequence
     bool supports_swa_compress() const {
-        return arch == LLM_ARCH_OPENPANGU || arch == LLM_ARCH_DEEPSEEK4 || arch == LLM_ARCH_LAGUNA;
+        return arch == LLM_ARCH_OPENPANGU || arch == LLM_ARCH_DEEPSEEK4
+            || arch == LLM_ARCH_LAGUNA   || arch == LLM_ARCH_GEMMA4;
     }
 
     static inline int hadamard_size(int head_size) {


### PR DESCRIPTION
Closes the gemma4 half of #1607. Posted the patch there first; opening as a PR at @ikawrakow's request so it can get CUDA coverage.

Follows the merged per-arch pattern — #2253 (openpangu), #2266 (deepseek4), #2310 (laguna) — rather than the ring cache in #2171.

### What it does

Adds `LLM_ARCH_GEMMA4` to `llama_model::supports_swa_compress()` and routes gemma4's sliding-window mask through the compacted-cache builder, so `--swa-compress` allocates the SWA layers at window size instead of at full `n_ctx`.

It is small because #2310 already generalised the shared helpers (`llm_build_kv()` taking `swa_head`, `llm_build_kqv()` taking `kv_view_offset`, `llm_build_kv_store()` using `kv.rows(il)`). gemma4's main graph path goes through `build_std_attention()`, so it does not hand-roll cache access:

- `src/llama-model.h` — allowlist entry.
- `src/graphs/build_gemma4.cpp` — `KQ_mask_swa` via `build_swa_mask_for_graph(hparams.n_swa, true)` when `kv_self.any_compacted()`, and `swa_head` passed to the one direct `llm_build_kv()` call on the shared-KV / no-`wv` branch.

The two hand-rolled builders in that file, `build_gemma4_graph_parallel()` and `build_gemma4_mtp()`, are already unreachable with the flag — split/replicated caches are refused in `llama_kv_cache_init()`, MTP in `llama_new_context_with_model()` for every arch but deepseek4. The added `GGML_ASSERT`s document that; they do not change behaviour.

### Performance — the objection to #2171

Measured on **Goetia-26B-A4B** (gemma4 26B-A4B; 30 layers, 25 sliding-window at `n_swa 1024` + 5 global, `key_length_swa 256` vs `key_length 512`). Dual Xeon Gold 6230, AVX-512 + VNNI, 20 threads on one NUMA node, `-fa on -rtr -c 262144 -b 2048 -ub 2048 -np 1`.

|  | flag off | `--swa-compress` |
|---|--:|--:|
| `KV self size` | 56,320.00 MiB | **5,720.00 MiB** |
| model + cache | 74,063 MiB | **23,463 MiB** |
| prefill, 20,530 tok | 439.7 s (46.7 t/s) | 441.6 s (46.5 t/s) — **−0.4%** |
| decode, 200 tok | 14.7 t/s | 15.0 t/s — **+2.4%** |

`rows = pad(0 sink + 1024 window + max(256, ub 2048)) = 3072`, so the 25 SWA layers go 51,200 → 600 MiB and the 5 global layers keep their 5,120 MiB.

Compaction fires every `3072 − 1024 = 2048` tokens, so that 20,530-token prefill spans about nine memmoves — they cost nothing measurable. With the flag **off**, `pp512`/`tg32` are unchanged from the unpatched build (62.52/14.06 vs 61.62/13.86, within run-to-run noise).

### Correctness

Greedy output at `temperature 0` is **byte-identical** with and without the flag, over a 20,530-token prompt plus 200 generated tokens. Prefix cache reuse still works (turn 2 reprocessed 17 of 1,728 tokens).

Per-layer differing head dims needed no handling — `n_embd_head_k(il)` is already keyed on `swa_layers[il]` throughout, and `llama_kv_cache_compact_swa` derives its stride from the tensor.

### What I could not test

1. **CUDA — untested.** Everything above is CPU-only; I have no GPU on this box. This is the main reason for the PR.
2. **Shared-KV layers.** gemma4 sets `n_layer_kv_from_start`, so trailing layers read a *donor* layer's cache while `is_compacted()`/`rows()` key on `il`. That is consistent only because every compacted layer shares one row count, which `llama_kv_cache_init()` already asserts. No previously-supported arch has shared-KV layers, so this path is new; it behaved correctly on the model I tested, but that model may not exercise every shape.
3. **The `op_params[4] = n_swa` FA hint.** With the window view engaged, `nek1 ≈ 3072` and `nblock*256 ≥ n_swa + 256`, so `first ≤ 0` and the hint no-ops — the same path laguna takes today. I reasoned about the iqk kernel only, not the CUDA one.

Happy to adjust the shape if you would rather it look different.
