### PR TITLE
test-jinja : write the python reference output as raw UTF-8 bytes

### DIFF
--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -2020,7 +2020,10 @@ env.globals["raise_exception"] = raise_exception
 
 template = env.from_string(tmpl)
 result = template.render(**vars_json)
-print(result, end='')
+# Write raw UTF-8 bytes rather than print(): on Windows sys.stdout is a text
+# stream, so print() would translate every \n into \r\n and also encode with
+# the console code page. Both corrupt the comparison against the C++ engine.
+sys.stdout.buffer.write(result.encode('utf-8'))
 )";
 
 static void test_template_py(testing & t, const std::string & name, const std::string & tmpl, const json & vars, const std::string & expect) {


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

### What

`test-jinja -py` renders each template twice — once with the C++ engine, once by
shelling out to python/jinja2 — and compares the strings. The python side ended
with:

```python
print(result, end='')
```

On Windows `sys.stdout` is a text stream, so every `\n` in the rendered result
became `\r\n` before the C++ side read it back. Any template whose output spans
more than one line compared unequal.

### Evidence

The failures had exactly one shape:

```
Template: "{% if true %}\nhello\n{% endif %}\n"
Expected: "hello\n"
Python  : "hello\r\n"

Expected: "{\n  \"a\": 1,\n  \"b\": [\n    1,\n    2\n  ]\n}"
Python  : "{\r\n  \"a\": 1,\r\n  \"b\": [\r\n    1,\r\n    2\r\n  ]\r\n}"
```

Checked mechanically rather than by eye: of the mismatches carrying both
strings, **7 of 7 differed only by `\r`, 0 differed in any other way**. The
affected cases were `trim_blocks`, `lstrip_blocks`, `tojson` with `indent`, and
all seven `indent` filter cases — every one multi-line.

Writing the bytes also pins the encoding. `print()` on Windows encodes with the
console code page, which corrupts non-ASCII template output; this suite has
plenty of it.

### Result

MSVC 19.41, python 3.14.2, jinja2 3.1.6:

```
before:  265 assertions, 265 failures    (jinja2 not installed)
then  :  265 assertions,  12 failures    (jinja2 installed, CRLF remaining)
after :  265 assertions,   0 failures
```

So the C++ engine already agreed with python/jinja2 on every case in the suite —
that agreement was simply unobservable on Windows. Full `ctest` goes 27/31 →
28/31 here.

### Note for reproducing

The test needs `jinja2` installed. Without it all 265 assertions fail with
`ModuleNotFoundError` and mask this defect completely, which is probably why it
went unnoticed.
