### PR TITLE
server: answer an over-long prompt with 400 exceed_context_size_error

### DIFF
--- a/examples/server/server-common.cpp
+++ b/examples/server/server-common.cpp
@@ -1102,6 +1102,10 @@ json format_error_response(const std::string& message, const enum error_type typ
         type_str = "unavailable_error";
         code = 503;
         break;
+    case ERROR_TYPE_EXCEED_CONTEXT_SIZE:
+        type_str = "exceed_context_size_error";
+        code = 400;
+        break;
     }
     return json{
         {"code", code},

--- a/examples/server/server-common.h
+++ b/examples/server/server-common.h
@@ -63,6 +63,7 @@ enum error_type {
     ERROR_TYPE_PERMISSION,
     ERROR_TYPE_UNAVAILABLE, // custom error
     ERROR_TYPE_NOT_SUPPORTED, // custom error
+    ERROR_TYPE_EXCEED_CONTEXT_SIZE, // custom error: the request does not fit the slot context (HTTP 400, as in llama.cpp)
 };
 
 extern bool server_verbose;

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -2384,10 +2384,10 @@ void server_context::send_error(const server_task& task, const std::string& erro
 }
 
 void server_context::send_error(const server_slot& slot, const std::string& error, const enum error_type type) {
-    send_error(slot.id_task, slot.id_multi, error, type);
+    send_error(slot.id_task, slot.id_multi, error, type, slot.n_prompt_tokens, slot.n_ctx);
 }
 
-void server_context::send_error(const int id_task, const int id_multi, const std::string& error, const enum error_type type ) {
+void server_context::send_error(const int id_task, const int id_multi, const std::string& error, const enum error_type type, const int32_t n_prompt_tokens, const int32_t n_ctx) {
     LOG_ERROR("task error", {
         {"id_multi", id_multi},
         {"id_task", id_task},
@@ -2400,6 +2400,8 @@ void server_context::send_error(const int id_task, const int id_multi, const std
     res->error = true;
     res->err_type = type;
     res->err_msg = error;
+    res->n_prompt_tokens = n_prompt_tokens;
+    res->n_ctx = n_ctx;
     queue_results.send(std::move(res));
 }
 
@@ -3466,7 +3468,7 @@ void server_context::context_shift() {
                     // we should never get here, because generation should already stopped in process_token()
                     slot.print_timings();
                     slot.release();
-                    send_error(slot, "context_length_exceeded: the request exceeds the available context size; context shift is disabled", ERROR_TYPE_SERVER);
+                    send_error(slot, "context_length_exceeded: the request exceeds the available context size; context shift is disabled", ERROR_TYPE_EXCEED_CONTEXT_SIZE);
                     continue;
                 }
                 // Shift context
@@ -3933,7 +3935,10 @@ void server_context::batch_pending_prompt(const int32_t n_ubatch, const int32_t 
                         // context shift for prompt processing
                         if (slot.ga_n == 1 && slot.n_prompt_tokens >= slot.n_ctx) {
                             if (!params_base.ctx_shift) {
-                                send_error(slot, "the request exceeds the available context size, try increasing it", ERROR_TYPE_SERVER);
+                                send_error(slot,
+                                        string_format("request (%d tokens) exceeds the available context size (%d tokens), try increasing it",
+                                            slot.n_prompt_tokens, slot.n_ctx),
+                                        ERROR_TYPE_EXCEED_CONTEXT_SIZE);
                                 slot.release();
                                 continue;
                             }

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -322,7 +322,7 @@ struct server_context {
 
     void send_error(const server_slot& slot, const std::string& error, const enum error_type type = ERROR_TYPE_SERVER);
 
-    void send_error(const int id_task, const int id_multi, const std::string& error, const enum error_type type = ERROR_TYPE_SERVER);
+    void send_error(const int id_task, const int id_multi, const std::string& error, const enum error_type type = ERROR_TYPE_SERVER, const int32_t n_prompt_tokens = 0, const int32_t n_ctx = 0);
 
     // if multimodal is enabled, send an error and return false
     bool check_no_mtmd(const int id_task);

--- a/examples/server/server-task.h
+++ b/examples/server/server-task.h
@@ -312,6 +312,10 @@ struct server_task_result_error : server_task_result {
 
     virtual json to_json() override {
         json res = format_error_response(err_msg, err_type);
+        if (err_type == ERROR_TYPE_EXCEED_CONTEXT_SIZE) {
+            res["n_prompt_tokens"] = n_prompt_tokens;
+            res["n_ctx"]           = n_ctx;
+        }
         return res;
     }
 };


### PR DESCRIPTION
ik_llama.cpp answers this condition with HTTP 500 and a bare server_error; upstream llama.cpp answers 400 with an exceed_context_size_error carrying n_prompt_tokens and n_ctx, which routers and agents rely on to trim the context and retry, because they treat any 5xx as a transient backend fault and fail over instead.

Add the error type with its 400 mapping, emit the two token counts alongside it, thread them through the error path and use the new type at the two context-size sites. The separate batch-size error keeps its existing type, exactly as upstream does.

Verified on a server with two slots: an over-long chat completion now returns 400 with both counts, a prompt that fits still returns 200, and context shifting still truncates as before.



- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
