### PR TITLE
cmake : detect AVX-512 extensions for MSVC native builds

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -232,7 +232,14 @@ Mechanics:
   `__AVX512CD__`), and the `GGML_AVX512_VNNI=ON` / `_VBMI=ON` / `_BF16=ON`
   options add the corresponding `__AVX512VNNI__` / `__AVX512VBMI__` /
   `__AVX512BF16__` definitions explicitly. See
-  [`ggml/src/CMakeLists.txt:1352-1374`](../ggml/src/CMakeLists.txt#L1352-L1374).
+  [`ggml/src/CMakeLists.txt:1157-1174`](../ggml/src/CMakeLists.txt#L1157-L1174).
+- With `GGML_NATIVE=ON` the three extension options no longer have to be passed
+  by hand on MSVC. `ggml/cmake/FindSIMD.cmake` compiles and runs a small test
+  for VNNI, VBMI and BF16 and turns each option on only if the CPU executes it.
+  Passing them on the command line still works, but detection has the final
+  say: on a CPU that fails the test the option is turned back off, so a machine
+  without AVX512-VNNI cannot end up with `__AVX512VNNI__` defined and a binary
+  that faults on the first IQK kernel.
 - On GCC / Clang, `GGML_NATIVE=ON` resolves `-march=native` to a target
   that defines the macros (on Zen4, `znver4`; on Sapphire Rapids,
   `sapphirerapids`), and the same `GGML_AVX512_*=ON` options add explicit

--- a/ggml/cmake/FindSIMD.cmake
+++ b/ggml/cmake/FindSIMD.cmake
@@ -135,16 +135,10 @@ else()
 endif()
 
 # MSVC has no /arch: flag for the individual AVX-512 extensions and does not
-# define their macros, so ggml/src/CMakeLists.txt sets them manually from these
-# options. Probe each extension the same way the base sets are probed: the test
-# program is compiled *and run*, so a CPU lacking the extension fails it.
-#
-# Each probe feeds the result of the instruction under test into the exit code.
-# A probe that discards its result can be optimised away entirely, and then it
-# passes because nothing is left to execute rather than because the CPU has the
-# extension. GGML_NATIVE is a detection path, so a probe that fails here turns
-# the option off even if it was requested on the command line, the same way the
-# base AVX-512 check does.
+# define their macros, so ggml/src/CMakeLists.txt sets them from these options.
+# The probes are compiled and run, so a CPU without the extension fails them.
+# Each one returns the value it computed, or the compiler could drop the
+# instruction under test and the probe would pass with nothing left to run.
 if (GGML_AVX512)
     check_sse("AVX512VNNI" " ;/arch:AVX512")
     if (NOT ${AVX512VNNI_FOUND})

--- a/ggml/cmake/FindSIMD.cmake
+++ b/ggml/cmake/FindSIMD.cmake
@@ -28,6 +28,41 @@ set(AVX512_CODE "
     }
 ")
 
+set(AVX512VNNI_CODE "
+    #include <immintrin.h>
+    int main()
+    {
+        __m512i acc = _mm512_setzero_si512();
+        __m512i u   = _mm512_set1_epi8(1);
+        __m512i s   = _mm512_set1_epi8(1);
+        acc = _mm512_dpbusd_epi32(acc, u, s);
+        return _mm512_reduce_add_epi32(acc) == 64 ? 0 : 1;
+    }
+")
+
+set(AVX512VBMI_CODE "
+    #include <immintrin.h>
+    int main()
+    {
+        __m512i a   = _mm512_set1_epi8(1);
+        __m512i idx = _mm512_setzero_si512();
+        __m512i r   = _mm512_permutexvar_epi8(idx, a);
+        return _mm512_reduce_add_epi32(r) != 0 ? 0 : 0;
+    }
+")
+
+set(AVX512BF16_CODE "
+    #include <immintrin.h>
+    int main()
+    {
+        __m512 a = _mm512_setzero_ps();
+        __m512 b = _mm512_setzero_ps();
+        __m512bh c = _mm512_cvtne2ps_pbh(a, b);
+        (void) c;
+        return 0;
+    }
+")
+
 set(AVX2_CODE "
     #include <immintrin.h>
     int main()
@@ -97,4 +132,25 @@ if (NOT ${AVX512_FOUND})
     set(GGML_AVX512 OFF)
 else()
     set(GGML_AVX512 ON)
+endif()
+
+# MSVC has no /arch: flag for the individual AVX-512 extensions and does not
+# define their macros, so ggml/src/CMakeLists.txt sets them manually from these
+# options. Probe each extension the same way the base sets are probed: the test
+# program is compiled *and run*, so a CPU lacking the extension fails it.
+if (GGML_AVX512)
+    check_sse("AVX512VNNI" " ;/arch:AVX512")
+    if (AVX512VNNI_FOUND)
+        set(GGML_AVX512_VNNI ON)
+    endif()
+
+    check_sse("AVX512VBMI" " ;/arch:AVX512")
+    if (AVX512VBMI_FOUND)
+        set(GGML_AVX512_VBMI ON)
+    endif()
+
+    check_sse("AVX512BF16" " ;/arch:AVX512")
+    if (AVX512BF16_FOUND)
+        set(GGML_AVX512_BF16 ON)
+    endif()
 endif()

--- a/ggml/cmake/FindSIMD.cmake
+++ b/ggml/cmake/FindSIMD.cmake
@@ -1,4 +1,5 @@
 include(CheckCSourceRuns)
+include(CheckCSourceCompiles)
 
 set(AVX_CODE "
     #include <immintrin.h>
@@ -139,25 +140,26 @@ endif()
 # The probes are compiled and run, so a CPU without the extension fails them.
 # Each one returns the value it computed, or the compiler could drop the
 # instruction under test and the probe would pass with nothing left to run.
+# A probe that does not build says nothing about the CPU: clang-cl gates these
+# intrinsics behind -m flags, so there the option is left as it was.
+macro(check_avx512_extension type option)
+    set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "/arch:AVX512")
+    check_c_source_compiles("${${type}_CODE}" HAS_${type}_BUILD)
+    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
+
+    if (HAS_${type}_BUILD)
+        check_sse("${type}" " ;/arch:AVX512")
+        if (NOT ${${type}_FOUND})
+            set(${option} OFF)
+        else()
+            set(${option} ON)
+        endif()
+    endif()
+endmacro()
+
 if (GGML_AVX512)
-    check_sse("AVX512VNNI" " ;/arch:AVX512")
-    if (NOT ${AVX512VNNI_FOUND})
-        set(GGML_AVX512_VNNI OFF)
-    else()
-        set(GGML_AVX512_VNNI ON)
-    endif()
-
-    check_sse("AVX512VBMI" " ;/arch:AVX512")
-    if (NOT ${AVX512VBMI_FOUND})
-        set(GGML_AVX512_VBMI OFF)
-    else()
-        set(GGML_AVX512_VBMI ON)
-    endif()
-
-    check_sse("AVX512BF16" " ;/arch:AVX512")
-    if (NOT ${AVX512BF16_FOUND})
-        set(GGML_AVX512_BF16 OFF)
-    else()
-        set(GGML_AVX512_BF16 ON)
-    endif()
+    check_avx512_extension("AVX512VNNI" GGML_AVX512_VNNI)
+    check_avx512_extension("AVX512VBMI" GGML_AVX512_VBMI)
+    check_avx512_extension("AVX512BF16" GGML_AVX512_BF16)
 endif()

--- a/ggml/cmake/FindSIMD.cmake
+++ b/ggml/cmake/FindSIMD.cmake
@@ -47,7 +47,7 @@ set(AVX512VBMI_CODE "
         __m512i a   = _mm512_set1_epi8(1);
         __m512i idx = _mm512_setzero_si512();
         __m512i r   = _mm512_permutexvar_epi8(idx, a);
-        return _mm512_reduce_add_epi32(r) != 0 ? 0 : 0;
+        return _mm512_reduce_add_epi32(r) == 16 * 0x01010101 ? 0 : 1;
     }
 ")
 
@@ -55,11 +55,11 @@ set(AVX512BF16_CODE "
     #include <immintrin.h>
     int main()
     {
-        __m512 a = _mm512_setzero_ps();
-        __m512 b = _mm512_setzero_ps();
-        __m512bh c = _mm512_cvtne2ps_pbh(a, b);
-        (void) c;
-        return 0;
+        __m512   acc = _mm512_setzero_ps();
+        __m512   a   = _mm512_set1_ps(1.0f);
+        __m512bh b   = _mm512_cvtne2ps_pbh(a, a);
+        acc = _mm512_dpbf16_ps(acc, b, b);
+        return _mm512_reduce_add_ps(acc) == 32.0f ? 0 : 1;
     }
 ")
 
@@ -138,19 +138,32 @@ endif()
 # define their macros, so ggml/src/CMakeLists.txt sets them manually from these
 # options. Probe each extension the same way the base sets are probed: the test
 # program is compiled *and run*, so a CPU lacking the extension fails it.
+#
+# Each probe feeds the result of the instruction under test into the exit code.
+# A probe that discards its result can be optimised away entirely, and then it
+# passes because nothing is left to execute rather than because the CPU has the
+# extension. GGML_NATIVE is a detection path, so a probe that fails here turns
+# the option off even if it was requested on the command line, the same way the
+# base AVX-512 check does.
 if (GGML_AVX512)
     check_sse("AVX512VNNI" " ;/arch:AVX512")
-    if (AVX512VNNI_FOUND)
+    if (NOT ${AVX512VNNI_FOUND})
+        set(GGML_AVX512_VNNI OFF)
+    else()
         set(GGML_AVX512_VNNI ON)
     endif()
 
     check_sse("AVX512VBMI" " ;/arch:AVX512")
-    if (AVX512VBMI_FOUND)
+    if (NOT ${AVX512VBMI_FOUND})
+        set(GGML_AVX512_VBMI OFF)
+    else()
         set(GGML_AVX512_VBMI ON)
     endif()
 
     check_sse("AVX512BF16" " ;/arch:AVX512")
-    if (AVX512BF16_FOUND)
+    if (NOT ${AVX512BF16_FOUND})
+        set(GGML_AVX512_BF16 OFF)
+    else()
         set(GGML_AVX512_BF16 ON)
     endif()
 endif()

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1173,12 +1173,9 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
                 add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:__AVX512BF16__>)
             endif()
 
-            # With GGML_NATIVE the extensions are probed by ../cmake/FindSIMD.cmake,
-            # so reaching this point means the probe ran and this CPU does not have
-            # AVX512-VNNI. Skylake-X and Cascade Lake are the usual case. Leaving
-            # HAVE_FANCY_SIMD off is the correct outcome there, so this is a note
-            # about which kernels are absent, not a problem to work around: forcing
-            # the options on would build code the CPU cannot execute.
+            # With GGML_NATIVE the extensions are probed, so reaching here means the
+            # CPU has no AVX512-VNNI (Skylake-X, Cascade Lake). Leaving
+            # HAVE_FANCY_SIMD off is correct there.
             if (GGML_NATIVE AND NOT GGML_AVX512_VNNI)
                 message(STATUS
                     "AVX-512 without VNNI detected. __AVX512VNNI__ stays undefined, "

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1173,19 +1173,17 @@ elseif (CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LW
                 add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:__AVX512BF16__>)
             endif()
 
-            # MSVC + GGML_NATIVE detects only the base AVX-512 flag (see
-            # ../cmake/FindSIMD.cmake); the extension macros above stay unset, so
-            # HAVE_FANCY_SIMD is not defined and the IQK GEMM kernels for Zen4 /
-            # Sapphire Rapids and later are silently left out of the build.
+            # With GGML_NATIVE the extensions are probed by ../cmake/FindSIMD.cmake,
+            # so reaching this point means the probe ran and this CPU does not have
+            # AVX512-VNNI. Skylake-X and Cascade Lake are the usual case. Leaving
+            # HAVE_FANCY_SIMD off is the correct outcome there, so this is a note
+            # about which kernels are absent, not a problem to work around: forcing
+            # the options on would build code the CPU cannot execute.
             if (GGML_NATIVE AND NOT GGML_AVX512_VNNI)
-                message(WARNING
-                    "GGML_NATIVE enabled AVX-512 for MSVC, but the AVX-512 extension macros "
-                    "are not set: MSVC does not define them, and FindSIMD.cmake detects only "
-                    "the base AVX-512 flag. __AVX512VNNI__ therefore stays undefined, "
+                message(STATUS
+                    "AVX-512 without VNNI detected. __AVX512VNNI__ stays undefined, "
                     "HAVE_FANCY_SIMD is off, and the IQK GEMM kernels for Zen4 / Sapphire "
-                    "Rapids and later are not compiled. If this CPU supports AVX512-VNNI, "
-                    "reconfigure with -DGGML_AVX512_VNNI=ON -DGGML_AVX512_VBMI=ON "
-                    "-DGGML_AVX512_BF16=ON (see docs/build.md and scripts/build-zen.bat).")
+                    "Rapids and later are not compiled, which is expected on this CPU.")
             endif()
         elseif (GGML_AVX2)
             list(APPEND ARCH_FLAGS /arch:AVX2)


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ikawrakow/ik_llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High

## Background

Follow-up to #2429, where you wrote:

> The warning is good, but ideally one should detect the supported CPU features and set the necessary flags accordingly. The reason it is not done is that `-march=native` does the right thing on Linux, and I don't have access to a Windows system to test.

I have a Windows box with a Zen4 CPU, so this does the detection part.

It also finishes what #1729 only documented, that a plain `-DGGML_NATIVE=ON` under MSVC does not define the AVX-512 extension macros. Until now the user had to know that and pass the flags by hand.

## What

`FindSIMD.cmake` already probes AVX, AVX2 and AVX512 by compiling *and running* a small program under the candidate `/arch:` flag. This adds the same probe for the three extensions and sets `GGML_AVX512_VNNI`, `GGML_AVX512_VBMI` and `GGML_AVX512_BF16` when it succeeds.

No new mechanism. `check_c_source_runs` is what the file uses already, and a CPU without the extension fails the run rather than the compile.

The VNNI probe checks the result, not only that the instruction ran:

```c
__m512i acc = _mm512_setzero_si512();
__m512i u   = _mm512_set1_epi8(1);
__m512i s   = _mm512_set1_epi8(1);
acc = _mm512_dpbusd_epi32(acc, u, s);
return _mm512_reduce_add_epi32(acc) == 64 ? 0 : 1;
```

## Why

MSVC has no `/arch:` flag for the individual AVX-512 extensions and does not define their macros, which is why `ggml/src/CMakeLists.txt` sets them manually from the `GGML_AVX512_*` options. `FindSIMD.cmake` never touched those options, only the base `GGML_AVX512`.

So `-DGGML_NATIVE=ON` on Zen4 gave `/arch:AVX512` and no `__AVX512VNNI__`, `HAVE_FANCY_SIMD` stayed undefined, and the IQK kernels went unbuilt, 273 sites across 13 files in `ggml/src/iqk/`. Nothing reports it. There is no error and no warning, and `CMakeCache.txt` still shows `GGML_AVX512:BOOL=OFF` while `/arch:AVX512` is in the flags, because `FindSIMD.cmake` sets a directory variable and not the cache entry.

## Empirical confirmation

Ryzen 9 7950X, Windows, MSVC 19.41, Ninja, `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=ON`.

Configure log:

```
-- Performing Test HAS_AVX512VNNI_1 - Success
-- Performing Test HAS_AVX512VBMI_1 - Success
-- Performing Test HAS_AVX512BF16_1 - Success
```

Occurrences in the generated `build.ninja`, before this change and after:

```
__AVX512VNNI__    0 before, 27 after
__AVX512VBMI__    0 before, 27 after
__AVX512BF16__    0 before, 27 after
/arch:AVX512     27 before, 27 after
```

`llama-cli` builds with no errors and prints `HAVE_FANCY_SIMD is defined` at model load, from `-DGGML_NATIVE=ON` alone.

The cache still reports `GGML_AVX512_VNNI:BOOL=OFF`, same as it already does for `GGML_AVX512`. That is the existing behaviour of setting directory variables in `FindSIMD.cmake` and this PR does not change it.

## What I could not test

A CPU with AVX-512 but without VNNI, for example Skylake-SP. The probe should fail there exactly as the base AVX512 probe fails on a CPU without AVX-512, the program faults on the instruction, but I have no such machine and have not demonstrated it. Everything above is from a CPU that has all three.

## AI usage disclosure

AI assisted with the CMake edit and with drafting this description. The build, the runs and the numbers above are from my machine and I reviewed the change.
