### PR TITLE
llama : reject a tensor whose stored size is smaller than its type needs

### DIFF
--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -79,6 +79,23 @@ struct llama_model_loader {
                         offs, data_offset, tensor_offset, ggml_nbytes(tensor), file->size());
                 throw std::runtime_error(format("tensor '%s' data is not within the file bounds, model is corrupted or incomplete", name));
             }
+
+            const int n_gguf_tensors = gguf_get_n_tensors(gguf_ctx);
+            const size_t t_offs = gguf_get_tensor_offset(gguf_ctx, tensor_idx);
+            size_t region = 0;
+            if (tensor_idx + 1 < n_gguf_tensors) {
+                const size_t next_offs = gguf_get_tensor_offset(gguf_ctx, tensor_idx + 1);
+                if (next_offs > t_offs) {
+                    region = next_offs - t_offs;
+                }
+            } else {
+                region = file->size() - offs;
+            }
+            if (region > 0 && ggml_nbytes(tensor) > region) {
+                throw std::runtime_error(format("tensor '%s' is stored in %zu bytes but %s needs %zu, "
+                            "the model is corrupted or was written by a broken quantizer", name, region,
+                            ggml_type_name(tensor->type), ggml_nbytes(tensor)));
+            }
         }
     };
     std::vector<llama_tensor_weight> weights;


### PR DESCRIPTION
### What

`llama_model_loader` validates two things about a tensor and misses a third.
It checks that the data lies inside the file:

```
if (offs + ggml_nbytes(tensor) < offs || offs + ggml_nbytes(tensor) > file->size()) {
    ... "tensor '%s' data is not within the file bounds, model is corrupted or incomplete"
```

and `check_tensor_dims()` checks the shape, and `create_tensor_as_view()` the
type. Nothing checks that the GGUF **reserved as many bytes for that tensor as
the type requires for that shape**.

So a file whose tensor regions are too small loads silently. Each short tensor
reads its tail out of the next tensor's data, the file-bounds check passes
because the neighbouring tensors supply the slack, and only the very last
tensor in the file could ever trip it.

### How it showed up

A published `IQ4_KSS` quantization of DeepSeek-V4-Flash-0731 reserves exactly
1 GiB for each `{4096, 2048, 256}` expert tensor. `IQ4_KSS` carries a 4-byte
per-row scale, so `ggml_row_size(IQ4_KSS, 4096)` is 2052, not 2048, and the
tensor needs 1 075 838 976 bytes — 2 MiB more than was reserved. 127 of the
file's 129 expert tensors are short in exactly this way; the two `IQ4_K` ones,
which have no per-row header, are correct.

2 MiB is 1022 rows, so rows 0–1025 of expert 255 are read correctly and rows
1026–2047 come from whatever follows in the file. Those rows dequantize to
`±inf`, the expert matmul returns NaN whenever a token routes to expert 255,
the NaN reaches the logits, and the run either aborts in the sampler at any
temperature above zero or — at `temperature 0`, where the argmax of an all-NaN
row still returns an index — silently emits tokens that render as nothing.

Which layer breaks depends on the prompt, because it depends on routing. For
`"Hello"`, expert 255 is selected in exactly one layer (13, ids
`[129, 44, 87, 255, 177, 33]`), and layer 13 is exactly where the first NaN
appears; layers 0–12 never select it and are clean.

That took several hours to trace from the sampler abort back to the file. With
the check below it is the first line of output:

```
llama_model_load: error loading model: tensor 'blk.0.ffn_gate_exps.weight' is stored in
1073741824 bytes but iq4_kss needs 1075838976, the model is corrupted or was written by
a broken quantizer
```

The quantizer is not this repo's: `quantize_iq4_kss()` returns
`nrows * ggml_row_size(...)` correctly both at HEAD and at the older commits I
checked, and the file's `quantize.imatrix.file` metadata points at a Windows
build I cannot identify. The point of this change is not to fix that writer —
it is that a reader which already checks shape and type should not accept a
byte extent it knows to be impossible.

### The change

Compare `ggml_nbytes(tensor)` against the space between this tensor's offset
and the next one, or the rest of the file for the last tensor, in the same
constructor as the existing bounds check and in the same style.

Alignment padding only ever makes the region larger than `ggml_nbytes()`, so a
well-formed file cannot trip it. The comparison is skipped when the next
offset is not greater than this one, so a file that stores tensors out of
index order is unaffected rather than rejected.

### Testing

Built with `-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86`, Ubuntu 24.04,
CUDA 13.0, RTX A6000 + RTX 3090.

- The broken file above: previously loaded and produced NaN; now refused at
  load with the message quoted above, on the first expert tensor.
- No false positive on six good GGUFs — `unsloth/DeepSeek-V4-Flash-0731-GGUF`
  `UD-Q4_K_XL` across its five shards plus a `Q8_0` DSpark draft model, so
  `f32`, `bf16`, `q8_0`, `Q4_K`, `Q6_K` and friends, single- and multi-file.
  They load and serve as before: 27.9 tok/s decode over 400 tokens, 231 tok/s
  prefill over 2810, draft acceptance 221/354 — unchanged from the same run on
  an unpatched build.
- `tests/test-backend-ops` does not reach the model loader, so I did not treat
  it as coverage.

### Prior art

No issue, pull request or discussion covers this. Queries against this repo:
`tensor stored size`, `corrupted quantizer size check`,
`gguf tensor size validation`, `nbytes region check loader`,
`tensor size validation loader` (issues and pull requests), and
`tensor size mismatch load`, `corrupted gguf silent`, `quantizer wrote short`
(discussions, via GraphQL). The five discussion hits for the first of those
are about tensor-parallel splitting and VRAM, not about validation.

### Notes

- AI disclosure, per CONTRIBUTING: I used Claude Code while investigating this
  and while drafting this description. The reproduction, the tensor-level
  localization and the before/after runs are from my own machine, and I
  understand and have tested the change.
- I have not reported the file to its publisher yet; I will, separately.

Review Complexity : Low
