### PR TITLE
sampling: preserve token history for repetition penalties

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -91,8 +91,6 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, co
                     trigger_tokens.data(), trigger_tokens.size())
                 : llama_sampler_init_grammar(vocab, grammar_str.c_str(), "root");
             if (grmr) {
-                result->prev.resize(params.n_prev);
-
                 result->grammar = grmr;
             }
         }
@@ -730,10 +728,12 @@ void common_sampler_accept(
         struct llama_context * ctx_main,
         llama_token token,
         bool is_generated) {
-    if (ctx_sampling->prev.size() > 0) {
-        ctx_sampling->prev.erase(ctx_sampling->prev.begin());
+    if (ctx_sampling->params.n_prev > 0) {
+        if (ctx_sampling->prev.size() >= static_cast<size_t>(ctx_sampling->params.n_prev)) {
+            ctx_sampling->prev.erase(ctx_sampling->prev.begin());
+        }
+        ctx_sampling->prev.push_back(token);
     }
-    ctx_sampling->prev.push_back(token);
 
     // grammar_should_apply() checks the reasoning budget state, so calculate this before we accept
     const auto accept_grammar = is_generated && grammar_should_apply(ctx_sampling);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,9 @@ function(llama_build_and_test source)
     set_property(TEST ${TEST_TARGET} PROPERTY LABELS ${LLAMA_TEST_LABEL})
 endfunction()
 
+llama_build(test-sampling-history.cpp)
+llama_test(test-sampling-history)
+
 # build test-tokenizer-0 target once and add many tests
 add_executable(test-tokenizer-0 test-tokenizer-0.cpp)
 target_link_libraries(test-tokenizer-0 PRIVATE common)
@@ -215,5 +218,3 @@ llama_target_and_test(test-autorelease.cpp        LABEL "model")
 get_filename_component(TEST_TARGET test-c.c NAME_WE)
 add_executable(${TEST_TARGET} test-c.c)
 target_link_libraries(${TEST_TARGET} PRIVATE llama)
-
-

--- a/tests/test-sampling-history.cpp
+++ b/tests/test-sampling-history.cpp
@@ -1,0 +1,39 @@
+#include "sampling.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+#include <vector>
+
+static void test_history_grows_to_capacity() {
+    common_sampler sampler{};
+    sampler.params.n_prev = 3;
+
+    common_sampler_accept(&sampler, nullptr, 10, false);
+    common_sampler_accept(&sampler, nullptr, 11, false);
+    common_sampler_accept(&sampler, nullptr, 12, false);
+
+    assert((sampler.prev == std::vector<llama_token>{10, 11, 12}));
+
+    common_sampler_accept(&sampler, nullptr, 13, false);
+
+    assert((sampler.prev == std::vector<llama_token>{11, 12, 13}));
+}
+
+static void test_zero_capacity_keeps_no_history() {
+    common_sampler sampler{};
+    sampler.params.n_prev = 0;
+
+    common_sampler_accept(&sampler, nullptr, 10, false);
+
+    assert(sampler.prev.empty());
+}
+
+int main() {
+    test_history_grows_to_capacity();
+    test_zero_capacity_keeps_no_history();
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #2398.

`common_sampler_accept()` erased the oldest history entry whenever `prev`
was non-empty. After starting with an empty history, every accepted token
therefore replaced the previous one, leaving repetition and presence
penalties with only a single token of context.

The grammar path partially masked this behavior by pre-sizing `prev`,
which explains the endpoint-dependent results reported in the issue.

This change:

- lets the history grow up to `n_prev`;
- evicts only the oldest token after reaching that capacity;
- keeps no history when `n_prev` is zero;
- removes the grammar-specific pre-sizing;
- adds a deterministic regression test for growth, eviction, and zero capacity.

Validation:

- the regression test fails on the previous implementation;
- `test-sampling-history` passes after the change;
- all build targets compile successfully;
- before the fix, identical `/completion` requests with the same prompt and
  seed produced identical output for `presence_penalty` 0/5 and
  `repeat_penalty` 1/3;
- after the fix, both penalties alter the generated continuation;
- `/v1/chat/completions` continues to honor the penalties.

AI disclosure: AI assistance was used for repository exploration and test
scaffolding. The bug was reproduced locally, and the resulting change was
reviewed, understood, and validated before submission.

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
