### PR TITLE
llama : propagate graph build failure instead of dereferencing null

### DIFF
--- a/src/llama-build-context.cpp
+++ b/src/llama-build-context.cpp
@@ -3053,6 +3053,11 @@ ggml_cgraph * llm_build_context::llama_build_graph(
             GGML_ABORT("fatal error");
     }
 
+    if (result == nullptr) {
+        llm.free();
+        return nullptr;
+    }
+
     result->n_batch = llm.n_tokens;
 
     // add on pooling layer

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -6802,6 +6802,9 @@ static int llama_decode_internal(
 #endif
 
             gf = llm_build_context::llama_build_graph(lctx, u_batch, false);
+            if (gf == nullptr) {
+                return GGML_STATUS_FAILED;
+            }
 #if IK_PRINT_TIMING
             tim2 = ggml_time_us();
             printf("build_graph(...): %d us\n", int(tim2-tim1));
@@ -7280,6 +7283,9 @@ static int llama_encode_internal(
     ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
 
     ggml_cgraph * gf = llm_build_context::llama_build_graph(lctx, batch, false);
+    if (gf == nullptr) {
+        return -1;
+    }
 
     // the output embeddings after the final encoder normalization
     struct ggml_tensor * embd = nullptr;
@@ -7705,6 +7711,9 @@ static int32_t llama_kv_cache_update_internal(struct llama_context & lctx) {
             return GGML_STATUS_FAILED;
         }
         ggml_cgraph * gf = llm_build_context::llama_build_graph(lctx, reserve_batch, true, lctx.cparams.worst_graph_tokens);
+        if (gf == nullptr) {
+            return GGML_STATUS_FAILED;
+        }
 
         // initialize scheduler with the worst-case graph
         lctx.reset_scheduler();
@@ -9089,6 +9098,10 @@ struct llama_context * llama_init_from_model(
                 return nullptr;
             }
             ggml_cgraph * gf = llm_build_context::llama_build_graph(*ctx, reserve_batch, true, cparams.worst_graph_tokens);
+            if (gf == nullptr) {
+                llama_free(ctx);
+                return nullptr;
+            }
 
             // initialize scheduler with the worst-case graph
             bool gf_success = ggml_backend_sched_reserve(ctx->sched, gf);


### PR DESCRIPTION
### What

`llm_build_context::llama_build_graph()` can return `nullptr`. The DSV4 DFlash
path does it deliberately:

```
ggml_cgraph * llm_build_context::build_dflash_dsv4() {
    ...
    if (!lctx.ensure_dflash_kv_cache_tensors((int32_t) ctx_len)) {
        LLAMA_LOG_ERROR("%s: failed to initialize DSV4 DFlash K/V cache\n", __func__);
        return nullptr;
    }
```

`build_dflash()` forwards it, and at the bottom of `llama_build_graph()` the
result is dereferenced unconditionally:

```
    result->n_batch = llm.n_tokens;
```

So when the DFlash K/V cache cannot be allocated — a condition the code
already detects and logs — the process segfaults instead of reporting the
failure.

Three notes on the shape of the fix, since it is slightly wider than the one
line that crashes:

- The early return calls `llm.free()` first, mirroring what the normal path
  already does before returning.
- None of the four `llama_build_graph()` call sites check the return value, so
  returning `nullptr` without checking there would just move the crash into
  `ggml_backend_sched_reserve()`. Each check uses the convention already in
  its own function — `GGML_STATUS_FAILED` in the decode and kv-update paths,
  `llama_free(ctx); return nullptr;` in `llama_init_from_model` (the same
  branch its `llama_prepare_dsv4_graph_inputs` failure takes), and `-1` in
  `llama_encode_internal`, which is what its own earlier early return uses.
- Only the `llama_init_from_model` site is reachable in the reproduction
  below. The other three are the same unchecked pattern on the same
  nullable return; I have not found an input that reaches them.

### Reproducing it

Serving DeepSeek-V4-Flash-0731 with a DSpark draft model, with enough expert
tensors overridden onto CUDA0 that the draft context no longer fits in the
remaining VRAM:

```
llama-server -m DeepSeek-V4-Flash-0731-UD-Q4_K_XL-00001-of-00005.gguf \
  -c 65536 -ngl 99 -ts 2,1 -mla 3 -t 32 -b 2048 -ub 1024 \
  -ot "blk\.[0-8]\.ffn_.*_exps=CUDA0" \
  -ot "blk\.1[1-4]\.ffn_.*_exps=CUDA1" \
  -ot "exps=CPU" \
  -md dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf -ngld 99 --spec-type dspark:n_max=2
```

Before (3bb386eb):

```
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 64.00 MiB on device 0: cudaMalloc failed: out of memory
operator(): failed to allocate dflash_v_ctx_cache buffer for layer 0 (67108864 bytes)
build_dflash_dsv4: failed to initialize DSV4 DFlash K/V cache
Segmentation fault (core dumped)
```

```
Thread 1 "llama-server" received signal SIGSEGV, Segmentation fault.
#0  llm_build_context::llama_build_graph(llama_context&, llama_batch const&, bool, int) () from build/src/libllama.so
#1  llama_init_from_model () from build/src/libllama.so
#2  common_speculative_init(common_params_speculative&, llama_context*) ()
#3  common_speculative_try_init(common_params_speculative&, llama_context*, common_speculative**) ()
#4  server_context::init() ()
#5  main ()
```

After, same command:

```
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 64.00 MiB on device 0: cudaMalloc failed: out of memory
operator(): failed to allocate dflash_v_ctx_cache buffer for layer 0 (67108864 bytes)
build_dflash_dsv4: failed to initialize DSV4 DFlash K/V cache
failed to create draft context
srv          init: failed to initialize speculative decoding context
 ERR [                    main] server init failed | error="speculative decoding context initialization failed"
```

The working path is unchanged. Same machine, same model, `-cd 8192` so the
draft context fits: 27.7 tok/s decode over a 400-token completion, 230 tok/s
prefill over 2810 tokens, draft acceptance 221/355 — the same numbers as
before the patch.

### Testing

- Built with `-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86` on Ubuntu 24.04,
  CUDA 13.0, RTX A6000 + RTX 3090.
- The before/after runs above are the test. `tests/test-backend-ops` does not
  reach this code (no ggml change here), so I did not treat it as coverage.

### Prior art

- No open or closed issue, PR or discussion covers this crash. Queries run
  against this repo: `segfault`, `SIGSEGV`, `null pointer`, `dereference`,
  `nullptr check`, `crash on out of memory` (issues and PRs), and
  `llama_build_graph null`, `segfault dflash`, `nullptr graph crash`
  (discussions, via GraphQL). #1612 is an unrelated open segfault — ngram
  speculation on GLM, mid-run at large context, no DFlash.
- #2366 is the same allocation failing, reached by a draft context inheriting
  a large target context, and was correctly closed as a configuration
  problem (`--ctx-size-draft`). On that reporter's hardware the allocation
  failure surfaced as an error; the crash here is what happens when it
  surfaces inside `build_dflash_dsv4()` instead.
- Same class as #2188 (unchecked value used before it was validated, found by
  a measured repro) and #1857 (a null buffer reaching a backend call), both
  merged.

### Notes

- Related, but not addressed here: when `ggml_backend_sched_reserve()` for the
  DFlash K/V scheduler fails (`src/llama-dflash.cpp:536`), the function returns
  false without setting `cache_reserved_rows`, so the reserve graph is rebuilt
  and retried on every decode step while the server keeps serving with 0% draft
  acceptance. That looks worth a separate change.
- AI disclosure, per CONTRIBUTING: I used Claude Code while investigating this
  and while drafting this description. The reproduction, the gdb backtrace and
  the before/after runs are from my own machine, and I understand and have
  tested the change.

Review Complexity : Low
