### PR TITLE
cmake : warn when GGML_NATIVE on MSVC leaves AVX-512 extensions unset

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1172,6 +1172,21 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
                 add_compile_definitions($<$<COMPILE_LANGUAGE:C>:__AVX512BF16__>)
                 add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:__AVX512BF16__>)
             endif()
+
+            # MSVC + GGML_NATIVE detects only the base AVX-512 flag (see
+            # ../cmake/FindSIMD.cmake); the extension macros above stay unset, so
+            # HAVE_FANCY_SIMD is not defined and the IQK GEMM kernels for Zen4 /
+            # Sapphire Rapids and later are silently left out of the build.
+            if (GGML_NATIVE AND NOT GGML_AVX512_VNNI)
+                message(WARNING
+                    "GGML_NATIVE enabled AVX-512 for MSVC, but the AVX-512 extension macros "
+                    "are not set: MSVC does not define them, and FindSIMD.cmake detects only "
+                    "the base AVX-512 flag. __AVX512VNNI__ therefore stays undefined, "
+                    "HAVE_FANCY_SIMD is off, and the IQK GEMM kernels for Zen4 / Sapphire "
+                    "Rapids and later are not compiled. If this CPU supports AVX512-VNNI, "
+                    "reconfigure with -DGGML_AVX512_VNNI=ON -DGGML_AVX512_VBMI=ON "
+                    "-DGGML_AVX512_BF16=ON (see docs/build.md and scripts/build-zen.bat).")
+            endif()
         elseif (GGML_AVX2)
             list(APPEND ARCH_FLAGS /arch:AVX2)
             if (GGML_AVXVNNI)


### PR DESCRIPTION
On MSVC, `-DGGML_NATIVE=ON` produces a build with `/arch:AVX512` but **without**
the IQK GEMM kernels for Zen4 / Sapphire Rapids, and nothing says so.

## Mechanism

`ggml/cmake/FindSIMD.cmake` sets only the base flag:

```cmake
check_sse("AVX512" " ;/arch:AVX512")
if (NOT ${AVX512_FOUND})
    set(GGML_AVX512 OFF)
else()
    set(GGML_AVX512 ON)
endif()
```

It never touches `GGML_AVX512_VBMI` / `_VNNI` / `_BF16`. Those are exactly the
options that `ggml/src/CMakeLists.txt` uses to define the extension macros
manually — as its own comment explains, because "MSVC has no compile-time flags
enabling specific AVX512 extensions, neither it defines the macros".

So `GGML_NATIVE=ON` on MSVC leaves `__AVX512VNNI__` undefined, and
`HAVE_FANCY_SIMD` (`ggml/src/iqk/iqk_config.h`) requires it:

```c
#if defined(__AVX512F__) && defined(__AVX512VNNI__) && defined(__AVX512VL__) \
 && defined(__AVX512BW__) && defined(__AVX512DQ__)
    #define HAVE_FANCY_SIMD
#endif
```

The result is that 273 code sites across 13 files in `ggml/src/iqk/` compile
their fallback branch — every quantized GEMM family plus the flash-attention
templates.

GCC and Clang are unaffected: `-march=native` defines the macros from the actual
CPU.

## Why it goes unnoticed

- no error, no warning: a missing `#define` just selects a different `#if` branch;
- `CMakeCache.txt` is actively misleading — it reports `GGML_AVX512:BOOL=OFF`
  while `/arch:AVX512` is in the compile flags, because `FindSIMD.cmake` sets a
  directory variable rather than the cache entry;
- the only honest signal is the `HAVE_FANCY_SIMD is / is NOT defined` line
  printed at model load, and nobody reads it during a build.

I hit this on a Ryzen 9 7950X: a build that configured cleanly and ran fine had
no fancy-SIMD kernels at all.

## This change

Warns at configure time when `GGML_NATIVE` enabled AVX-512 under MSVC but
`GGML_AVX512_VNNI` is off. It only warns — no compiled behaviour changes, so
nobody's existing build silently acquires different characteristics.

The condition is deliberately narrow: it requires `GGML_NATIVE`. A user who
passes `-DGGML_AVX512=ON` without VNNI made an explicit choice; a user who asks
for "native" reasonably expects the build to match their CPU.

## Verification

Both cases configured on Windows, MSVC 19.41, Ninja, Ryzen 9 7950X:

- `-DGGML_NATIVE=ON` alone → `CMake Warning at ggml/src/CMakeLists.txt:1181`
- `-DGGML_NATIVE=ON -DGGML_AVX512=ON -DGGML_AVX512_VBMI=ON -DGGML_AVX512_VNNI=ON -DGGML_AVX512_BF16=ON`
  → no warning

Both complete `Generating done`.

For reference, the flags the warning recommends are the ones already in
`scripts/build-zen.bat` (#1734) and `docs/build.md` (#1733).

## Origin

This is not an ik_llama.cpp regression. `ggml/cmake/FindSIMD.cmake` here is
**byte-identical** to the file currently in `ggml-org/llama.cpp` at
`ggml/src/ggml-cpu/cmake/FindSIMD.cmake`, including the AVX-512 block above,
and neither copy mentions VNNI, VBMI or BF16 anywhere. Both projects call it
from the same `if (MSVC) / if (GGML_NATIVE)` position and carry the same
"MSVC ... Do it manually" comment next to the manual macro definitions.

So the cause is shared with upstream llama.cpp and still live there. What
differs is the consequence: in ik_llama.cpp the missing `__AVX512VNNI__`
switches off `HAVE_FANCY_SIMD`, which gates 273 sites across 13 files in
`ggml/src/iqk/` — every quantized GEMM family plus the flash-attention
templates. I have not assessed the equivalent impact on llama.cpp's own
kernels, so this PR only claims the cause is shared, not the severity.

The warning added here is local to this repository and does not depend on
anything changing upstream.
