### PR TITLE
ggml: Optimize the AVX-512 VNNI path on Intel Cascade Lake

### DIFF
--- a/ggml/src/iqk/iqk_gemm_kquants.cpp
+++ b/ggml/src/iqk/iqk_gemm_kquants.cpp
@@ -1896,32 +1896,32 @@ static void mul_mat_q8_k_r16_q8_k(int n, const void * vx, size_t bx, const DataI
     int nbl = n / QK_K;
     __m512  acc[nrc_y] = {};
     __m512i isum[nrc_y] = {};
+    __m512i isum2[nrc_y] = {};
     __m512i qx[4];
     for (int ix = 0; ix < nrc_x; ix += 16) {
         const block_q8_k_r16 * iq16 = (const block_q8_k_r16 *)((const char *)vx + ix*bx);
         for (int ibl = 0; ibl < nbl; ++ibl) { // Block of 256
             auto d4 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *)iq16[ibl].d));
+            _Pragma("GCC unroll 2")
             for (int ib = 0; ib < QK_K/16; ++ib) {
                 qx[0] = _mm512_loadu_si512((const __m512i *)iq16[ibl].qs+4*ib+0);
                 qx[1] = _mm512_loadu_si512((const __m512i *)iq16[ibl].qs+4*ib+1);
                 qx[2] = _mm512_loadu_si512((const __m512i *)iq16[ibl].qs+4*ib+2);
                 qx[3] = _mm512_loadu_si512((const __m512i *)iq16[ibl].qs+4*ib+3);
                 for (int iy = 0; iy < nrc_y; ++iy) {
-                    auto y128 = _mm_loadu_si128((const __m128i*)q8.y[iy][ibl].qs+ib);
-                    auto y256 = MM256_SET1_M128I(y128);
-                    auto y = _mm512_inserti32x8(_mm512_castsi256_si512(y256), y256, 1);
-                    isum[iy] = _mm512_dpbusd_epi32(isum[iy], qx[0], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0x00)));
-                    isum[iy] = _mm512_dpbusd_epi32(isum[iy], qx[1], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0x55)));
-                    isum[iy] = _mm512_dpbusd_epi32(isum[iy], qx[2], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0xaa)));
-                    isum[iy] = _mm512_dpbusd_epi32(isum[iy], qx[3], _mm512_shuffle_epi32(y, _MM_PERM_ENUM(0xff)));
+                    const int8_t * yb = q8.y[iy][ibl].qs + 16*ib;
+                    isum [iy] = _mm512_dpbusd_epi32(isum [iy], qx[0], _mm512_set1_epi32(*(const int32_t *)(yb +  0)));
+                    isum2[iy] = _mm512_dpbusd_epi32(isum2[iy], qx[1], _mm512_set1_epi32(*(const int32_t *)(yb +  4)));
+                    isum [iy] = _mm512_dpbusd_epi32(isum [iy], qx[2], _mm512_set1_epi32(*(const int32_t *)(yb +  8)));
+                    isum2[iy] = _mm512_dpbusd_epi32(isum2[iy], qx[3], _mm512_set1_epi32(*(const int32_t *)(yb + 12)));
                 }
             }
             auto m4 = _mm512_mul_ps(d4, _mm512_set1_ps(-128.f));
             for (int iy = 0; iy < nrc_y; ++iy) {
                 auto d4y = _mm512_mul_ps(d4, _mm512_set1_ps(q8.scale(iy, ibl)));
-                acc[iy] = _mm512_fmadd_ps(d4y, _mm512_cvtepi32_ps(isum[iy]), acc[iy]);
+                acc[iy] = _mm512_fmadd_ps(d4y, _mm512_cvtepi32_ps(_mm512_add_epi32(isum[iy], isum2[iy])), acc[iy]);
                 acc[iy] = _mm512_fmadd_ps(m4,  _mm512_set1_ps(q8.y[iy][ibl].sum), acc[iy]);
-                isum[iy] = _mm512_setzero_si512();
+                isum[iy] = isum2[iy] = _mm512_setzero_si512();
             }
         }
         for (int iy = 0; iy < nrc_y; ++iy) {

--- a/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
+++ b/ggml/src/iqk/iqk_gemm_legacy_quants.cpp
@@ -1782,22 +1782,17 @@ static void mul_mat_q6_0_r4_q8_2(int n, const void * vx, size_t bx, const DataIn
 
 #ifdef HAVE_FANCY_SIMD
 inline __m512i qx_r8_q8_dot_product(const __m512i * qx, const int8_t * y) {
-    auto y4l = _mm_loadu_si128((const __m128i*)y+0);
-    auto y4h = _mm_loadu_si128((const __m128i*)y+1);
-    auto y8l = MM256_SET1_M128I(y4l);
-    auto y8h = MM256_SET1_M128I(y4h);
-    auto yl  = _mm512_inserti32x8(_mm512_castsi256_si512(y8l), y8l, 1);
-    auto yh  = _mm512_inserti32x8(_mm512_castsi256_si512(y8h), y8h, 1);
-    auto sumi = _mm512_setzero_si512();
-    sumi = _mm512_dpbusd_epi32(sumi, qx[0], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0x00)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[1], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0x55)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[2], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0xaa)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[3], _mm512_shuffle_epi32(yl, _MM_PERM_ENUM(0xff)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[4], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0x00)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[5], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0x55)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[6], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0xaa)));
-    sumi = _mm512_dpbusd_epi32(sumi, qx[7], _mm512_shuffle_epi32(yh, _MM_PERM_ENUM(0xff)));
-    return sumi;
+    auto s0 = _mm512_setzero_si512();
+    auto s1 = _mm512_setzero_si512();
+    s0 = _mm512_dpbusd_epi32(s0, qx[0], _mm512_set1_epi32(*(const int32_t *)(y +  0)));
+    s1 = _mm512_dpbusd_epi32(s1, qx[1], _mm512_set1_epi32(*(const int32_t *)(y +  4)));
+    s0 = _mm512_dpbusd_epi32(s0, qx[2], _mm512_set1_epi32(*(const int32_t *)(y +  8)));
+    s1 = _mm512_dpbusd_epi32(s1, qx[3], _mm512_set1_epi32(*(const int32_t *)(y + 12)));
+    s0 = _mm512_dpbusd_epi32(s0, qx[4], _mm512_set1_epi32(*(const int32_t *)(y + 16)));
+    s1 = _mm512_dpbusd_epi32(s1, qx[5], _mm512_set1_epi32(*(const int32_t *)(y + 20)));
+    s0 = _mm512_dpbusd_epi32(s0, qx[6], _mm512_set1_epi32(*(const int32_t *)(y + 24)));
+    s1 = _mm512_dpbusd_epi32(s1, qx[7], _mm512_set1_epi32(*(const int32_t *)(y + 28)));
+    return _mm512_add_epi32(s0, s1);
 }
 inline __m256i qx_r8_q8_dot_product(const __m256i * qx, const int8_t * y) {
     auto y4l = _mm_loadu_si128((const __m128i*)y+0);
@@ -1876,6 +1871,7 @@ static void mul_mat_q8_0_r8_q8_2(int n, const void * vx, size_t bx, const DataIn
                                                                           _mm256_loadu_si256((const __m256i *)q8h[4*ib4+k].qs+j), 1);
                         qx[j] = _mm512_add_epi8(qx[j], _mm512_set1_epi8(127));
                     }
+                    _Pragma("GCC unroll 8")
                     for (int iy = 0; iy < nrc_y; ++iy) {
                         auto sumi = qx_r8_q8_dot_product(qx, q8.y[iy][ib4].qs+32*k);
                         auto dy = _mm512_set1_ps(d8[8*iy+k]);


### PR DESCRIPTION
qx_r8_q8_dot_product: relieve AVX execution port pressure by turning `vpshufd` into `vpbroadcastd` that execute on the load ports. Two independent accumulators to break up a dependency chain. Prevent compiler from rolling the `iy` loop.
mul_mat_q8_k_r16_q8_k: Embedded {1to16} broadcast and two alternating accumulators to break up a dependency chain. Prevent compiler from rolling `ib` loop.

Approx. +25% pp512 for Q8_0 and +35% pp512 for IQ4_XS on Xeon 6240 with LLVM/Clang 22.1.8.


- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
