### PR TITLE
qwen4exp: add result_norm naming for MTP spec decode

### DIFF
--- a/src/graphs/build_qwen4exp.cpp
+++ b/src/graphs/build_qwen4exp.cpp
@@ -531,6 +531,7 @@ ggml_cgraph * llm_build_context::build_qwen4exp() {
     }
 
     cur = llm_build_lora_mm(lctx, ctx0, model.output, cur);
+    cb(cur, "result_norm", -1);
     cb(cur, "result_output", -1);
 
     ggml_build_forward_expand(gf, cur);


### PR DESCRIPTION
One-line fix. The qwen4exp graph produces result_output but never names result_norm. MTP spec decode needs result_norm to find the final hidden state.