### PR TITLE
Replace four 256 round+convert pairs with two AVX-512 embedded roundings with the same guarantee

### DIFF
--- a/ggml/src/iqk/iqk_common.h
+++ b/ggml/src/iqk/iqk_common.h
@@ -595,9 +595,22 @@ static inline float convert_to_q8_k_r8(int k, float d0, const __m256i * qx, cons
     if (dnew < 1.f) {
         dnew = 1.f; needs_scaling = false;
     }
-    auto scale = _mm256_set1_ps(std::abs(dnew) > 1e-9f ? 1/dnew : 0.f);
+    const float inv_dnew = std::abs(dnew) > 1e-9f ? 1/dnew : 0.f;
+#ifdef HAVE_FANCY_SIMD
+    auto scale = _mm512_set1_ps(inv_dnew);
+#else
+    auto scale = _mm256_set1_ps(inv_dnew);
+#endif
     for (int ib32 = 0; ib32 < 8; ++ib32) {
         if (needs_scaling) {
+#ifdef HAVE_FANCY_SIMD
+            auto w0 = _mm512_cvt_roundps_epi32(_mm512_mul_ps(scale, _mm512_cvtepi32_ps(_mm512_cvtepi16_epi32(qs[2*ib32+0]))), _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+            auto w1 = _mm512_cvt_roundps_epi32(_mm512_mul_ps(scale, _mm512_cvtepi32_ps(_mm512_cvtepi16_epi32(qs[2*ib32+1]))), _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+            auto i0 = _mm512_castsi512_si256(w0);
+            auto i1 = _mm512_extracti64x4_epi64(w0, 1);
+            auto i2 = _mm512_castsi512_si256(w1);
+            auto i3 = _mm512_extracti64x4_epi64(w1, 1);
+#else
             auto i0 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(qs[2*ib32+0]));
             auto i1 = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(qs[2*ib32+0], 1));
             auto i2 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(qs[2*ib32+1]));
@@ -606,6 +619,7 @@ static inline float convert_to_q8_k_r8(int k, float d0, const __m256i * qx, cons
             i1 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i1)), _MM_ROUND_NEAREST));
             i2 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i2)), _MM_ROUND_NEAREST));
             i3 = _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i3)), _MM_ROUND_NEAREST));
+#endif
             i0 = _mm256_packs_epi32(i0, i1);
             i2 = _mm256_packs_epi32(i2, i3);
             i0 = _mm256_packs_epi16(i0, i2);


### PR DESCRIPTION
When profiling `iqk_convert_iq4_xs_q8_k_r8` I found an opportunity in `convert_to_q8_k_r8` to save a few instructions while preserving the same rounding-mode guarantees (round to nearest, tie even) when you `HAVE_FANCY_SIMD`.

In iqk_common.h the following idiom is used (grandfathered from llama.cpp):

    _mm256_cvtps_epi32(_mm256_round_ps(_mm256_mul_ps(scale, _mm256_cvtepi32_ps(i0)), _MM_ROUND_NEAREST));

`_mm256_cvtps_epi32` already rounds, and then `_mm256_round_ps` rounds again, explicitly, which generates an additional instruction (clang: `vroundps`, gcc: `vrndscaleps`), which does nothing.

I guess this is written defensively, since plausibly something could change the MXCSR register and then` _mm256_round_ps` is the safety net. One could argue that you could just delete the extra rounding, but on AVX-512 we can have our cake and eat it too by using an embedded rounding instead:

    mm512_cvt_roundps_epi32(..., _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)

This preserves the same rounding guarantee (regardless of MXCSR setting) and saves some instructions: 4 `vrndscaleps` + 4 `vcvtps2dq` become 2 `vcvtps2dq {rn-sae}`. The commit gates it on `HAVE_FANCY_SIMD`, since AVX2 cannot do that.

I've benchmarked this on Qwen3-Coder-30B-A3B-Instruct-IQ4_K, since it exercises this code path. With `-ub 512` I have +1.47% pp512 improvement. On a sort of 'synthetic' benchmark with Qwen3.8-27B-IQ4_XS and `-ub` set to `32` to work the repack path harder I get +6.49% pp512 on Xeon Gold 6240. 

Note that the same pattern exists in other places (iqk_convert_q6_k_q8_0_r8, iqk_convert_q3_k_q8_0_r8, iqk_convert_q3_k_q8_k_r8, iqk_convert_iq2_xs_q8_0_r8, iqk_convert_iq2_s_q8_0_r8 and iqk_convert_iq5_k_q8_0_r8).

Disclosure: PR written by me, Opus 5 found the optimization opportunity in convert_to_q8_k_r8.

- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
