### PR TITLE
chat template : emit the trailing newline in the ChatGLM4 generation prompt

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -12807,7 +12807,7 @@ static int32_t llama_chat_apply_template_internal(
             ss << "<|" << role << "|>" << "\n" << message->content;
         }
         if (add_ass) {
-            ss << "<|assistant|>";
+            ss << "<|assistant|>" << "\n";
         }
     } else if (tmpl == LLM_CHAT_TEMPLATE_MINICPM) {
         // MiniCPM-3B-OpenHermes-2.5-v2-GGUF


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

### What

The built-in `chatglm4` branch ends the generation prompt with `<|assistant|>`.
The model's jinja template and the expected output in the test both end it with
`<|assistant|>\n`:

```
tests/test-chat-template.cpp:574   ...{% if add_generation_prompt %}<|assistant|>\n{% endif %}
tests/test-chat-template.cpp:575   "...Another question<|assistant|>\n"
src/llama.cpp:12810                ss << "<|assistant|>";
```

### Why it diverged

The expected string was updated to match the jinja template in `ab1d7407`
(2026-03-09, "common : introduce composable PEG parser combinators ... and new
jinja template engine", #1369). The built-in path was not — it still carries the
form inherited from mainline in `0ceeb117` (2024-07-27). `test-chat-template`
has been failing on that case since.

The adjacent `GLMEdge` case is the useful contrast: its template ends with
`<|assistant|>` and no newline, its expected output likewise, and it is
unaffected by this change.

### Verification

Built and run on Windows / MSVC 19.41, CPU-only Release:

- before: `test-chat-template` aborts on the ChatGLM4 case
  (`Assertion failed: output == test_case.expected_output`, line 729; the
  `0xC0000409` exit code is MSVC's `abort()` via `__fastfail`, not a stack
  overrun);
- after: the ChatGLM4 case passes;
- full suite unchanged at 27/31 — no regression.

### Not fixed here

The test aborts on the first mismatch, so fixing this one reveals the next:
`GLMEdge`. That template contains `<|assistant|>` and `<|user|>` but not
`[gMASK]<sop>`, so `llama_chat_detect_template` resolves it to
`LLM_CHAT_TEMPLATE_FALCON_3` and it renders in Falcon-3's role-per-line shape.
There is no GLMEdge template implementation in `src/` at all. That is a
separate defect of a different size, and cases after `GLMEdge` remain
unverified for the same reason. I have deliberately kept this PR to the
one-line change; happy to open a second one for GLMEdge if it is wanted.
