### PR TITLE
Draft: Qwen3.8-Flash-Next combined CUDA performance stack

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2665,6 +2665,7 @@ extern "C" {
             struct ggml_tensor  * q,
             struct ggml_tensor  * w,
             struct ggml_tensor  * mask,
+            struct ggml_tensor  * blk_idx,
             enum ggml_unary_op    op,
             int                   n_top_k);
 

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4450,16 +4450,44 @@ GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
 
 #ifdef USE_CUDA_GRAPH
 
-static inline const void * ggml_cuda_graph_get_key(ggml_cgraph * cgraph) {
-    return cgraph->nodes[0];
+// CUDA graph executables are shape-fixed. A split pointer alone aliases alternating batch
+// shapes (for example target verification batches during speculative decoding), repeatedly
+// recapturing one entry until graphs are disabled. Mix representative endpoint shapes into
+// the key while keeping this O(1) on the hot path.
+static inline uint64_t ggml_cuda_graph_get_key(ggml_cgraph * cgraph) {
+    GGML_ASSERT(cgraph->n_nodes > 0);
+
+    uint64_t key = (uint64_t) (uintptr_t) cgraph->nodes[0];
+    auto mix = [&key](uint64_t value) {
+        key = (key ^ value) * 0x100000001b3ULL;
+    };
+
+    mix(cgraph->n_nodes);
+    for (int d = 0; d < GGML_MAX_DIMS; ++d) {
+        mix(cgraph->nodes[0]->ne[d]);
+        mix(cgraph->nodes[cgraph->n_nodes - 1]->ne[d]);
+    }
+    return key;
 }
 
-static inline ggml_cuda_graph * ggml_cuda_get_graph(ggml_backend_cuda_context & ctx, const void * key) {
-    auto & graph = ctx.cuda_graphs[key];
-    if (!graph) {
-        graph = std::make_unique<ggml_cuda_graph>();
+static inline ggml_cuda_graph * ggml_cuda_get_graph(ggml_backend_cuda_context & ctx, uint64_t key) {
+    static constexpr size_t MAX_CUDA_GRAPHS = 64;
+
+    auto it = ctx.cuda_graphs.find(key);
+    if (it == ctx.cuda_graphs.end()) {
+        while (ctx.cuda_graphs.size() >= MAX_CUDA_GRAPHS) {
+            auto lru = ctx.cuda_graphs.begin();
+            for (auto candidate = ctx.cuda_graphs.begin(); candidate != ctx.cuda_graphs.end(); ++candidate) {
+                if (candidate->second->last_used_time < lru->second->last_used_time) {
+                    lru = candidate;
+                }
+            }
+            ctx.cuda_graphs.erase(lru);
+        }
+        it = ctx.cuda_graphs.emplace(key, std::make_unique<ggml_cuda_graph>()).first;
     }
-    return graph.get();
+    it->second->last_used_time = ggml_time_us();
+    return it->second.get();
 }
 
 static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_cuda_graph * graph, ggml_cgraph * cgraph,

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -4045,7 +4045,14 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
             ggml_cuda_up_gate_unary(ctx, dst);
             break;
         case GGML_OP_SCALE:
-            ggml_cuda_op_scale(ctx, dst);
+            if (fusion && i + 1 < cgraph->n_nodes &&
+                cgraph->nodes[i+1]->op == GGML_OP_UNARY &&
+                cgraph->nodes[i+1]->src[0] == dst &&
+                ggml_cuda_op_scale_unary(ctx, cgraph->nodes[i+1])) {
+                i += 1;
+            } else {
+                ggml_cuda_op_scale(ctx, dst);
+            }
             break;
         case GGML_OP_SOFTCAP:
             ggml_cuda_op_softcap(ctx, dst);

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -889,7 +889,10 @@ struct ggml_backend_cuda_context {
 
     ggml_cuda_graph * cur_graph = nullptr;
 
-    std::unordered_map<const void *, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;
+    // A captured CUDA graph is valid only for the tensor shapes it captured. Key each
+    // split by both its first node and representative shapes so alternating batch sizes
+    // (notably speculative verification) retain separate executable graphs.
+    std::unordered_map<uint64_t, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;
 
 #endif
 

--- a/ggml/src/ggml-cuda/fattn-new-mma.cu
+++ b/ggml/src/ggml-cuda/fattn-new-mma.cu
@@ -2279,6 +2279,10 @@ void ggml_cuda_flash_attn_ext_mma_new(ggml_backend_cuda_context & ctx, ggml_tens
         GGML_ASSERT(Q->ne[0] == 256 && V->ne[0] == 256);
         if (gqa_ratio % 6 == 0) {
             ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
+        //if (gqa_ratio == 12) {
+        //    ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 16>(ctx, dst);
+        //} else if (gqa_ratio == 6) {
+        //    ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 1, 8>(ctx, dst);
         } else {
             GGML_ABORT("Not implemented");
         }

--- a/ggml/src/ggml-cuda/graph.cuh
+++ b/ggml/src/ggml-cuda/graph.cuh
@@ -25,6 +25,7 @@ struct ggml_cuda_graph {
         }
     }
     uint64_t uid = 0;
+    int64_t last_used_time = 0;
     cudaGraph_t graph = nullptr;
     cudaGraphExec_t instance = nullptr;
     size_t num_nodes = 0;

--- a/ggml/src/ggml-cuda/indexer_topk.cu
+++ b/ggml/src/ggml-cuda/indexer_topk.cu
@@ -49,6 +49,32 @@ static __global__ void k_fused_relu_mul_sum_rows_2(const kq_t * __restrict__ kq,
     dst[ncols*row + col] = sum;
 }
 
+template <typename kq_t, typename mask_t>
+static __global__ void k_fused_relu_mul_sum_rows_3(const kq_t * __restrict__ kq, const float * __restrict__ w, const mask_t * __restrict__ m,
+        const int * __restrict__ cell_idx, float * __restrict__ dst, const int ncols, int ncols_kq, const int nhead, size_t nbm) {
+    const int row = blockIdx.x;
+    const int col = blockIdx.y*blockDim.x + threadIdx.x;
+    if (col >= ncols) {
+        return;
+    }
+
+    int64_t step = ncols_kq*nhead;
+    auto this_w  = w + blockIdx.x*nhead;
+    auto this_m  = (const mask_t *)((const char *)m + nbm*row);
+
+    int col_kq = cell_idx[col];
+
+    float sum = (float)this_m[col];
+    auto this_kq = kq + row * step;
+    for (int head = 0; head < nhead; ++head) {
+        float relu = (float)this_kq[col_kq];
+        relu = relu > 0.0f ? relu : 0.0f;
+        sum += relu * this_w[head];
+        this_kq += ncols_kq;
+    }
+    dst[ncols*row + col] = sum;
+}
+
 static __global__ void k_copy_topk(const int * __restrict__ sorted, int * dst, const int ncols, const int n_top_k) {
     const int row = blockIdx.x;
     const int col = threadIdx.x;
@@ -66,16 +92,24 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
     auto q = dst->src[1];
     auto w = dst->src[2];
     auto m = dst->src[3];
+    auto c = dst->src[4];
     int n_top_k = dst->ne[0];
-    int n_kv    = k->ne[1];
+    int n_kv    = m->ne[0];
     int n_head  = q->ne[1];
     //if (k->type != GGML_TYPE_F16 && !ggml_is_quantized(k->type)) printf("%s: K is %s?\n", __func__, ggml_type_name(k->type));
     GGML_ASSERT(k->type == GGML_TYPE_F16 || k->type == GGML_TYPE_BF16 ||
                 k->type == GGML_TYPE_F32 || ggml_is_quantized(k->type));
     GGML_ASSERT(k->ne[2] == 1 || k->ne[3] == 1);
-    GGML_ASSERT(k->ne[1] > n_top_k);
-    GGML_ASSERT(k->ne[1] == m->ne[0]);
     GGML_ASSERT(k->ne[0] == q->ne[0]);
+    if (c) {
+        GGML_ASSERT(c->type == GGML_TYPE_I32);
+        GGML_ASSERT(ggml_nrows(c) == 1);
+        GGML_ASSERT(c->ne[0] == m->ne[0]);
+        //printf("Using cell_idx: k = %ld x %ld, c = %ld, n_kv = %d\n", k->ne[0], k->ne[1], c->ne[0], n_kv);
+    } else {
+        GGML_ASSERT(k->ne[1] > n_top_k);
+        GGML_ASSERT(k->ne[1] == m->ne[0]);
+    }
     GGML_ASSERT(q->ne[2] == m->ne[1]);
     GGML_ASSERT(q->ne[1] == w->ne[0]);
     GGML_ASSERT(q->ne[2] == w->ne[1]);
@@ -94,7 +128,7 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
         max_rows = std::min<int>(max_rows, q->ne[2]);
         int nstep = (q->ne[2] + max_rows - 1)/max_rows;
 
-        ggml_cuda_pool_alloc<half>  kq(ctx.pool(), int64_t(n_kv)*q->ne[1]*max_rows);
+        ggml_cuda_pool_alloc<half>  kq(ctx.pool(), k->ne[1]*q->ne[1]*max_rows);
         ggml_cuda_pool_alloc<float> score(ctx.pool(), int64_t(n_kv)*max_rows);
         ggml_cuda_pool_alloc<int>   sorted(ctx.pool(), int64_t(n_kv)*max_rows);
         ggml_cuda_pool_alloc<half>  q_f16(ctx.pool(), q->ne[0]*q->ne[1]*max_rows);
@@ -135,26 +169,45 @@ void ggml_cuda_op_indexer_topk(ggml_backend_cuda_context & ctx, ggml_tensor * ds
                     CUBLAS_COMPUTE_16F,
                     CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 
-            int nblocks = (k->ne[1] + k_block_size - 1)/k_block_size;
-            dim3 grid(nrows, nblocks, 1);
-            if (m->type == GGML_TYPE_F32) {
-                k_fused_relu_mul_sum_rows_2<<<grid, k_block_size, 0, ctx.stream()>>>(kq.get(),
-                        (const float *)w->data + first_row*q->ne[1],
-                        (const float *)((const char *)m->data + first_row*m->nb[1]),
-                        score.get(), k->ne[1], q->ne[1], m->nb[1]);
+            if (c) {
+                int nblocks = (n_kv + k_block_size - 1)/k_block_size;
+                dim3 grid(nrows, nblocks, 1);
+                if (m->type == GGML_TYPE_F32) {
+                    k_fused_relu_mul_sum_rows_3<<<grid, k_block_size, 0, ctx.stream()>>>(kq.get(),
+                            (const float *)w->data + first_row*q->ne[1],
+                            (const float *)((const char *)m->data + first_row*m->nb[1]),
+                            (const int *)c->data,
+                            score.get(), n_kv, k->ne[1], q->ne[1], m->nb[1]);
+                } else {
+                    k_fused_relu_mul_sum_rows_3<<<grid, k_block_size, 0, ctx.stream()>>>(kq.get(),
+                            (const float *)w->data + first_row*q->ne[1],
+                            (const half  *)((const char *)m->data + first_row*m->nb[1]),
+                            (const int *)c->data,
+                            score.get(), n_kv, k->ne[1], q->ne[1], m->nb[1]);
+                }
+                CUDA_CHECK(cudaGetLastError());
             } else {
-                k_fused_relu_mul_sum_rows_2<<<grid, k_block_size, 0, ctx.stream()>>>(kq.get(),
-                        (const float *)w->data + first_row*q->ne[1],
-                        (const half  *)((const char *)m->data + first_row*m->nb[1]),
-                        score.get(), k->ne[1], q->ne[1], m->nb[1]);
+                int nblocks = (k->ne[1] + k_block_size - 1)/k_block_size;
+                dim3 grid(nrows, nblocks, 1);
+                if (m->type == GGML_TYPE_F32) {
+                    k_fused_relu_mul_sum_rows_2<<<grid, k_block_size, 0, ctx.stream()>>>(kq.get(),
+                            (const float *)w->data + first_row*q->ne[1],
+                            (const float *)((const char *)m->data + first_row*m->nb[1]),
+                            score.get(), k->ne[1], q->ne[1], m->nb[1]);
+                } else {
+                    k_fused_relu_mul_sum_rows_2<<<grid, k_block_size, 0, ctx.stream()>>>(kq.get(),
+                            (const float *)w->data + first_row*q->ne[1],
+                            (const half  *)((const char *)m->data + first_row*m->nb[1]),
+                            score.get(), k->ne[1], q->ne[1], m->nb[1]);
+                }
+                CUDA_CHECK(cudaGetLastError());
             }
-            CUDA_CHECK(cudaGetLastError());
 
-            argsort_f32_i32_cuda_cub(ctx.pool(), score.get(), sorted.get(), k->ne[1], nrows, GGML_SORT_ORDER_DESC, ctx.stream());
+            argsort_f32_i32_cuda_cub(ctx.pool(), score.get(), sorted.get(), n_kv, nrows, GGML_SORT_ORDER_DESC, ctx.stream());
             CUDA_CHECK(cudaGetLastError());
 
             k_copy_topk<<<nrows, k_block_size, 0, ctx.stream()>>>(sorted.get(),
-                    (int *)((char *)dst->data + first_row*dst->nb[1]), k->ne[1], dst->ne[0]);
+                    (int *)((char *)dst->data + first_row*dst->nb[1]), n_kv, dst->ne[0]);
             CUDA_CHECK(cudaGetLastError());
         }
 

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -92,6 +92,15 @@ static __global__ void fused_mul_sigmoid_f32(int ne0, const float * x, const flo
     dst[i] = y[i] / (1.0f + expf(-x[row]));
 }
 
+static __global__ void fused_mul_sigmoid_f32(const float * x, const float * y, float * dst, const int k) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    dst[i] = y[i] / (1.0f + expf(-x[i]));
+}
+
 static __global__ void fused_mul_silu_f32(int ne0, const float * x, const float * y, float * dst, const int k, float limit) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 
@@ -310,6 +319,11 @@ static void fused_mul_relu_f32_cuda(const float * x, const float * y, float * ds
     fused_mul_relu_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, y, dst, k);
 }
 
+static void fused_mul_sigmoid_f32_cuda(const float * x, const float * y, float * dst, const int k, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_RELU_BLOCK_SIZE - 1) / CUDA_RELU_BLOCK_SIZE;
+    fused_mul_sigmoid_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, y, dst, k);
+}
+
 static void fused_mul_gelu_f32_cuda(const float * x, const float * y, float * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_GELU_BLOCK_SIZE - 1) / CUDA_GELU_BLOCK_SIZE;
     fused_mul_gelu_f32<<<num_blocks, CUDA_SILU_BLOCK_SIZE, 0, stream>>>(x, y, dst, k);
@@ -433,6 +447,7 @@ void ggml_fused_mul_unary(ggml_backend_cuda_context & ctx, ggml_unary_op op,
         case GGML_UNARY_OP_SILU: fused_mul_silu_f32_cuda(src0_d, src1_d, dst_d, nelements, limit, stream); break;
         case GGML_UNARY_OP_RELU: fused_mul_relu_f32_cuda(src0_d, src1_d, dst_d, nelements, stream); break;
         case GGML_UNARY_OP_GELU: fused_mul_gelu_f32_cuda(src0_d, src1_d, dst_d, nelements, stream); break;
+        case GGML_UNARY_OP_SIGMOID: fused_mul_sigmoid_f32_cuda(src0_d, src1_d, dst_d, nelements, stream); break;
         default: GGML_ASSERT(false);
     }
 }

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -38,6 +38,16 @@ static __global__ void silu_f32(const float * x, float * dst, const int k) {
     dst[i] = x[i] / (1.0f + expf(-x[i]));
 }
 
+static __global__ void scaled_silu_f32(const float * x, float * dst, const int k, float scale) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    float sx = scale*x[i];
+    dst[i] = sx / (1.0f + expf(-sx));
+}
+
 #if 0
 static __global__ void swiglu_f32(const float * x, float * dst, const int k, const int ne0, const int64_t nb1) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
@@ -215,6 +225,15 @@ static __global__ void sigmoid_f32(const float * x, float * dst, const int k) {
     dst[i] = 1.0f / (1.0f + expf(-x[i]));
 }
 
+static __global__ void scaled_sigmoid_f32(const float * x, float * dst, const int k, float scale) {
+    const int i = blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+    dst[i] = 1.0f / (1.0f + expf(-scale*x[i]));
+}
+
 static __global__ void biased_sigmoid_f32(const float * x, const float * bias, float * dst, float * dst_biased, const int k, const int ncols) {
     const int i = blockDim.x*blockIdx.x + threadIdx.x;
 
@@ -361,6 +380,16 @@ static void relu_f32_cuda(const float * x, float * dst, const int k, cudaStream_
 static void sigmoid_f32_cuda(const float * x, float * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_SIGMOID_BLOCK_SIZE - 1) / CUDA_SIGMOID_BLOCK_SIZE;
     sigmoid_f32<<<num_blocks, CUDA_SIGMOID_BLOCK_SIZE, 0, stream>>>(x, dst, k);
+}
+
+static void scaled_sigmoid_f32_cuda(const float * x, float * dst, const int k, float scale, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_SIGMOID_BLOCK_SIZE - 1) / CUDA_SIGMOID_BLOCK_SIZE;
+    scaled_sigmoid_f32<<<num_blocks, CUDA_SIGMOID_BLOCK_SIZE, 0, stream>>>(x, dst, k, scale);
+}
+
+static void scaled_silu_f32_cuda(const float * x, float * dst, const int k, float scale, cudaStream_t stream) {
+    const int num_blocks = (k + CUDA_SIGMOID_BLOCK_SIZE - 1) / CUDA_SIGMOID_BLOCK_SIZE;
+    scaled_silu_f32<<<num_blocks, CUDA_SIGMOID_BLOCK_SIZE, 0, stream>>>(x, dst, k, scale);
 }
 
 static void biased_sigmoid_f32_cuda(const float * x, const float * bias, float * dst, float * dst_biased, const int k, const int ncols, cudaStream_t stream) {
@@ -550,6 +579,23 @@ void ggml_cuda_op_sigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT( dst->type == GGML_TYPE_F32);
 
     sigmoid_f32_cuda(src0_d, dst_d, ggml_nelements(src0), stream);
+}
+
+bool ggml_cuda_op_scale_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    auto src = dst->src[0];
+    if (src->op != GGML_OP_SCALE) return false;
+    auto src0 = src->src[0];
+    if (src0->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32) return false;
+    auto op = (ggml_unary_op)dst->op_params[0];
+    if (op != GGML_UNARY_OP_SILU && op != GGML_UNARY_OP_SIGMOID) return false;
+    float scale;
+    memcpy(&scale, src->op_params, sizeof(scale));
+    if (op == GGML_UNARY_OP_SILU) {
+        scaled_silu_f32_cuda((const float *)src0->data, (float *)dst->data, ggml_nelements(src0), scale, ctx.stream());
+    } else {
+        scaled_sigmoid_f32_cuda((const float *)src0->data, (float *)dst->data, ggml_nelements(src0), scale, ctx.stream());
+    }
+    return true;
 }
 
 void ggml_cuda_op_biased_sigmoid(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/unary.cuh
+++ b/ggml/src/ggml-cuda/unary.cuh
@@ -101,3 +101,5 @@ void ggml_cuda_op_multi_add(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 void ggml_cuda_fused_softplus(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_fused_mul_exp_mul(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+bool ggml_cuda_op_scale_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -10332,12 +10332,19 @@ struct ggml_tensor * ggml_indexer_topk(
             struct ggml_tensor  * q,
             struct ggml_tensor  * w,
             struct ggml_tensor  * mask,
+            struct ggml_tensor  * blk_idx,
             enum ggml_unary_op    op,
             int                   n_top_k) {
     GGML_ASSERT(k->ne[2] == 1 && k->ne[3] == 1);
-    GGML_ASSERT(k->ne[1] > n_top_k);
-    GGML_ASSERT(k->ne[1] == mask->ne[0]);
     GGML_ASSERT(k->ne[0] == q->ne[0]);
+    if (blk_idx) {
+        GGML_ASSERT(ggml_nrows(blk_idx) == 1);
+        GGML_ASSERT(blk_idx->ne[0] > n_top_k);
+        GGML_ASSERT(blk_idx->type == GGML_TYPE_I32);
+    } else {
+        GGML_ASSERT(k->ne[1] == mask->ne[0]);
+        GGML_ASSERT(k->ne[1] > n_top_k);
+    }
     GGML_ASSERT(q->ne[2] == mask->ne[1]);
     GGML_ASSERT(q->ne[1] == w->ne[0]);
     GGML_ASSERT(q->ne[2] == w->ne[1]);
@@ -10349,6 +10356,7 @@ struct ggml_tensor * ggml_indexer_topk(
     result->src[1] = q;
     result->src[2] = w;
     result->src[3] = mask;
+    result->src[4] = blk_idx;
 
     return result;
 }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6700,8 +6700,7 @@ static struct ggml_tensor * ggml_fused_mul_unary_impl(
         result->src[1] = b;
         return result;
     }
-    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU);
-    //GGML_ASSERT(ggml_are_same_shape(b, a));
+    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU || op == GGML_UNARY_OP_SIGMOID);
 
     bool is_node = false;
 
@@ -17069,7 +17068,7 @@ static void ggml_compute_forward_fused_mul_unary_f32(
     GGML_ASSERT(ggml_is_contiguous_1(src0));
     GGML_ASSERT(ggml_are_same_shape(src0, dst));
     GGML_ASSERT(ggml_are_same_shape(src0, src1));
-    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU);
+    GGML_ASSERT(op == GGML_UNARY_OP_GELU || op == GGML_UNARY_OP_RELU || op == GGML_UNARY_OP_SILU || op == GGML_UNARY_OP_SIGMOID);
 
     for (int i1 = ir0; i1 < ir1; i1++) {
         float * z = (float *) ((char *) dst->data  + i1*( dst->nb[1]));
@@ -17078,6 +17077,7 @@ static void ggml_compute_forward_fused_mul_unary_f32(
         switch (op) {
             case GGML_UNARY_OP_GELU: ggml_vec_gelu_f32(nc, z, x); ggml_vec_mul_f32(nc, z, z, y); break;
             case GGML_UNARY_OP_RELU: ggml_vec_relu_f32(nc, z, x); ggml_vec_mul_f32(nc, z, z, y); break;
+            case GGML_UNARY_OP_SIGMOID: ggml_vec_sigmoid_f32(nc, z, x); ggml_vec_mul_f32(nc, z, z, y); break;
             case GGML_UNARY_OP_SILU: {
                 if (limit < 1e-6f) {
                     ggml_vec_mul_silu_f32(nc, z, x, y);

--- a/src/graphs/build_deepseek2.cpp
+++ b/src/graphs/build_deepseek2.cpp
@@ -503,7 +503,7 @@ ggml_tensor * llm_build_context::build_deepseek2_dsa_indexer(
             cb(indexer_score, "dsa_indexer_score_sink", il);
             ggml_build_forward_expand(gf, indexer_score);
         }
-        auto topk = ggml_indexer_topk(ctx0, indexer_k_b, indexer_q, indexer_weights, indexer_score, GGML_UNARY_OP_RELU, n_top_k);
+        auto topk = ggml_indexer_topk(ctx0, indexer_k_b, indexer_q, indexer_weights, indexer_score, nullptr, GGML_UNARY_OP_RELU, n_top_k);
         if (supports_op(topk)) {
             ggml_build_forward_expand(gf, topk);
             return topk;

--- a/src/graphs/build_deepseek4.cpp
+++ b/src/graphs/build_deepseek4.cpp
@@ -778,7 +778,7 @@ static ggml_tensor * dsv4_build_lid_top_k_shared(
                 indexer_mask->ne[0], n_tokens, indexer_mask->nb[1],
                 s*n_tokens*indexer_mask->nb[1]);
 
-        ggml_tensor * cur = ggml_indexer_topk(ctx0, k, q, w, mask,
+        ggml_tensor * cur = ggml_indexer_topk(ctx0, k, q, w, mask, nullptr,
                 GGML_UNARY_OP_RELU, n_top_k);
         if (selected) {
             selected = ggml_concat(ctx0, selected, cur, 1);

--- a/src/graphs/build_openpangu.cpp
+++ b/src/graphs/build_openpangu.cpp
@@ -390,7 +390,7 @@ ggml_tensor * llm_build_context::build_openpangu_attention(
                 // The op reads the mask row-strided, so the raw view suffices.
                 ggml_tensor * idx_mask = ggml_view_2d(ctx0, KQ_mask, n_kv, n_tokens,
                                                       KQ_mask->nb[1], 0);
-                fused_sel_idx = ggml_indexer_topk(ctx0, k_all_idx, q_idx, w_idx, idx_mask,
+                fused_sel_idx = ggml_indexer_topk(ctx0, k_all_idx, q_idx, w_idx, idx_mask, nullptr,
                                                   GGML_UNARY_OP_RELU, (int) topk);    // [topk, T] i32
             }
             if (fused_sel_idx && supports_op(fused_sel_idx)) {

--- a/src/graphs/build_qwen4exp.cpp
+++ b/src/graphs/build_qwen4exp.cpp
@@ -174,7 +174,7 @@ static ggml_tensor * qwen4exp_ple(
         const llama_hparams & hparams,
         const delta_net   & delta,
         ggml_tensor       * hidden,
-        ggml_tensor       * rows,
+        ggml_tensor       * emb,
         ggml_tensor       * state_all,
         bool                reset_state,
         const std::vector<bool> & reset_pos,
@@ -184,13 +184,6 @@ static ggml_tensor * qwen4exp_ple(
         const llm_build_cb & cb) {
     const int32_t hc      = hparams.dsv4_hc_mult;
     const int32_t hc_dim  = hc * n_embd;
-    const int32_t n_heads = hparams.ple_n_heads;
-
-    // get_rows lays the head dimension out slowest, which is the flatten order the
-    // projections expect
-    ggml_tensor * emb = ggml_get_rows(ctx0, model.tok_embd_per_layer, rows);
-    emb = ggml_reshape_2d(ctx0, emb, hparams.ple_head_dim * n_heads, n_tokens);
-    cb(emb, "ple_embd", il);
 
     ggml_tensor * key   = llm_build_context::llm_build_lora_mm(lctx, ctx0, model.layers[il].ple_key,   emb);
     ggml_tensor * value = llm_build_context::llm_build_lora_mm(lctx, ctx0, model.layers[il].ple_value, emb);
@@ -447,6 +440,7 @@ ggml_cgraph * llm_build_context::build_qwen4exp() {
     const int32_t hc = hparams.dsv4_hc_mult;
 
     ggml_tensor * inpL = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
+    ggml_build_forward_expand(gf, inpL);
     ggml_tensor * inp_pos = build_inp_pos();
     ggml_tensor * inp_out_ids = n_tokens > 1 ? build_inp_out_ids() : nullptr;
     ggml_tensor * KQ_mask = build_inp_KQ_mask();
@@ -457,19 +451,29 @@ ggml_cgraph * llm_build_context::build_qwen4exp() {
 
     float KQ_scale = hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
 
+    ggml_tensor * ple_emb = nullptr;
+    if (hparams.ple_n_heads > 0) {
+        lctx.inp_ple_rows = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, hparams.ple_n_heads * n_tokens);
+        cb(lctx.inp_ple_rows, "inp_ple_rows", -1);
+        ggml_set_input(lctx.inp_ple_rows);
+
+        // Gather the host-resident PLE table alongside the token embedding. Keeping these
+        // two input-side operations in one graph split avoids a second CPU/GPU round trip
+        // when the PLE layer is reached later in the model.
+        ple_emb = ggml_get_rows(ctx0, model.tok_embd_per_layer, lctx.inp_ple_rows);
+        ple_emb = ggml_reshape_2d(ctx0, ple_emb,
+                hparams.ple_head_dim * hparams.ple_n_heads, n_tokens);
+        cb(ple_emb, "ple_embd", -1);
+        ggml_build_forward_expand(gf, ple_emb);
+    } else {
+        lctx.inp_ple_rows = nullptr;
+    }
+
     // the wide residual starts as hc identical copies of the embedding
     ggml_tensor * res_hc = ggml_repeat_4d(ctx0,
             ggml_reshape_3d(ctx0, inpL, n_embd, 1, n_tokens),
             n_embd, hc, n_tokens, 1);
     cb(res_hc, "hc_residual", -1);
-
-    if (hparams.ple_n_heads > 0) {
-        lctx.inp_ple_rows = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, hparams.ple_n_heads * n_tokens);
-        cb(lctx.inp_ple_rows, "inp_ple_rows", -1);
-        ggml_set_input(lctx.inp_ple_rows);
-    } else {
-        lctx.inp_ple_rows = nullptr;
-    }
 
     // the same test the delta-net path uses for its own state
     const bool ple_reset_state = batch.pos != nullptr && batch.pos[0] == 0;
@@ -482,7 +486,7 @@ ggml_cgraph * llm_build_context::build_qwen4exp() {
         ggml_tensor * inject = nullptr;
 
         if (hparams.is_ple(il)) {
-            res_hc = qwen4exp_ple(*this, ctx0, gf, lctx, model, hparams, delta, res_hc, lctx.inp_ple_rows,
+            res_hc = qwen4exp_ple(*this, ctx0, gf, lctx, model, hparams, delta, res_hc, ple_emb,
                     kv_self.s_l[il], ple_reset_state, ple_reset_pos, n_embd, n_tokens, il, cb);
         }
 

--- a/src/graphs/build_qwen4exp.cpp
+++ b/src/graphs/build_qwen4exp.cpp
@@ -40,11 +40,20 @@ static ggml_tensor * qwen4exp_hc_mix(
     cb(xn, "hc_norm", il);
 
     ggml_tensor * lo = llm_build_context::llm_build_lora_mm(lctx, ctx0, w_down, xn);
-    lo = ggml_silu(ctx0, ggml_scale(ctx0, lo, 1.0f / (float) hc));
-    ggml_tensor * gate = ggml_sigmoid(ctx0, llm_build_context::llm_build_lora_mm(lctx, ctx0, w_up, lo));
-    cb(gate, "hc_gate", il);
+    cb(lo, "mix_down", il);
+    lo = ggml_scale(ctx0, lo, 1.0f / (float) hc);
+    cb(lo, "mix_down_scaled", il);
+    lo = ggml_silu(ctx0, lo);
+    cb(lo, "mix_down_silu", il);
+    auto up = llm_build_context::llm_build_lora_mm(lctx, ctx0, w_up, lo);
+    cb(up, "mix_up", il);
+    auto gated = ggml_fused_mul_unary(ctx0, up, xn, GGML_UNARY_OP_SIGMOID);
+    cb(gated, "mix_gated", il);
+    //auto gate = ggml_sigmoid(ctx0, up);
+    ////ggml_tensor * gate = ggml_sigmoid(ctx0, llm_build_context::llm_build_lora_mm(lctx, ctx0, w_up, lo));
+    //cb(gate, "hc_gate", il);
 
-    ggml_tensor * gated = ggml_mul(ctx0, xn, gate);
+    //ggml_tensor * gated = ggml_mul(ctx0, xn, gate);
     gated = ggml_reshape_3d(ctx0, gated, n_embd, hc, nt);
 
     ggml_tensor * mixed = ggml_multi_add(ctx0,

--- a/src/graphs/build_qwen4exp.cpp
+++ b/src/graphs/build_qwen4exp.cpp
@@ -386,9 +386,11 @@ static ggml_tensor * qwen4exp_qsa_mask(
     // causal mask can still drop cells inside a selected block. The op scores and sorts
     // internally, so the n_kv by n_tokens score matrix is never materialized.
     if (lctx.cparams.fused_idx_topk) {
-        ggml_tensor * k_cells = ggml_get_rows_ext(ctx0, pooled, inp->cell_blk, true, false);
-        k_cells = ggml_reshape_3d(ctx0, k_cells, idx_dim, n_kv, 1);
-        ggml_tensor * fused = ggml_indexer_topk(ctx0, k_cells, q, inp->head_w, cut_mask,
+        //ggml_tensor * k_cells = ggml_get_rows_ext(ctx0, pooled, inp->cell_blk, true, false);
+        //k_cells = ggml_reshape_3d(ctx0, k_cells, idx_dim, n_kv, 1);
+        //ggml_tensor * fused = ggml_indexer_topk(ctx0, k_cells, q, inp->head_w, cut_mask,
+        //        GGML_UNARY_OP_RELU, width);
+        ggml_tensor * fused = ggml_indexer_topk(ctx0, pooled, q, inp->head_w, cut_mask, inp->cell_blk,
                 GGML_UNARY_OP_RELU, width);
         cb(fused, "qsa_top_k", il);
         ggml_build_forward_expand(gf, fused);


### PR DESCRIPTION
## Purpose

Integration/benchmark branch for Qwen3.8-Flash-Next on current `main` (`15dddc60`). This deliberately stacks the still-open CUDA work so it can be tested as one unit:

- #2374: compressed-cache QSA top-k path
- #2375: Qwen4Exp scale/sigmoid/silu fusions
- mainline llama.cpp `6fe74980162a`: gather the host-resident PLE embedding with the input-side graph split
- cafe-llama.cpp `bdc64d0f51ff`: keep separate bounded CUDA graph executables for alternating batch shapes

It does **not** include #2369 in this PR. I tested that separately with a standalone MTP head; on this host the current `gpu-fallback` checkpoint path and ~40% aggregate draft acceptance made decoding slower, so merging it into the non-speculative speed stack would not meet the no-regression goal.

## Validation

Hardware: RTX 5060 Ti 16 GiB, Ryzen 9 8945HS. Model: AtomicChat Qwen3.8-Flash-Next AD-4.27bpw Q4_K_M-M64. Runtime: one GPU, `--n-cpu-moe 45 --defer-experts`, 128K context, q8 K/V/indexer, `-b 4096 -ub 2048`, eight CPU threads.

- CUDA 13 build succeeds for SM 86 + 120a.
- PLE scheduling change reduces reported graph splits from 96 to 94.
- Greedy output SHA-256 hashes match the #2374/#2375 baseline for short and 38,869-token prompts, both cold and prompt-cache reuse paths.
- Warm ABBA comparison versus the #2374/#2375 image was within noise:
  - short decode: 20.47-20.63 tok/s vs 20.54-20.65 tok/s
  - 38,869-token prefill: 257.81 tok/s vs 258.23 tok/s
  - long-context decode: 17.29 tok/s vs 17.52 tok/s
- Earlier same-host testing of #2374+#2375 versus `main` found +0.6-1.1% on short decode and a directional +12-14% on long-context decode (single long run, so not claimed as statistical).

The shape-keyed CUDA graph change is expected to matter primarily once verification batch sizes alternate under MTP; it is neutral in the no-spec A/B above.

## Caveats

- #2374 remains CUDA-only and requires attention/indexer cache residency on CUDA, as documented in that PR.
- This is a draft integration PR while the component PRs are reviewed; commits retain original authorship.
- Full `ctest` in the CUDA build has four pre-existing/environment failures (missing model/libcurl, subprocess creation in the Jinja Python harness, and the known ChatGLM template newline mismatch); the modified CUDA and Qwen4Exp translation units build cleanly.
