### PR TITLE
Cuda : fix DSA v_offset for quantized K/V caches

### DIFF
--- a/ggml/src/ggml-cuda/dsa_attn.cu
+++ b/ggml/src/ggml-cuda/dsa_attn.cu
@@ -296,7 +296,9 @@ bool ggml_cuda_dsa_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
     ggml_cuda_pool_alloc<half> v16(ctx.pool());
     size_t v_offset = 0;
     if (is_k_view) {
-        v_offset = (const half *)V->data - (const half *)K->data;
+        // Using /sizeof(half) is only correct for f16 K/V, for a quantized cache(i.e. q8_0) it yields the wrong column
+        const size_t v_byte_off = (const char *)V->data - (const char *)K->data;
+        v_offset = v_byte_off / ggml_type_size(K->type) * ggml_blck_size(K->type);
     } else {
         v16.alloc(v_cache_size);
     }


### PR DESCRIPTION
## Configuration
 
I run GLM-5.2 `Q3_K_M`, ik_llama `15dddc60`, 2x RTX 3090(P2P enabled), EPYC 7543, 512GB RAM, CUDA 12.4.
 
```
llama-server -m GLM-5.2-Q3_K_M-00001-of-00008.gguf \
  -ngl 999 -ot "exps=CPU" -sm layer -ts 0.80,1.20 -mg 0 \
  -c 250000 -fa on -dsa -amb 1024 \
  --cache-type-k q8_0 --cache-type-v q8_0 \
  -t 32 -tb 32 -b 2048 -ub 2048 --parallel 1 \
  --jinja --no-context-shift --host 127.0.0.1 --port 8080
```
 
## Issue and reproduction
 
Previously I ran GLM 5.2 Q2 with `f16` kv, but after switching to Q3_K_M I decided to drop kv quality to `q8_0`. 
And I noticed that subagent tool calls in Opencode started returning garbage.
Two examples of such failures:
 
```
phil:
</think> </think></think>
errupted_</think> (
'saitert
'siet</think>nitient (-</arg_value>
```
 
```
= the the the
="="/ained theainedainedaineduntedientainedainededitedainedotoned='ailained/=
... en'en'en'en'en'en ... 'eniron'en'en<arg_value>'en'en'en-en
```

Unfortunately I was unable to reproduce the issue with the synthetic scripts(needle-in-haystack passed on the failing configuration 5/5 at 230k context), but it had 100% reproduction rate with making opencode execute subagent which called tools.
 
| KV cache | -dsa | -ictk | result |
|---|---|---|---|
| f16  | on  | f16  | ok |
| q8_0 | off | f16  | ok |
| q8_0 | on  | f16  | corrupt |
| q8_0 | on  | q8_0 | corrupt |
 
Adding `-ictk f16` didn't not help and further triangulation showed that `-dsa` was the real culprit
 
## Fix and testing

So using claude I was able to find suspicious place in the code where offset was calculated under the assumption it's always *16 bit*:
```c
v_offset = (const half *)V->data - (const half *)K->data;
```
and updated it with what seems to me the appropriate version to properly access kv table:
```c
const size_t v_byte_off = (const char *)V->data - (const char *)K->data;
v_offset = v_byte_off / ggml_type_size(K->type) * ggml_blck_size(K->type);
```

After applying the fix I ran CI: 18/20 tests pass before and after the patch, with two failures in both runs: `test-tokenizer-0-bert-bge` and `test-chat-template`

Also I ran the long coding session in opencode which previously failed and it worked ok with all the subagents and them calling tools.

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low: Two lines in one file. No change to the f16 path, kernels, quantization or model loading.

AI disclosure (per contribution guidelines): AI assisted with locating the bad offset computation.
I understand the change, reproduced the issue and the fix myself and and tested it on the hardware above