### PR TITLE
chat template : add the GLMEdge template, ported from llama.cpp

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -221,6 +221,7 @@ enum llm_chat_template {
     LLM_CHAT_TEMPLATE_LLAMA_3,
     LLM_CHAT_TEMPLATE_CHATGLM_3,
     LLM_CHAT_TEMPLATE_CHATGLM_4,
+    LLM_CHAT_TEMPLATE_GLMEDGE,
     LLM_CHAT_TEMPLATE_MINICPM,
     LLM_CHAT_TEMPLATE_EXAONE_3,
     LLM_CHAT_TEMPLATE_RWKV_WORLD,
@@ -269,6 +270,7 @@ static const std::map<std::string, llm_chat_template> LLM_CHAT_TEMPLATES = {
     { "llama3",            LLM_CHAT_TEMPLATE_LLAMA_3           },
     { "chatglm3",          LLM_CHAT_TEMPLATE_CHATGLM_3         },
     { "chatglm4",          LLM_CHAT_TEMPLATE_CHATGLM_4         },
+    { "glmedge",           LLM_CHAT_TEMPLATE_GLMEDGE           },
     { "minicpm",           LLM_CHAT_TEMPLATE_MINICPM           },
     { "exaone3",           LLM_CHAT_TEMPLATE_EXAONE_3          },
     { "rwkv-world",        LLM_CHAT_TEMPLATE_RWKV_WORLD        },
@@ -12467,7 +12469,7 @@ static llm_chat_template llama_chat_detect_template(const std::string & tmpl) {
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|end|>")) {
         return LLM_CHAT_TEMPLATE_PHI_3;
     } else if (tmpl_contains("<|assistant|>") && tmpl_contains("<|user|>")) {
-        return LLM_CHAT_TEMPLATE_FALCON_3;
+        return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
     } else if (tmpl == "falcon_e" && (tmpl_contains("assistant") && tmpl_contains("user"))) {
         return LLM_CHAT_TEMPLATE_FALCON_E;
     } else if (tmpl_contains("<|user|>") && tmpl_contains("<|endoftext|>")) {
@@ -12802,6 +12804,14 @@ static int32_t llama_chat_apply_template_internal(
         }
     } else if (tmpl == LLM_CHAT_TEMPLATE_CHATGLM_4) {
         ss << "[gMASK]" << "<sop>";
+        for (auto message : chat) {
+            std::string role(message->role);
+            ss << "<|" << role << "|>" << "\n" << message->content;
+        }
+        if (add_ass) {
+            ss << "<|assistant|>";
+        }
+    } else if (tmpl == LLM_CHAT_TEMPLATE_GLMEDGE) {
         for (auto message : chat) {
             std::string role(message->role);
             ss << "<|" << role << "|>" << "\n" << message->content;


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

### What

`tests/test-chat-template.cpp` has a `GLMEdge` case, but there is no GLMEdge
template implementation in `src/` — `git log -S GLMEDGE --all -- src` returns
nothing. Its template contains `<|assistant|>` and `<|user|>` but not
`[gMASK]<sop>`, so `llama_chat_detect_template` falls through to
`LLM_CHAT_TEMPLATE_FALCON_3` and renders it in Falcon-3's role-per-line shape.

### Ported, not invented

This is `ggml-org/llama.cpp` `src/llama-chat.cpp`, which has carried the
template for a while. Four hunks:

- enum value beside `LLM_CHAT_TEMPLATE_CHATGLM_4`;
- `{ "glmedge", ... }` in the name map;
- detection — at the site that returned `FALCON_3` unconditionally:

  ```cpp
  return tmpl_contains("</s>") ? LLM_CHAT_TEMPLATE_FALCON_3 : LLM_CHAT_TEMPLATE_GLMEDGE;
  ```

  Falcon-3 templates carry `</s>`, GLMEdge ones do not. Both satisfy the
  surrounding `<|assistant|>` + `<|user|>` condition, which is why one was
  swallowing the other;
- render — the ChatGLM4 body without the `[gMASK]<sop>` prefix and without a
  trailing newline on the generation prompt.

### Verification

MSVC 19.41, CPU-only Release:

- `test-chat-template` now reaches case **23 of 33**, up from 19;
- the `GLMEdge` case passes, and no previously passing case regressed;
- full `ctest` stays at 28/31.

### Not fixed here

The test aborts on the first mismatch, so this fix reveals the next one:
case 23, `ibm-granite/granite-3.0-8b-instruct`. Cases 24–33 remain unverified
for the same reason. Each needs its own look; I have kept this PR to the port.

Related: #2425 fixes the ChatGLM4 case that used to abort the same test
earlier. Mainline's `chatglm4` branch also ends with `ss << "<|assistant|>\n";`,
which corroborates that change.
