### PR TITLE
server: exclude generation-span checkpoints for DSV4

### DIFF
--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3643,6 +3643,13 @@ void server_context::create_checkpoint_at_interval(server_slot & slot, checkpoin
     if (!this->params_base.do_checkpoint) {
         return;
     }
+    if (origin != CHECKPOINT_ORIGIN_FEED &&
+            (llama_model_is_deepseek4(model) || llama_model_is_openpangu(model))) {
+        // DSV4/openPangu exclude generation-span checkpoints (see create_checkpoint);
+        // bail before the interval check so the decoder path does not re-enter
+        // here on every token once the interval is reached
+        return;
+    }
     if (this->params_base.ctx_checkpoints_interval <= 0) {
         return;
     }

--- a/examples/server/server-context.cpp
+++ b/examples/server/server-context.cpp
@@ -3639,7 +3639,7 @@ static bool verify_restored_checkpoint(
     return true;
 }
 
-void server_context::create_checkpoint_at_interval(server_slot & slot) {
+void server_context::create_checkpoint_at_interval(server_slot & slot, checkpoint_origin origin) {
     if (!this->params_base.do_checkpoint) {
         return;
     }
@@ -3648,7 +3648,7 @@ void server_context::create_checkpoint_at_interval(server_slot & slot) {
     }
     auto pos = llama_kv_cache_seq_pos_max(slot.ctx, slot.id);
     if (slot.checkpoint_pos + this->params_base.ctx_checkpoints_interval <= pos) {
-        bool created = create_checkpoint(slot);
+        bool created = create_checkpoint(slot, origin);
         if (created) {
             slot.checkpoint_pos = pos;
         }
@@ -3719,6 +3719,10 @@ void server_context::apply_checkpoint(server_slot & slot) {
                     }
 
                     slot.checkpoint_pos = it->pos_max;
+
+                    // Recompute the feed alignment after a restore so checkpoints
+                    // taken during the re-prefill record true prompt coordinates.
+                    slot.n_past_offset = slot.n_past_prompt - slot.n_past;
 
                     SLT_WRN(slot, "restored context checkpoint took  %.2f ms (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", (ggml_time_us() - t_start) / 1000.0, it->pos_min, it->pos_max, it->n_tokens, slot.n_past, (float)checkpoint_size / 1024 / 1024);
                 }
@@ -3806,7 +3810,7 @@ static std::list<server_prompt_checkpoint>::iterator evict_checkpoint_by_varianc
     return it;
 }
 
-bool server_context::create_checkpoint(server_slot & slot) {
+bool server_context::create_checkpoint(server_slot & slot, checkpoint_origin origin) {
     bool do_checkpoint = !slot.image_just_processed;
     int32_t pos_min = llama_kv_cache_seq_pos_min(slot.ctx, slot.id);
     const auto pos_max = llama_kv_cache_seq_pos_max(slot.ctx, slot.id);
@@ -3817,6 +3821,16 @@ bool server_context::create_checkpoint(server_slot & slot) {
 
     // no need to create checkpoints that are too close together
     do_checkpoint = do_checkpoint && (slot.server_cached_prompt.checkpoints.empty() || slot.cache_tokens.n_tokens() > slot.server_cached_prompt.checkpoints.back().n_tokens);
+
+    // DSV4/openPangu only: exclude checkpoints spanning generated tokens;
+    // their prompt coordinate is extrapolated, not measured.
+    if (do_checkpoint && origin != CHECKPOINT_ORIGIN_FEED &&
+            (llama_model_is_deepseek4(model) || llama_model_is_openpangu(model))) {
+        SLT_WRN(slot, "not creating generation-span checkpoint (pos_max = %d, n_prompt_tokens = %d, n_past_offset = %d, n_decoded = %d) at %s: prompt coordinate would be a creation-time extrapolation across generated tokens\n",
+            pos_max, slot.n_prompt_tokens, slot.n_past_offset, slot.n_decoded,
+            origin == CHECKPOINT_ORIGIN_RELEASE ? "slot release" : "generation interval");
+        return false;
+    }
 
     if (do_checkpoint) {
         const int64_t t_start = ggml_time_us();
@@ -4409,7 +4423,7 @@ bool server_context::accept_special_token(const server_slot& slot, const  llama_
 void server_context::release_slot_after_final_response(server_slot & slot) {
     slot.print_timings();
     if (params_base.do_checkpoint) {
-        create_checkpoint(slot);
+        create_checkpoint(slot, CHECKPOINT_ORIGIN_RELEASE);
     }
     slot.release();
     slot.released = true;
@@ -4766,9 +4780,9 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
                 // save checkpoint during prompt processing
                 if (slot.command == SLOT_COMMAND_LOAD_PROMPT) {
                     if (slot.do_checkpoint) {
-                        create_checkpoint(slot);
+                        create_checkpoint(slot, CHECKPOINT_ORIGIN_FEED);
                     } else {
-                        create_checkpoint_at_interval(slot);
+                        create_checkpoint_at_interval(slot, CHECKPOINT_ORIGIN_FEED);
                     }
                 }
                 continue; // continue loop of slots
@@ -4839,13 +4853,13 @@ void server_context::process_batch_tokens(int32_t & n_batch) {
                 metrics.on_prompt_eval(slot);
                 // create checkpoint after prompt processing ends
                 if (params_base.ctx_checkpoints_tolerance<=0 && params_base.do_checkpoint) {
-                    create_checkpoint(slot);
+                    create_checkpoint(slot, CHECKPOINT_ORIGIN_FEED);
                 }
             }
 
             // create checkpoint during generation
             if (slot.n_decoded > 1) {
-                create_checkpoint_at_interval(slot);
+                create_checkpoint_at_interval(slot, CHECKPOINT_ORIGIN_GENERATION);
             }
 
             slot.t_token_generation = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;

--- a/examples/server/server-context.h
+++ b/examples/server/server-context.h
@@ -23,6 +23,12 @@ enum slot_command {
     SLOT_COMMAND_RELEASE,
 };
 
+enum checkpoint_origin {
+    CHECKPOINT_ORIGIN_FEED,       // prompt tokens only; coordinate is measured
+    CHECKPOINT_ORIGIN_GENERATION, // spans generated tokens; coordinate is extrapolated
+    CHECKPOINT_ORIGIN_RELEASE,    // spans generated tokens; coordinate is extrapolated
+};
+
 struct server_slot {
     int id;
     int id_task = -1;
@@ -390,11 +396,11 @@ struct server_context {
     // Re-aggregates all active vectors and updates the model state
     bool apply_control_vectors_internal();
 
-    bool create_checkpoint(server_slot & slot);
+    bool create_checkpoint(server_slot & slot, checkpoint_origin origin);
 
     void apply_checkpoint(server_slot & slot);
 
-    void create_checkpoint_at_interval(server_slot & slot);
+    void create_checkpoint_at_interval(server_slot & slot, checkpoint_origin origin);
 
     void release_slot_after_final_response(server_slot & slot);
 };


### PR DESCRIPTION
Continued from https://github.com/ikawrakow/ik_llama.cpp/pull/2432

## Review complexity

- [x] Low
- [ ] Medium
- [ ] High

Addresses https://github.com/ikawrakow/ik_llama.cpp/issues/2424. Debugged, fixed, tested with the help of GLM-5.3.  

## Summary

On the DeepSeek-V4 (DSV4 / openPangu) backend, a request's KV cache can stop growing. `n_past` freezes at an old value while the conversation keeps getting longer, and within a session's cache it does not recover: the restore loop re-selects the same bad checkpoint each turn. Only a reset of the cached prefix (a restart, a context compaction, or a new session) clears it. This PR fixes the root cause: context checkpoints created at slot release and during generation record a prompt coordinate that is guessed, not measured, and restoring one re-feeds already-cached tokens and pins the prefix matcher.

## Root cause

The server saves context checkpoints, and each checkpoint records `pos_max_prompt`, the position in the *next* prompt that this cache position corresponds to.

For a checkpoint created while the cache holds only prompt tokens, that coordinate is measured: the cache grows as the prompt is processed, so the server knows exactly where each cache position sits in the prompt.

But a checkpoint created at slot release or during generation spans **generated** tokens. The cache holds the model's raw output tokens; that text has not yet been re-serialized through the chat template, so the server doesn't know where this text would sit in the next prompt. So the server assumes:

```
pos_max_prompt = pos_max + n_past_offset
```

where `n_past_offset` is how much further along the prompt is than the cache at the same text. The server measures it by subtracting the cached-position match length from the prompt-position match length when a request is processed (`n_past_offset = n_past_prompt - n_past`).

That offset was correct at the start of the request, when the cache only held prompt text, but the server assumes it's still the same after the model's response. When such a checkpoint is restored, the prompt resume is clamped to the stale coordinate:

```
pos_next_prompt = min(prompt.pos_next(n_past_prompt), pos_max_prompt + 1)
```

The server re-feeds tokens that are already cached, so a span of text ends up duplicated in the cache. The prefix matcher cannot get past that duplicated span, so `n_past` stays frozen.

## Fix

Thread a `checkpoint_origin` (`FEED` / `GENERATION` / `RELEASE`) through `create_checkpoint` and `create_checkpoint_at_interval`, and for DSV4/openPangu exclude only `RELEASE` and `GENERATION` creations.

- `FEED` checkpoints (the prompt-tolerance point, mid-feed intervals, and the prompt-end site) are created while the cache holds only prompt tokens, so their coordinates are measured.
- `RELEASE` and `GENERATION` checkpoints are created while the cache spans generated tokens, so their coordinates are guesses; these are now skipped for DSV4/openPangu.

With every restore falling to a measured feed-time checkpoint, the cache rewinds and recovers.

This fix is consistent with how mainline does it, where checkpoints snapshot only prompt tokens at prefill, so the resume point is limited to never go past where the checkpoint's prompt tokens ended.