### PR TITLE
llama: refuse a KV cache type with per-row metadata, do not crash

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -8430,6 +8430,22 @@ struct llama_context * llama_init_from_model(
         }
     }
 
+    // A KV cache type that carries per-row metadata (row_meta_size > 0, today only q8_KV) cannot be used for the
+    // standard K/V cache: llm_build_kv() views one cache row of n_embd_{k,v}_gqa values as n_head_kv sub-rows of
+    // n_embd_head_{k,v}, and ggml_row_size() adds the metadata block to EVERY sub-row, so the 3-D view is
+    // n_head_kv * row_meta_size bytes longer than the row it is a view of. Without this check the run dies with
+    // "GGML_ASSERT(... data_size + view_offs <= ggml_nbytes(view_src))" in ggml_view_3d() (V side, at graph build)
+    // or with a SIGSEGV inside quantize_row_q8_KV() from ggml_compute_forward_dup() (K side, at first decode).
+    for (int i = 0; i < 2; ++i) {
+        const ggml_type t = i == 0 ? params.type_k : params.type_v;
+        if (ggml_internal_get_type_traits(t).row_meta_size > 0) {
+            LLAMA_LOG_ERROR("%s: %s cannot be used as a %s-cache type: it stores per-row metadata, which the "
+                    "per-head KV cache views do not account for (use f16, bf16, q8_0, q6_0, q5_0, q5_1, q4_0, "
+                    "q4_1 or iq4_nl)\n", __func__, ggml_type_name(t), i == 0 ? "K" : "V");
+            return nullptr;
+        }
+    }
+
     //if (params.flash_attn && model->hparams.n_embd_head_k != model->hparams.n_embd_head_v) {
     //    LLAMA_LOG_WARN("%s: flash_attn requires n_embd_head_k == n_embd_head_v - forcing off\n", __func__);
     //    params.flash_attn = false;


### PR DESCRIPTION
-ctk q8_KV or -ctv q8_KV kills llama-bench and llama-server on a GQA model, in two different ways.

On the V side, at graph build: ggml.c GGML_ASSERT(view_src == NULL || data_size == 0 || data_size + view_offs <= ggml_nbytes(view_src)) fails, from ggml_view_3d through llm_build_context::llm_build_kv, build_std_attention and build_qwen35. On the K side, at the first decode: SIGSEGV in quantize_row_q8_KV from ggml_compute_forward_dup. Reproduced 3 times out of 3 on Qwen3.8-27B (qwen35, n_head 24, n_head_kv 4, head dim 256) with -fa on. Every other accepted KV type (f16, bf16, q8_0, q6_0, q5_0, q5_1, q4_0, q4_1, iq4_nl) runs fine.

q8_KV is the only cache type with row_meta_size > 0, 8 bytes. llm_build_kv() views one cache row holding n_embd_v_gqa values as n_head_kv sub-rows of n_embd_head_v, with nb1 = ggml_row_size(type, n_embd_head_v). ggml_row_size() adds the metadata block to every sub-row, so the view is n_head_kv * 8 bytes longer than the row it views: for this model 4 * (256+8) = 1056 against (1024+8) = 1032, which is the assert. The K path reaches the CPU quantize_row_q8_KV() with the same mismatched stride and walks off the row.

Reject any cache type with row_meta_size > 0 at context creation with an actionable message, exactly as llama_new_context_with_model() already does for the openPangu latent and indexer cache types. That turns two hard crashes into a one-line error.

This does not make q8_KV work for the standard cache. Doing that needs the per-head view arithmetic to subtract the metadata, which is a design change rather than a guard.

Verified with llama-bench -m <model> -fa 1 -ctk q8_KV -ctv f16 -p 512 -n 32, and the same with -ctv q8_KV: the run now prints "q8_KV cannot be used as a K-cache type: ..." and exits non-zero without a core dump.



- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
