### PR TITLE
server: use context checkpoints for compacted (--swa-compress) KV caches

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -1800,19 +1800,22 @@ bool server_context::launch_slot_with_task(server_slot& slot, server_task& task)
     } while (false);
     slot.allow_rules_prev = slot.allow_rules;
 
+    bool do_checkpoint = params_base.ctx_checkpoints_n > 0;
+    // make checkpoints only for completion tasks
+    do_checkpoint = do_checkpoint && task.type == SERVER_TASK_TYPE_COMPLETION;
+    // make a checkpoint of the parts of the memory that cannot be rolled back.
+    // checkpoints are created only if:
+    // - the model architecture is marked as recurrent or hybrid, or has private per-position state (DSV4)
+    params_base.do_checkpoint = do_checkpoint &&
+        (llama_model_has_recurrent(llama_get_model(slot.ctx)) ||
+         llama_model_is_openpangu(llama_get_model(slot.ctx))  ||
+         llama_model_is_deepseek4(llama_get_model(slot.ctx))  ||
+         llama_kv_cache_is_compacted(slot.ctx));
+
     if (llama_model_has_recurrent(llama_get_model(slot.ctx)) ||
         llama_model_is_openpangu(llama_get_model(slot.ctx)) ||
         llama_model_is_deepseek4(llama_get_model(slot.ctx))) {
         params_base.can_ban_phrases = false;
-        bool do_checkpoint = params_base.ctx_checkpoints_n > 0;
-        // make checkpoints only for completion tasks
-        do_checkpoint = do_checkpoint && task.type == SERVER_TASK_TYPE_COMPLETION;
-        // make a checkpoint of the parts of the memory that cannot be rolled back.
-        // checkpoints are created only if:
-        // - the model architecture is marked as recurrent or hybrid, or has private per-position state (DSV4)
-        //
-        // TODO: try to make this conditional on the context or the memory module, instead of the model type
-        params_base.do_checkpoint = do_checkpoint;
         if (slot.n_buffer != 0) {
             LLAMA_LOG_WARN("banned strings is not supported by recurrent model, it will be disabled.\n");
         }
@@ -3655,8 +3658,12 @@ void server_context::apply_checkpoint(server_slot & slot) {
     const auto pos_min_thold = std::max(0, pos_next - 1);
     const bool is_dsv4 = llama_model_is_deepseek4(model);
     const bool is_openpangu = llama_model_is_openpangu(model);
+    const bool is_compacted = llama_kv_cache_is_compacted(slot.ctx);
     if (slot.n_past > 0 && slot.n_past < slot.cache_tokens.n_tokens()) {
         int32_t pos_min = llama_kv_cache_seq_pos_min(slot.ctx, slot.id);
+        if (is_compacted) {
+            pos_min = std::max(pos_min, (int32_t) llama_kv_cache_swa_rewind_floor(slot.ctx));
+        }
 
         // DSV4 and openPangu have pos_min=0 (no eviction) so the guard always blocks them
         if (pos_min >= pos_min_thold || is_dsv4 || is_openpangu) {
@@ -3667,7 +3674,7 @@ void server_context::apply_checkpoint(server_slot & slot) {
                 slot.server_cached_prompt.checkpoints.rbegin(),
                 slot.server_cached_prompt.checkpoints.rend(),
                 [&](const auto & cur) {
-                    return cur.pos_max < (is_dsv4 || is_openpangu ? pos_next : pos_min_thold);
+                    return cur.pos_max < (is_dsv4 || is_openpangu || is_compacted ? pos_next : pos_min_thold);
                 }
             );
 
@@ -3695,7 +3702,7 @@ void server_context::apply_checkpoint(server_slot & slot) {
                 }
 
                 if (!do_reset) {
-                    if (is_dsv4 || is_openpangu) {
+                    if (is_dsv4 || is_openpangu || is_compacted) {
                         pos_next = std::min(pos_next, it->pos_max + 1);
                     } else {
                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));

--- a/include/llama.h
+++ b/include/llama.h
@@ -710,6 +710,10 @@ extern "C" {
     // Returns true if the model is openPangu (conv-only recurrent state that rides the spec-rollback checkpoint)
     LLAMA_API bool llama_model_is_openpangu(const struct llama_model * model);
 
+    LLAMA_API bool llama_kv_cache_is_compacted(const struct llama_context * ctx);
+
+    LLAMA_API llama_pos llama_kv_cache_swa_rewind_floor(const struct llama_context * ctx);
+
     // Returns true if the model is a Gemma 4 MTP assistant (external frozen-KV speculative drafter)
     LLAMA_API bool llama_model_is_gemma4_mtp_assistant(const struct llama_model * model);
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -10083,6 +10083,17 @@ void llama_kv_cache_seq_div(struct llama_context * ctx, llama_seq_id seq_id, lla
     llama_kv_cache_seq_div(ctx->kv_self, seq_id, p0, p1, d);
 }
 
+bool llama_kv_cache_is_compacted(const struct llama_context * ctx) {
+    return ctx && ctx->kv_self.any_compacted();
+}
+
+llama_pos llama_kv_cache_swa_rewind_floor(const struct llama_context * ctx) {
+    if (!ctx || !ctx->kv_self.any_compacted() || ctx->kv_self.pos_base_swa == 0) {
+        return 0;
+    }
+    return ctx->kv_self.pos_base_swa + (llama_pos) ctx->kv_self.window_swa;
+}
+
 llama_pos llama_kv_cache_seq_pos_min(struct llama_context * ctx, llama_seq_id seq_id) {
     if (ctx->kv_self.hybrid || ctx->kv_self.recurrent) {
         return llama_kv_cache_seq_pos_max(ctx->kv_self, seq_id);


### PR DESCRIPTION
Fixes the prompt-cache regression @aadametz reported on #2378. Applies to every arch on the `supports_swa_compress()` allowlist — openpangu, deepseek4, laguna, gemma4, and DFlash/DSpark from #2384.

Review Complexity : Medium

*Prepared with AI assistance (analysis, patch and benchmarking); reviewed and tested by me on the hardware below.*

### Problem

Once a conversation's divergence point falls below the compacted window, the rewind is refused and the whole history is re-prefilled, every turn:

```
llama_kv_cache_seq_rm: --swa-compress cannot rewind to position 5957: the compacted
    window starts at 6144 and would lose the 1024 positions before 5957
kv cache rm [p0, end)  p0=0
```

The refusal is correct — the rows are gone. The fallback is what is missing. Context checkpoints exist for this and are never reached:

1. `params_base.do_checkpoint` was assigned only inside the recurrent/openPangu/DSV4 branch, so no checkpoint was created for anything else. The `TODO` there already asked for this to key on the memory module rather than the model type.
2. `apply_checkpoint()` gates on `llama_kv_cache_seq_pos_min()`, which reads `cells[]` — owned by the full-attention layers — so it reports 0 on a compacted cache.

The state serializer already carries compacted layers in partial state, so this only reaches machinery that was already correct.

### Why the rewind floor, and not a boolean

`llama_kv_cache_swa_rewind_floor()` mirrors the allow-condition in `llama_kv_cache_seq_rm()`, and `apply_checkpoint()` raises `pos_min` to it.

Gating on "is the cache compacted" alone is the smaller change and it is worse than the bug: it also diverts rewinds that would have succeeded inside the window, costing a full reprocess when no checkpoint exists. Measured at **36,012 prefill tokens against 28,632 unpatched**.

### Results

Goetia-26B-A4B (gemma4), CPU-only, `-c 16384`, greedy, 12 turns, history rewritten ~2760 tokens behind the head from turn 7:

| | prefill tokens | wall | refusals |
|---|--:|--:|--:|
| no `--swa-compress` | 19,329 | 251 s | 0 |
| `--swa-compress`, before | 28,632 | 360 s | 5 |
| `--swa-compress`, after | 24,284 | 316 s | 0 |

Turns 1–7 are token-for-token identical to the uncompressed baseline. The remainder on turns 8–11 is checkpoint coverage, not refusals — 37 of 43 checkpoints are erased as invalidated before use, so there may be more available here.

### Controls

- `--ctx-checkpoints 0`: byte-identical to the unpatched build.
- Models that already checkpointed are unaffected: qwen3.6-35B-A3B, and qwen3.8-27B with MTP (which exercises `common_speculative_trim_sequence` in the same path) — identical per-turn prefill counts and identical output.
- Repeat runs match 12/12 in both builds, so the differences above are not run-to-run noise.

### Note on checkpoint memory

A checkpoint carries the compacted window rows — 48–319 MiB each here, bounded by the row count rather than by `n_ctx`. With `ctx_checkpoints_n` defaulting to 32 that can add several GiB to a feature bought for memory. A lower default when the cache is compacted may be worth considering; left alone here rather than guessed at.
